### PR TITLE
Remove some global vars

### DIFF
--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -41,13 +41,13 @@ using namespace std;
 
 
 // 100 Gly - on the order of the current size of the universe
-const float DSO_OCTREE_ROOT_SIZE   = 1.0e11f;
+constexpr const float DSO_OCTREE_ROOT_SIZE   = 1.0e11f;
 
-static const float DSO_OCTREE_MAGNITUDE   = 8.0f;
-//static const float DSO_EXTRA_ROOM         = 0.01f; // Reserve 1% capacity for extra DSOs
-                                                   // (useful as a complement of binary loaded DSOs)
+constexpr const float DSO_OCTREE_MAGNITUDE   = 8.0f;
+//constexpr const float DSO_EXTRA_ROOM         = 0.01f; // Reserve 1% capacity for extra DSOs
+                                                      // (useful as a complement of binary loaded DSOs)
 
-const char* DSODatabase::FILE_HEADER      = "CEL_DSOs";
+constexpr char FILE_HEADER[]                 = "CEL_DSOs";
 
 // Used to sort DSO pointers by catalog number
 struct PtrCatalogNumberOrderingPredicate

--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -64,8 +64,6 @@ class DSODatabase
 
     static DSODatabase* read(std::istream&);
 
-    static const char* FILE_HEADER;
-
     double getAverageAbsoluteMagnitude() const;
 
 private:

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -27,8 +27,6 @@ using namespace std;
 // #define USE_GLSL_STRUCTS
 #define POINT_FADE 0
 
-ShaderManager g_ShaderManager;
-
 enum ShaderVariableType
 {
     Shader_Float,
@@ -58,6 +56,8 @@ static const string CommonHeader("#version 120\n");
 ShaderManager&
 GetShaderManager()
 {
+    static ShaderManager g_ShaderManager;
+
     return g_ShaderManager;
 }
 

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -30,13 +30,13 @@ using namespace Eigen;
 using namespace std;
 
 
-static string HDCatalogPrefix("HD ");
-static string HIPPARCOSCatalogPrefix("HIP ");
-static string GlieseCatalogPrefix("Gliese ");
-static string RossCatalogPrefix("Ross ");
-static string LacailleCatalogPrefix("Lacaille ");
-static string TychoCatalogPrefix("TYC ");
-static string SAOCatalogPrefix("SAO ");
+constexpr const char HDCatalogPrefix[]        = "HD ";
+constexpr const char HIPPARCOSCatalogPrefix[] = "HIP ";
+constexpr const char GlieseCatalogPrefix[]    = "Gliese ";
+constexpr const char RossCatalogPrefix[]      = "Ross ";
+constexpr const char LacailleCatalogPrefix[]  = "Lacaille ";
+constexpr const char TychoCatalogPrefix[]     = "TYC ";
+constexpr const char SAOCatalogPrefix[]       = "SAO ";
 
 // The size of the root star octree node is also the maximum distance
 // distance from the Sun at which any star may be located. The current
@@ -137,11 +137,11 @@ static bool parseHDCatalogNumber(const string& name,
 static bool parseTychoCatalogNumber(const string& name,
                                     uint32_t* catalogNumber)
 {
-    if (compareIgnoringCase(name, TychoCatalogPrefix, TychoCatalogPrefix.length()) == 0)
+    int len = strlen(TychoCatalogPrefix);
+    if (compareIgnoringCase(name, TychoCatalogPrefix, len) == 0)
     {
         unsigned int tyc1 = 0, tyc2 = 0, tyc3 = 0;
-        if (sscanf(string(name, TychoCatalogPrefix.length(),
-                   string::npos).c_str(),
+        if (sscanf(string(name, len, string::npos).c_str(),
                    " %u-%u-%u", &tyc1, &tyc2, &tyc3) == 3)
         {
             *catalogNumber = (uint32_t) (tyc3 * 1000000000 + tyc2 * 10000 + tyc1);

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -44,13 +44,13 @@ constexpr const char SAOCatalogPrefix[]       = "SAO ";
 // local group of galaxies. A larger value should be OK, but the
 // performance implications for octree traversal still need to be
 // investigated.
-static const float STAR_OCTREE_ROOT_SIZE  = 10000000.0f;
+constexpr const float STAR_OCTREE_ROOT_SIZE   = 10000000.0f;
 
-static const float STAR_OCTREE_MAGNITUDE  = 6.0f;
-//static const float STAR_EXTRA_ROOM        = 0.01f; // Reserve 1% capacity for extra stars
+constexpr const float STAR_OCTREE_MAGNITUDE   = 6.0f;
+//constexpr const float STAR_EXTRA_ROOM        = 0.01f; // Reserve 1% capacity for extra stars
 
-const char* StarDatabase::FILE_HEADER            = "CELSTARS";
-const char* StarDatabase::CROSSINDEX_FILE_HEADER = "CELINDEX";
+constexpr const char FILE_HEADER[]            = "CELSTARS";
+constexpr const char CROSSINDEX_FILE_HEADER[] = "CELINDEX";
 
 
 // Used to sort stars by catalog number

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -175,9 +175,6 @@ class StarDatabase
 
     static StarDatabase* read(std::istream&);
 
-    static const char* FILE_HEADER;
-    static const char* CROSSINDEX_FILE_HEADER;
-
 private:
     bool createStar(Star* star,
                     StcDisposition disposition,


### PR DESCRIPTION
At least now I don't have double free on exit, see #150 .

Instead of 
```
static ShaderManager g_ShaderManager;
return g_ShaderManager;
```
I initially made
```
static ShaderManager* g_ShaderManager = nullptr;
if(g_ShaderManager == nullptr)
    g_ShaderManager = new ShaderManager;
return *g_ShaderManager;
```

Both variants don't have any issues, but the 1st is faster.