### PR TITLE
[DON'T MERGE] Load SSC fragments dynamically

### DIFF
--- a/src/celestia/celx.cpp
+++ b/src/celestia/celx.cpp
@@ -3537,6 +3537,23 @@ static int celestia_play(lua_State*)
 }
 
 
+static int celestia_from_ssc(lua_State* l)
+{
+    Celx_CheckArgs(l, 2, 2, "Function celestia:from_ssc requires exactly one argument");
+    CelestiaCore* appCore = this_celestia(l);
+    const char* s = Celx_SafeGetString(l, 2, AllErrors, "First argument to celestia:from_ssc must be a string");
+    if (s == nullptr)
+    {
+        lua_pushboolean(l, false);
+        return 1;
+    }
+    istringstream in(s);
+    bool ret = LoadSolarSystemObjects(in, *appCore->getSimulation()->getUniverse(), "");
+
+    lua_pushboolean(l, ret);
+    return 1;
+}
+
 static void CreateCelestiaMetaTable(lua_State* l)
 {
     Celx_CreateClassMetatable(l, Celx_Celestia);
@@ -3638,6 +3655,8 @@ static void CreateCelestiaMetaTable(lua_State* l)
     Celx_RegisterMethod(l, "verbosity", celestia_verbosity);
     // Dummy command for compatibility purpose
     Celx_RegisterMethod(l, "play", celestia_play);
+
+    Celx_RegisterMethod(l, "from_ssc", celestia_from_ssc);
 
     lua_pop(l, 1);
 }


### PR DESCRIPTION
It's so simple to reuse existing infrastructure that I'm in doubt whether we need something else :)

just an example:
```
ssc = [[
"Foo Bar" "Sol"
{
        Class   "asteroid"  # Candidate to the Dwarf Planet
        Texture "bstar.jpg" 
        Color   [ 0.00 1.00 0.00 ]
        BlendTexture    false
        Radius  317.5   
        OrbitColor      [ 0.27451 0.078431 0.54902 ]
        Visible true    
        Clickable       true
        EllipticalOrbit
        {
                Epoch   2457800.5  # 2017 Feb 16+
                Period  1132.45737104527
                SemiMajorAxis   1080
                Eccentricity    0.99
                Inclination     26
                AscendingNode   131
                ArgOfPericenter 29
                MeanAnomaly     320
        }
        UniformRotation
        {
                Period  6
        }
        Albedo  0.131
}
]]

if (celestia:from_ssc(ssc)) then
    print("okay")
else
    print("not okay")
end
```