### PR TITLE
Replace sscanf with C++11 methods where appropriate

### DIFF
--- a/src/celestia/url.cpp
+++ b/src/celestia/url.cpp
@@ -107,29 +107,29 @@ bool CelestiaState::loadState(std::map<std::string, std::string> params)
 
     orientation = Quatf(ow, ox, oy, oz);
 
-    if (params["select"] != "")
+    if (params.count("select") != 0)
         selectedBodyName = params["select"];
-    if (params["track"] != "")
+    if (params.count("track") != 0)
         trackedBodyName = params["track"];
-    if (params["ltd"] != "")
+    if (params.count("ltd") != 0)
         lightTimeDelay = (strcmp(params["ltd"].c_str(), "1") == 0);
     else
         lightTimeDelay = false;
 
-    if (params["fov"] != "")
+    if (params.count("fov") != 0)
     {
         if (sscanf(params["fov"].c_str(), "%f", &fieldOfView) != 1.0f)
             return false;
     }
 
-    if (params["ts"] != "")
+    if (params.count("ts") != 0)
     {
         if (sscanf(params["ts"].c_str(), "%f", &timeScale) != 1.0f)
             return false;
     }
 
     int paused = 0;
-    if (params["p"] != "")
+    if (params.count("p") != 0)
     {
         if (sscanf(params["p"].c_str(), "%d", &paused) != 1)
             return false;
@@ -139,12 +139,12 @@ bool CelestiaState::loadState(std::map<std::string, std::string> params)
     }
 
     // Render settings
-    if (params["rf"] != "")
+    if (params.count("rf") != 0)
     {
         if (sscanf(params["rf"].c_str(), "%d", &renderFlags) != 1)
             return false;
     }
