### PR TITLE
Better pkg-config support for LUA and other fixes

### DIFF
--- a/celestia.pro
+++ b/celestia.pro
@@ -761,7 +761,9 @@ unix {
     fonts.path            = $$WORKDIR/fonts
     fonts.files           = $$FONT_SOURCE/*.txf
     scripts.path          = $$WORKDIR/scripts
-    scripts.files         = scripts/*.celx
+    scripts.files         = scripts/*.celx scripts/*.cel
+    images.path           = $$WORKDIR/images
+    images.files          = images/*
     configuration.path    = $$WORKDIR
     configuration.files  += $$CONFIGURATION_FILES \
                            $$CONFIGURATION_SOURCE/guide.cel \
@@ -799,5 +801,5 @@ unix {
 
     INSTALLS += target data textures lores_textures hires_textures \
     flares models shaders fonts scripts locale extras extras-standard \
-    configuration desktop icon128 splash
+    configuration desktop icon128 splash images
 }

--- a/celestia.pro
+++ b/celestia.pro
@@ -632,15 +632,17 @@ unix {
 
     CONFIG += link_pkgconfig
 
-    LUALIST = lua lua51 lua52 lua53
+    LUALIST = lua lua5.1 lua51 lua5.2 lua52 lua5.3 lua53
     for(libpc, LUALIST):system(pkg-config --exists $${libpc}):LUAPC = $${libpc}
     isEmpty (LUAPC) {error("No shared Lua library found!")}
 
     message("LUA version: " $${LUAPC})
     
-    equals(LUAPC, "lua53"): DEFINES += LUA_VER=0x050300
-    equals(LUAPC, "lua52"): DEFINES += LUA_VER=0x050200
-    equals(LUAPC, "lua51"): DEFINES += LUA_VER=0x050100
+    LUA_VER = 0x050000
+    system(pkg-config --atleast-version 5.1 $$LUAPC):LUA_VER = 0x050100
+    system(pkg-config --atleast-version 5.2 $$LUAPC):LUA_VER = 0x050200
+    system(pkg-config --atleast-version 5.3 $$LUAPC):LUA_VER = 0x050300
+    DEFINES += LUA_VER=$$LUA_VER
 
     PKGCONFIG += glu $$LUAPC libpng libjpeg theora
 }

--- a/config.tests/spice/main.cpp
+++ b/config.tests/spice/main.cpp
@@ -1,2 +1,2 @@
-#include "spiceinterface.h"
+#include "SpiceUsr.h"
 int main() { return 0; }

--- a/src/celephem/spicerotation.cpp
+++ b/src/celephem/spicerotation.cpp
@@ -97,7 +97,7 @@ SpiceRotation::init(const string& path,
     // Load required kernel files
     if (requiredKernels != nullptr)
     {
-        for (const auto& kernel : requiredKernels)
+        for (const auto& kernel : *requiredKernels)
         {
             string filepath = path + string("/data/") + kernel;
             if (!LoadSpiceKernel(filepath))


### PR DESCRIPTION
1) In Debian & Co we have both, in OpenSUSE with dot, in Arch without, Gentoo and CentOS don't have version at all.
2) integrate some useful patches from https://build.opensuse.org/package/show/home:munix9:unstable/celestia
