### PR TITLE
Disable GLContext usage as it does nothing now

### DIFF
--- a/src/celengine/CMakeLists.txt
+++ b/src/celengine/CMakeLists.txt
@@ -48,8 +48,8 @@ set(CELENGINE_SOURCES
   galaxy.cpp
   galaxy.h
   geometry.h
-  glcontext.cpp
-  glcontext.h
+  #glcontext.cpp
+  #glcontext.h
   globular.cpp
   globular.h
   glshader.cpp

--- a/src/celengine/cmdparser.cpp
+++ b/src/celengine/cmdparser.cpp
@@ -13,7 +13,9 @@
 
 #include "astro.h"
 #include "cmdparser.h"
+#ifdef USE_GLCONTEXT
 #include "glcontext.h"
+#endif
 #include <celutil/util.h>
 #include <celutil/debug.h>
 #include <celmath/mathlib.h>
@@ -700,7 +702,9 @@ Command* CommandParser::parseCommand()
 
         cmd = new CommandRenderPath(glcpath);
 #else
+#ifdef USE_GLCONTEXT
         cmd = new CommandRenderPath(GLContext::GLPath_GLSL);
+#endif
 #endif
     }
     else if (commandName == "splitview")

--- a/src/celengine/command.cpp
+++ b/src/celengine/command.cpp
@@ -11,7 +11,9 @@
 #include "astro.h"
 #include "asterism.h"
 #include "execution.h"
+#ifdef USE_GLCONTEXT
 #include "glcontext.h"
+#endif
 #include <celestia/celestiacore.h>
 #include <celestia/imagecapture.h>
 #include <celestia/celx_internal.h>
@@ -680,6 +682,7 @@ void CommandSetTextureResolution::process(ExecutionEnvironment& env)
 ////////////////
 // Set RenderPath command. Left for compatibility.
 
+#ifdef USE_GLCONTEXT
 CommandRenderPath::CommandRenderPath(GLContext::GLRenderPath _path) :
     path(_path)
 {
@@ -697,6 +700,7 @@ void CommandRenderPath::process(ExecutionEnvironment& /*env*/)
     }
 #endif
 }
+#endif
 
 
 ////////////////

--- a/src/celengine/command.h
+++ b/src/celengine/command.h
@@ -592,6 +592,7 @@ class CommandSetTextureResolution : public InstantaneousCommand
 };
 
 
+#ifdef USE_GLCONTEXT
 class CommandRenderPath : public InstantaneousCommand
 {
  public:
@@ -601,6 +602,7 @@ class CommandRenderPath : public InstantaneousCommand
  private:
     GLContext::GLRenderPath path;
 };
+#endif
 
 
 class CommandSplitView : public InstantaneousCommand

--- a/src/celengine/deepskyobj.h
+++ b/src/celengine/deepskyobj.h
@@ -15,7 +15,9 @@
 #include <iostream>
 #include <celmath/ray.h>
 #include <celengine/catentry.h>
+#ifdef USE_GLCONTEXT
 #include <celengine/glcontext.h>
+#endif
 #include <celengine/parser.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/src/celengine/lodspheremesh.h
+++ b/src/celengine/lodspheremesh.h
@@ -12,7 +12,9 @@
 #define CELENGINE_LODSPHEREMESH_H_
 
 #include <celengine/texture.h>
+#ifdef USE_GLCONTEXT
 #include <celengine/glcontext.h>
+#endif
 #include <Eigen/Geometry>
 #include <celmath/frustum.h>
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -924,11 +924,17 @@ bool Renderer::OrbitPathListEntry::operator<(const Renderer::OrbitPathListEntry&
 }
 
 
