### PR TITLE
Added missing <cstring> include.

### DIFF
--- a/src/celengine/image.cpp
+++ b/src/celengine/image.cpp
@@ -65,6 +65,7 @@ extern "C" {
 #include <iostream>
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
 using namespace std;
 


### PR DESCRIPTION
This is needed for image.cpp to compile on modern Linux distros.