### PR TITLE
Added debug octree stats.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,11 @@ if(NOT "${build_type_lc}" STREQUAL "debug")
   add_definitions(-DNO_DEBUG -DEIGEN_NO_DEBUG)
 endif()
 
+# Turning all debug on dramatically decreses performance
+if(OCTREE_DEBUG)
+  add_definitions(-DOCTREE_DEBUG)
+endif()
+
 include_directories("${CMAKE_SOURCE_DIR}/src" ${CMAKE_BINARY_DIR})
 
 # configure a header file to pass some of the CMake settings

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -160,7 +160,8 @@ void DSODatabase::findVisibleDSOs(DSOHandler&    dsoHandler,
                                   const Quaternionf& obsOrient,
                                   float fovY,
                                   float aspectRatio,
-                                  float limitingMag) const
+                                  float limitingMag,
+                                  OctreeProcStats *stats) const
 {
     // Compute the bounding planes of an infinite view frustum
     Hyperplane<double, 3> frustumPlanes[5];
@@ -187,7 +188,8 @@ void DSODatabase::findVisibleDSOs(DSOHandler&    dsoHandler,
                                       obsPos,
                                       frustumPlanes,
                                       limitingMag,
-                                      DSO_OCTREE_ROOT_SIZE);
+                                      DSO_OCTREE_ROOT_SIZE,
+                                      stats);
 }
 
 

--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -47,7 +47,8 @@ class DSODatabase
                          const Eigen::Quaternionf& obsOrientation,
                          float fovY,
                          float aspectRatio,
-                         float limitingMag) const;
+                         float limitingMag,
+                         OctreeProcStats * = nullptr) const;
 
     void findCloseDSOs(DSOHandler& dsoHandler,
                        const Eigen::Vector3d& obsPosition,

--- a/src/celengine/dsooctree.cpp
+++ b/src/celengine/dsooctree.cpp
@@ -74,12 +74,14 @@ void DSOOctree::processVisibleObjects(DSOHandler&    processor,
                                       double         scale,
                                       OctreeProcStats *stats) const
 {
+#ifdef OCTREE_NODE
     size_t h;
     if (stats != nullptr)
     {
         h = stats->height + 1;
         stats->nodes++;
     }
+#endif
     // See if this node lies within the view frustum
 
     // Test the cubic octree node against each one of the five
@@ -102,8 +104,10 @@ void DSOOctree::processVisibleObjects(DSOHandler&    processor,
 
     for (unsigned int i=0; i<nObjects; ++i)
     {
+#ifdef OCTREE_NODE
         if (stats != nullptr)
             stats->objects++;
+#endif
         DeepSkyObject* _obj = _firstObject[i];
         float  absMag      = _obj->getAbsoluteMagnitude();
         if (absMag < dimmest)
@@ -131,11 +135,15 @@ void DSOOctree::processVisibleObjects(DSOHandler&    processor,
                                                     limitingFactor,
                                                     scale * 0.5f,
                                                     stats);
+#ifdef OCTREE_DEBUG
                 if (stats != nullptr && stats->height > h)
                     h = stats->height;
+#endif
             }
+#ifdef OCTREE_DEBUG
             if (stats != nullptr)
                 stats->height = h;
+#endif
         }
     }
 }

