### PR TITLE
Some random fixes

### DIFF
--- a/src/celengine/astro.cpp
+++ b/src/celengine/astro.cpp
@@ -86,7 +86,6 @@ struct LeapSecondRecord
 // to the date in the table.
 static const LeapSecondRecord LeapSeconds[] =
 {
-    { 10, 2441317.5 }, // 1 Jan 1972
     { 11, 2441499.5 }, // 1 Jul 1972
     { 12, 2441683.5 }, // 1 Jan 1973
     { 13, 2442048.5 }, // 1 Jan 1974
@@ -113,7 +112,7 @@ static const LeapSecondRecord LeapSeconds[] =
     { 34, 2454832.5 }, // 1 Jan 2009
     { 35, 2456109.5 }, // 1 Jul 2012
     { 36, 2457204.5 }, // 1 Jul 2015
-    { 37, 2457388.5 }, // 1 Jan 2016
+    { 37, 2457754.5 }, // 1 Jan 2017
 };
 
 

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -175,9 +175,9 @@ void Universe::markObject(const Selection& sel,
     if (iter != markers->end())
     {
         // Handle the case when the object is already marked.  If the
-        // priority is higher than the existing marker, replace it.
+        // priority is higher or equal to the existing marker, replace it.
         // Otherwise, do nothing.
-        if (priority > iter->priority())
+        if (priority >= iter->priority())
             markers->erase(iter);
         else
             return;


### PR DESCRIPTION
1. Leap seconds: remove 1 Jan 1972 as there were no leap seconds that day, replace 1 Jan 2016 with 1 Jan 2017 as we had one on 1 Jan 2017 not 1 Jan 2016.
1. Allow to replace markers with the same priority. Markers created by GUI have the same priority.