### PR TITLE
1.6.2: update supported lua versions

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -375,13 +375,15 @@ AC_ARG_WITH([lua],
 
 if (test "$enable_lua" != "no"); then
 	LUA_VER=0
+	PKG_CHECK_MODULES(LUA, lua5.2 >= 5.2.0, LUA_VER=0x050200, [
+	PKG_CHECK_MODULES(LUA, lua >= 5.2.0, LUA_VER=0x050200, [
 	PKG_CHECK_MODULES(LUA, lua5.1 >= 5.1.0, LUA_VER=0x050100, 
 		[ PKG_CHECK_MODULES(LUA, lua >= 5.1.0, LUA_VER=0x050100, 
 		  [ PKG_CHECK_MODULES(LUA, lua50 >= 5.0.0 lua50 < 5.1.0, LUA_VER=0x050000,
 		    [ PKG_CHECK_MODULES(LUA, lua >= 5.0.0 lua < 5.1.0, LUA_VER=0x050000, AC_MSG_RESULT([no])) ] 
 		    ) ] 
 		) ]
-	)
+	) ] ) ] )
 	if (test "$LUA_VER" = "0x050000"); then
 		PKG_CHECK_MODULES(LUALIB, lualib50 >= 5.0.0 lualib50 < 5.1.0, ,
 			[ PKG_CHECK_MODULES(LUALIB, lualib >= 5.0.0 lualib < 5.1.0, , AC_MSG_RESULT([no])) ]

--- a/configure.in
+++ b/configure.in
@@ -375,20 +375,13 @@ AC_ARG_WITH([lua],
 
 if (test "$enable_lua" != "no"); then
 	LUA_VER=0
+	PKG_CHECK_MODULES(LUA, lua5.3 >= 5.3.0, LUA_VER=0x050300, [
+	PKG_CHECK_MODULES(LUA, lua >= 5.3.0, LUA_VER=0x050300, [
 	PKG_CHECK_MODULES(LUA, lua5.2 >= 5.2.0, LUA_VER=0x050200, [
 	PKG_CHECK_MODULES(LUA, lua >= 5.2.0, LUA_VER=0x050200, [
-	PKG_CHECK_MODULES(LUA, lua5.1 >= 5.1.0, LUA_VER=0x050100, 
-		[ PKG_CHECK_MODULES(LUA, lua >= 5.1.0, LUA_VER=0x050100, 
-		  [ PKG_CHECK_MODULES(LUA, lua50 >= 5.0.0 lua50 < 5.1.0, LUA_VER=0x050000,
-		    [ PKG_CHECK_MODULES(LUA, lua >= 5.0.0 lua < 5.1.0, LUA_VER=0x050000, AC_MSG_RESULT([no])) ] 
-		    ) ] 
-		) ]
-	) ] ) ] )
-	if (test "$LUA_VER" = "0x050000"); then
-		PKG_CHECK_MODULES(LUALIB, lualib50 >= 5.0.0 lualib50 < 5.1.0, ,
-			[ PKG_CHECK_MODULES(LUALIB, lualib >= 5.0.0 lualib < 5.1.0, , AC_MSG_RESULT([no])) ]
-			)
-	fi
+	PKG_CHECK_MODULES(LUA, lua5.1 >= 5.1.0, LUA_VER=0x050100, [
+	PKG_CHECK_MODULES(LUA, lua >= 5.1.0, LUA_VER=0x050100, AC_MSG_RESULT([no])) ]
+	) ] ) ] ) ] ) ] )
 	if (test "$LUA_VER" = "0"); then
 		if (test "x$enable_lua" != "xauto"); then
 			AC_ERROR([Lua not found (explicitly enabled)!])

--- a/scripts/eclipticgrid.celx
+++ b/scripts/eclipticgrid.celx
@@ -1,3 +1,5 @@
+-- Title: Toggle Eclipic Grid
+
 t = {} -- create table
 t.equatorialgrid = 	false
 t.galacticgrid = 	false

--- a/scripts/galacticgrid.celx
+++ b/scripts/galacticgrid.celx
@@ -1,3 +1,5 @@
+-- Title: Toggle Galactic Grid
+
 t = {} -- create table
 t.equatorialgrid = 	false
 t.galacticgrid = 	not celestia:getrenderflags().galacticgrid