-    if (params["lm"] != "")
+    if (params.count("lm") != 0)
     {
         if (sscanf(params["lm"].c_str(), "%d", &labelMode) != 1)
             return false;
@@ -170,14 +170,7 @@ Url::Url(std::string  str, CelestiaCore *core):
 
     // Version labelling of cel URLs was only added in Celestia 1.5, cel URL
     // version 2. Assume any URL without a version is version 1.
-    if (params["ver"] != "")
-    {
-        sscanf(params["ver"].c_str(), "%u", &version);
-    }
-    else
-    {
-        version = 1;
-    }
+    version = params.count("ver") == 0 ? 1 : (unsigned) stoi(params["ver"]);
 
     pos = urlStr.find('/', 6);
     if (pos == std::string::npos)
@@ -469,7 +462,7 @@ void Url::initVersion2(std::map<std::string, std::string>& params,
 {
     if (type != Settings)
     {
-        if (params["dist"] != "")
+        if (params.count("dist") != 0)
             type = Relative;
         else
             type = Absolute;
@@ -487,63 +480,46 @@ void Url::initVersion2(std::map<std::string, std::string>& params,
                                    BigFix(params["z"]));
 
             float ow, ox, oy, oz;
-            sscanf(params["ow"].c_str(), "%f", &ow);
-            sscanf(params["ox"].c_str(), "%f", &ox);
-            sscanf(params["oy"].c_str(), "%f", &oy);
-            sscanf(params["oz"].c_str(), "%f", &oz);
+            ow = stof(params["ow"]);
+            ox = stof(params["ox"]);
+            oy = stof(params["oy"]);
+            oz = stof(params["oz"]);
 
             orientation = Quaternionf(ow, ox, oy, oz);
 
             // Intentional Fall-Through
         case Relative:
-            if (params["dist"] != "") {
-                sscanf(params["dist"].c_str(), "%lf", &distance);
-            }
-            if (params["long"] != "") {
-                sscanf(params["long"].c_str(), "%lf", &longitude);
-            }
-            if (params["lat"] != "") {
-                sscanf(params["lat"].c_str(), "%lf", &latitude);
-            }
-            if (params["select"] != "") {
+            if (params.count("dist") != 0)
+                distance = stof(params["dist"]);
+            if (params.count("long") != 0)
+                longitude = stof(params["long"]);
+            if (params.count("lat") != 0)
+                latitude = stof(params["lat"]);
+            if (params.count("select") != 0)
                 selectedStr = params["select"];
-            }
-            if (params["track"] != "") {
+            if (params.count("track") != 0)
                 trackedStr = params["track"];
-            }
-            if (params["ltd"] != "") {
-                lightTimeDelay = (strcmp(params["ltd"].c_str(), "1") == 0);
-            } else {
-                lightTimeDelay = false;
-            }
-            if (params["fov"] != "") {
-                sscanf(params["fov"].c_str(), "%f", &fieldOfView);
-            }
-            if (params["ts"] != "") {
-                sscanf(params["ts"].c_str(), "%f", &timeScale);
-            }
-            if (params["p"] != "") {
-                int pauseInt = 0;
-                sscanf(params["p"].c_str(), "%d", &pauseInt);
-                pauseState = pauseInt == 1;
-            }
+            if (params.count("fov") != 0)
+                fieldOfView = stof(params["fov"]);
+            if (params.count("ts") != 0)
+                timeScale = stof(params["ts"]);
+
+            lightTimeDelay = params.count("ltd") != 0 && params["ltd"] == "1";
+            pauseState = params.count("p") != 0 && stoi(params["p"]) == 1;
             break;
         case Settings:
             break;
     }
 
-    if (params["rf"] != "") {
-        int rf;
-        sscanf(params["rf"].c_str(), "%d", &rf);
-        renderFlags = (uint64_t) rf;
+    if (params.count("rf") != 0)
+    {
+        renderFlags = static_cast<uint64_t>(stoi(params["rf"]));
         // older celestia versions didn't know about new renderer flags
         if ((renderFlags & Renderer::ShowPlanets) != 0)
             renderFlags |= NewRenderFlags;
     }
-    if (params["lm"] != "") {
-        sscanf(params["lm"].c_str(), "%d", &labelMode);
-    }
-
+    if (params.count("lm") != 0)
+        labelMode = stoi(params["lm"]);
 }
 
 
@@ -564,55 +540,51 @@ void Url::initVersion3(std::map<std::string, std::string>& params,
                            BigFix(params["z"]));
 
     float ow, ox, oy, oz;
-    sscanf(params["ow"].c_str(), "%f", &ow);
-    sscanf(params["ox"].c_str(), "%f", &ox);
-    sscanf(params["oy"].c_str(), "%f", &oy);
-    sscanf(params["oz"].c_str(), "%f", &oz);
+    ow = stof(params["ow"]);
+    ox = stof(params["ox"]);
+    oy = stof(params["oy"]);
+    oz = stof(params["oz"]);
 
     orientation = Quaternionf(ow, ox, oy, oz);
 
-    if (params["select"] != "")
+    if (params.count("select") != 0)
         selectedStr = params["select"];
-    if (params["track"] != "")
+    if (params.count("track") != 0)
         trackedStr = params["track"];
-    if (params["ltd"] != "")
-        lightTimeDelay = (strcmp(params["ltd"].c_str(), "1") == 0);
+    if (params.count("ltd") != 0)
+        lightTimeDelay = params["ltd"] == "1";
     else
         lightTimeDelay = false;
 
-    if (params["fov"] != "")
-        sscanf(params["fov"].c_str(), "%f", &fieldOfView);
-    if (params["ts"] != "")
-        sscanf(params["ts"].c_str(), "%f", &timeScale);
+    if (params.count("fov") != 0)
+        fieldOfView = stof(params["fov"]);
+    if (params.count("ts") != 0)
+        timeScale = stof(params["ts"]);
 
-    int paused = 0;
-    if (params["p"] != "")
-        sscanf(params["p"].c_str(), "%d", &paused);
-    pauseState = paused == 1;
+    pauseState = params.count("p") != 0 && stoi(params["p"]) == 1;
 
     // Render settings
-    if (params["rf"] != "")
+    if (params.count("rf") != 0)
     {
         if (version == 4)
         {
-            sscanf(params["rf"].c_str(), "%I64u", &renderFlags);
+            renderFlags = static_cast<uint64_t>(stoull(params["rf"]));
         }
         else
         {
-            int rf;
-            sscanf(params["rf"].c_str(), "%d", &rf);
-            renderFlags = (uint64_t) rf;
+            // old renderer flags are int
+            renderFlags = static_cast<uint64_t>(stoi(params["rf"]));
             // older celestia versions didn't know about new renderer flags
             if ((renderFlags & Renderer::ShowPlanets) != 0)
                 renderFlags |= NewRenderFlags;
         }
     }
-    if (params["lm"] != "")
-        sscanf(params["lm"].c_str(), "%d", &labelMode);
+    if (params.count("lm") != 0)
+        labelMode = stoi(params["lm"]);
 
     int timeSourceInt = 0;
-    if (params["tsrc"] != "")
-        sscanf(params["tsrc"].c_str(), "%d", &timeSourceInt);
+    if (params.count("tsrc") != 0)
+        timeSourceInt = stoi(params["tsrc"]);
     if (timeSourceInt >= 0 && timeSourceInt < TimeSourceCount)
         timeSource = (TimeSource) timeSourceInt;
     else


### PR DESCRIPTION
Basically i just wanted to fix `sscanf(params["rf"].c_str(), "%I64u", &renderFlags);` as `%I64u` is M$-only extension, but this file file is *so* ugly that I couldn't resist to rewrite it a little bit. Once I'll rewrite it completely.