--- a/src/celengine/dsooctree.cpp
+++ b/src/celengine/dsooctree.cpp
@@ -71,8 +71,15 @@ void DSOOctree::processVisibleObjects(DSOHandler&    processor,
                                       const PointType& obsPosition,
                                       const Hyperplane<double, 3>*  frustumPlanes,
                                       float          limitingFactor,
-                                      double         scale) const
+                                      double         scale,
+                                      OctreeProcStats *stats) const
 {
+    size_t h;
+    if (stats != nullptr)
+    {
+        h = stats->height + 1;
+        stats->nodes++;
+    }
     // See if this node lies within the view frustum
 
     // Test the cubic octree node against each one of the five
@@ -95,6 +102,8 @@ void DSOOctree::processVisibleObjects(DSOHandler&    processor,
 
     for (unsigned int i=0; i<nObjects; ++i)
     {
+        if (stats != nullptr)
+            stats->objects++;
         DeepSkyObject* _obj = _firstObject[i];
         float  absMag      = _obj->getAbsoluteMagnitude();
         if (absMag < dimmest)
@@ -120,8 +129,13 @@ void DSOOctree::processVisibleObjects(DSOHandler&    processor,
                                                     obsPosition,
                                                     frustumPlanes,
                                                     limitingFactor,
-                                                    scale * 0.5f);
+                                                    scale * 0.5f,
+                                                    stats);
+                if (stats != nullptr && stats->height > h)
+                    h = stats->height;
             }
+            if (stats != nullptr)
+                stats->height = h;
         }
     }
 }

--- a/src/celengine/octree.h
+++ b/src/celengine/octree.h
@@ -25,6 +25,13 @@
 // OBJ's limiting property defined by the octree particular specialization: ie. we use [absolute magnitude] for star octrees, etc.
 // For details, see notes below.
 
+struct OctreeProcStats
+{
+    size_t nodes { 0 };
+    size_t height { 0 };
+    size_t objects { 0 };
+};
+
 template <class OBJ, class PREC> class OctreeProcessor
 {
  public:
@@ -118,7 +125,8 @@ template <class OBJ, class PREC> class StaticOctree
                                const PointType&                  obsPosition,
                                const Eigen::Hyperplane<PREC, 3>* frustumPlanes,
                                float                             limitingFactor,
-                               PREC                              scale) const;
+                               PREC                              scale,
+                               OctreeProcStats * = nullptr) const;
 
     void processCloseObjects(OctreeProcessor<OBJ, PREC>&        processor,
                              const PointType&                   obsPosition,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -6731,16 +6731,22 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
     else
         starRenderer.starVertexBuffer->startSprites();
 
+#ifdef OCTREE_DEBUG
     m_starProcStats.nodes = 0;
     m_starProcStats.height = 0;
     m_starProcStats.objects = 0;
+#endif
     starDB.findVisibleStars(starRenderer,
                             obsPos.cast<float>(),
                             observer.getOrientationf(),
                             degToRad(fov),
                             (float) windowWidth / (float) windowHeight,
                             faintestMagNight,
+#ifdef OCTREE_DEBUG
                             &m_starProcStats);
+#else
+                            nullptr);
+#endif
 
     starRenderer.starVertexBuffer->render();
     starRenderer.glareVertexBuffer->render();
@@ -7005,16 +7011,22 @@ void Renderer::renderDeepSkyObjects(const Universe&  universe,
 
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
+#ifdef OCTREE_DEBUG
     m_dsoProcStats.objects = 0;
     m_dsoProcStats.nodes = 0;
     m_dsoProcStats.height = 0;
+#endif
     dsoDB->findVisibleDSOs(dsoRenderer,
                            obsPos,
                            observer.getOrientationf(),
                            degToRad(fov),
                            (float) windowWidth / (float) windowHeight,
                            2 * faintestMagNight,
+#ifdef OCTREE_DEBUG
                            &m_dsoProcStats);
+#else
+                            nullptr);
+#endif
 
     // clog << "DSOs processed: " << dsoRenderer.dsosProcessed << endl;
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -6731,12 +6731,16 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
     else
         starRenderer.starVertexBuffer->startSprites();
 
+    m_starProcStats.nodes = 0;
+    m_starProcStats.height = 0;
+    m_starProcStats.objects = 0;
     starDB.findVisibleStars(starRenderer,
                             obsPos.cast<float>(),
                             observer.getOrientationf(),
                             degToRad(fov),
                             (float) windowWidth / (float) windowHeight,
-                            faintestMagNight);
+                            faintestMagNight,
+                            &m_starProcStats);
 
     starRenderer.starVertexBuffer->render();
     starRenderer.glareVertexBuffer->render();
