### PR TITLE
fix extra-standard to copy directory hierarchy

### DIFF
--- a/extras-standard/cassini/CMakeLists.txt
+++ b/extras-standard/cassini/CMakeLists.txt
@@ -8,4 +8,7 @@ set(CASSINI_SOURCES
   models/huygens.3ds
 )
 
-install(FILES ${CASSINI_SOURCES} DESTINATION "${DATADIR}/extras-standard/cassini")
+foreach ( file ${CASSINI_SOURCES} )
+    get_filename_component( dir ${file} DIRECTORY )
+    install( FILES ${file} DESTINATION "${DATADIR}/extras-standard/cassini/${dir}" )
+  endforeach()

--- a/extras-standard/galileo/CMakeLists.txt
+++ b/extras-standard/galileo/CMakeLists.txt
@@ -5,4 +5,7 @@ set(GALILEO_SOURCES
   models/galileo.3ds
 )
 
-install(FILES ${GALILEO_SOURCES} DESTINATION "${DATADIR}/extras-standard/galileo")
+foreach ( file ${GALILEO_SOURCES} )
+    get_filename_component( dir ${file} DIRECTORY )
+    install( FILES ${file} DESTINATION "${DATADIR}/extras-standard/galileo/${dir}" )
+  endforeach()

--- a/extras-standard/hubble/CMakeLists.txt
+++ b/extras-standard/hubble/CMakeLists.txt
@@ -3,4 +3,7 @@ set(HUBBLE_SOURCES
   models/hubble.cmod
 )
 
-install(FILES ${HUBBLE_SOURCES} DESTINATION "${DATADIR}/extras-standard/hubble")
+foreach ( file ${HUBBLE_SOURCES} )
+    get_filename_component( dir ${file} DIRECTORY )
+    install( FILES ${file} DESTINATION "${DATADIR}/extras-standard/hubble/${dir}" )
+  endforeach()

--- a/extras-standard/iss/CMakeLists.txt
+++ b/extras-standard/iss/CMakeLists.txt
@@ -38,5 +38,8 @@ set(ISS_SOURCES
   textures/medres/issusaf.jpg
   models/iss.cmod
 )
+foreach ( file ${ISS_SOURCES} )
+    get_filename_component( dir ${file} DIRECTORY )
+    install( FILES ${file} DESTINATION "${DATADIR}/extras-standard/iss/${dir}" )
+  endforeach()
 
-install(FILES ${ISS_SOURCES} DESTINATION "${DATADIR}/extras-standard/iss")

--- a/extras-standard/mir/CMakeLists.txt
+++ b/extras-standard/mir/CMakeLists.txt
@@ -3,4 +3,7 @@ set(MIR_SOURCES
   mir.ssc
 )
 
-install(FILES ${EXTRA_MIR_SOURCES} DESTINATION "${DATADIR}/extras-standard/mir")
+foreach ( file ${MIR_SOURCES} )
+    get_filename_component( dir ${file} DIRECTORY )
+    install( FILES ${file} DESTINATION "${DATADIR}/extras-standard/mir/${dir}" )
+  endforeach()


### PR DESCRIPTION
The cmakefiles install everything into the base directory which means that the models don't appear.