### PR TITLE
Fix new warnings

### DIFF
--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -111,7 +111,7 @@ class Body : public CatEntry
      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
      Body(PlanetarySystem*, const std::string& name);
-    ~Body();
+     virtual ~Body();
 
     // Object class enumeration:
     // All of these values must be powers of two so that they can

--- a/src/celengine/star.h
+++ b/src/celengine/star.h
@@ -239,7 +239,7 @@ class Star : public CatEntry
 {
 public:
     Star() = default;
-    ~Star();
+    virtual ~Star();
 
     virtual Selection toSelection();
 

--- a/src/celestia/celx_object.cpp
+++ b/src/celestia/celx_object.cpp
@@ -493,6 +493,8 @@ static int object_type(lua_State* l)
     case Selection::Type_Nil:
         tname = "null";
         break;
+    default:
+        break;
     }
 
     lua_pushstring(l, tname);


### PR DESCRIPTION
 - warning: deleting object of polymorphic class type ‘Star’ which has
   non-virtual destructor might cause undefined behavior
   [-Wdelete-non-virtual-dtor]
 - enumeration value ‘Type_Generic’ not handled in switch [-Wswitch]