### PR TITLE
Fix Lua Version Preprocessor Warning

### DIFF
--- a/src/celestia/celx.h
+++ b/src/celestia/celx.h
@@ -12,10 +12,6 @@
 #ifndef _CELESTIA_CELX_H_
 #define _CELESTIA_CELX_H_
 
-#ifndef LUA_VER
-#define LUA_VER 0x050100
-#endif
-
 #include <iostream>
 #include <string>
 #include <vector>
@@ -23,7 +19,11 @@
 #include <celutil/timer.h>
 #include <celengine/observer.h>
 
-#if LUA_VER < 0x050300
+#ifndef LUA_VERSION_NUM
+#define LUA_VERSION_NUM 501
+#endif
+
+#if LUA_VERSION_NUM < 503
 int lua_isinteger(lua_State *L, int index);
 #endif
 

--- a/src/celestia/celx_observer.cpp
+++ b/src/celestia/celx_observer.cpp
@@ -920,7 +920,7 @@ void CreateObserverMetaTable(lua_State* l)
 
     celx.registerMethod("__tostring", observer_tostring);
     celx.registerMethod("isvalid", observer_isvalid);
-#if LUA_VER < 0x050200
+#if LUA_VERSION_NUM < 502
     celx.registerMethod("goto", observer_goto);
 #endif
     celx.registerMethod("gotoobject", observer_goto);


### PR DESCRIPTION
Modify the version checking of Lua in src/celestia/celx.h and celx_observer.cpp to fix a warning. It may break the OSX build since src/celestia/macosx/celestia.xcode/project.pbxproj and src/celestia/macosx/celestia.xcodeproj/project.pbxproj is using the old version checking, but anyway OSX is not supported currently.