### PR TITLE
Fix bad translations of Sol into Seoul

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -1885,7 +1885,7 @@ msgstr "&تحديد"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "سول"
+msgstr "زحل"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/bg.po
+++ b/po/bg.po
@@ -1862,7 +1862,7 @@ msgstr "&Маркирай"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Сеул"
+msgstr "Слънце"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/de.po
+++ b/po/de.po
@@ -1855,7 +1855,7 @@ msgstr "&Markierung setzen"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seoul"
+msgstr "Sonne"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/el.po
+++ b/po/el.po
@@ -1851,7 +1851,7 @@ msgstr "&Σημείωση"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Σεούλ"
+msgstr "Ήλιος"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/es.po
+++ b/po/es.po
@@ -1852,7 +1852,7 @@ msgstr "&Marcar"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seúl"
+msgstr "Sol"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/fr.po
+++ b/po/fr.po
@@ -1855,7 +1855,7 @@ msgstr "&Marquer"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Séoul"
+msgstr "Soleil"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/gl.po
+++ b/po/gl.po
@@ -1859,7 +1859,7 @@ msgstr "&Marcar"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seúl"
+msgstr "Sol"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/hu.po
+++ b/po/hu.po
@@ -1854,7 +1854,7 @@ msgstr "Jelöl"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Szöul"
+msgstr "Nap"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/it.po
+++ b/po/it.po
@@ -1858,7 +1858,7 @@ msgstr "Marca (&M) "
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seoul"
+msgstr "Sole"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/ja.po
+++ b/po/ja.po
@@ -1850,7 +1850,7 @@ msgstr "マーカー(&M)"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "ソウル"
+msgstr "太陽"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/ko.po
+++ b/po/ko.po
@@ -1852,7 +1852,7 @@ msgstr "마커(&M)"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "서울"
+msgstr "태양"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/lt.po
+++ b/po/lt.po
@@ -1846,7 +1846,7 @@ msgstr "&Žymėti"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seulas"
+msgstr "Saulė"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/lv.po
+++ b/po/lv.po
@@ -1852,7 +1852,7 @@ msgstr "&Iezīmēt"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seula"
+msgstr "Saule"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/nb.po
+++ b/po/nb.po
@@ -1851,7 +1851,7 @@ msgstr "&Merk"
 
 #: src/celestia/gtk/menu-context.cpp:377
 msgid "Sol"
-msgstr ""
+msgstr "Solen"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/nl.po
+++ b/po/nl.po
@@ -1849,7 +1849,7 @@ msgstr "&Markeer"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seoul"
+msgstr "Zon"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/no.po
+++ b/po/no.po
@@ -1854,7 +1854,7 @@ msgstr "&Marker"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seoul"
+msgstr "Sol"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/pl.po
+++ b/po/pl.po
@@ -1849,7 +1849,7 @@ msgstr "&Zaznacz"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seul"
+msgstr "słońce"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/pt.po
+++ b/po/pt.po
@@ -1852,7 +1852,7 @@ msgstr "&Marcar"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seul"
+msgstr "Sol"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1852,7 +1852,7 @@ msgstr "&Marcar"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seul"
+msgstr "Sol"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/ro.po
+++ b/po/ro.po
@@ -1849,7 +1849,7 @@ msgstr "&Marchează"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seul"
+msgstr "Soare"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/ru.po
+++ b/po/ru.po
@@ -1852,7 +1852,7 @@ msgstr "Поставить &метку"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Сеул"
+msgstr "Солнце"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/sk.po
+++ b/po/sk.po
@@ -1857,7 +1857,7 @@ msgstr "&Označiť"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Soul"
+msgstr "Slnko"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/sv.po
+++ b/po/sv.po
@@ -1849,7 +1849,7 @@ msgstr "&Markera"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seoul"
+msgstr "Sol"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/tr.po
+++ b/po/tr.po
@@ -1831,7 +1831,7 @@ msgstr ""
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Seoul"
+msgstr "Güneş"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/uk.po
+++ b/po/uk.po
@@ -1854,7 +1854,7 @@ msgstr "&Позначити"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "Сеул"
+msgstr "Сонце"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1847,7 +1847,7 @@ msgstr "标记(&M)"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "首尔"
+msgstr "太阳"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1844,7 +1844,7 @@ msgstr "標示(&M)"
 #: src/celestia/gtk/menu-context.cpp:377
 #, fuzzy
 msgid "Sol"
-msgstr "首爾"
+msgstr "太陽"
 
 #: src/celestia/gtk/menu-context.cpp:410
 #: src/celestia/kde/selectionpopup.cpp:359


### PR DESCRIPTION
In several languages "Sol" entry of src/celestia/gtk/menu-context.cpp has been translated into "Seoul".

I took the translated text of "Sun" of src/celestia/celestiacore.cpp to fix this for all languages.