### PR TITLE
fixed crash when loading of celx script failed

### DIFF
--- a/src/celestia/celx.cpp
+++ b/src/celestia/celx.cpp
@@ -919,6 +919,9 @@ bool LuaState::handleMouseButtonEvent(float x, float y, int button, bool down)
 // Returns true if a handler is registered for the tick event
 bool LuaState::handleTickEvent(double dt)
 {
+    if (!costate)
+        return true;
+
     CelestiaCore* appCore = getAppCore(costate, NoErrors);
     if (appCore == NULL)
     {


### PR DESCRIPTION
When script got a error during loading, the timer runns and celestia crashes when timer calls LuaState::handleTickEvent