### PR TITLE
Qt - Prepend APPDIR for absolute paths for AppImage builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,3 +62,7 @@ addons:
     - libpng
     - lua
     - qt5
+
+branches:
+  only:
+    - appimage_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,3 @@ addons:
     - libpng
     - lua
     - qt5
-
-branches:
-  only:
-    - appimage_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,17 +21,18 @@ set(DISPLAY_NAME "Celestia")
 #
 #
 #
-option(ENABLE_CELX    "Enable celx scripting, requires Lua library? (Default: on)" ON)
-option(ENABLE_SPICE   "Use spice library? (Default: off)" OFF)
-option(ENABLE_NLS     "Enable interface translation? (Default: on)" ON)
-option(ENABLE_GLUT    "Build simple Glut frontend? (Default: on)" OFF)
-option(ENABLE_GTK     "Build GTK2 frontend (Unix only)? (Default: off)" OFF)
-option(ENABLE_QT      "Build Qt frontend? (Default: on)" ON)
-option(ENABLE_WIN     "Build Windows native frontend? (Default: on)" ON)
-option(ENABLE_THEORA  "Support video capture to OGG Theora? (Default: on)" ON)
-option(ENABLE_TOOLS   "Build different tools? (Default: off)" OFF)
-option(NATIVE_OSX_APP "Support native OSX paths read data from (Default: off)" OFF)
-option(FAST_MATH      "Build with unsafe fast-math compiller option (Default: off)" OFF)
+option(ENABLE_CELX     "Enable celx scripting, requires Lua library? (Default: on)" ON)
+option(ENABLE_SPICE    "Use spice library? (Default: off)" OFF)
+option(ENABLE_NLS      "Enable interface translation? (Default: on)" ON)
+option(ENABLE_GLUT     "Build simple Glut frontend? (Default: on)" OFF)
+option(ENABLE_GTK      "Build GTK2 frontend (Unix only)? (Default: off)" OFF)
+option(ENABLE_QT       "Build Qt frontend? (Default: on)" ON)
+option(ENABLE_WIN      "Build Windows native frontend? (Default: on)" ON)
+option(ENABLE_THEORA   "Support video capture to OGG Theora? (Default: on)" ON)
+option(ENABLE_TOOLS    "Build different tools? (Default: off)" OFF)
+option(NATIVE_OSX_APP  "Support native OSX paths read data from (Default: off)" OFF)
+option(FAST_MATH       "Build with unsafe fast-math compiller option (Default: off)" OFF)
+option(ENABLE_APPIMAGE "Build AppImage package? (Default: off)" OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type." FORCE)
@@ -62,9 +63,10 @@ if(UNIX AND (NOT APPLE) AND (NOT CYGWIN))
   set(_UNIX true)
 endif()
 
-# Theora supported on Unix-like systems only, but not on OSX
+# Theora/AppImage supported on Unix-like systems only, but not on OSX
 if(NOT _UNIX)
   set(ENABLE_THEORA OFF)
+  set(ENABLE_APPIMAGE OFF)
 endif()
 
 # _USE_MATH_DEFINES enables use of math constants like M_PI,
@@ -118,6 +120,10 @@ endif()
 
 if(_UNIX)
   find_package(PkgConfig)
+endif()
+
+if(_UNIX AND ENABLE_APPIMAGE)
+  add_definitions(-DAPPIMAGE)
 endif()
 
 if(_UNIX AND ENABLE_THEORA)

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -208,6 +208,12 @@ void CelestiaAppWindow::init(const QString& qConfigFileName,
         QString dataDir = QApplication::applicationDirPath() + "/../Resources";
 #else
         QString dataDir = CONFIG_DATA_DIR;
+#ifdef APPIMAGE
+        QString appimageDir = QString::fromLocal8Bit(::getenv("APPDIR"));
+        if (!appimageDir.isEmpty()) {
+            dataDir = appimageDir + "/" + dataDir;
+        }
+#endif
 #endif
         QString celestia_data_dir = dataDir;
         QDir::setCurrent(celestia_data_dir);

--- a/src/celestia/qt/qtmain.cpp
+++ b/src/celestia/qt/qtmain.cpp
@@ -76,6 +76,12 @@ int main(int argc, char *argv[])
     QString splashDir = QApplication::applicationDirPath() + "/../Resources/splash/";
 #else
     QString splashDir = SPLASH_DIR;
+#ifdef APPIMAGE
+    QString appimageDir = QString::fromLocal8Bit(::getenv("APPDIR"));
+    if (!appimageDir.isEmpty()) {
+        splashDir = appimageDir + "/" + splashDir;
+    }
+#endif
 #endif
     QPixmap pixmap(splashDir + "splash.png");
     QSplashScreen splash(pixmap);
@@ -92,6 +98,11 @@ int main(int argc, char *argv[])
     QString localeDir = QApplication::applicationDirPath() + "/../Resources/locale";
 #else
     QString localeDir = LOCALEDIR;
+#ifdef APPIMAGE
+    if (!appimageDir.isEmpty()) {
+        localeDir = appimageDir + "/" + localeDir;
+    }
+#endif
 #endif
     bindtextdomain("celestia", localeDir.toUtf8().data());
     bind_textdomain_codeset("celestia", "UTF-8");


### PR DESCRIPTION
Added cmake option ENABLE_APPIMAGE and compiler definition APPIMAGE
Prepend APPDIR env var for absolute paths for AppImage builds,
see https://docs.appimage.org/packaging-guide/environment-variables.html