--- a/scripts/horizontalgrid.celx
+++ b/scripts/horizontalgrid.celx
@@ -1,3 +1,5 @@
+-- Title: Toggle Horizontal Grid
+
 t = {} -- create table
 t.equatorialgrid = 	false
 t.galacticgrid = 	false

--- a/scripts/marktype.celx
+++ b/scripts/marktype.celx
@@ -1,3 +1,5 @@
+-- Title: Mark all D stars
+
 function mark_spectraltype(x)
     local obs = celestia:getobserver()
     local nstars = celestia:getstarcount()

--- a/scripts/randstar.celx
+++ b/scripts/randstar.celx
@@ -6,6 +6,6 @@ while 1 do
     index = math.floor(nstars * math.random())
     star = celestia:getstar(index)
     celestia:select(star)
-    obs:goto(star, 10)
+    obs:gotoobject(star, 10)
     wait(10)
 end

--- a/scripts/tour-system.celx
+++ b/scripts/tour-system.celx
@@ -1,7 +1,7 @@
-function goto(o, t)
+function gotoobject(o, t)
     local obs = celestia:getobserver()
     obs:follow(o)
-    obs:goto(o, t)
+    obs:gotoobject(o, t)
         while (obs:travelling()) do
         wait(0)
     end
@@ -11,7 +11,7 @@ function visit(o)
     local i, v
     celestia:select(o)
     celestia:flash(o:type() .. " - " .. o:name())
-    goto(o, 3)
+    gotoobject(o, 3)
     wait(0.5)
     local children = o:getchildren()
     for i, v in ipairs(children) do

--- a/scripts/tour-system.celx
+++ b/scripts/tour-system.celx
@@ -1,3 +1,5 @@
+-- Title: Tour around Solar system objects
+
 function gotoobject(o, t)
     local obs = celestia:getobserver()
     obs:follow(o)

--- a/scripts/z-dist.celx
+++ b/scripts/z-dist.celx
@@ -20,7 +20,7 @@ end
 
 function rgb2hex(r,g,b)
    -- Converts color code from RGB to Hex
-   local hex = string.format("#%.2x%.2x%.2x", r,g,b)
+   local hex = string.format("#%.2x%.2x%.2x", math.floor(r), math.floor(g), math.floor(b))
    return hex
 end
 

--- a/src/celengine/scriptobject.h
+++ b/src/celengine/scriptobject.h
@@ -13,18 +13,10 @@
 #define _CELENGINE_SCRIPTOBJECT_H_
 
 #ifndef LUA_VER
-#define LUA_VER 0x050000
+#define LUA_VER 0x050100
 #endif
 
-#if LUA_VER >= 0x050100
 #include "lua.hpp"
-#else
-extern "C" {
-#include "lua.h"
-#include "lualib.h"
-}
-#endif
-
 #include <string>
 #include <celengine/parser.h>
 

