### PR TITLE
DSO .h file fixes

### DIFF
--- a/src/celengine/deepskyobj.h
+++ b/src/celengine/deepskyobj.h
@@ -97,7 +97,7 @@ class DeepSkyObject : public CatEntry
                         float pixelSize,
                         const Renderer*) = 0;
 
-    virtual unsigned int getRenderMask() const { return 0; }
+    virtual uint64_t getRenderMask() const { return 0; }
     virtual unsigned int getLabelMask() const { return 0; }
 
     enum : uint32_t

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -458,7 +458,7 @@ void Galaxy::renderGalaxyEllipsoid(const Vec3f& offset,
 #endif
 
 
-unsigned int Galaxy::getRenderMask() const
+uint64_t Galaxy::getRenderMask() const
 {
     return Renderer::ShowGalaxies;
 }

--- a/src/celengine/galaxy.h
+++ b/src/celengine/galaxy.h
@@ -68,7 +68,7 @@ class Galaxy : public DeepSkyObject
     static float getLightGain();
     static void  setLightGain(float);
 
-    virtual unsigned int getRenderMask() const;
+    virtual uint64_t getRenderMask() const;
     virtual unsigned int getLabelMask() const;
 
     virtual const char* getObjTypeName() const;

--- a/src/celengine/galaxy.h
+++ b/src/celengine/galaxy.h
@@ -30,36 +30,24 @@ class Galaxy : public DeepSkyObject
  public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    virtual const char* getType() const;
-    virtual void setType(const std::string&);
-    virtual std::string getDescription() const;
-    virtual std::string getCustomTmpName() const;
-    virtual void setCustomTmpName(const std::string&);
+    const char* getType() const override;
+    void setType(const std::string&) override;
+    std::string getDescription() const override;
+    std::string getCustomTmpName() const;
+    void setCustomTmpName(const std::string&);
 
     float getDetail() const;
     void setDetail(float);
-    //    float getBrightness() const;
-    //    void setBrightness();
 
-    virtual bool pick(const celmath::Ray3d& ray,
-                      double& distanceToPicker,
-                      double& cosAngleToBoundCenter) const;
-    virtual bool load(AssociativeArray*, const std::string&);
-    virtual void render(const Eigen::Vector3f& offset,
-                        const Eigen::Quaternionf& viewerOrientation,
-                        float brightness,
-                        float pixelSize,
-                        const Renderer* r = nullptr);
-    virtual void renderGalaxyPointSprites(const Eigen::Vector3f& offset,
-                                          const Eigen::Quaternionf& viewerOrientation,
-                                          float brightness,
-                                          float pixelSize);
-#if 0
-    virtual void renderGalaxyEllipsoid(const Eigen::Vector3f& offset,
-                                       const Eigen::Quaternionf& viewerOrientation,
-                                       float brightness,
-                                       float pixelSize);
-#endif
+    bool pick(const celmath::Ray3d& ray,
+              double& distanceToPicker,
+              double& cosAngleToBoundCenter) const override;
+    bool load(AssociativeArray*, const std::string&) override;
+    void render(const Eigen::Vector3f& offset,
+                const Eigen::Quaternionf& viewerOrientation,
+                float brightness,
+                float pixelSize,
+                const Renderer* r = nullptr) override;
 
     GalacticForm* getForm() const;
 
@@ -68,10 +56,10 @@ class Galaxy : public DeepSkyObject
     static float getLightGain();
     static void  setLightGain(float);
 
-    virtual uint64_t getRenderMask() const;
-    virtual unsigned int getLabelMask() const;
+    uint64_t getRenderMask() const override;
+    unsigned int getLabelMask() const override;
 
-    virtual const char* getObjTypeName() const;
+    const char* getObjTypeName() const override;
 
  public:
     enum GalaxyType {
@@ -94,15 +82,22 @@ class Galaxy : public DeepSkyObject
     };
 
  private:
-    float detail{ 1.0f };
-    std::string* customTmpName{ nullptr };
-    //    float brightness;
-    GalaxyType type{ S0 };
+    void renderGalaxyPointSprites(const Eigen::Vector3f& offset,
+                                  const Eigen::Quaternionf& viewerOrientation,
+                                  float brightness,
+                                  float pixelSize);
+#if 0
+    void renderGalaxyEllipsoid(const Eigen::Vector3f& offset,
+                               const Eigen::Quaternionf& viewerOrientation,
+                               float brightness,
+                               float pixelSize);
+#endif
+
+    float         detail{ 1.0f };
+    std::string*  customTmpName{ nullptr };
+    GalaxyType    type{ S0 };
     GalacticForm* form{ nullptr };
 
-    static float lightGain;
+    static float  lightGain;
 };