+#ifdef USE_GLCONTEXT
 bool Renderer::init(GLContext* _context,
+#else
+bool Renderer::init(
+#endif
                     int winWidth, int winHeight,
                     DetailOptions& _detailOptions)
 {
+#ifdef USE_GLCONTEXT
     context = _context;
+#endif
     detailOptions = _detailOptions;
 
     // Initialize static meshes and textures common to all instances of Renderer
@@ -6409,7 +6415,9 @@ template <class OBJ, class PREC> class ObjectRenderer : public OctreeProcessor<O
  public:
     const Observer* observer{ nullptr };
 
+#ifdef USE_GLCONTEXT
     GLContext* context{ nullptr };
+#endif
     Renderer*  renderer{ nullptr };
 
     Eigen::Vector3f viewNormal;
@@ -6687,7 +6695,9 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
     Vector3d obsPos = observer.getPosition().toLy();
 
     PointStarRenderer starRenderer;
+#ifdef USE_GLCONTEXT
     starRenderer.context           = context;
+#endif
     starRenderer.renderer          = this;
     starRenderer.starDB            = &starDB;
     starRenderer.observer          = &observer;
@@ -6986,7 +6996,9 @@ void Renderer::renderDeepSkyObjects(const Universe&  universe,
 
     DSODatabase* dsoDB  = universe.getDSOCatalog();
 
+#ifdef USE_GLCONTEXT
     dsoRenderer.context          = context;
+#endif
     dsoRenderer.renderer         = this;
     dsoRenderer.dsoDB            = dsoDB;
     dsoRenderer.orientationMatrix= observer.getOrientationf().conjugate().toRotationMatrix();

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -16,7 +16,9 @@
 #include <celengine/universe.h>
 #include <celengine/observer.h>
 #include <celengine/selection.h>
+#ifdef USE_GLCONTEXT
 #include <celengine/glcontext.h>
+#endif
 #include <celengine/starcolors.h>
 #include <celengine/rendcontext.h>
 #include <celtxf/texturefont.h>
@@ -103,7 +105,11 @@ class Renderer
         double linearFadeFraction;
     };
 
+#ifdef USE_GLCONTEXT
     bool init(GLContext*, int, int, DetailOptions&);
+#else
+    bool init(int, int, DetailOptions&);
+#endif
     void shutdown() {};
     void resize(int, int);
 
@@ -245,7 +251,9 @@ class Renderer
     float getBrightness();
 #endif
 
+#ifdef USE_GLCONTEXT
     GLContext* getGLContext() { return context; }
+#endif
 
     void setStarStyle(StarStyle);
     StarStyle getStarStyle() const;
@@ -626,7 +634,9 @@ class Renderer
 #endif
 
  private:
+#ifdef USE_GLCONTEXT
     GLContext* context;
+#endif
     ShaderManager* shaderManager{ nullptr };
 
     int windowWidth;

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -1396,6 +1396,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
         break;
 
     case '\026':  // Ctrl+V
+#ifdef USE_GLCONTEXT
         {
             GLContext* context = renderer->getGLContext();
             GLContext::GLRenderPath path = context->getRenderPath();
@@ -1413,6 +1414,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
                 notifyWatchers(RenderFlagsChanged);
             }
         }
+#endif
         break;
 
     case '\027':  // Ctrl+W
@@ -4264,12 +4266,14 @@ bool CelestiaCore::initRenderer()
                              Renderer::ShowAtmospheres |
                              Renderer::ShowAutoMag);
 
+#ifdef USE_GLCONTEXT
     GLContext* context = new GLContext();
 
     context->init(config->ignoreGLExtensions);
     // Choose the render path, starting with the least desirable
     context->setRenderPath(GLContext::GLPath_GLSL);
     //fmt::printf(_("render path: %i\n"), context->getRenderPath());
+#endif
 
     Renderer::DetailOptions detailOptions;
     detailOptions.orbitPathSamplePoints = config->orbitPathSamplePoints;
@@ -4280,7 +4284,11 @@ bool CelestiaCore::initRenderer()
     detailOptions.linearFadeFraction = config->linearFadeFraction;
 
     // Prepare the scene for rendering.
+#ifdef USE_GLCONTEXT
     if (!renderer->init(context, (int) width, (int) height, detailOptions))
