### PR TITLE
[appveyor] Use previous image

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ branches:
   - master
 
 # Build worker image (VM template)
-image: Visual Studio 2015
+image: "Previous Visual Studio 2015"
 
 # clone directory
 clone_folder: c:\projects\celestia


### PR DESCRIPTION
it looks like after the recent update we have issues with vcpkg. so let's just use an old image.