### PR TITLE
Add missing Linux installation info to readme

### DIFF
--- a/README
+++ b/README
@@ -72,9 +72,12 @@ Then do the following actions in Celestia's source directory:
 mkdir build && cd build
 qmake -qt=5 PREFIX=/opt/celestia -o Makefile ../celestia.pro
 make
+sudo make install
 
 You can speedup build passing option -jN to make where N is a number of
 your CPU cores.
+
+An executable binary will be installed to /opt/celestia/bin/Celestia_QT.
 
 GETTING STARTED
 ---------------


### PR DESCRIPTION
Leaving this information out makes installing Celestia on Linux inaccessible to users who are less familiar with building from source (and, I would argue, also anyone who takes instructions very literally). It also just kinda doesn't make sense given that the rest of the instructions are nice and detailed :)