### PR TITLE
fixed file-io with qt, check key 'y' and 'Y'.

### DIFF
--- a/src/celestia/celx.cpp
+++ b/src/celestia/celx.cpp
@@ -741,7 +741,7 @@ bool LuaState::charEntered(const char* c_p)
     if (ioMode == Asking && getTime() > timeout)
     {
         int stackTop = lua_gettop(costate);
-        if (strcmp(c_p, "y") == 0)
+        if (strcmp(c_p, "y") == 0 || strcmp(c_p, "Y") == 0)
         {
 #if LUA_VER >= 0x050100
             openLuaLibrary(costate, LUA_LOADLIBNAME, luaopen_package);


### PR DESCRIPTION
Comming from CelestiaGlWidget::keyPressEvent() case VK_Y:
Checking 'y' and 'Y' if user has caps lock enabled or pressed the 'Y' key