--- a/src/celengine/scriptorbit.cpp
+++ b/src/celengine/scriptorbit.cpp
@@ -73,8 +73,7 @@ ScriptedOrbit::initialize(const std::string& moduleName,
 
     if (!moduleName.empty())
     {
-        lua_pushstring(luaState, "require");
-        lua_gettable(luaState, LUA_GLOBALSINDEX);
+        lua_getglobal(luaState, "require");
         if (!lua_isfunction(luaState, -1))
         {
             clog << "Cannot load ScriptedOrbit package: 'require' function is unavailable\n";
@@ -92,8 +91,7 @@ ScriptedOrbit::initialize(const std::string& moduleName,
     }
 
     // Get the orbit generator function
-    lua_pushstring(luaState, funcName.c_str());
-    lua_gettable(luaState, LUA_GLOBALSINDEX);
+    lua_getglobal(luaState, funcName.c_str());
 
     if (lua_isfunction(luaState, -1) == 0)
     {
@@ -157,9 +155,8 @@ ScriptedOrbit::initialize(const std::string& moduleName,
     luaOrbitObjectName = GenerateScriptObjectName();
 
     // Attach the name to the script orbit
-    lua_pushstring(luaState, luaOrbitObjectName.c_str());
     lua_pushvalue(luaState, -2); // dup the orbit object on top of stack
-    lua_settable(luaState, LUA_GLOBALSINDEX);
+    lua_setglobal(luaState, luaOrbitObjectName.c_str());
 
     // Now, call orbit object methods to get the bounding radius
     // and valid time range.
@@ -206,8 +203,7 @@ ScriptedOrbit::computePosition(double tjd) const
 {
     Point3d pos(0.0, 0.0, 0.0);
 
-    lua_pushstring(luaState, luaOrbitObjectName.c_str());
-    lua_gettable(luaState, LUA_GLOBALSINDEX);
+    lua_getglobal(luaState, luaOrbitObjectName.c_str());
     if (lua_istable(luaState, -1))
     {
         lua_pushstring(luaState, "position");

--- a/src/celengine/scriptrotation.cpp
+++ b/src/celengine/scriptrotation.cpp
@@ -74,8 +74,7 @@ ScriptedRotation::initialize(const std::string& moduleName,
 
     if (!moduleName.empty())
     {
-        lua_pushstring(luaState, "require");
-        lua_gettable(luaState, LUA_GLOBALSINDEX);
+        lua_getglobal(luaState, "require");
         if (!lua_isfunction(luaState, -1))
         {
             clog << "Cannot load ScriptedRotation package: 'require' function is unavailable\n";
@@ -93,8 +92,7 @@ ScriptedRotation::initialize(const std::string& moduleName,
     }
 
     // Get the rotation generator function
-    lua_pushstring(luaState, funcName.c_str());
-    lua_gettable(luaState, LUA_GLOBALSINDEX);
+    lua_getglobal(luaState, funcName.c_str());
 
     if (lua_isfunction(luaState, -1) == 0)
     {
@@ -131,9 +129,8 @@ ScriptedRotation::initialize(const std::string& moduleName,
     luaRotationObjectName = GenerateScriptObjectName();
 
     // Attach the name to the script rotation
-    lua_pushstring(luaState, luaRotationObjectName.c_str());
     lua_pushvalue(luaState, -2); // dup the rotation object on top of stack
-    lua_settable(luaState, LUA_GLOBALSINDEX);
+    lua_setglobal(luaState, luaRotationObjectName.c_str());
 
     // Get the rest of the rotation parameters; they are all optional.
     period          = SafeGetLuaNumber(luaState, -1, "period", 0.0);
@@ -160,8 +157,7 @@ ScriptedRotation::spin(double tjd) const
 {
     if (tjd != lastTime || !cacheable)
     {
-        lua_pushstring(luaState, luaRotationObjectName.c_str());
-        lua_gettable(luaState, LUA_GLOBALSINDEX);
+        lua_getglobal(luaState, luaRotationObjectName.c_str());
         if (lua_istable(luaState, -1))
         {
             lua_pushstring(luaState, "orientation");

--- a/src/celestia/celx.cpp
+++ b/src/celestia/celx.cpp
@@ -268,9 +268,13 @@ static void openLuaLibrary(lua_State* l,
                            const char* name,
                            lua_CFunction func)
 {
+#if LUA_VER >= 0x050200
+    luaL_requiref(l, name, func, 1);
+#else
     lua_pushcfunction(l, func);
     lua_pushstring(l, name);
     lua_call(l, 1, 0);
+#endif
 }
 #endif
 
@@ -297,8 +301,13 @@ static void getField(lua_State* l, int index, const char* key)
     // When we move to Lua 5.1, this will be replaced by:
     // lua_getfield(l, index, key);
     lua_pushstring(l, key);
-
-    if (index != LUA_GLOBALSINDEX && index != LUA_REGISTRYINDEX)
+#ifdef LUA_GLOBALSINDEX
+    if (index == LUA_GLOBALSINDEX) {
+      lua_gettable(l, index);
+      return;
+    }
+#endif
+    if (index != LUA_REGISTRYINDEX)
         lua_gettable(l, index - 1);
     else
         lua_gettable(l, index);
@@ -503,7 +512,7 @@ LuaState::LuaState() :
     ioMode(NoIO),
     eventHandlerEnabled(false)
 {
-    state = lua_open();
+    state = luaL_newstate();
     timer = CreateTimer();
     screenshotCount = 0;
 }
@@ -583,8 +592,7 @@ void LuaState::cleanup()
             lua_pop(state,1);
         }
     }
-    lua_pushstring(costate, CleanupCallback);
-    lua_gettable(costate, LUA_GLOBALSINDEX);
+    lua_getglobal(costate, CleanupCallback);
     if (lua_isnil(costate, -1))
     {
         return;
@@ -653,8 +661,11 @@ static int resumeLuaThread(lua_State *L, lua_State *co, int narg)
     //if (!lua_checkstack(co, narg))
     //   luaL_error(L, "too many arguments to resume");
     lua_xmove(L, co, narg);
-
+#if LUA_VER >= 0x050200
+    status = lua_resume(co, NULL, narg);
+#else
     status = lua_resume(co, narg);
+#endif
 #if LUA_VER >= 0x050100
     if (status == 0 || status == LUA_YIELD)
 #else
@@ -768,8 +779,7 @@ bool LuaState::charEntered(const char* c_p)
     int stack_top = lua_gettop(costate);
 #endif
     bool result = true;
-    lua_pushstring(costate, KbdCallback);
-    lua_gettable(costate, LUA_GLOBALSINDEX);
+    lua_getglobal(costate, KbdCallback);
     lua_pushstring(costate, c_p);
     timeout = getTime() + 1.0;
     if (lua_pcall(costate, 1, 1, 0) != 0)
@@ -962,7 +972,12 @@ int LuaState::loadScript(istream& in, const string& streamname)
         lua_settable(state, LUA_REGISTRYINDEX);
     }
 
+#if LUA_VER >= 0x050200
+    int status = lua_load(state, readStreamChunk, &info, streamname.c_str(),
+			  NULL);
+#else
     int status = lua_load(state, readStreamChunk, &info, streamname.c_str());
+#endif
     if (status != 0)
         cout << "Error loading script: " << lua_tostring(state, -1) << '\n';
 
@@ -3157,8 +3172,7 @@ static int celestia_requestkeyboard(lua_State* l)
     if (lua_toboolean(l, 2))
     {
         // Check for existence of charEntered:
-        lua_pushstring(l, KbdCallback);
-        lua_gettable(l, LUA_GLOBALSINDEX);
+        lua_getglobal(l, KbdCallback);
         if (lua_isnil(l, -1))
         {
             Celx_DoError(l, "script requested keyboard, but did not provide callback");
@@ -3559,16 +3573,14 @@ bool LuaState::init(CelestiaCore* appCore)
         return false;
     }
 
-    lua_pushstring(state, "KM_PER_MICROLY");
     lua_pushnumber(state, (lua_Number)KM_PER_LY/1e6);
-    lua_settable(state, LUA_GLOBALSINDEX);
+    lua_setglobal(state, "KM_PER_MICROLY");
 
     loadLuaLibs(state);
 
     // Create the celestia object
-    lua_pushstring(state, "celestia");
     celestia_new(state, appCore);
-    lua_settable(state, LUA_GLOBALSINDEX);
+    lua_setglobal(state, "celestia");
     // add reference to appCore in the registry
     lua_pushstring(state, "celestia-appcore");
     lua_pushlightuserdata(state, static_cast<void*>(appCore));
@@ -3583,8 +3595,7 @@ bool LuaState::init(CelestiaCore* appCore)
     lua_settable(state, LUA_REGISTRYINDEX);
 
 #if 0
-    lua_pushstring(state, "dofile");
-    lua_gettable(state, LUA_GLOBALSINDEX); // function "dofile" on stack
+    lua_getglobal(state, "dofile"); // function "dofile" on stack
     lua_pushstring(state, "luainit.celx"); // parameter
     if (lua_pcall(state, 1, 0, 0) != 0) // execute it
     {
@@ -3604,7 +3615,7 @@ bool LuaState::init(CelestiaCore* appCore)
 void LuaState::setLuaPath(const string& s)
 {
 #if LUA_VER >= 0x050100
-    lua_getfield(state, LUA_GLOBALSINDEX, "package");
+    lua_getglobal(state, "package");
     lua_pushstring(state, s.c_str());
     lua_setfield(state, -2, "path");
     lua_pop(state, 1);
@@ -4118,7 +4129,7 @@ void LuaState::allowLuaPackageAccess()
     openLuaLibrary(state, LUA_LOADLIBNAME, luaopen_package);
 
     // Disallow loadlib
-    lua_getfield(state, LUA_GLOBALSINDEX, "package");
+    lua_getglobal(state, "package");
     lua_pushnil(state);
     lua_setfield(state, -2, "loadlib");
     lua_pop(state, 1);

--- a/src/celestia/celx.cpp
+++ b/src/celestia/celx.cpp
@@ -294,24 +294,6 @@ void CelxLua::initMaps()
 }
 
 
-static void getField(lua_State* l, int index, const char* key)
-{
-    // When we move to Lua 5.1, this will be replaced by:
-    // lua_getfield(l, index, key);
-    lua_pushstring(l, key);
-#ifdef LUA_GLOBALSINDEX
-    if (index == LUA_GLOBALSINDEX) {
-      lua_gettable(l, index);
-      return;
-    }
-#endif
-    if (index != LUA_REGISTRYINDEX)
-        lua_gettable(l, index - 1);
-    else
-        lua_gettable(l, index);
-}
-
-
 // Wrapper for a CEL-script, including the needed Execution Environment
 class CelScriptWrapper : public ExecutionEnvironment
 {
@@ -796,7 +778,7 @@ bool LuaState::handleKeyEvent(const char* key)
     }
 
     // get the registered event table
-    getField(costate, LUA_REGISTRYINDEX, EventHandlers);
+    lua_getfield(costate, LUA_REGISTRYINDEX, EventHandlers);
     if (!lua_istable(costate, -1))
     {
         cerr << "Missing event handler table";
@@ -805,7 +787,7 @@ bool LuaState::handleKeyEvent(const char* key)
     }
 
     bool handled = false;
-    getField(costate, -1, KeyHandler);
+    lua_getfield(costate, -1, KeyHandler);
     if (lua_isfunction(costate, -1))
     {
         lua_remove(costate, -2);        // remove the key event table from the stack
@@ -845,7 +827,7 @@ bool LuaState::handleMouseButtonEvent(float x, float y, int button, bool down)
     }
 
     // get the registered event table
-    getField(costate, LUA_REGISTRYINDEX, EventHandlers);
+    lua_getfield(costate, LUA_REGISTRYINDEX, EventHandlers);
     if (!lua_istable(costate, -1))
     {
         cerr << "Missing event handler table";
@@ -854,7 +836,7 @@ bool LuaState::handleMouseButtonEvent(float x, float y, int button, bool down)
     }
 
     bool handled = false;
-    getField(costate, -1, down ? MouseDownHandler : MouseUpHandler);
+    lua_getfield(costate, -1, down ? MouseDownHandler : MouseUpHandler);
     if (lua_isfunction(costate, -1))
     {
         lua_remove(costate, -2);        // remove the key event table from the stack
@@ -903,7 +885,7 @@ bool LuaState::handleTickEvent(double dt)
     }
 
     // get the registered event table
-    getField(costate, LUA_REGISTRYINDEX, EventHandlers);
+    lua_getfield(costate, LUA_REGISTRYINDEX, EventHandlers);
     if (!lua_istable(costate, -1))
     {
         cerr << "Missing event handler table";
@@ -912,7 +894,7 @@ bool LuaState::handleTickEvent(double dt)
     }
 
     bool handled = false;
-    getField(costate, -1, TickHandler);
+    lua_getfield(costate, -1, TickHandler);
     if (lua_isfunction(costate, -1))
     {
         lua_remove(costate, -2);        // remove the key event table from the stack

--- a/src/celestia/celx.cpp
+++ b/src/celestia/celx.cpp
@@ -512,7 +512,11 @@ LuaState::LuaState() :
     ioMode(NoIO),
     eventHandlerEnabled(false)
 {
+#if LUA_VER >= 0x050100
     state = luaL_newstate();
+#else
+    state = lua_open();
+#endif
     timer = CreateTimer();
     screenshotCount = 0;
 }
@@ -3548,6 +3552,9 @@ bool LuaState::init(CelestiaCore* appCore)
     openLuaLibrary(state, LUA_MATHLIBNAME, luaopen_math);
     openLuaLibrary(state, LUA_TABLIBNAME, luaopen_table);
     openLuaLibrary(state, LUA_STRLIBNAME, luaopen_string);
+#if LUA_VER >= 0x050200
+    openLuaLibrary(state, LUA_COLIBNAME, luaopen_coroutine);
+#endif
     // Make the package library, except the loadlib function, available
     // for celx regardless of script system access policy.
 		allowLuaPackageAccess();

--- a/src/celestia/celx.cpp
+++ b/src/celestia/celx.cpp
@@ -915,6 +915,9 @@ bool LuaState::handleMouseButtonEvent(float x, float y, int button, bool down)
 // Returns true if a handler is registered for the tick event
 bool LuaState::handleTickEvent(double dt)
 {
+    if (!costate)
+        return true;
+
     CelestiaCore* appCore = getAppCore(costate, NoErrors);
     if (appCore == NULL)
     {

--- a/src/celestia/celx.cpp
+++ b/src/celestia/celx.cpp
@@ -3343,7 +3343,7 @@ static int celestia_requestsystemaccess(lua_State* l)
 static int celestia_getscriptpath(lua_State* l)
 {
     // ignore possible argument for future extensions
-    Celx_CheckArgs(l, 1, 1, "No argument expected for celestia:requestsystemaccess()");
+    Celx_CheckArgs(l, 1, 1, "No argument expected for celestia:getscriptpath()");
     this_celestia(l);
     lua_pushstring(l, "celestia-scriptpath");
     lua_gettable(l, LUA_REGISTRYINDEX);

--- a/src/celestia/celx.h
+++ b/src/celestia/celx.h
@@ -16,20 +16,16 @@
 #include <string>
 
 #ifndef LUA_VER
-#define LUA_VER 0x050000
+#define LUA_VER 0x050100
 #endif
 
-#if LUA_VER >= 0x050100
 #include "lua.hpp"
-#else
-extern "C" {
-#include "lua.h"
-#include "lualib.h"
-}
-#endif
-
 #include <celutil/timer.h>
 #include <celengine/observer.h>
+
+#if LUA_VER < 0x050300
+int lua_isinteger(lua_State *L, int index);
+#endif
 
 class CelestiaCore;
 class View;

--- a/src/celestia/celx_gl.cpp
+++ b/src/celestia/celx_gl.cpp
@@ -221,7 +221,6 @@ static int gl_PushMatrix(lua_State* l)
 void LoadLuaGraphicsLibrary(lua_State* l)
 {
     CelxLua celx(l);
-    lua_pushstring(l, "gl");
     lua_newtable(l);
     
     celx.registerMethod("Frustum", gl_Frustum);
@@ -259,11 +258,10 @@ void LoadLuaGraphicsLibrary(lua_State* l)
     celx.registerValue("NEAREST", GL_NEAREST);
     celx.registerValue("SRC_ALPHA", GL_SRC_ALPHA);
     celx.registerValue("ONE_MINUS_SRC_ALPHA", GL_ONE_MINUS_SRC_ALPHA);
-    lua_settable(l, LUA_GLOBALSINDEX);
+    lua_setglobal(l, "gl");
     
-    lua_pushstring(l, "glu");
     lua_newtable(l);
     celx.registerMethod("LookAt", glu_LookAt);
     celx.registerMethod("Ortho2D", glu_Ortho2D);
-    lua_settable(l, LUA_GLOBALSINDEX);
+    lua_setglobal(l, "glu");
 }

--- a/src/celestia/celx_observer.cpp
+++ b/src/celestia/celx_observer.cpp
@@ -895,7 +895,10 @@ void CreateObserverMetaTable(lua_State* l)
     
     celx.registerMethod("__tostring", observer_tostring);
     celx.registerMethod("isvalid", observer_isvalid);
+#if LUA_VER < 0x050200
     celx.registerMethod("goto", observer_goto);
+#endif
+    celx.registerMethod("gotoobject", observer_goto);
     celx.registerMethod("gotolonglat", observer_gotolonglat);
     celx.registerMethod("gotolocation", observer_gotolocation);
     celx.registerMethod("gotodistance", observer_gotodistance);


### PR DESCRIPTION
1. Add 5.2 and 5.3
1. Drop 5.0

Except 5caaff9 and 5424902 these commits are backported from master. 5caaff9 is taken from a fedora29 patch and it's based on comments present in the original code.

Dunno if bd51baf and 85fa5dd should be backported as well.