+#else
+    if (!renderer->init((int) width, (int) height, detailOptions))
+#endif
     {
         fatalError(_("Failed to initialize renderer"), false);
         return false;

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -565,7 +565,9 @@ void CelestiaAppWindow::writeSettings()
     settings.setValue("LabelMode", renderer->getLabelMode());
     settings.setValue("AmbientLightLevel", renderer->getAmbientLightLevel());
     settings.setValue("StarStyle", renderer->getStarStyle());
+#ifdef USE_GLCONTEXT
     settings.setValue("RenderPath", (int) renderer->getGLContext()->getRenderPath());
+#endif
     settings.setValue("TextureResolution", renderer->getResolution());
     ColorTableType colorsst;
     const ColorTemperatureTable* current = renderer->getStarColorTable();

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -35,7 +35,9 @@
 #include "celestia/imagecapture.h"
 #include "celestia/celestiacore.h"
 #include "celengine/simulation.h"
+#ifdef USE_GLCONTEXT
 #include "celengine/glcontext.h"
+#endif
 
 #include "qtglwidget.h"
 
@@ -88,6 +90,7 @@ void CelestiaGlWidget::paintGL()
 }
 
 
+#ifdef USE_GLCONTEXT
 static GLContext::GLRenderPath getBestAvailableRenderPath(const GLContext& /*glc*/)
 {
 #if 0
@@ -104,6 +107,7 @@ static GLContext::GLRenderPath getBestAvailableRenderPath(const GLContext& /*glc
 
     return GLContext::GLPath_GLSL;
 }
+#endif
 
 
 /*!
@@ -137,6 +141,7 @@ void CelestiaGlWidget::initializeGL()
     appCore->getSimulation()->setFaintestVisible((float) settings.value("Preferences/VisualMagnitude", DEFAULT_VISUAL_MAGNITUDE).toDouble());
 
     // Read the saved render path
+#ifdef USE_GLCONTEXT
     GLContext::GLRenderPath bestPath = getBestAvailableRenderPath(*appRenderer->getGLContext());
     GLContext::GLRenderPath savedPath = (GLContext::GLRenderPath) settings.value("RenderPath", bestPath).toInt();
 
@@ -149,6 +154,7 @@ void CelestiaGlWidget::initializeGL()
         usePath = bestPath;
 
     appRenderer->getGLContext()->setRenderPath(usePath);
+#endif
 
     appCore->setScreenDpi(logicalDpiY());
 

--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -28,7 +28,9 @@
 #include "qtappwin.h"
 #include "qtpreferencesdialog.h"
 #include "celengine/render.h"
+#ifdef USE_GLCONTEXT
 #include "celengine/glcontext.h"
+#endif
 #include "celestia/celestiacore.h"
 
 
@@ -67,8 +69,10 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
     // Get flags
     Renderer* renderer = appCore->getRenderer();
     Observer* observer = appCore->getSimulation()->getActiveObserver();
+#ifdef USE_GLCONTEXT
     GLContext* glContext = appCore->getRenderer()->getGLContext();
     GLContext::GLRenderPath renderPath = glContext->getRenderPath();
+#endif
 
     uint64_t renderFlags = renderer->getRenderFlags();
     int orbitMask = renderer->getOrbitMask();
@@ -164,10 +168,14 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
     ui.featureSizeSlider->setValue(minimumFeatureSize);
     ui.featureSizeEdit->setText(QString::number(minimumFeatureSize));
 
+#ifdef USE_GLCONTEXT
     if (glContext->renderPathSupported(GLContext::GLPath_GLSL))
         ui.renderPathBox->addItem(_("OpenGL 2.0"), GLContext::GLPath_GLSL);
 
     SetComboBoxValue(ui.renderPathBox, renderPath);
+#else
+    ui.renderPathBox->addItem(_("OpenGL 2.1"), 0);
+#endif
 
     ui.antialiasLinesCheck->setChecked(renderFlags & Renderer::ShowSmoothLines);
     ui.tintedIlluminationCheck->setChecked(renderFlags & Renderer::ShowTintedIllumination);
@@ -699,10 +707,12 @@ void PreferencesDialog::on_featureSizeEdit_textEdited(const QString& text)
 
 void PreferencesDialog::on_renderPathBox_currentIndexChanged(int index)
 {
+#ifdef USE_GLCONTEXT
     GLContext* glContext = appCore->getRenderer()->getGLContext();
     QVariant itemData = ui.renderPathBox->itemData(index, Qt::UserRole);
     GLContext::GLRenderPath renderPath = (GLContext::GLRenderPath) itemData.toInt();
     glContext->setRenderPath(renderPath);
+#endif
 }
 
 

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -186,7 +186,9 @@ struct AppPreferences
     string altSurfaceName;
     uint32_t textureResolution;
     Renderer::StarStyle starStyle;
+#ifdef USE_GLCONTEXT
     GLContext::GLRenderPath renderPath;
+#endif
     bool renderPathSet;
 };
 
@@ -2528,8 +2530,10 @@ static bool LoadPreferencesFromRegistry(LPTSTR regkey, AppPreferences& prefs)
     GetRegistryValue(key, "StarsColor", &prefs.starsColor, sizeof(prefs.starsColor));
     prefs.starStyle = Renderer::FuzzyPointStars;
     GetRegistryValue(key, "StarStyle", &prefs.starStyle, sizeof(prefs.starStyle));
+#ifdef USE_GLCONTEXT
     prefs.renderPath = GLContext::GLPath_GLSL;
     prefs.renderPathSet = GetRegistryValue(key, "RenderPath", &prefs.renderPath, sizeof(prefs.renderPath));
+#endif
 
     GetRegistryValue(key, "LastVersion", &prefs.lastVersion, sizeof(prefs.lastVersion));
     GetRegistryValue(key, "TextureResolution", &prefs.textureResolution, sizeof(prefs.textureResolution));
@@ -2587,7 +2591,9 @@ static bool SavePreferencesToRegistry(LPTSTR regkey, AppPreferences& prefs)
     SetRegistryInt(key, "LastVersion", prefs.lastVersion);
     SetRegistryInt(key, "StarStyle", prefs.starStyle);
     SetRegistryInt(key, "StarsColor", prefs.starsColor);
+#ifdef USE_GLCONTEXT
     SetRegistryInt(key, "RenderPath", prefs.renderPath);
+#endif
     SetRegistry(key, "AltSurface", prefs.altSurfaceName);
     SetRegistryInt(key, "TextureResolution", prefs.textureResolution);
 
@@ -2629,7 +2635,9 @@ static bool GetCurrentPreferences(AppPreferences& prefs)
         prefs.starsColor = ColorTable_Enhanced;
     if (current == GetStarColorTable(ColorTable_Blackbody_D65))
         prefs.starsColor = ColorTable_Blackbody_D65;
+#ifdef USE_GLCONTEXT
     prefs.renderPath = appCore->getRenderer()->getGLContext()->getRenderPath();
+#endif
     prefs.textureResolution = appCore->getRenderer()->getResolution();
 
     return true;
@@ -3494,12 +3502,14 @@ int APIENTRY WinMain(HINSTANCE hInstance,
         appCore->setDateFormat((astro::Date::Format) prefs.dateFormat);
         appCore->getSimulation()->getActiveObserver()->setDisplayedSurface(prefs.altSurfaceName);
         appCore->getRenderer()->setResolution(prefs.textureResolution);
+#ifdef USE_GLCONTEXT
         if (prefs.renderPathSet)
         {
             GLContext* glContext = appCore->getRenderer()->getGLContext();
             if (glContext->renderPathSupported(prefs.renderPath))
                 glContext->setRenderPath(prefs.renderPath);
         }
+#endif
     }
     else
     {


### PR DESCRIPTION
maybe later when we have different renderers we'll restore it so i have used `#if 0` instead of removal. but why not to have smaller resulting binary?