### PR TITLE
Enable compilation with unsafe fast math option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(ENABLE_WIN     "Build Windows native frontend? (Default: on)" ON)
 option(ENABLE_THEORA  "Support video capture to OGG Theora? (Default: on)" ON)
 option(ENABLE_TOOLS   "Build different tools? (Default: off)" OFF)
 option(NATIVE_OSX_APP "Support native OSX paths read data from (Default: off)" OFF)
+option(FAST_MATH      "Build with unsafe fast-math compiller option (Default: off)" OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type." FORCE)
@@ -40,6 +41,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 if(NOT MSVC)
   # Qt requires -fPIC, so build all code with it
   add_compile_options(-fPIC)
+  if(FAST_MATH)
+    add_compile_options("-ffast-math")
+  endif()
 else()
   # Disabled warnings
   # C4244, C4267, C4503: implicit type conversion to a smaller type
@@ -48,6 +52,9 @@ else()
   # Additional options
   # bigobj: generate more object sections than allowed by default
   add_compile_options("/wd4244" "/wd4267" "/wd4503" "/wd4800" "/bigobj")
+  if(FAST_MATH)
+    add_compile_options("/fp:fast")
+  endif()
 endif()
 
 if(UNIX AND (NOT APPLE) AND (NOT CYGWIN))


### PR DESCRIPTION
Experimental feature hidden behind a cmake option, should potentially speed up floating point math.

On the other hand with it we might have incorrect calculation results.