### PR TITLE
Less invasive version of "Generalisation of Namedatabase".

### DIFF
--- a/data/globulars.dsc
+++ b/data/globulars.dsc
@@ -24,7 +24,7 @@
 # ------------------------------------------------------ 
 
 
-Globular "47 Tuc:NGC 104:Melotte 1:HD 2051:RBS 55:GCl 1:C 0021-723:xi Tuc"
+Globular "47 Tuc:NGC 104:Melotte 1:HD 2051:RBS 55:GCl 1:C 0021-723:XI Tuc"
 {
         RA          	    0.4014  # [hours]
         Dec         	  -72.0808  # [degrees]
@@ -374,7 +374,7 @@ Globular "NGC 5053:GCl 23:C 1313+179"
         InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5053"
 }
 
-Globular "Omega Cen:NGC 5139:HD 116790:GCl 24:C 1323-472"
+Globular "OME Cen:NGC 5139:HD 116790:GCl 24:C 1323-472"
 {
         RA          	   13.4458  # [hours]
         Dec         	  -47.4769  # [degrees]

--- a/src/celengine/name.cpp
+++ b/src/celengine/name.cpp
@@ -6,7 +6,7 @@ uint32_t NameDatabase::getNameCount() const
     return nameIndex.size();
 }
 
-void NameDatabase::add(const uint32_t catalogNumber, const std::string& name)
+void NameDatabase::add(const uint32_t catalogNumber, const std::string& name, bool replaceGreek)
 {
     if (name.length() != 0)
     {
@@ -17,9 +17,10 @@ void NameDatabase::add(const uint32_t catalogNumber, const std::string& name)
 #endif
         // Add the new name
         //nameIndex.insert(NameIndex::value_type(name, catalogNumber));
-
-        nameIndex[name]   = catalogNumber;
-        numberIndex.insert(NumberIndex::value_type(catalogNumber, name));
+        std::string fname = ReplaceGreekLetterAbbr(name);
+        
+        nameIndex[fname]   = catalogNumber;
+        numberIndex.insert(NumberIndex::value_type(catalogNumber, fname));
     }
 }
 void NameDatabase::erase(const uint32_t catalogNumber)

--- a/src/celengine/name.cpp
+++ b/src/celengine/name.cpp
@@ -18,8 +18,8 @@ void NameDatabase::add(const uint32_t catalogNumber, const std::string& name, bo
         // Add the new name
         //nameIndex.insert(NameIndex::value_type(name, catalogNumber));
         std::string fname = ReplaceGreekLetterAbbr(name);
-        
-        nameIndex[fname]   = catalogNumber;
+
+        nameIndex[fname] = catalogNumber;
         numberIndex.insert(NumberIndex::value_type(catalogNumber, fname));
     }
 }
@@ -83,17 +83,35 @@ NameDatabase::NumberIndex::const_iterator NameDatabase::getFinalNameIter() const
     return numberIndex.end();
 }
 
-std::vector<std::string> NameDatabase::getCompletion(const std::string& name) const
+std::vector<std::string> NameDatabase::getCompletion(const std::string& name, bool greek) const
 {
+    if (greek)
+    {
+        auto compList = getGreekCompletion(name);
+        compList.push_back(name);
+        return getCompletion(compList);
+    }
+
     std::vector<std::string> completion;
     int name_length = UTF8Length(name);
 
     for (NameIndex::const_iterator iter = nameIndex.begin(); iter != nameIndex.end(); ++iter)
     {
-        if (!UTF8StringCompare(iter->first, name, name_length))
+        if (!UTF8StringCompare(iter->first, name, name_length, true))
         {
             completion.push_back(iter->first);
         }
+    }
+    return completion;
+}
+
+std::vector<std::string> NameDatabase::getCompletion(const std::vector<std::string> &list) const
+{
+    std::vector<std::string> completion;
+    for (const auto &n : list)
+    {
+        for (const auto &nn : getCompletion(n, false))
+            completion.emplace_back(nn);
     }
     return completion;
 }

