### PR TITLE
Fix a couple of undefined references

### DIFF
--- a/src/celengine/Makefile.am
+++ b/src/celengine/Makefile.am
@@ -1,7 +1,10 @@
 noinst_LIBRARIES = libcelengine.a
 noinst_HEADERS = $(wildcard *.h)
 
-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/thirdparty/Eigen -I$(top_srcdir)/thirdparty/curveplot/include
+AM_CPPFLAGS = -I$(top_srcdir)/src \
+	      -I$(top_srcdir)/thirdparty/Eigen \
+	      -I$(top_srcdir)/thirdparty/curveplot/include \
+	      -I$(top_srcdir)/thirdparty/glew/include
 
 libcelengine_a_CXXFLAGS = $(LUA_CFLAGS) $(SPICE_CFLAGS) $(GLEW_CFLAGS)
 
@@ -75,4 +78,5 @@ libcelengine_a_SOURCES = \
 	vertexprog.cpp \
 	virtualtex.cpp \
 	visibleregion.cpp \
+	../../thirdparty/glew/src/glew.c \
 	../../thirdparty/curveplot/src/curveplot.cpp

--- a/src/celestia/Makefile.am
+++ b/src/celestia/Makefile.am
@@ -14,7 +14,8 @@ endif
 
 if ENABLE_GTK
 SUBDIRS += gtk
-celestiaGTKLIBS = $(GTK_LIBS) gtk/libgtkgui.a
+celestiaGTKLIBS = gtk/libgtkgui.a
+LIBS += $(GTK_LIBS)
 endif
 
 if ENABLE_QT


### PR DESCRIPTION
While playing with the git sources I found a couple of undefined references regarding gtk and glew. These two commits should fix this.