### PR TITLE
Fix Qt compatibility and some other fixes

### DIFF
--- a/src/celestia/qt/QtAudioManager.cpp
+++ b/src/celestia/qt/QtAudioManager.cpp
@@ -1,4 +1,3 @@
-
 #include <iostream>
 #include <QtCore/QDir>
 #include <QtCore/QUrl>
@@ -7,18 +6,19 @@
 using namespace std;
 
 void QtAudioManager::createChannel(int id, double vol, bool looped, QString fn, bool nopause) {
-    QMediaPlayer *player = new QMediaPlayer(this);
     QString path;
 
     if (QDir::isRelativePath(fn)) {
         QDir fpath = QDir::current();
         fpath.cd("sounds");
-		#ifdef Q_OS_LINUX
-			if (!fpath.exists(fn)) { fpath.cd(CONFIG_DATA_DIR); fpath.cd("sounds"); }
-		#endif
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
         if (!fpath.exists(fn)) {
-//            cout << "Cannot play \'" << fn.toUtf8().data() << "\'No file found.\n";
-            cout << "Cannot play relative\'" << fpath.path().toUtf8().data() << "/" << fn.toUtf8().data() << "\': No file found.\n";
+            fpath.cd(CONFIG_DATA_DIR);
+            fpath.cd("sounds");
+        }
+#endif
+        if (!fpath.exists(fn)) {
+            cerr << "Cannot play relative\'" << fpath.path().toUtf8().data() << "/" << fn.toUtf8().data() << "\': No file found.\n";
             return;
         }
         QUrl url = QUrl::fromLocalFile(fpath.filePath(fn));
@@ -26,14 +26,14 @@ void QtAudioManager::createChannel(int id, double vol, bool looped, QString fn, 
     } else {
         QDir fpath = QDir::fromNativeSeparators(fn);
         if (!fpath.exists(fn)) {
-            cout << "Cannot play absolute \'" << fpath.path().toUtf8().data() << "/" << fn.toUtf8().data() << "\': No file found.\n";
+            cerr << "Cannot play absolute \'" << fpath.path().toUtf8().data() << "/" << fn.toUtf8().data() << "\': No file found.\n";
             return;
         }
         QUrl url = QUrl::fromLocalFile(fn);
         path = url.url(QUrl::NormalizePathSegments);
     }
     
-
+    QMediaPlayer *player = new QMediaPlayer(this);
     player->setPlaylist(new QMediaPlaylist(player));
     freeChannel(id);
     _channels.insert(id, player);
@@ -61,7 +61,6 @@ void QtAudioManager::playChannel(int channel, double vol, bool looped, const cha
             freeChannel(channel);
         }
     } else {
-
         if (fname.length() > 0) {
             createChannel(channel, vol, looped, fname, nopause);
             playChannel(channel);
@@ -76,7 +75,9 @@ void QtAudioManager::playAll() {
 }
 
 void QtAudioManager::pauseAll() {
+#ifndef NO_DEBUG
     cout << "pauseAll()\n";
+#endif
     for (ChannelsContainer::iterator it = _channels.begin(); it != _channels.end(); it++) {
         if (!getChannelNoPause(it.key())) {
             (*it)->pause();
@@ -98,5 +99,5 @@ void QtAudioManager::resumeAll() {
 }
 
 void QtAudioManager::logError(QMediaPlayer::Error err) {
-    cout << "An error occured: " << err << endl;
+    cerr << "An error occured: " << err << endl;
 }

--- a/src/celestia/qt/QtAudioManager.cpp
+++ b/src/celestia/qt/QtAudioManager.cpp
@@ -41,7 +41,11 @@ void QtAudioManager::createChannel(int id, double vol, bool looped, QString fn, 
     setChannelLoop(id, looped);
     setChannelFile(id, path);
     setChannelNoPause(id, nopause);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
     connect(player, QOverload<QMediaPlayer::Error>::of(&QMediaPlayer::error), this, &QtAudioManager::logError);
+#else
+    connect(player, SIGNAL(error(QMediaPlayer::Error)), this, SLOT(logError(QMediaPlayer::Error)));
+#endif
 }
 
 void QtAudioManager::playChannel(int channel, double vol, bool looped, const char *f, bool nopause) {

--- a/src/celestia/qt/QtCelestiaCoreApplication.h
+++ b/src/celestia/qt/QtCelestiaCoreApplication.h
@@ -5,8 +5,6 @@
 #include <src/celestia/CelestiaCoreApplication.h>
 
 namespace CelestiaQt {
-    Q_NAMESPACE
-
     class RenderFlag : public QObject {
         Q_OBJECT
 


### PR DESCRIPTION
1.    Fix compatibility with older Qt versions (Closes: #55)
2.    QtAudioManager fixes
    
      1) Better check for Unix-like systems
      2) Use std::cerr to report errors instead of std::cout
      3) Move QMediaPlayer creation to prevent memory leak

