### PR TITLE
Lua 5.2 and 5.3 fixes

### DIFF
--- a/celestia.pro
+++ b/celestia.pro
@@ -602,9 +602,13 @@ unix {
 
     CONFIG += link_pkgconfig
 
-    LUALIST = lua52 lua51 lua
+    LUALIST = lua53 lua52 lua51 lua
     for(libpc, LUALIST):system(pkg-config --exists $${libpc}):LUAPC = $${libpc}
     isEmpty (LUAPC) {error("No shared Lua library found!")}
+
+    equals(LUAPC, "lua53"): DEFINES += LUA_VER=0x050300
+    equals(LUAPC, "lua52"): DEFINES += LUA_VER=0x050200
+    equals(LUAPC, "lua51"): DEFINES += LUA_VER=0x050100
 
     PKGCONFIG += glu $$LUAPC libpng theora
     INCLUDEPATH += /usr/local/cspice/include
@@ -671,7 +675,7 @@ macx {
     LIBS += macosx/lib/cspice.a
 }
 
-DEFINES += CELX LUA_VER=0x050200
+DEFINES += CELX
 
 # QMAKE_CXXFLAGS += -ffast-math
 

--- a/scripts/eclipticgrid.celx
+++ b/scripts/eclipticgrid.celx
@@ -1,3 +1,5 @@
+-- Title: Toggle Eclipic Grid
+
 t = {} -- create table
 t.equatorialgrid = 	false
 t.galacticgrid = 	false

--- a/scripts/galacticgrid.celx
+++ b/scripts/galacticgrid.celx
@@ -1,3 +1,5 @@
+-- Title: Toggle Galactic Grid
+
 t = {} -- create table
 t.equatorialgrid = 	false
 t.galacticgrid = 	not celestia:getrenderflags().galacticgrid

--- a/scripts/horizontalgrid.celx
+++ b/scripts/horizontalgrid.celx
@@ -1,3 +1,5 @@
+-- Title: Toggle Horizontal Grid
+
 t = {} -- create table
 t.equatorialgrid = 	false
 t.galacticgrid = 	false

--- a/scripts/marktype.celx
+++ b/scripts/marktype.celx
@@ -1,3 +1,5 @@
+-- Title: Mark all D stars
+
 function mark_spectraltype(x)
     local obs = celestia:getobserver()
     local nstars = celestia:getstarcount()

--- a/scripts/randstar.celx
+++ b/scripts/randstar.celx
@@ -6,6 +6,6 @@ while 1 do
     index = math.floor(nstars * math.random())
     star = celestia:getstar(index)
     celestia:select(star)
-    obs:goto(star, 10)
+    obs:gotoobject(star, 10)
     wait(10)
 end

--- a/scripts/tour-system.celx
+++ b/scripts/tour-system.celx
@@ -1,7 +1,7 @@
-function goto(o, t)
+function gotoobject(o, t)
     local obs = celestia:getobserver()
     obs:follow(o)
-    obs:goto(o, t)
+    obs:gotoobject(o, t)
         while (obs:travelling()) do
         wait(0)
     end
@@ -11,7 +11,7 @@ function visit(o)
     local i, v
     celestia:select(o)
     celestia:flash(o:type() .. " - " .. o:name())
-    goto(o, 3)
+    gotoobject(o, 3)
     wait(0.5)
     local children = o:getchildren()
     for i, v in ipairs(children) do

--- a/scripts/tour-system.celx
+++ b/scripts/tour-system.celx
@@ -1,3 +1,5 @@
+-- Title: Tour around Solar system objects
+
 function gotoobject(o, t)
     local obs = celestia:getobserver()
     obs:follow(o)

--- a/scripts/z-dist.celx
+++ b/scripts/z-dist.celx
@@ -20,7 +20,7 @@ end
 
 function rgb2hex(r,g,b)
    -- Converts color code from RGB to Hex
-   local hex = string.format("#%.2x%.2x%.2x", r,g,b)
+   local hex = string.format("#%.2x%.2x%.2x", math.floor(r), math.floor(g), math.floor(b))
    return hex
 end
 

--- a/src/celestia/celx.cpp
+++ b/src/celestia/celx.cpp
@@ -515,7 +515,11 @@ LuaState::LuaState() :
     ioMode(NoIO),
     eventHandlerEnabled(false)
 {
+#if LUA_VER >= 0x050100
     state = luaL_newstate();
+#else
+    state = lua_open();
+#endif
     timer = CreateTimer();
     screenshotCount = 0;
 }
@@ -3678,6 +3682,9 @@ bool LuaState::init(CelestiaCore* appCore)
     openLuaLibrary(state, LUA_MATHLIBNAME, luaopen_math);
     openLuaLibrary(state, LUA_TABLIBNAME, luaopen_table);
     openLuaLibrary(state, LUA_STRLIBNAME, luaopen_string);
+#if LUA_VER >= 0x050200
+    openLuaLibrary(state, LUA_COLIBNAME, luaopen_coroutine);
+#endif
     // Make the package library, except the loadlib function, available
     // for celx regardless of script system access policy.
     allowLuaPackageAccess();

--- a/src/celestia/celx_observer.cpp
+++ b/src/celestia/celx_observer.cpp
@@ -899,7 +899,10 @@ void CreateObserverMetaTable(lua_State* l)
 
     celx.registerMethod("__tostring", observer_tostring);
     celx.registerMethod("isvalid", observer_isvalid);
+#if LUA_VER < 0x050200
     celx.registerMethod("goto", observer_goto);
+#endif
+    celx.registerMethod("gotoobject", observer_goto);
     celx.registerMethod("gotolonglat", observer_gotolonglat);
     celx.registerMethod("gotolocation", observer_gotolocation);
     celx.registerMethod("gotodistance", observer_gotodistance);


### PR DESCRIPTION
Currently on unix platforms we can build Celestia only with Lua 5.2 support, but its support isn't complete.
This PR tries to fix issues we have:
1. It restores usage of older Lua versions (5.1 and 5.0).
1. Adds fixes to enable script usage (loads coroutines library used internally).
1. Adds a new method `gotoobject` behaving exactly as `goto` method. When compiled against Lua < 5.2 both methods exist, with Lua >= 5.2 only `gotoobject`. This change is required because Lua 5.2 introduced `goto` statement so we can't use `goto` as function name anymore.

Windows and OSX build are not affected because they have Lua 5.1 hardcoded.

I don't insist on `gotoobject` name we can find a better one.

My suggestion is support Lua 5.1 as a main Lua version and announce experimental support support for Lua 5.2 and 5.3 so extension authors have time to fix their scripts.