@@ -7001,12 +7005,16 @@ void Renderer::renderDeepSkyObjects(const Universe&  universe,
 
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
+    m_dsoProcStats.objects = 0;
+    m_dsoProcStats.nodes = 0;
+    m_dsoProcStats.height = 0;
     dsoDB->findVisibleDSOs(dsoRenderer,
                            obsPos,
                            observer.getOrientationf(),
                            degToRad(fov),
                            (float) windowWidth / (float) windowHeight,
-                           2 * faintestMagNight);
+                           2 * faintestMagNight,
+                           &m_dsoProcStats);
 
     // clog << "DSOs processed: " << dsoRenderer.dsosProcessed << endl;
 

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -375,8 +375,10 @@ class Renderer
         LightingState::EclipseShadowVector* eclipseShadows;
     };
 
+#ifdef OCTREE_DEBUG
     OctreeProcStats m_starProcStats;
     OctreeProcStats m_dsoProcStats;
+#endif
  private:
     struct SkyVertex
     {

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -375,6 +375,8 @@ class Renderer
         LightingState::EclipseShadowVector* eclipseShadows;
     };
 
+    OctreeProcStats m_starProcStats;
+    OctreeProcStats m_dsoProcStats;
  private:
     struct SkyVertex
     {

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -490,7 +490,8 @@ void StarDatabase::findVisibleStars(StarHandler& starHandler,
                                     const Quaternionf& orientation,
                                     float fovY,
                                     float aspectRatio,
-                                    float limitingMag) const
+                                    float limitingMag,
+                                    OctreeProcStats *stats) const
 {
     // Compute the bounding planes of an infinite view frustum
     Hyperplane<float, 3> frustumPlanes[5];
@@ -513,7 +514,8 @@ void StarDatabase::findVisibleStars(StarHandler& starHandler,
                                       position,
                                       frustumPlanes,
                                       limitingMag,
-                                      STAR_OCTREE_ROOT_SIZE);
+                                      STAR_OCTREE_ROOT_SIZE,
+                                      stats);
 }
 
 

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -121,7 +121,8 @@ class StarDatabase
                           const Eigen::Quaternionf&   obsOrientation,
                           float fovY,
                           float aspectRatio,
-                          float limitingMag) const;
+                          float limitingMag,
+                          OctreeProcStats * = nullptr) const;
 
     void findCloseStars(StarHandler& starHandler,
                         const Eigen::Vector3f& obsPosition,

--- a/src/celengine/staroctree.cpp
+++ b/src/celengine/staroctree.cpp
@@ -89,8 +89,15 @@ void StarOctree::processVisibleObjects(StarHandler&    processor,
                                        const Vector3f& obsPosition,
                                        const Hyperplane<float, 3>*   frustumPlanes,
                                        float           limitingFactor,
-                                       float           scale) const
+                                       float           scale,
+                                       OctreeProcStats *stats) const
 {
+    size_t h;
+    if (stats != nullptr)
+    {
+        h = stats->height + 1;
+        stats->nodes++;
+    }
     // See if this node lies within the view frustum
 
     // Test the cubic octree node against each one of the five
@@ -112,6 +119,8 @@ void StarOctree::processVisibleObjects(StarHandler&    processor,
 
     for (unsigned int i=0; i<nObjects; ++i)
     {
+        if (stats != nullptr)
+            stats->objects++;
         const Star& obj = _firstObject[i];
 
         if (obj.getAbsoluteMagnitude() < dimmest)
@@ -137,8 +146,14 @@ void StarOctree::processVisibleObjects(StarHandler&    processor,
                                                     obsPosition,
                                                     frustumPlanes,
                                                     limitingFactor,
-                                                    scale * 0.5f);
+                                                    scale * 0.5f,
+                                                    stats
+                                                   );
+                if (stats != nullptr && stats->height > h)
+                    h = stats->height;
             }
+            if (stats != nullptr)
+                stats->height = h;
         }
     }
 }

