### PR TITLE
Fix random abnormal termination when enabling RefAxes (Closes: #302)

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -6222,10 +6222,12 @@ void Renderer::buildLabelLists(const Frustum& viewFrustum,
 
     for (auto& render_item : renderList)
     {
+        if (render_item.renderableType != RenderListEntry::RenderableBody)
+            continue;
+
         int classification = render_item.body->getOrbitClassification();
 
-        if (render_item.renderableType == RenderListEntry::RenderableBody &&
-            (classification & labelClassMask)                       &&
+        if ((classification & labelClassMask) != 0 &&
             viewFrustum.testSphere(render_item.position, render_item.radius) != Frustum::Outside)
         {
             const Body* body = render_item.body;


### PR DESCRIPTION
```
struct RenderListEntry
{
    EIGEN_MAKE_ALIGNED_OPERATOR_NEW

    enum RenderableType
    {
        RenderableStar,
        RenderableBody,
        RenderableCometTail,
        RenderableReferenceMark,
    };

    union
    {
        const Star* star;
        Body* body;
        const ReferenceMark* refMark;
    };
...
```

So, if  it's not a RenderableBody `render_item.body` must not be used.

I wonder that nobody was hit by this bug before.