### PR TITLE
Replace celestia.vcproj with celestia.vcxproj in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ pkgdatadir = @datadir@/@PACKAGE@
 dosstuff = \
 	celestia.iss \
 	celestia.sln \
-	celestia.vcproj
+	celestia.vcxproj
 
 noinst_DATA = \
 	coding-standards.html \


### PR DESCRIPTION
This was missed in the previous commit, since the problem didn't exsist on the branch I was on. I honestly don't know what this is used for though.