### PR TITLE
Replace the apple macro in qt project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,9 +267,6 @@ if(WIN32)
 endif()
 
 if(APPLE)
-  # Dirty hack to prevent AIFF.h inclusion which provides `struct Marker`
-  # conflicting with out `class Marker`.
-  add_definitions(-D__AIFF__)
   if (NATIVE_OSX_APP)
     add_definitions(-DNATIVE_OSX_APP)
   endif()

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -10,9 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifdef TARGET_OS_MAC
-#include <Carbon/Carbon.h>
-#endif
+
 #include <ctime>
 
 #include <QIcon>
@@ -64,7 +62,7 @@
 #if defined(_WIN32)
 #include "celestia/avicapture.h"
 // TODO: Add Mac support
-#elif !defined(TARGET_OS_MAC)
+#elif !defined(__APPLE__)
 #ifdef THEORA
 #include "celestia/oggtheoracapture.h"
 #endif
@@ -638,7 +636,7 @@ void CelestiaAppWindow::slotGrabImage()
 void CelestiaAppWindow::slotCaptureVideo()
 {
 // TODO: Add Mac support
-#if defined(_WIN32) || (defined(THEORA) && !defined(TARGET_OS_MAC))
+#if defined(_WIN32) || (defined(THEORA) && !defined(__APPLE__))
     QString dir;
     QSettings settings;
     settings.beginGroup("Preferences");
@@ -1117,7 +1115,7 @@ void CelestiaAppWindow::createMenus()
     QAction* captureVideoAction = new QAction(QIcon(":/icons/capture-video.png"),
                                               _("Capture &video"), this);
     // TODO: Add Mac support for video capture
-#if defined(TARGET_OS_MAC) || (!defined(_WIN32) && !defined(THEORA))
+#if defined(__APPLE__) || (!defined(_WIN32) && !defined(THEORA))
     captureVideoAction->setEnabled(false);
 #endif
     captureVideoAction->setShortcut(QString(_("Shift+F10")));

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -186,7 +186,7 @@ void CelestiaGlWidget::mouseMoveEvent(QMouseEvent* m)
     if (m->modifiers() & ControlModifier)
         buttons |= CelestiaCore::ControlKey;
 
-#ifdef TARGET_OS_MAC
+#ifdef __APPLE__
     // On the Mac, right dragging is be simulated with Option+left drag.
     // We may want to enable this on other platforms, though it's mostly only helpful
     // for users with single button mice.


### PR DESCRIPTION
Forgot to edit the qt ones in the previous pr.

Since we are not calling mac functions directly, there's no longer the need for including Carbon.h, thus it should not mess around the Marker class defined in the system AIFF.h, removing the hack in the CMakeLists