--- a/src/celengine/name.h
+++ b/src/celengine/name.h
@@ -37,7 +37,7 @@ class NameDatabase
 
     uint32_t getNameCount() const;
 
-    void add(const uint32_t, const std::string&);
+    void add(const uint32_t, const std::string&, bool parseGreek = true);
 
     // delete all names associated with the specified catalog number
     void erase(const uint32_t);

--- a/src/celengine/name.h
+++ b/src/celengine/name.h
@@ -48,7 +48,8 @@ class NameDatabase
     NumberIndex::const_iterator getFirstNameIter(const uint32_t catalogNumber) const;
     NumberIndex::const_iterator getFinalNameIter() const;
 
-    std::vector<std::string> getCompletion(const std::string& name) const;
+    std::vector<std::string> getCompletion(const std::string& name, bool greek = true) const;
+    std::vector<std::string> getCompletion(const std::vector<std::string> &list) const;
 
  protected:
     NameIndex   nameIndex;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1318,7 +1318,7 @@ void Renderer::addAnnotation(vector<Annotation>& annotations,
         }
         else
         {
-            a.labelText = ReplaceGreekLetterAbbr(labelText);
+            a.labelText = labelText;
         }
         a.markerRep = markerRep;
         a.color = color;

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -433,7 +433,7 @@ string StarDatabase::getStarNameList(const Star& star, const unsigned int maxNam
         if (count != 0)
             starNames += " / ";
 
-        starNames += ReplaceGreekLetterAbbr(iter->second.c_str());
+        starNames += iter->second;
         ++iter;
         ++count;
     }

--- a/src/celengine/starname.cpp
+++ b/src/celengine/starname.cpp
@@ -18,6 +18,10 @@ using namespace std;
 
 uint32_t StarNameDatabase::findCatalogNumberByName(const string& name) const
 {
+    uint32_t catalogNumber = getCatalogNumberByName(name);
+    if (catalogNumber != Star::InvalidCatalogNumber)
+        return catalogNumber;
+
     string priName   = name;
     string altName;
 
@@ -31,7 +35,7 @@ uint32_t StarNameDatabase::findCatalogNumberByName(const string& name) const
         if (con != nullptr)
         {
             char digit  = ' ';
-            int len     = prefix.length();
+            int len = prefix.length();
 
             // If the first character of the prefix is a letter
             // and the last character is a digit, we may have
@@ -40,7 +44,7 @@ uint32_t StarNameDatabase::findCatalogNumberByName(const string& name) const
             if (len > 2 && isalpha(prefix[0]) && isdigit(prefix[len - 1]))
             {
                 --len;
-                digit   = prefix[len];
+                digit = prefix[len];
             }
 
             // We have a valid constellation as the last part
@@ -59,34 +63,34 @@ uint32_t StarNameDatabase::findCatalogNumberByName(const string& name) const
                 }
                 else
                 {
-                    priName  = letter + digit + ' ' + con->getAbbreviation();
+                    priName = letter + digit + ' ' + con->getAbbreviation();
                 }
             }
             else
             {
                 // Something other than a Bayer designation
-                priName  = prefix + ' ' + con->getAbbreviation();
+                priName = prefix + ' ' + con->getAbbreviation();
             }
         }
     }
 
-    uint32_t catalogNumber   = getCatalogNumberByName(priName);
+    catalogNumber = getCatalogNumberByName(priName);
     if (catalogNumber != Star::InvalidCatalogNumber)
         return catalogNumber;
 
-    priName        += " A";  // try by appending an A
-    catalogNumber   = getCatalogNumberByName(priName);
+    priName += " A";  // try by appending an A
+    catalogNumber = getCatalogNumberByName(priName);
     if (catalogNumber != Star::InvalidCatalogNumber)
         return catalogNumber;
 
     // If the first search failed, try using the alternate name
     if (altName.length() != 0)
     {
-        catalogNumber   = getCatalogNumberByName(altName);
+        catalogNumber = getCatalogNumberByName(altName);
         if (catalogNumber == Star::InvalidCatalogNumber)
         {
-            altName        += " A";
-            catalogNumber   = getCatalogNumberByName(altName);
+            altName += " A";
+            catalogNumber = getCatalogNumberByName(altName);
         }   // Intentional fallthrough.
     }
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3763,7 +3763,7 @@ void CelestiaCore::renderOverlay()
         glTranslatef(0.0f, fontHeight * 3.0f + 35.0f, 0.0f);
         glColor4f(0.6f, 0.6f, 1.0f, 1.0f);
         overlay->beginText();
