### PR TITLE
[cmake] Fix USE_SPICE macro definition creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,8 @@ if(ENABLE_SPICE)
 
     include_directories("${CMAKE_SOURCE_DIR}/thirdparty/Spice/include")
     add_library(CSPICE::CSPICE ALIAS Spice)
-    add_definitions(-DUSE_SPICE)
   endif()
+  add_definitions(-DUSE_SPICE)
 endif()
 
 if(_UNIX)


### PR DESCRIPTION
Taken from https://build.opensuse.org/package/view_file/home:munix9:unstable/celestia/fix-USE_SPICE.patch?expand=1