### PR TITLE
Use vertex buffer when displaying orbits

### DIFF
--- a/src/celengine/curveplot.cpp
+++ b/src/celengine/curveplot.cpp
@@ -31,7 +31,7 @@
 #if DEBUG_ADAPTIVE_SPLINE
 #define USE_VERTEX_BUFFER 0
 #else
-#define USE_VERTEX_BUFFER 0
+#define USE_VERTEX_BUFFER 1
 #endif
 
 #include "curveplot.h"
@@ -164,7 +164,7 @@ public:
         vbobj(0),
         currentStripLength(0)
     {
-        data = new Vector4f[capacity];
+        data = new Vertex[capacity];
     }
 
     ~HighPrec_VertexBuffer()
@@ -181,11 +181,15 @@ public:
         }
 
         glEnableClientState(GL_VERTEX_ARRAY);
+        glEnableClientState(GL_COLOR_ARRAY);
 
         mapBuffer();
 
-        Vector4f* vertexBase = vbobj ? (Vector4f*) nullptr : data;
-        glVertexPointer(3, GL_FLOAT, sizeof(Vector4f), vertexBase);
+        Vector4f* vertexBase = vbobj ? (Vector4f*) offsetof(Vertex, position) : &data[0].position;
+        glVertexPointer(3, GL_FLOAT, sizeof(Vertex), vertexBase);
+
+        Vector4f* colorBase = vbobj ? (Vector4f*) offsetof(Vertex, color) : &data[0].color;
+        glColorPointer(4, GL_FLOAT, sizeof(Vertex), colorBase);
 
         stripLengths.clear();
         currentStripLength = 0;
@@ -200,6 +204,7 @@ public:
 #if USE_VERTEX_BUFFER
         if (vbobj)
         {
+            glDisableClientState(GL_COLOR_ARRAY);
             glDisableClientState(GL_VERTEX_ARRAY);
             glBindBuffer(GL_ARRAY_BUFFER, 0);
         }
@@ -209,13 +214,16 @@ public:
     inline void vertex(const Vector3d& v)
     {
 #if USE_VERTEX_BUFFER
-        data[currentPosition++].segment<3>(0) = v.cast<float>();
+        data[currentPosition].position.segment<3>(0) = v.cast<float>();
+        data[currentPosition].color = color;
+        ++currentPosition;
         ++currentStripLength;
         if (currentPosition == capacity)
         {
             flush();
 
-            data[0].segment<3>(0) = v.cast<float>();
+            data[0].position.segment<3>(0) = v.cast<float>();
+            data[0].color = color;
             currentPosition = 1;
             currentStripLength = 1;
         }
@@ -227,13 +235,16 @@ public:
     inline void vertex(const Vector4d& v)
     {
 #if USE_VERTEX_BUFFER
-        data[currentPosition++] = v.cast<float>();
+        data[currentPosition].position = v.cast<float>();
+        data[currentPosition].color = color;
+        ++currentPosition;
         ++currentStripLength;
         if (currentPosition == capacity)
         {
             flush();
 
-            data[0] = v.cast<float>();
+            data[0].position = v.cast<float>();
+            data[0].color = color;
             currentPosition = 1;
             currentStripLength = 1;
         }
@@ -245,13 +256,16 @@ public:
     inline void vertex(const Vector4d& v, const Vector4f& color)
     {
 #if USE_VERTEX_BUFFER
-        data[currentPosition++] = v.cast<float>();
+        data[currentPosition].position = v.cast<float>();
+        data[currentPosition].color = color;
+        ++currentPosition;
         ++currentStripLength;
         if (currentPosition == capacity)
         {
             flush();
 
-            data[0] = v.cast<float>();
+            data[0].position = v.cast<float>();
+            data[0].color = color;
             currentPosition = 1;
             currentStripLength = 1;
         }
@@ -314,7 +328,7 @@ public:
             glGenBuffers(1, &vbobj);
             glBindBuffer(GL_ARRAY_BUFFER, vbobj);
             glBufferData(GL_ARRAY_BUFFER,
-                         capacity * sizeof(Vector4f),
+                         capacity * sizeof(Vertex),
                          nullptr,
                          GL_STREAM_DRAW);
         }
@@ -330,11 +344,11 @@ public:
             // be discarded and overwritten. It enables renaming in the driver,
             // hopefully resulting in performance gains.
             glBufferData(GL_ARRAY_BUFFER,
-                         capacity * sizeof(Vector4f),
+                         capacity * sizeof(Vertex),
                          nullptr,
                          GL_STREAM_DRAW);
 
-            data = reinterpret_cast<Vector4f*>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
+            data = reinterpret_cast<Vertex*>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         }
     }
 