-        *overlay << _("Target name: ") << typedText;
+        fmt::fprintf(*overlay, _("Target name: %s"), typedText);
         overlay->endText();
         overlay->setFont(font);
         if (typedTextCompletion.size() >= 1)

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3219,7 +3219,7 @@ static string getSelectionName(const Selection& sel, const Universe& univ)
     case Selection::Type_DeepSky:
         return univ.getDSOCatalog()->getDSOName(sel.deepsky(), false);
     case Selection::Type_Star:
-        return ReplaceGreekLetterAbbr(univ.getStarCatalog()->getStarName(*sel.star(), true));
+        return univ.getStarCatalog()->getStarName(*sel.star(), true);
     case Selection::Type_Location:
         return sel.location()->getName(false);
     default:
@@ -3242,7 +3242,7 @@ static void displaySelectionName(Overlay& overlay,
         break;
     case Selection::Type_Star:
         //displayStarName(overlay, *(sel.star()), *univ.getStarCatalog());
-        overlay << ReplaceGreekLetterAbbr(univ.getStarCatalog()->getStarName(*sel.star(), true));
+        overlay << univ.getStarCatalog()->getStarName(*sel.star(), true);
         break;
     case Selection::Type_Location:
         overlay << sel.location()->getName(true);
@@ -3763,7 +3763,7 @@ void CelestiaCore::renderOverlay()
         glTranslatef(0.0f, fontHeight * 3.0f + 35.0f, 0.0f);
         glColor4f(0.6f, 0.6f, 1.0f, 1.0f);
         overlay->beginText();
-        *overlay << _("Target name: ") << ReplaceGreekLetterAbbr(typedText);
+        *overlay << _("Target name: ") << typedText;
         overlay->endText();
         overlay->setFont(font);
         if (typedTextCompletion.size() >= 1)
@@ -3788,7 +3788,7 @@ void CelestiaCore::renderOverlay()
                         glColor4f(1.0f, 0.6f, 0.6f, 1);
                     else
                         glColor4f(0.6f, 0.6f, 1.0f, 1);
-                    *overlay << ReplaceGreekLetterAbbr(*iter) << "\n";
+                    *overlay << *iter << "\n";
                 }
                 overlay->endText();
                 glPopMatrix();

--- a/src/celutil/utf8.cpp
+++ b/src/celutil/utf8.cpp
@@ -697,7 +697,14 @@ static std::string noAbbrev;
 
 // Greek alphabet crud . . . should probably moved to it's own module.
 