-
-//std::ostream& operator<<(std::ostream& s, const Galaxy::GalaxyType& sc);
-
 #endif // _GALAXY_H_

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -494,7 +494,7 @@ void Globular::renderGlobularPointSprites(
     glEnd();
 }
 
-unsigned int Globular::getRenderMask() const
+uint64_t Globular::getRenderMask() const
 {
     return Renderer::ShowGlobulars;
 }

--- a/src/celengine/globular.h
+++ b/src/celengine/globular.h
@@ -69,7 +69,7 @@ class Globular : public DeepSkyObject
                                             float pixelSize);
     GlobularForm* getForm() const;
 
-    virtual unsigned int getRenderMask() const;
+    virtual uint64_t getRenderMask() const;
     virtual unsigned int getLabelMask() const;
     virtual const char* getObjTypeName() const;
 

--- a/src/celengine/globular.h
+++ b/src/celengine/globular.h
@@ -38,11 +38,11 @@ class Globular : public DeepSkyObject
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     Globular();
-    virtual const char* getType() const;
-    virtual void setType(const std::string&);
-    virtual std::string getDescription() const;
-    virtual std::string getCustomTmpName() const;
-    virtual void setCustomTmpName(const std::string&);
+    const char* getType() const override;
+    void setType(const std::string&) override;
+    std::string getDescription() const override;
+    std::string getCustomTmpName() const;
+    void setCustomTmpName(const std::string&);
     float getDetail() const;
     void  setDetail(float);
     float getCoreRadius() const;
@@ -52,42 +52,42 @@ class Globular : public DeepSkyObject
     float getHalfMassRadius() const;
     unsigned int cSlot(float) const;
 
-    virtual float getBoundingSphereRadius() const { return tidalRadius; }
+    float getBoundingSphereRadius() const override { return tidalRadius; }
 
-    virtual bool pick(const celmath::Ray3d& ray,
-                      double& distanceToPicker,
-                      double& cosAngleToBoundCenter) const;
-    virtual bool load(AssociativeArray*, const std::string&);
-    virtual void render(const Eigen::Vector3f& offset,
-                        const Eigen::Quaternionf& viewerOrientation,
-                        float brightness,
-                        float pixelSize,
-                        const Renderer* r = nullptr);
-    virtual void renderGlobularPointSprites(const Eigen::Vector3f& offset,
-                                            const Eigen::Quaternionf& viewerOrientation,
-                                            float brightness,
-                                            float pixelSize);
+    bool pick(const celmath::Ray3d& ray,
+              double& distanceToPicker,
+              double& cosAngleToBoundCenter) const override;
+    bool load(AssociativeArray*, const std::string&) override;
+    void render(const Eigen::Vector3f& offset,
+                const Eigen::Quaternionf& viewerOrientation,
+                float brightness,
+                float pixelSize,
+                const Renderer* r = nullptr) override;
+
     GlobularForm* getForm() const;
 
-    virtual uint64_t getRenderMask() const;
-    virtual unsigned int getLabelMask() const;
-    virtual const char* getObjTypeName() const;
+    uint64_t getRenderMask() const override;
+    unsigned int getLabelMask() const override;
+    const char* getObjTypeName() const override;
 
  private:
+    void renderGlobularPointSprites(const Eigen::Vector3f& offset,
+                                    const Eigen::Quaternionf& viewerOrientation,
+                                    float brightness,
+                                    float pixelSize);
+
    // Reference values ( = data base averages) of core radius, King concentration
    // and mu25 isophote radius:
-
     static constexpr float R_c_ref = 0.83f, C_ref = 2.1f, R_mu25 = 40.32f;
 
     void recomputeTidalRadius();
 
- private:
-    float detail{ 1.0f };
-    std::string* customTmpName{ nullptr };
+    float         detail{ 1.0f };
+    std::string*  customTmpName{ nullptr };
     GlobularForm* form{ nullptr };
-    float r_c{ R_c_ref };
-    float c{ C_ref };
-    float tidalRadius{ 0.0f };
+    float         r_c{ R_c_ref };
+    float         c{ C_ref };
+    float         tidalRadius{ 0.0f };
 };
 
 #endif // _GLOBULAR_H_

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -107,7 +107,7 @@ void Nebula::render(const Vector3f& /*unused*/,
 }
 
 
-unsigned int Nebula::getRenderMask() const
+uint64_t Nebula::getRenderMask() const
 {
     return Renderer::ShowNebulae;
 }

--- a/src/celengine/nebula.h
+++ b/src/celengine/nebula.h
@@ -20,27 +20,27 @@ class Nebula : public DeepSkyObject
 
     Nebula() = default;
 
