### PR TITLE
Private shader manager & GLContext cleanup

### DIFF
--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -20,6 +20,7 @@
 #include "asterism.h"
 #include "parser.h"
 #include "vecgl.h"
+#include "render.h"
 
 using namespace std;
 
@@ -106,7 +107,7 @@ bool Asterism::isColorOverridden() const
 
 /*! Draw visible asterisms.
  */
-void AsterismList::render(Color defaultColor)
+void AsterismList::render(const Color& defaultColor, const Renderer& renderer)
 {
     if (vboId == 0)
     {
@@ -129,7 +130,7 @@ void AsterismList::render(Color defaultColor)
         glBindBuffer(GL_ARRAY_BUFFER, vboId);
     }
 
-    CelestiaGLProgram* prog = GetShaderManager().getShader(shadprop);
+    CelestiaGLProgram* prog = renderer.getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
 

--- a/src/celengine/asterism.h
+++ b/src/celengine/asterism.h
@@ -18,6 +18,7 @@
 #include "stardb.h"
 #include "shadermanager.h"
 
+class Renderer;
 class AsterismList;
 
 class Asterism
@@ -60,7 +61,7 @@ class Asterism
 class AsterismList : public std::vector<Asterism*>
 {
  public:
-    void render(Color color);
+    void render(const Color& color, const Renderer& renderer);
 
  private:
     void cleanup();

--- a/src/celengine/boundaries.cpp
+++ b/src/celengine/boundaries.cpp
@@ -13,6 +13,7 @@
 #include <GL/glew.h>
 #include "boundaries.h"
 #include "astro.h"
+#include "render.h"
 
 using namespace Eigen;
 using namespace std;
@@ -71,7 +72,7 @@ void ConstellationBoundaries::lineto(float ra, float dec)
 }
 
 
-void ConstellationBoundaries::render(Color color)
+void ConstellationBoundaries::render(const Color& color, const Renderer& renderer)
 {
     if (vboId == 0)
     {
@@ -88,7 +89,7 @@ void ConstellationBoundaries::render(Color color)
         glBindBuffer(GL_ARRAY_BUFFER, vboId);
     }
 
-    CelestiaGLProgram* prog = GetShaderManager().getShader(shadprop);
+    CelestiaGLProgram* prog = renderer.getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
 

--- a/src/celengine/boundaries.h
+++ b/src/celengine/boundaries.h
@@ -18,6 +18,7 @@
 #include "celutil/color.h"
 #include "shadermanager.h"
 
+class Renderer;
 
 class ConstellationBoundaries
 {
@@ -33,7 +34,7 @@ class ConstellationBoundaries
 
     void moveto(float ra, float dec);
     void lineto(float ra, float dec);
-    void render(Color color);
+    void render(const Color& color, const Renderer& renderer);
 
  private:
     void cleanup();

--- a/src/celengine/deepskyobj.h
+++ b/src/celengine/deepskyobj.h
@@ -89,8 +89,7 @@ class DeepSkyObject : public CatEntry
                       double& distanceToPicker,
                       double& cosAngleToBoundCenter) const = 0;
     virtual bool load(AssociativeArray*, const std::string& resPath);
-    virtual void render(const GLContext& context,
-                        const Eigen::Vector3f& offset,
+    virtual void render(const Eigen::Vector3f& offset,
                         const Eigen::Quaternionf& viewerOrientation,
                         float brightness,
                         float pixelSize,

--- a/src/celengine/deepskyobj.h
+++ b/src/celengine/deepskyobj.h
@@ -21,6 +21,7 @@
 #include <Eigen/Geometry>
 
 class Selection;
+class Renderer;
 
 constexpr const float DSO_DEFAULT_ABS_MAGNITUDE = -1000.0f;
 
@@ -92,7 +93,8 @@ class DeepSkyObject : public CatEntry
                         const Eigen::Vector3f& offset,
                         const Eigen::Quaternionf& viewerOrientation,
                         float brightness,
-                        float pixelSize) = 0;
+                        float pixelSize,
+                        const Renderer*) = 0;
 
     virtual unsigned int getRenderMask() const { return 0; }
     virtual unsigned int getLabelMask() const { return 0; }

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -251,8 +251,7 @@ bool Galaxy::load(AssociativeArray* params, const string& resPath)
 }
 
 
-void Galaxy::render(const GLContext& context,
-                    const Vector3f& offset,
+void Galaxy::render(const Vector3f& offset,
                     const Quaternionf& viewerOrientation,
                     float brightness,
                     float pixelSize,
@@ -260,11 +259,11 @@ void Galaxy::render(const GLContext& context,
 {
     if (form == nullptr)
     {
-        //renderGalaxyEllipsoid(context, offset, viewerOrientation, brightness, pixelSize);
+        //renderGalaxyEllipsoid(offset, viewerOrientation, brightness, pixelSize);
     }
     else
     {
-        renderGalaxyPointSprites(context, offset, viewerOrientation, brightness, pixelSize);
+        renderGalaxyPointSprites(offset, viewerOrientation, brightness, pixelSize);
     }
 }
 
@@ -274,8 +273,7 @@ inline void glVertex4(const Vector4f& v)
     glVertex3fv(v.data());
 }
 
-void Galaxy::renderGalaxyPointSprites(const GLContext& /*unused*/,
-                                      const Vector3f& offset,
+void Galaxy::renderGalaxyPointSprites(const Vector3f& offset,
                                       const Quaternionf& viewerOrientation,
                                       float brightness,
                                       float pixelSize)
@@ -399,8 +397,7 @@ void Galaxy::renderGalaxyPointSprites(const GLContext& /*unused*/,
 
 
 #if 0
-void Galaxy::renderGalaxyEllipsoid(const GLContext& context,
-                                   const Vec3f& offset,
+void Galaxy::renderGalaxyEllipsoid(const Vec3f& offset,
                                    const Quatf&,
                                    float,
                                    float pixelSize)

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -255,7 +255,8 @@ void Galaxy::render(const GLContext& context,
                     const Vector3f& offset,
                     const Quaternionf& viewerOrientation,
                     float brightness,
-                    float pixelSize)
+                    float pixelSize,
+                    const Renderer* /* unused */)
 {
     if (form == nullptr)
     {

--- a/src/celengine/galaxy.h
+++ b/src/celengine/galaxy.h
@@ -45,19 +45,17 @@ class Galaxy : public DeepSkyObject
                       double& distanceToPicker,
                       double& cosAngleToBoundCenter) const;
     virtual bool load(AssociativeArray*, const std::string&);
-    virtual void render(const GLContext& context,
-                        const Eigen::Vector3f& offset,
+    virtual void render(const Eigen::Vector3f& offset,
                         const Eigen::Quaternionf& viewerOrientation,
                         float brightness,
-                        float pixelSize);
-    virtual void renderGalaxyPointSprites(const GLContext& context,
-                                          const Eigen::Vector3f& offset,
+                        float pixelSize,
+                        const Renderer* r = nullptr);
+    virtual void renderGalaxyPointSprites(const Eigen::Vector3f& offset,
                                           const Eigen::Quaternionf& viewerOrientation,
                                           float brightness,
                                           float pixelSize);
 #if 0
-    virtual void renderGalaxyEllipsoid(const GLContext& context,
-                                       const Eigen::Vector3f& offset,
+    virtual void renderGalaxyEllipsoid(const Eigen::Vector3f& offset,
                                        const Eigen::Quaternionf& viewerOrientation,
                                        float brightness,
                                        float pixelSize);

--- a/src/celengine/glcontext.cpp
+++ b/src/celengine/glcontext.cpp
@@ -88,15 +88,3 @@ GLContext::GLRenderPath GLContext::nextRenderPath()
 #endif
     return GLPath_GLSL;
 }
-
-
-bool GLContext::extensionSupported(const string& ext) const
-{
-    return (find(extensions.begin(), extensions.end(), ext) != extensions.end());
-}
-
-
-bool GLContext::bumpMappingSupported() const
-{
-    return true;
-}

--- a/src/celengine/glcontext.h
+++ b/src/celengine/glcontext.h
@@ -16,12 +16,9 @@
 class GLContext
 {
  public:
-    GLContext() = default;
-    virtual ~GLContext() = default;
-
     enum GLRenderPath
     {
-        GLPath_GLSL              = 8,
+        GLPath_GLSL = 8,
     };
 
     void init(const std::vector<std::string>& ignoreExt);
@@ -31,11 +28,7 @@ class GLContext
     bool renderPathSupported(GLRenderPath) const;
     GLRenderPath nextRenderPath();
 
-    bool extensionSupported(const std::string&) const;
-
     int getMaxTextures() const { return maxSimultaneousTextures; };
-    bool hasMultitexture() const { return true; };
-    bool bumpMappingSupported() const;
 
  private:
     GLRenderPath renderPath{ GLPath_GLSL };

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -325,21 +325,21 @@ bool Globular::load(AssociativeArray* params, const string& resPath)
 }
 
 
-void Globular::render(const GLContext& context,
-                    const Vector3f& offset,
-                    const Quaternionf& viewerOrientation,
-                    float brightness,
-                    float pixelSize)
+void Globular::render(const Vector3f& offset,
+                      const Quaternionf& viewerOrientation,
+                      float brightness,
+                      float pixelSize,
+                      const Renderer* /* unused */)
 {
 #ifdef __CELVEC__
-    renderGlobularPointSprites(context, fromEigen(offset), fromEigen(viewerOrientation), brightness, pixelSize);
+    renderGlobularPointSprites(fromEigen(offset), fromEigen(viewerOrientation), brightness, pixelSize);
 #else
-    renderGlobularPointSprites(context, offset, viewerOrientation, brightness, pixelSize);
+    renderGlobularPointSprites(offset, viewerOrientation, brightness, pixelSize);
 #endif
 }
 
 
-void Globular::renderGlobularPointSprites(const GLContext& /*unused*/,
+void Globular::renderGlobularPointSprites(
 #ifdef __CELVEC__
                                       const Vec3f& offset,
                                       const Quatf& viewerOrientation,

--- a/src/celengine/globular.h
+++ b/src/celengine/globular.h
@@ -66,12 +66,12 @@ class Globular : public DeepSkyObject
                       double& distanceToPicker,
                       double& cosAngleToBoundCenter) const;
     virtual bool load(AssociativeArray*, const std::string&);
-    virtual void render(const GLContext& context,
-                        const Eigen::Vector3f& offset,
+    virtual void render(const Eigen::Vector3f& offset,
                         const Eigen::Quaternionf& viewerOrientation,
                         float brightness,
-                        float pixelSize);
-    virtual void renderGlobularPointSprites(const GLContext& context,
+                        float pixelSize,
+                        const Renderer* r = nullptr);
+    virtual void renderGlobularPointSprites(
 #ifdef __CELVEC__
                                             const Vec3f& offset,
                                             const Quatf& viewerOrientation,

--- a/src/celengine/lodspheremesh.cpp
+++ b/src/celengine/lodspheremesh.cpp
@@ -156,20 +156,16 @@ static Vector3f spherePoint(int theta, int phi)
 #endif
 
 
-void LODSphereMesh::render(const GLContext& context,
-                           const Frustum& frustum,
+void LODSphereMesh::render(const Frustum& frustum,
                            float pixWidth,
                            Texture** tex,
                            int nTextures)
 {
-    render(context,
-           Normals | TexCoords0, frustum, pixWidth, tex,
-           nTextures);
+    render(Normals | TexCoords0, frustum, pixWidth, tex, nTextures);
 }
 
 
-void LODSphereMesh::render(const GLContext& context,
-                           unsigned int attributes,
+void LODSphereMesh::render(unsigned int attributes,
                            const Frustum& frustum,
                            float pixWidth,
                            Texture* tex0,
@@ -188,12 +184,11 @@ void LODSphereMesh::render(const GLContext& context,
         textures[nTextures++] = tex2;
     if (tex3 != nullptr)
         textures[nTextures++] = tex3;
-    render(context, attributes, frustum, pixWidth, textures, nTextures);
+    render(attributes, frustum, pixWidth, textures, nTextures);
 }
 
 
-void LODSphereMesh::render(const GLContext& context,
-                           unsigned int attributes,
+void LODSphereMesh::render(unsigned int attributes,
                            const Frustum& frustum,
                            float pixWidth,
                            Texture** tex,
@@ -235,7 +230,7 @@ void LODSphereMesh::render(const GLContext& context,
         nTextures = 0;
 
 
-    RenderInfo ri(step, attributes, frustum, context);
+    RenderInfo ri(step, attributes, frustum);
 
     // If one of the textures is split into subtextures, we may have to
     // use extra patches, since there can be at most one subtexture per patch.

--- a/src/celengine/lodspheremesh.h
+++ b/src/celengine/lodspheremesh.h
@@ -30,15 +30,12 @@ public:
     LODSphereMesh();
     ~LODSphereMesh();
 
-    void render(const GLContext&,
-                unsigned int attributes, const Frustum&, float pixWidth,
+    void render(unsigned int attributes, const Frustum&, float pixWidth,
                 Texture** tex, int nTextures);
-    void render(const GLContext&,
-                unsigned int attributes, const Frustum&, float pixWidth,
+    void render(unsigned int attributes, const Frustum&, float pixWidth,
                 Texture* tex0 = nullptr, Texture* tex1 = nullptr,
                 Texture* tex2 = nullptr, Texture* tex3 = nullptr);
-    void render(const GLContext&,
-                const Frustum&, float pixWidth,
+    void render(const Frustum&, float pixWidth,
                 Texture** tex, int nTextures);
 
     enum {
@@ -56,12 +53,10 @@ public:
     {
         RenderInfo(int _step,
                    unsigned int _attr,
-                   const Frustum& _frustum,
-                   const GLContext& _context) :
+                   const Frustum& _frustum) :
             step(_step),
             attributes(_attr),
-            frustum(_frustum),
-            context(_context)
+            frustum(_frustum)
         {};
 
         int step;
@@ -73,7 +68,6 @@ public:
         Eigen::Vector3f fp[8];    // frustum points, for culling
 #endif
         int texLOD[MAX_SPHERE_MESH_TEXTURES];
-        const GLContext& context;
     };
 
     int renderPatches(int phi0, int theta0,

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -84,7 +84,8 @@ void Nebula::render(const GLContext& /*glcontext*/,
                     const Vector3f& /*unused*/,
                     const Quaternionf& /*unused*/,
                     float /*unused*/,
-                    float pixelSize)
+                    float pixelSize,
+                    const Renderer* renderer)
 {
     Geometry* g = nullptr;
     if (geometry != InvalidResource)
@@ -97,7 +98,7 @@ void Nebula::render(const GLContext& /*glcontext*/,
     glScalef(getRadius(), getRadius(), getRadius());
     glRotate(getOrientation());
 
-    GLSLUnlit_RenderContext rc(getRadius());
+    GLSLUnlit_RenderContext rc(renderer, getRadius());
     rc.setPointScale(2.0f * getRadius() / pixelSize);
     g->render(rc);
     glUseProgram(0);

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -80,8 +80,7 @@ bool Nebula::load(AssociativeArray* params, const string& resPath)
 }
 
 
-void Nebula::render(const GLContext& /*glcontext*/,
-                    const Vector3f& /*unused*/,
+void Nebula::render(const Vector3f& /*unused*/,
                     const Quaternionf& /*unused*/,
                     float /*unused*/,
                     float pixelSize,

--- a/src/celengine/nebula.h
+++ b/src/celengine/nebula.h
@@ -28,8 +28,7 @@ class Nebula : public DeepSkyObject
                       double& distanceToPicker,
                       double& cosAngleToBoundCenter) const;
     virtual bool load(AssociativeArray*, const std::string&);
-    virtual void render(const GLContext& context,
-                        const Eigen::Vector3f& offset,
+    virtual void render(const Eigen::Vector3f& offset,
                         const Eigen::Quaternionf& viewerOrientation,
                         float brightness,
                         float pixelSize,

--- a/src/celengine/nebula.h
+++ b/src/celengine/nebula.h
@@ -13,7 +13,6 @@
 #include <celutil/reshandle.h>
 #include <celengine/deepskyobj.h>
 
-
 class Nebula : public DeepSkyObject
 {
  public:
@@ -33,7 +32,8 @@ class Nebula : public DeepSkyObject
                         const Eigen::Vector3f& offset,
                         const Eigen::Quaternionf& viewerOrientation,
                         float brightness,
-                        float pixelSize);
+                        float pixelSize,
+                        const Renderer* renderer);
 
     virtual unsigned int getRenderMask() const;
     virtual unsigned int getLabelMask() const;

--- a/src/celengine/opencluster.cpp
+++ b/src/celengine/opencluster.cpp
@@ -63,8 +63,7 @@ bool OpenCluster::load(AssociativeArray* params, const string& resPath)
 }
 
 
-void OpenCluster::render(const GLContext& /*unused*/,
-                         const Vector3f& /*unused*/,
+void OpenCluster::render(const Vector3f& /*unused*/,
                          const Quaternionf& /*unused*/,
                          float /*unused*/,
                          float /*unused*/,

--- a/src/celengine/opencluster.cpp
+++ b/src/celengine/opencluster.cpp
@@ -67,7 +67,8 @@ void OpenCluster::render(const GLContext& /*unused*/,
                          const Vector3f& /*unused*/,
                          const Quaternionf& /*unused*/,
                          float /*unused*/,
-                         float /*unused*/)
+                         float /*unused*/,
+                         const Renderer* /*unused*/)
 {
     // Nothing to do right now; open clusters are only visible as their
     // constituent stars and a label when labels are turned on.  A good idea

--- a/src/celengine/opencluster.h
+++ b/src/celengine/opencluster.h
@@ -33,7 +33,8 @@ class OpenCluster : public DeepSkyObject
                         const Eigen::Vector3f& offset,
                         const Eigen::Quaternionf& viewerOrientation,
                         float brightness,
-                        float pixelSize);
+                        float pixelSize,
+                        const Renderer* r = nullptr);
 
     virtual unsigned int getRenderMask() const;
     virtual unsigned int getLabelMask() const;

--- a/src/celengine/opencluster.h
+++ b/src/celengine/opencluster.h
@@ -29,8 +29,7 @@ class OpenCluster : public DeepSkyObject
                       double& distanceToPicker,
                       double& cosAngleToBoundCenter) const;
     virtual bool load(AssociativeArray*, const std::string&);
-    virtual void render(const GLContext& context,
-                        const Eigen::Vector3f& offset,
+    virtual void render(const Eigen::Vector3f& offset,
                         const Eigen::Quaternionf& viewerOrientation,
                         float brightness,
                         float pixelSize,

--- a/src/celengine/rendcontext.h
+++ b/src/celengine/rendcontext.h
@@ -15,6 +15,7 @@
 #include <celmodel/mesh.h>
 #include <Eigen/Geometry>
 
+class Renderer;
 
 class RenderContext
 {
@@ -22,7 +23,7 @@ class RenderContext
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     RenderContext(const cmod::Material*);
-    RenderContext();
+    RenderContext(const Renderer*);
     virtual ~RenderContext() = default;
 
     virtual void makeCurrent(const cmod::Material&) = 0;
@@ -59,6 +60,7 @@ class RenderContext
     Eigen::Quaternionf cameraOrientation;  // required for drawing billboards
 
  protected:
+    const Renderer* renderer { nullptr };
     bool usePointSize{ false };
     bool useNormals{ true };
     bool useColors{ false };
@@ -72,16 +74,16 @@ class GLSL_RenderContext : public RenderContext
  public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    GLSL_RenderContext(const LightingState& ls, float _objRadius, const Eigen::Quaternionf& orientation);
-    GLSL_RenderContext(const LightingState& ls, const Eigen::Vector3f& _objScale, const Eigen::Quaternionf& orientation);
-    virtual ~GLSL_RenderContext();
+    GLSL_RenderContext(const Renderer* r, const LightingState& ls, float _objRadius, const Eigen::Quaternionf& orientation);
+    GLSL_RenderContext(const Renderer* r, const LightingState& ls, const Eigen::Vector3f& _objScale, const Eigen::Quaternionf& orientation);
+    ~GLSL_RenderContext() override;
 
-    virtual void makeCurrent(const cmod::Material&);
-    virtual void setVertexArrays(const cmod::Mesh::VertexDescription& desc,
-                                 const void* vertexData);
+    void makeCurrent(const cmod::Material&) override;
+    void setVertexArrays(const cmod::Mesh::VertexDescription& desc,
+                         const void* vertexData) override;
 
-    virtual void setLunarLambert(float);
-    virtual void setAtmosphere(const Atmosphere*);
+    void setLunarLambert(float);
+    void setAtmosphere(const Atmosphere*);
 
  private:
      void initLightingEnvironment();
@@ -106,12 +108,12 @@ class GLSL_RenderContext : public RenderContext
 class GLSLUnlit_RenderContext : public RenderContext
 {
  public:
-    GLSLUnlit_RenderContext(float _objRadius);
-    virtual ~GLSLUnlit_RenderContext();
+    GLSLUnlit_RenderContext(const Renderer* r, float _objRadius);
+    ~GLSLUnlit_RenderContext() override;
 
-    virtual void makeCurrent(const cmod::Material&);
-    virtual void setVertexArrays(const cmod::Mesh::VertexDescription& desc,
-                                 const void* vertexData);
+    void makeCurrent(const cmod::Material&) override;
+    void setVertexArrays(const cmod::Mesh::VertexDescription& desc,
+                         const void* vertexData) override;
 
  private:
     void initLightingEnvironment();
@@ -126,4 +128,3 @@ class GLSLUnlit_RenderContext : public RenderContext
 
 
 #endif // _CELENGINE_RENDCONTEXT_H_
-

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -458,7 +458,6 @@ void PointStarVertexBuffer::setTexture(Texture* _texture)
 
 
 Renderer::Renderer() :
-    context(0),
     windowWidth(0),
     windowHeight(0),
     fov(FOV),
@@ -4156,8 +4155,7 @@ static void setupBumpTexenvAmbient(Color ambientColor)
 
 static void renderSphereDefault(const RenderInfo& ri,
                                 const Frustum& frustum,
-                                bool lit,
-                                const GLContext& context)
+                                bool lit)
 {
     if (lit)
         glEnable(GL_LIGHTING);
@@ -4176,8 +4174,7 @@ static void renderSphereDefault(const RenderInfo& ri,
 
     glColor(ri.color);
 
-    g_lodSphere->render(context,
-                        LODSphereMesh::Normals | LODSphereMesh::TexCoords0,
+    g_lodSphere->render(LODSphereMesh::Normals | LODSphereMesh::TexCoords0,
                         frustum, ri.pixWidth,
                         ri.baseTex);
     if (ri.nightTex != nullptr && ri.useTexEnvCombine)
@@ -4205,8 +4202,7 @@ static void renderSphereDefault(const RenderInfo& ri,
         glBlendFunc(GL_ONE, GL_ONE);
 #endif
         glAmbientLightColor(Color::Black); // Disable ambient light
-        g_lodSphere->render(context,
-                            LODSphereMesh::Normals | LODSphereMesh::TexCoords0,
+        g_lodSphere->render(LODSphereMesh::Normals | LODSphereMesh::TexCoords0,
                             frustum, ri.pixWidth,
                             ri.nightTex);
         glAmbientLightColor(ri.ambientColor);
@@ -4221,8 +4217,7 @@ static void renderSphereDefault(const RenderInfo& ri,
         ri.overlayTex->bind();
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        g_lodSphere->render(context,
-                            LODSphereMesh::Normals | LODSphereMesh::TexCoords0,
+        g_lodSphere->render(LODSphereMesh::Normals | LODSphereMesh::TexCoords0,
                             frustum, ri.pixWidth,
                             ri.overlayTex);
         glBlendFunc(GL_ONE, GL_ONE);
@@ -4781,11 +4776,11 @@ void Renderer::renderObject(const Vector3f& pos,
                                  scaleFactors,
                                  textureResolution,
                                  renderFlags,
-                                 obj.orientation, viewFrustum, *context, this);
+                                 obj.orientation, viewFrustum, this);
         }
         else
         {
-            renderSphereDefault(ri, viewFrustum, false, *context);
+            renderSphereDefault(ri, viewFrustum, false);
         }
     }
     else
@@ -4876,7 +4871,6 @@ void Renderer::renderObject(const Vector3f& pos,
                                       radius * atmScale,
                                       obj.orientation,
                                       viewFrustum,
-                                      *context,
                                       this);
             }
             else
@@ -4961,14 +4955,12 @@ void Renderer::renderObject(const Vector3f& pos,
                                   renderFlags,
                                   obj.orientation,
                                   viewFrustum,
-                                  *context,
                                   this);
             }
             else
             {
                 glDisable(GL_LIGHTING);
-                g_lodSphere->render(*context,
-                                    LODSphereMesh::Normals | LODSphereMesh::TexCoords0,
+                g_lodSphere->render(LODSphereMesh::Normals | LODSphereMesh::TexCoords0,
                                     viewFrustum,
                                     ri.pixWidth,
                                     cloudTex);
@@ -6940,8 +6932,7 @@ void DSORenderer::process(DeepSkyObject* const & dso,
                 glPushMatrix();
                 glTranslate(relPos);
 
-                dso->render(*context,
-                            relPos,
+                dso->render(relPos,
                             observer->getOrientationf(),
                             (float) brightness,
                             pixelSize,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -305,6 +305,8 @@ class Renderer
                              LabelVerticalAlignment valign = VerticalAlignBottom,
                              float size = 0.0f);
 
+   ShaderManager& getShaderManager() const { return *shaderManager; }
+
     // Callbacks for renderables; these belong in a special renderer interface
     // only visible in object's render methods.
     void beginObjectAnnotations();
@@ -622,6 +624,7 @@ class Renderer
 
  private:
     GLContext* context;
+    ShaderManager* shaderManager{ nullptr };
 
     int windowWidth;
     int windowHeight;

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -57,7 +57,8 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
                        uint64_t renderFlags,
                        const Quaternionf& planetOrientation,
                        const Frustum& frustum,
-                       const GLContext& context)
+                       const GLContext& context,
+                       const Renderer* renderer)
 {
     float radius = semiAxes.maxCoeff();
 
@@ -224,7 +225,7 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
 
 
     // Get a shader for the current rendering configuration
-    CelestiaGLProgram* prog = GetShaderManager().getShader(shadprop);
+    CelestiaGLProgram* prog = renderer->getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
 
@@ -300,11 +301,12 @@ void renderGeometry_GLSL(Geometry* geometry,
                          float geometryScale,
                          uint64_t renderFlags,
                          const Quaternionf& planetOrientation,
-                         double tsec)
+                         double tsec,
+                         const Renderer* renderer)
 {
     glDisable(GL_LIGHTING);
 
-    GLSL_RenderContext rc(ls, geometryScale, planetOrientation);
+    GLSL_RenderContext rc(renderer, ls, geometryScale, planetOrientation);
 
     if ((renderFlags & Renderer::ShowAtmospheres) != 0)
     {
@@ -352,11 +354,12 @@ void renderGeometry_GLSL_Unlit(Geometry* geometry,
                                float geometryScale,
                                uint64_t /* renderFlags */,
                                const Quaternionf& /* planetOrientation */,
-                               double tsec)
+                               double tsec,
+                               const Renderer* renderer)
 {
     glDisable(GL_LIGHTING);
 
-    GLSLUnlit_RenderContext rc(geometryScale);
+    GLSLUnlit_RenderContext rc(renderer, geometryScale);
 
     rc.setPointScale(ri.pointScale);
 
@@ -397,7 +400,8 @@ void renderClouds_GLSL(const RenderInfo& ri,
                        uint64_t renderFlags,
                        const Quaternionf& planetOrientation,
                        const Frustum& frustum,
-                       const GLContext& context)
+                       const GLContext& context,
+                       const Renderer* renderer)
 {
     float radius = semiAxes.maxCoeff();
 
@@ -474,7 +478,7 @@ void renderClouds_GLSL(const RenderInfo& ri,
     }
 
     // Get a shader for the current rendering configuration
-    CelestiaGLProgram* prog = GetShaderManager().getShader(shadprop);
+    CelestiaGLProgram* prog = renderer->getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
 
@@ -530,7 +534,8 @@ renderAtmosphere_GLSL(const RenderInfo& ri,
                       float radius,
                       const Quaternionf& /*planetOrientation*/,
                       const Frustum& frustum,
-                      const GLContext& context)
+                      const GLContext& context,
+                      const Renderer* renderer)
 {
     // Currently, we just skip rendering an atmosphere when there are no
     // light sources, even though the atmosphere would still the light
@@ -547,7 +552,7 @@ renderAtmosphere_GLSL(const RenderInfo& ri,
     shadprop.lightModel = ShaderProperties::AtmosphereModel;
 
     // Get a shader for the current rendering configuration
-    CelestiaGLProgram* prog = GetShaderManager().getShader(shadprop);
+    CelestiaGLProgram* prog = renderer->getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
 
@@ -626,7 +631,8 @@ void renderRings_GLSL(RingSystem& rings,
                       float planetOblateness,
                       unsigned int textureResolution,
                       bool renderShadow,
-                      unsigned int nSections)
+                      unsigned int nSections,
+                      const Renderer* renderer)
 {
     float inner = rings.innerRadius / planetRadius;
     float outer = rings.outerRadius / planetRadius;
@@ -651,7 +657,7 @@ void renderRings_GLSL(RingSystem& rings,
 
 
     // Get a shader for the current rendering configuration
-    CelestiaGLProgram* prog = GetShaderManager().getShader(shadprop);
+    CelestiaGLProgram* prog = renderer->getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
 
@@ -751,7 +757,8 @@ void renderGeometryShadow_GLSL(Geometry* geometry,
                               const LightingState& ls,
                               float geometryScale,
                               const Quaternionf& planetOrientation,
-                              double tsec)
+                              double tsec,
+                              const Renderer* renderer)
 {
     glDisable(GL_LIGHTING);
 
@@ -768,7 +775,7 @@ void renderGeometryShadow_GLSL(Geometry* geometry,
     // Render backfaces only in order to reduce self-shadowing artifacts
     glCullFace(GL_FRONT);
 
-    GLSL_RenderContext rc(ls, geometryScale, planetOrientation);
+    GLSL_RenderContext rc(renderer, ls, geometryScale, planetOrientation);
 
     rc.setPointScale(ri.pointScale);
 

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -57,7 +57,6 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
                        uint64_t renderFlags,
                        const Quaternionf& planetOrientation,
                        const Frustum& frustum,
-                       const GLContext& context,
                        const Renderer* renderer)
 {
     float radius = semiAxes.maxCoeff();
@@ -280,8 +279,7 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
     unsigned int attributes = LODSphereMesh::Normals;
     if (ri.bumpTex != nullptr)
         attributes |= LODSphereMesh::Tangents;
-    g_lodSphere->render(context,
-                        attributes,
+    g_lodSphere->render(attributes,
                         frustum, ri.pixWidth,
                         textures[0], textures[1], textures[2], textures[3]);
 
@@ -400,7 +398,6 @@ void renderClouds_GLSL(const RenderInfo& ri,
                        uint64_t renderFlags,
                        const Quaternionf& planetOrientation,
                        const Frustum& frustum,
-                       const GLContext& context,
                        const Renderer* renderer)
 {
     float radius = semiAxes.maxCoeff();
@@ -515,8 +512,7 @@ void renderClouds_GLSL(const RenderInfo& ri,
     unsigned int attributes = LODSphereMesh::Normals;
     if (cloudNormalMap != nullptr)
         attributes |= LODSphereMesh::Tangents;
-    g_lodSphere->render(context,
-                        attributes,
+    g_lodSphere->render(attributes,
                         frustum, ri.pixWidth,
                         textures[0], textures[1], textures[2], textures[3]);
 
@@ -534,7 +530,6 @@ renderAtmosphere_GLSL(const RenderInfo& ri,
                       float radius,
                       const Quaternionf& /*planetOrientation*/,
                       const Frustum& frustum,
-                      const GLContext& context,
                       const Renderer* renderer)
 {
     // Currently, we just skip rendering an atmosphere when there are no
@@ -580,8 +575,7 @@ renderAtmosphere_GLSL(const RenderInfo& ri,
     glDepthMask(GL_FALSE);
     glBlendFunc(GL_ONE, GL_SRC_ALPHA);
 
-    g_lodSphere->render(context,
-                        LODSphereMesh::Normals,
+    g_lodSphere->render(LODSphereMesh::Normals,
                         frustum,
                         ri.pixWidth,
                         nullptr);

--- a/src/celengine/renderglsl.h
+++ b/src/celengine/renderglsl.h
@@ -16,6 +16,7 @@
 #include <celengine/lightenv.h>
 #include <Eigen/Geometry>
 
+class Renderer;
 
 void renderEllipsoid_GLSL(const RenderInfo& ri,
                        const LightingState& ls,
@@ -26,7 +27,8 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
                        uint64_t renderFlags,
                        const Eigen::Quaternionf& planetOrientation,
                        const Frustum& frustum,
-                       const GLContext& context);
+                       const GLContext& context,
+                       const Renderer* renderer);
 
 void renderGeometry_GLSL(Geometry* geometry,
                          const RenderInfo& ri,
@@ -36,7 +38,8 @@ void renderGeometry_GLSL(Geometry* geometry,
                          float geometryScale,
                          uint64_t renderFlags,
                          const Eigen::Quaternionf& planetOrientation,
-                         double tsec);
+                         double tsec,
+                         const Renderer* renderer);
 
 void renderClouds_GLSL(const RenderInfo& ri,
                        const LightingState& ls,
@@ -49,7 +52,8 @@ void renderClouds_GLSL(const RenderInfo& ri,
                        uint64_t renderFlags,
                        const Eigen::Quaternionf& planetOrientation,
                        const Frustum& frustum,
-                       const GLContext& context);
+                       const GLContext& context,
+                       const Renderer* renderer);
 
 void renderAtmosphere_GLSL(const RenderInfo& ri,
                            const LightingState& ls,
@@ -57,7 +61,8 @@ void renderAtmosphere_GLSL(const RenderInfo& ri,
                            float radius,
                            const Eigen::Quaternionf& planetOrientation,
                            const Frustum& frustum,
-                           const GLContext& context);
+                           const GLContext& context,
+                           const Renderer* renderer);
 
 void renderRings_GLSL(RingSystem& rings,
                       RenderInfo& ri,
@@ -66,7 +71,8 @@ void renderRings_GLSL(RingSystem& rings,
                       float planetOblateness,
                       unsigned int textureResolution,
                       bool renderShadow,
-                      unsigned int nSections);
+                      unsigned int nSections,
+                      const Renderer* renderer);
 
 void renderGeometry_GLSL_Unlit(Geometry* geometry,
                                const RenderInfo& ri,
@@ -74,7 +80,8 @@ void renderGeometry_GLSL_Unlit(Geometry* geometry,
                                float geometryScale,
                                uint64_t renderFlags,
                                const Eigen::Quaternionf& planetOrientation,
-                               double tsec);
+                               double tsec,
+                               const Renderer* renderer);
 
 
 class FramebufferObject

--- a/src/celengine/renderglsl.h
+++ b/src/celengine/renderglsl.h
@@ -27,7 +27,6 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
                        uint64_t renderFlags,
                        const Eigen::Quaternionf& planetOrientation,
                        const Frustum& frustum,
-                       const GLContext& context,
                        const Renderer* renderer);
 
 void renderGeometry_GLSL(Geometry* geometry,
@@ -52,7 +51,6 @@ void renderClouds_GLSL(const RenderInfo& ri,
                        uint64_t renderFlags,
                        const Eigen::Quaternionf& planetOrientation,
                        const Frustum& frustum,
-                       const GLContext& context,
                        const Renderer* renderer);
 
 void renderAtmosphere_GLSL(const RenderInfo& ri,
@@ -61,7 +59,6 @@ void renderAtmosphere_GLSL(const RenderInfo& ri,
                            float radius,
                            const Eigen::Quaternionf& planetOrientation,
                            const Frustum& frustum,
-                           const GLContext& context,
                            const Renderer* renderer);
 
 void renderRings_GLSL(RingSystem& rings,

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -53,14 +53,6 @@ static const char* errorFragmentShaderSource =
 
 static const char* CommonHeader = "#version 120\n";
 
-ShaderManager&
-GetShaderManager()
-{
-    static ShaderManager g_ShaderManager;
-
-    return g_ShaderManager;
-}
-
 
 ShaderProperties::ShaderProperties() :
     nLights(0),

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -294,6 +294,4 @@ class ShaderManager
     std::map<ShaderProperties, CelestiaGLProgram*> shaders;
 };
 
-extern ShaderManager& GetShaderManager();
-
 #endif // _CELENGINE_SHADERMANAGER_H_


### PR DESCRIPTION
As a part of anti-static variables crusade ShaderManager was mad a Renderer private variable.

GLContext has unneeded functions removed and it's not passed to functions which don't use it any more.