--- a/src/celengine/staroctree.cpp
+++ b/src/celengine/staroctree.cpp
@@ -92,12 +92,14 @@ void StarOctree::processVisibleObjects(StarHandler&    processor,
                                        float           scale,
                                        OctreeProcStats *stats) const
 {
+#ifdef OCTREE_DEBUG
     size_t h;
     if (stats != nullptr)
     {
         h = stats->height + 1;
         stats->nodes++;
     }
+#endif
     // See if this node lies within the view frustum
 
     // Test the cubic octree node against each one of the five
@@ -119,8 +121,10 @@ void StarOctree::processVisibleObjects(StarHandler&    processor,
 
     for (unsigned int i=0; i<nObjects; ++i)
     {
+#ifdef OCTREE_DEBUG
         if (stats != nullptr)
             stats->objects++;
+#endif
         const Star& obj = _firstObject[i];
 
         if (obj.getAbsoluteMagnitude() < dimmest)
@@ -149,11 +153,15 @@ void StarOctree::processVisibleObjects(StarHandler&    processor,
                                                     scale * 0.5f,
                                                     stats
                                                    );
+#ifdef OCTREE_DEBUG
                 if (stats != nullptr && stats->height > h)
                     h = stats->height;
+#endif
             }
+#ifdef OCTREE_DEBUG
             if (stats != nullptr)
                 stats->height = h;
+#endif
         }
     }
 }

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3468,7 +3468,8 @@ void CelestiaCore::renderOverlay()
         overlay->beginText();
         *overlay << '\n';
         if (showFPSCounter)
-            fmt::fprintf(*overlay, _("FPS: %.1f, vis. stars stats: [ %i : %i : %i ], vis. DSOs stats: [ %i : %i : %i ]\n"),
+#ifdef OCTREE_DEBUG
+            fmt::fprintf(*overlay, _("FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : %zu : %zu ]\n"),
                          fps,
                          getRenderer()->m_starProcStats.objects,
                          getRenderer()->m_starProcStats.nodes,
@@ -3476,6 +3477,9 @@ void CelestiaCore::renderOverlay()
                          getRenderer()->m_dsoProcStats.objects,
                          getRenderer()->m_dsoProcStats.nodes,
                          getRenderer()->m_dsoProcStats.height);
+#else
+            fmt::fprintf(*overlay, _("FPS: %.1f\n"), fps);
+#endif
         else
             *overlay << '\n';
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3468,7 +3468,14 @@ void CelestiaCore::renderOverlay()
         overlay->beginText();
         *overlay << '\n';
         if (showFPSCounter)
-            fmt::fprintf(*overlay, _("FPS: %.1f\n"), fps);
+            fmt::fprintf(*overlay, _("FPS: %.1f, vis. stars stats: [ %i : %i : %i ], vis. DSOs stats: [ %i : %i : %i ]\n"),
+                         fps,
+                         getRenderer()->m_starProcStats.objects,
+                         getRenderer()->m_starProcStats.nodes,
+                         getRenderer()->m_starProcStats.height,
+                         getRenderer()->m_dsoProcStats.objects,
+                         getRenderer()->m_dsoProcStats.nodes,
+                         getRenderer()->m_dsoProcStats.height);
         else
             *overlay << '\n';
 


### PR DESCRIPTION
It displays, next to fps counter, stats of processing star and DSO octrees while looking for visible objects. From left to right numbers means: 
1. total objects count in visited nodes
2. total visited nodes count
3. max length of nodes path while traversing
I think this is usefull for reference while testing octree behaviour. Maybe display placement is a bit unfortunate, but I'm not familiar with render code enough to create better one.