-Greek* Greek::instance = nullptr;
+Greek* Greek::m_instance = nullptr;
+
+Greek* Greek::getInstance()
+{
+    if (m_instance == nullptr)
+        m_instance = new Greek();
+    return m_instance;
+}
 
 Greek::Greek()
 {
@@ -720,17 +727,15 @@ Greek::~Greek()
 
 const std::string& Greek::canonicalAbbreviation(const std::string& letter)
 {
-    if (instance == nullptr)
-        instance = new Greek();
-
+    Greek *instance = Greek::getInstance();
     int i;
-    for (i = 0; i < Greek::instance->nLetters; i++)
+    for (i = 0; i < instance->nLetters; i++)
     {
         if (compareIgnoringCase(letter, instance->names[i]) == 0)
             return instance->abbrevs[i];
     }
 
-    for (i = 0; i < Greek::instance->nLetters; i++)
+    for (i = 0; i < instance->nLetters; i++)
     {
         if (compareIgnoringCase(letter, instance->abbrevs[i]) == 0)
             return instance->abbrevs[i];
@@ -738,7 +743,7 @@ const std::string& Greek::canonicalAbbreviation(const std::string& letter)
 
     if (letter.length() == 2)
     {
-        for (i = 0; i < Greek::instance->nLetters; i++)
+        for (i = 0; i < instance->nLetters; i++)
         {
             if (letter[0] == greekAlphabetUTF8[i][0] &&
                 letter[1] == greekAlphabetUTF8[i][1])
@@ -757,15 +762,16 @@ const std::string& Greek::canonicalAbbreviation(const std::string& letter)
 //! superscripts.
 std::string ReplaceGreekLetterAbbr(const std::string& str)
 {
+    Greek *instance = Greek::getInstance();
     std::string ret = str;
 
     if (str[0] >= 'A' && str[0] <= 'Z' &&
         str[1] >= 'A' && str[1] <= 'Z')
     {
         // Linear search through all letter abbreviations
-        for (int i = 0; i < Greek::instance->nLetters; i++)
+        for (int i = 0; i < instance->nLetters; i++)
         {
-            const std::string& abbr = Greek::instance->abbrevs[i];
+            const std::string& abbr = instance->abbrevs[i];
             if (str.compare(0, abbr.length(), abbr) == 0 &&
                 (str[abbr.length()] == ' ' || isdigit(str[abbr.length()])))
             {
@@ -808,11 +814,12 @@ std::string ReplaceGreekLetterAbbr(const std::string& str)
 unsigned int
 ReplaceGreekLetterAbbr(char *dst, unsigned int dstSize, const char* src, unsigned int srcLength)
 {
+    Greek *instance = Greek::getInstance();
     if (src[0] >= 'A' && src[0] <= 'Z' &&
         src[1] >= 'A' && src[1] <= 'Z')
     {
         // Linear search through all letter abbreviations
-        for (unsigned int i = 0; i < (unsigned int) Greek::instance->nLetters; i++)
+        for (unsigned int i = 0; i < (unsigned int) instance->nLetters; i++)
         {
             const char* abbr = canonicalAbbrevs[i];
             unsigned int j = 0;

--- a/src/celutil/utf8.h
+++ b/src/celutil/utf8.h
@@ -11,7 +11,7 @@
 #define _CELUTIL_UTF8_
 
 #include <string>
-#include <wchar.h>
+#include <vector>
 
 #define UTF8_DEGREE_SIGN         "\302\260"
 #define UTF8_MULTIPLICATION_SIGN "\303\227"
@@ -24,7 +24,7 @@ bool UTF8Decode(const std::string& str, int pos, wchar_t& ch);
 bool UTF8Decode(const char* str, int pos, int length, wchar_t& ch);
 int UTF8Encode(wchar_t ch, char* s);
 int UTF8StringCompare(const std::string& s0, const std::string& s1);
-int UTF8StringCompare(const std::string& s0, const std::string& s1, size_t n);
+int UTF8StringCompare(const std::string& s0, const std::string& s1, size_t n, bool ignoreCase = false);
 
 class UTF8StringOrderingPredicate
 {
@@ -122,5 +122,7 @@ private:
     std::string* names;
     std::string* abbrevs;
 };
+
+std::vector<std::string> getGreekCompletion(const std::string &);
 
 #endif // _CELUTIL_UTF8_

--- a/src/celutil/utf8.h
+++ b/src/celutil/utf8.h
@@ -114,9 +114,10 @@ class Greek
     };
 
     static const std::string& canonicalAbbreviation(const std::string&);
-
+private:
+    static Greek* m_instance;
  public:
-    static Greek* instance;
+    static Greek* getInstance();
     int nLetters;
     std::string* names;
     std::string* abbrevs;


### PR DESCRIPTION
Extracted from parent branch on @375gnu request.
It does:
1. better static Greek class initialization.
2. storing already formatted names in NameDatabase (make Bayer notation avaliable for DSOs too, so closes #169 ).
3. adaptation of completion mechanism for Greek letters in names.
4. addition of Bayer notation for two globulars.