@@ -348,14 +362,29 @@ public:
         }
 #endif
     }
+
+    void setColor(const Vector4f &aColor)
+    {
+#if USE_VERTEX_BUFFER
+        color = aColor;
+#else
+        glColor4fv(aColor.data());
+#endif
+    }
         
 private:
     unsigned int currentPosition;
     unsigned int capacity;
-    Vector4f* data;
+    struct Vertex
+    {
+        Vector4f position;
+        Vector4f color;
+    };
+    Vertex* data;
     GLuint vbobj;
     unsigned int currentStripLength;
     vector<unsigned int> stripLengths;
+    Vector4f color;
 };
 
 
@@ -651,7 +680,8 @@ CurvePlot::render(const Affine3d& modelview,
                   double nearZ,
                   double farZ,
                   const Vector3d viewFrustumPlaneNormals[],
-                  double subdivisionThreshold) const
+                  double subdivisionThreshold,
+                  const Vector4f& color) const
 {
     // Flag to indicate whether we need to issue a glBegin()
     bool restartCurve = true;
@@ -671,6 +701,7 @@ CurvePlot::render(const Affine3d& modelview,
 
     vbuf.createVertexBuffer();
     vbuf.setup();
+    vbuf.setColor(color);
 
     for (unsigned int i = 1; i < m_samples.size(); i++)
     {
@@ -793,7 +824,8 @@ CurvePlot::render(const Affine3d& modelview,
                   const Vector3d viewFrustumPlaneNormals[],
                   double subdivisionThreshold,
                   double startTime,
-                  double endTime) const
+                  double endTime,
+                  const Vector4f& color) const
 {
     // Flag to indicate whether we need to issue a glBegin()
     bool restartCurve = true;
@@ -820,6 +852,7 @@ CurvePlot::render(const Affine3d& modelview,
 
     vbuf.createVertexBuffer();
     vbuf.setup();
+    vbuf.setColor(color);
 
     bool firstSegment = true;
     bool lastSegment = false;

--- a/src/celengine/curveplot.h
+++ b/src/celengine/curveplot.h
@@ -71,14 +71,16 @@ class CurvePlot
                 double nearZ,
                 double farZ,
                 const Eigen::Vector3d viewFrustumPlaneNormals[],
-                double subdivisionThreshold) const;
+                double subdivisionThreshold,
+                const Eigen::Vector4f& color) const;
     void render(const Eigen::Affine3d& modelview,
                 double nearZ,
                 double farZ,
                 const Eigen::Vector3d viewFrustumPlaneNormals[],
                 double subdivisionThreshold,
                 double startTime,
-                double endTime) const;
+                double endTime,
+                const Eigen::Vector4f& color) const;
     void renderFaded(const Eigen::Affine3d& modelview,
                      double nearZ,
                      double farZ,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1782,7 +1782,8 @@ void Renderer::renderOrbit(const OrbitPathListEntry& orbitPath,
             cachedOrbit->render(modelview,
                                 nearZ, farZ, viewFrustumPlaneNormals,
                                 subdivisionThreshold,
-                                windowStart, windowEnd);
+                                windowStart, windowEnd,
+                                orbitColor);
         }
         else
         {
@@ -1803,14 +1804,16 @@ void Renderer::renderOrbit(const OrbitPathListEntry& orbitPath,
             cachedOrbit->render(modelview,
                                 nearZ, farZ, viewFrustumPlaneNormals,
                                 subdivisionThreshold,
-                                cachedOrbit->startTime(), t);
+                                cachedOrbit->startTime(), t,
+                                orbitColor);
         }
         else
         {
             // Show the entire trajectory
             cachedOrbit->render(modelview,
                                 nearZ, farZ, viewFrustumPlaneNormals,
-                                subdivisionThreshold);
+                                subdivisionThreshold,
+                                orbitColor);
         }
     }
 


### PR DESCRIPTION
I noticed that there's already code in place to display orbits with vertex buffers, but disabled. It was mostly working except that colors are ignored (when displaying faded orbits), so I fixed it.

This isn't exactly modern OpenGL (glVertexPointer/etc are deprecated) but should be a bit more efficient than using immediate mode.