### PR TITLE
Fullscreen

### DIFF
--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -907,7 +907,10 @@ void CelestiaAppWindow::slotToggleFullScreen()
         // Switch to window
         menuBar()->setFixedHeight(menuBar()->sizeHint().height());
         setWindowState(Qt::WindowNoState);
-        readSettings();
+        QSettings settings;
+        settings.beginGroup("MainWindow");
+        settings.setValue("Fullscreen", false);
+        readSettings();     // restore last windowed settings
     }
     else
     {


### PR DESCRIPTION
This is the fixes for issue #70
I added additionally a visual studio 2005 project with Qt Visual Studio Plugin

Switching to full screen saves the current tool bars in registry and disable them.
Switching back to window, the settings was restored to the tool bars