### PR TITLE
Fix mouse move resulting in wrong movement in simulation

### DIFF
--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -204,20 +204,23 @@ void CelestiaGlWidget::mouseMoveEvent(QMouseEvent* m)
             // Hide the cursor.
             setCursor(QCursor(Qt::BlankCursor));
             cursorVisible = false;
-
-            // Save the cursor position
-            QPoint pt;
-            pt.setX(x);
-            pt.setY(y);
-
-            // Store a local and global location
-            saveLocalCursorPos = pt;
-            pt = mapToGlobal(pt);
-            saveGlobalCursorPos = pt;
+        }
+        else
+        {
+            // Calculate mouse delta from local coordinate then move it back to the saved location
+            appCore->mouseMove(x - saveLocalCursorPos.rx(), y - saveLocalCursorPos.ry(), buttons);
         }
 
-        // Calculate mouse delta from local coordinate then move it back to the saved location
-        appCore->mouseMove(x - saveLocalCursorPos.rx(), y - saveLocalCursorPos.ry(), buttons);
+        // Save the cursor position
+        QPoint pt;
+        pt.setX(x);
+        pt.setY(y);
+
+        // Store a local and global location
+        saveLocalCursorPos = pt;
+        pt = mapToGlobal(pt);
+        saveGlobalCursorPos = pt;
+
         QCursor::setPos(saveGlobalCursorPos);
     }
     else


### PR DESCRIPTION
The mouse movement mapped to celestiacore is incorrect.

The offset distance should be the current location offset by the location the last time mouseMoveEvent is called, whereas the current implementation uses the current location offset by  the location the last time when the cursor is still visible. To resolve it saveLocalCursorPos and saveGlobalCursorPos is in both occasion.