-    virtual const char* getType() const;
-    virtual void setType(const std::string&);
-    virtual std::string getDescription() const;
+    const char* getType() const override;
+    void setType(const std::string&) override;
+    std::string getDescription() const override;
 
-    virtual bool pick(const celmath::Ray3d& ray,
-                      double& distanceToPicker,
-                      double& cosAngleToBoundCenter) const;
-    virtual bool load(AssociativeArray*, const std::string&);
-    virtual void render(const Eigen::Vector3f& offset,
-                        const Eigen::Quaternionf& viewerOrientation,
-                        float brightness,
-                        float pixelSize,
-                        const Renderer* renderer);
+    bool pick(const celmath::Ray3d& ray,
+              double& distanceToPicker,
+              double& cosAngleToBoundCenter) const override;
+    bool load(AssociativeArray*, const std::string&) override;
+    void render(const Eigen::Vector3f& offset,
+                const Eigen::Quaternionf& viewerOrientation,
+                float brightness,
+                float pixelSize,
+                const Renderer* renderer) override;
 
-    virtual uint64_t getRenderMask() const;
-    virtual unsigned int getLabelMask() const;
+    uint64_t getRenderMask() const override;
+    unsigned int getLabelMask() const override;
 
     void setGeometry(ResourceHandle);
     ResourceHandle getGeometry() const;
 
-    virtual const char* getObjTypeName() const;
+    const char* getObjTypeName() const override;
 
  public:
     enum NebulaType

--- a/src/celengine/nebula.h
+++ b/src/celengine/nebula.h
@@ -34,7 +34,7 @@ class Nebula : public DeepSkyObject
                         float pixelSize,
                         const Renderer* renderer);
 
-    virtual unsigned int getRenderMask() const;
+    virtual uint64_t getRenderMask() const;
     virtual unsigned int getLabelMask() const;
 
     void setGeometry(ResourceHandle);

--- a/src/celengine/opencluster.cpp
+++ b/src/celengine/opencluster.cpp
@@ -77,7 +77,7 @@ void OpenCluster::render(const Vector3f& /*unused*/,
 }
 
 
-unsigned int OpenCluster::getRenderMask() const
+uint64_t OpenCluster::getRenderMask() const
 {
     return Renderer::ShowOpenClusters;
 }

--- a/src/celengine/opencluster.h
+++ b/src/celengine/opencluster.h
@@ -35,7 +35,7 @@ class OpenCluster : public DeepSkyObject
                         float pixelSize,
                         const Renderer* r = nullptr);
 
-    virtual unsigned int getRenderMask() const;
+    virtual uint64_t getRenderMask() const;
     virtual unsigned int getLabelMask() const;
 
     virtual const char* getObjTypeName() const;

--- a/src/celengine/opencluster.h
+++ b/src/celengine/opencluster.h
@@ -21,27 +21,28 @@ class OpenCluster : public DeepSkyObject
 
     OpenCluster() = default;
 
-    virtual const char* getType() const;
-    virtual void setType(const std::string&);
-    virtual std::string getDescription() const;
+    const char* getType() const override;
+    void setType(const std::string&) override;
+    std::string getDescription() const override;
 
-    virtual bool pick(const celmath::Ray3d& ray,
-                      double& distanceToPicker,
-                      double& cosAngleToBoundCenter) const;
-    virtual bool load(AssociativeArray*, const std::string&);
-    virtual void render(const Eigen::Vector3f& offset,
-                        const Eigen::Quaternionf& viewerOrientation,
-                        float brightness,
-                        float pixelSize,
-                        const Renderer* r = nullptr);
+    bool pick(const celmath::Ray3d& ray,
+              double& distanceToPicker,
+              double& cosAngleToBoundCenter) const override;
+    bool load(AssociativeArray*, const std::string&) override;
+    void render(const Eigen::Vector3f& offset,
+                const Eigen::Quaternionf& viewerOrientation,
+                float brightness,
+                float pixelSize,
+                const Renderer* r = nullptr) override;
 
-    virtual uint64_t getRenderMask() const;
-    virtual unsigned int getLabelMask() const;
+    uint64_t getRenderMask() const override;
+    unsigned int getLabelMask() const override;
 
-    virtual const char* getObjTypeName() const;
+    const char* getObjTypeName() const override;
 
  public:
-    enum ClusterType {
+    enum ClusterType
+    {
         Open          = 0,
         Globular      = 1,
         NotDefined    = 2


### PR DESCRIPTION
1. Render flags are 64 bit now
2. Modern C++ recommends to mark methods with `override` instead of `virtual` in this case you really override an existing method instead of introducing a new one by mistake.