### PR TITLE
Add missing semicolon in shader definition (Closes: #203)

### DIFF
--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -2229,7 +2229,7 @@ ShaderManager::buildFragmentShader(const ShaderProperties& props)
 
                 if (props.nLights == 0)
                 {
-                    source += "0.0f\n";
+                    source += "0.0f;\n";
                 }
                 else
                 {


### PR DESCRIPTION
The bigger problem is "why the reporter doesn't have any light sources?".