### PR TITLE
Faster ring drawing using GL2.0 methods

### DIFF
--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -20,6 +20,7 @@
 #include <celutil/utf8.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <GL/glew.h>
 #include <string>
 #include <vector>
 #include <map>
@@ -86,6 +87,7 @@ class RingSystem
     float outerRadius;
     Color color;
     MultiResTexture texture;
+    GLuint vboId{ 0 };
 
     RingSystem(float inner, float outer) :
         innerRadius(inner), outerRadius(outer),

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -564,7 +564,6 @@ Renderer::~Renderer()
 
 
 Renderer::DetailOptions::DetailOptions() :
-    ringSystemSections(100),
     orbitPathSamplePoints(100),
     shadowTextureSize(256),
     eclipseTextureSize(128),
@@ -4772,7 +4771,6 @@ void Renderer::renderObject(const Vector3f& pos,
                          radius, 1.0f - obj.semiAxes.y(),
                          textureResolution,
                          (renderFlags & ShowRingShadows) != 0 && lit,
-                         detailOptions.ringSystemSections,
                          this);
     }
 
@@ -4940,7 +4938,6 @@ void Renderer::renderObject(const Vector3f& pos,
                              radius, 1.0f - obj.semiAxes.y(),
                              textureResolution,
                              (renderFlags & ShowRingShadows) != 0 && lit,
-                             detailOptions.ringSystemSections,
                              this);
         }
     }

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -95,7 +95,6 @@ class Renderer
     struct DetailOptions
     {
         DetailOptions();
-        unsigned int ringSystemSections;
         unsigned int orbitPathSamplePoints;
         unsigned int shadowTextureSize;
         unsigned int eclipseTextureSize;

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -669,7 +669,6 @@ void renderRings_GLSL(RingSystem& rings,
                       float planetOblateness,
                       unsigned int textureResolution,
                       bool renderShadow,
-                      unsigned int nSections,
                       const Renderer* renderer)
 {
     float inner = rings.innerRadius / planetRadius;

--- a/src/celengine/renderglsl.h
+++ b/src/celengine/renderglsl.h
@@ -68,7 +68,6 @@ void renderRings_GLSL(RingSystem& rings,
                       float planetOblateness,
                       unsigned int textureResolution,
                       bool renderShadow,
-                      unsigned int nSections,
                       const Renderer* renderer);
 
 void renderGeometry_GLSL_Unlit(Geometry* geometry,

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -4260,7 +4260,6 @@ bool CelestiaCore::initRenderer()
     //fmt::printf(_("render path: %i\n"), context->getRenderPath());
 
     Renderer::DetailOptions detailOptions;
-    detailOptions.ringSystemSections = config->ringSystemSections;
     detailOptions.orbitPathSamplePoints = config->orbitPathSamplePoints;
     detailOptions.shadowTextureSize = config->shadowTextureSize;
     detailOptions.eclipseTextureSize = config->eclipseTextureSize;

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -135,7 +135,6 @@ CelestiaConfig* ReadCelestiaConfig(const string& filename, CelestiaConfig *confi
     config->linearFadeFraction = 0.0f;
     configParams->getNumber("LinearFadeFraction", config->linearFadeFraction);
 
-    config->ringSystemSections = getUint(configParams, "RingSystemSections", 100);
     config->orbitPathSamplePoints = getUint(configParams, "OrbitPathSamplePoints", 100);
     config->shadowTextureSize = getUint(configParams, "ShadowTextureSize", 256);
     config->eclipseTextureSize = getUint(configParams, "EclipseTextureSize", 128);

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -61,7 +61,6 @@ public:
     // Renderer detail options
     unsigned int shadowTextureSize;
     unsigned int eclipseTextureSize;
-    unsigned int ringSystemSections;
     unsigned int orbitPathSamplePoints;
 
     unsigned int aaSamples;


### PR DESCRIPTION
Now only during the 1st frame ring shape is calculated, following frames are drawn much faster.

ringSystemSections option was deleted. If we want perfect circle shape of our rings we can do this using GLSL.

I have one issue unclarified regarding API used, so I'll keep it unmerged until I found an answer.