### PR TITLE
Fix matrix order in multiplication

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2634,7 +2634,7 @@ void Renderer::draw(const Observer& observer,
 #ifdef __CELVEC__
         Point3f center = render_item.position * viewMat;
 #else
-        Vector3f center = render_item.position * viewMat;
+        Vector3f center = viewMat * render_item.position;
 #endif
 
         bool convex = true;


### PR DESCRIPTION
Old vector library is row based, while Eigen is column based by default,
so matrix order should be swapped.

// I don't see any visual changes