### PR TITLE
Make options maps common to all scripts

### DIFF
--- a/src/celestia/CMakeLists.txt
+++ b/src/celestia/CMakeLists.txt
@@ -35,6 +35,7 @@ elseif(_UNIX AND ENABLE_THEORA)
 endif()
 
 add_library(celestia STATIC ${CELESTIA_SOURCES}
+                            $<TARGET_OBJECTS:celcommonscript>
                             $<TARGET_OBJECTS:cellegacyscript>
                             $<TARGET_OBJECTS:celluascript>)
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -66,6 +66,7 @@
 using namespace Eigen;
 using namespace std;
 using namespace celmath;
+using namespace celestia::scripts;
 
 static const int DragThreshold = 3;
 
@@ -177,7 +178,8 @@ CelestiaCore::CelestiaCore() :
        routine will be called much later. */
     renderer(new Renderer()),
     timer(new Timer()),
-    execEnv(new CoreExecutionEnvironment(*this))
+    execEnv(new CoreExecutionEnvironment(*this)),
+    m_scriptMaps(make_shared<ScriptMaps>())
 {
 
     for (int i = 0; i < KeyCount; i++)
@@ -361,7 +363,7 @@ void CelestiaCore::runScript(const fs::path& filename)
         }
         else
         {
-            CommandParser parser(scriptfile);
+            CommandParser parser(scriptfile, m_scriptMaps);
             CommandSequence* script = parser.parse();
             if (script == nullptr)
             {
@@ -4709,4 +4711,21 @@ void CelestiaCore::setTypedText(const char *c_p)
             typedText = typedTextCompletion[0];
     }
 #endif
+}
+
+vector<Observer*> CelestiaCore::getObservers() const
+{
+    vector<Observer*> observerList;
+    for (const auto view : views)
+        if (view->type == View::ViewWindow)
+            observerList.push_back(view->observer);
+    return observerList;
+}
+
+View* CelestiaCore::getViewByObserver(const Observer *obs) const
+{
+    for (const auto view : views)
+         if (view->observer == obs)
+             return view;
+    return nullptr;
 }

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -31,6 +31,8 @@
 #ifdef CELX
 #include <celscript/lua/celx.h>
 #endif
+#include <celscript/common/scriptmaps.h>
+
 class Url;
 
 // class CelestiaWatcher;
@@ -52,7 +54,8 @@ public:
 class CelestiaCore // : public Watchable<CelestiaCore>
 {
  public:
-    enum {
+    enum
+    {
         LeftButton   = 0x01,
         MiddleButton = 0x02,
         RightButton  = 0x04,
@@ -60,7 +63,8 @@ class CelestiaCore // : public Watchable<CelestiaCore>
         ControlKey   = 0x10,
     };
 
-    enum CursorShape {
+    enum CursorShape
+    {
         ArrowCursor         = 0,
         UpArrowCursor       = 1,
         CrossCursor         = 2,
@@ -80,13 +84,15 @@ class CelestiaCore // : public Watchable<CelestiaCore>
         WhatsThisCursor     = 16,
     };
 
-    enum {
+    enum
+    {
         Joy_XAxis           = 0,
         Joy_YAxis           = 1,
         Joy_ZAxis           = 2,
     };
 
-    enum {
+    enum
+    {
         JoyButton1          = 0,
         JoyButton2          = 1,
         JoyButton3          = 2,
@@ -98,7 +104,8 @@ class CelestiaCore // : public Watchable<CelestiaCore>
         JoyButtonCount      = 8,
     };
 
-    enum {
+    enum
+    {
         Key_Left            =  1,
         Key_Right           =  2,
         Key_Up              =  3,
@@ -258,6 +265,8 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     void setFaintest(float);
     void setFaintestAutoMag();
 
+    std::vector<Observer*> getObservers() const;
+    View* getViewByObserver(const Observer*) const;
     void splitView(View::Type type, View* av = nullptr, float splitPos = 0.5f);
     void singleView(View* av = nullptr);
     void deleteView(View* v = nullptr);
@@ -325,6 +334,8 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     const std::string& getTypedText() const { return typedText; }
     void setTypedText(const char *);
 
+    const std::shared_ptr<celestia::scripts::ScriptMaps>& scriptMaps() const { return m_scriptMaps; }
+
  protected:
     bool readStars(const CelestiaConfig&, ProgressNotifier*);
     void renderOverlay();
@@ -389,6 +400,7 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     LuaState* luaHook{ nullptr };     // Lua hook context
     LuaState* luaSandbox{ nullptr };  // Safe Lua context for ssc scripts
 #endif // CELX
+    std::shared_ptr<celestia::scripts::ScriptMaps> m_scriptMaps;
 
     enum ScriptState
     {

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -2925,7 +2925,7 @@ static void HandleOpenScript(HWND hWnd, CelestiaCore* appCore)
             }
             else
             {
-                CommandParser parser(scriptfile);
+                CommandParser parser(scriptfile, appCore->scriptMaps());
                 CommandSequence* script = parser.parse();
                 if (script == NULL)
                 {
@@ -4025,7 +4025,7 @@ LRESULT CALLBACK MainWindowProc(HWND hWnd,
                         {
                             // TODO: Need to fix memory leak with scripts;
                             // a refcount is probably required.
-                            CommandParser parser(scriptfile);
+                            CommandParser parser(scriptfile, appCore->scriptMaps());
                             CommandSequence* script = parser.parse();
                             if (script == NULL)
                             {

--- a/src/celscript/CMakeLists.txt
+++ b/src/celscript/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(common)
 add_subdirectory(legacy)
 if(ENABLE_CELX)
   add_subdirectory(lua)

--- a/src/celscript/common/CMakeLists.txt
+++ b/src/celscript/common/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(SCRIPT_COMMON_SOURCES
+  scriptmaps.cpp
+  scriptmaps.h
+)
+
+add_library(celcommonscript OBJECT ${SCRIPT_COMMON_SOURCES})

--- a/src/celscript/common/scriptmaps.cpp
+++ b/src/celscript/common/scriptmaps.cpp
@@ -1,0 +1,223 @@
+#include "scriptmaps.h"
+#include <celestia/celestiacore.h>
+#include <celengine/render.h>
+
+namespace celestia
+{
+namespace scripts
+{
+
+void initRenderFlagMap(FlagMap64 &RenderFlagMap)
+{
+    RenderFlagMap["orbits"]              = Renderer::ShowOrbits;
+    RenderFlagMap["fadingorbits"]        = Renderer::ShowFadingOrbits;
+    RenderFlagMap["cloudmaps"]           = Renderer::ShowCloudMaps;
+    RenderFlagMap["constellations"]      = Renderer::ShowDiagrams;
+    RenderFlagMap["galaxies"]            = Renderer::ShowGalaxies;
+    RenderFlagMap["globulars"]           = Renderer::ShowGlobulars;
+    RenderFlagMap["planets"]             = Renderer::ShowPlanets;
+    RenderFlagMap["dwarfplanets"]        = Renderer::ShowDwarfPlanets;
+    RenderFlagMap["moons"]               = Renderer::ShowMoons;
+    RenderFlagMap["minormoons"]          = Renderer::ShowMinorMoons;
+    RenderFlagMap["asteroids"]           = Renderer::ShowAsteroids;
+    RenderFlagMap["comets"]              = Renderer::ShowComets;
+    RenderFlagMap["spasecrafts"]         = Renderer::ShowSpacecrafts;
+    RenderFlagMap["stars"]               = Renderer::ShowStars;
+    RenderFlagMap["nightmaps"]           = Renderer::ShowNightMaps;
+    RenderFlagMap["eclipseshadows"]      = Renderer::ShowEclipseShadows;
+    RenderFlagMap["planetrings"]         = Renderer::ShowPlanetRings;
+    RenderFlagMap["ringshadows"]         = Renderer::ShowRingShadows;
+    RenderFlagMap["comettails"]          = Renderer::ShowCometTails;
+    RenderFlagMap["boundaries"]          = Renderer::ShowBoundaries;
+    RenderFlagMap["markers"]             = Renderer::ShowMarkers;
+    RenderFlagMap["automag"]             = Renderer::ShowAutoMag;
+    RenderFlagMap["atmospheres"]         = Renderer::ShowAtmospheres;
+    RenderFlagMap["grid"]                = Renderer::ShowCelestialSphere;
+    RenderFlagMap["equatorialgrid"]      = Renderer::ShowCelestialSphere;
+    RenderFlagMap["galacticgrid"]        = Renderer::ShowGalacticGrid;
+    RenderFlagMap["eclipticgrid"]        = Renderer::ShowEclipticGrid;
+    RenderFlagMap["horizontalgrid"]      = Renderer::ShowHorizonGrid;
+    RenderFlagMap["smoothlines"]         = Renderer::ShowSmoothLines;
+    RenderFlagMap["partialtrajectories"] = Renderer::ShowPartialTrajectories;
+    RenderFlagMap["nebulae"]             = Renderer::ShowNebulae;
+    RenderFlagMap["openclusters"]        = Renderer::ShowOpenClusters;
+    RenderFlagMap["cloudshadows"]        = Renderer::ShowCloudShadows;
+    RenderFlagMap["ecliptic"]            = Renderer::ShowEcliptic;
+}
+
+void initLabelFlagMap(FlagMap &LabelFlagMap)
+{
+    LabelFlagMap["planets"]              = Renderer::PlanetLabels;
+    LabelFlagMap["dwarfplanets"]         = Renderer::DwarfPlanetLabels;
+    LabelFlagMap["moons"]                = Renderer::MoonLabels;
+    LabelFlagMap["minormoons"]           = Renderer::MinorMoonLabels;
+    LabelFlagMap["spacecraft"]           = Renderer::SpacecraftLabels;
+    LabelFlagMap["asteroids"]            = Renderer::AsteroidLabels;
+    LabelFlagMap["comets"]               = Renderer::CometLabels;
+    LabelFlagMap["constellations"]       = Renderer::ConstellationLabels;
+    LabelFlagMap["stars"]                = Renderer::StarLabels;
+    LabelFlagMap["galaxies"]             = Renderer::GalaxyLabels;
+    LabelFlagMap["globulars"]            = Renderer::GlobularLabels;
+    LabelFlagMap["locations"]            = Renderer::LocationLabels;
+    LabelFlagMap["nebulae"]              = Renderer::NebulaLabels;
+    LabelFlagMap["openclusters"]         = Renderer::OpenClusterLabels;
+    LabelFlagMap["i18nconstellations"]   = Renderer::I18nConstellationLabels;
+}
+
+void initBodyTypeMap(FlagMap &BodyTypeMap)
+{
+    BodyTypeMap["Planet"]                = Body::Planet;
+    BodyTypeMap["DwarfPlanet"]           = Body::DwarfPlanet;
+    BodyTypeMap["Moon"]                  = Body::Moon;
+    BodyTypeMap["MinorMoon"]             = Body::MinorMoon;
+    BodyTypeMap["Asteroid"]              = Body::Asteroid;
+    BodyTypeMap["Comet"]                 = Body::Comet;
+    BodyTypeMap["Spacecraft"]            = Body::Spacecraft;
+    BodyTypeMap["Invisible"]             = Body::Invisible;
+    BodyTypeMap["Star"]                  = Body::Stellar;
+    BodyTypeMap["Unknown"]               = Body::Unknown;
+}
+
+void initLocationFlagMap(FlagMap64 &LocationFlagMap)
+{
+    LocationFlagMap["city"]              = Location::City;
+    LocationFlagMap["observatory"]       = Location::Observatory;
+    LocationFlagMap["landingsite"]       = Location::LandingSite;
+    LocationFlagMap["crater"]            = Location::Crater;
+    LocationFlagMap["vallis"]            = Location::Vallis;
+    LocationFlagMap["mons"]              = Location::Mons;
+    LocationFlagMap["planum"]            = Location::Planum;
+    LocationFlagMap["chasma"]            = Location::Chasma;
+    LocationFlagMap["patera"]            = Location::Patera;
+    LocationFlagMap["mare"]              = Location::Mare;
+    LocationFlagMap["rupes"]             = Location::Rupes;
+    LocationFlagMap["tessera"]           = Location::Tessera;
+    LocationFlagMap["regio"]             = Location::Regio;
+    LocationFlagMap["chaos"]             = Location::Chaos;
+    LocationFlagMap["terra"]             = Location::Terra;
+    LocationFlagMap["volcano"]           = Location::EruptiveCenter;
+    LocationFlagMap["astrum"]            = Location::Astrum;
+    LocationFlagMap["corona"]            = Location::Corona;
+    LocationFlagMap["dorsum"]            = Location::Dorsum;
+    LocationFlagMap["fossa"]             = Location::Fossa;
+    LocationFlagMap["catena"]            = Location::Catena;
+    LocationFlagMap["mensa"]             = Location::Mensa;
+    LocationFlagMap["rima"]              = Location::Rima;
+    LocationFlagMap["undae"]             = Location::Undae;
+    LocationFlagMap["tholus"]            = Location::Tholus;
+    LocationFlagMap["reticulum"]         = Location::Reticulum;
+    LocationFlagMap["planitia"]          = Location::Planitia;
+    LocationFlagMap["linea"]             = Location::Linea;
+    LocationFlagMap["fluctus"]           = Location::Fluctus;
+    LocationFlagMap["farrum"]            = Location::Farrum;
+    LocationFlagMap["insula"]            = Location::Insula;
+    LocationFlagMap["albedo"]            = Location::Albedo;
+    LocationFlagMap["arcus"]             = Location::Arcus;
+    LocationFlagMap["cavus"]             = Location::Cavus;
+    LocationFlagMap["colles"]            = Location::Colles;
+    LocationFlagMap["facula"]            = Location::Facula;
+    LocationFlagMap["flexus"]            = Location::Flexus;
+    LocationFlagMap["flumen"]            = Location::Flumen;
+    LocationFlagMap["fretum"]            = Location::Fretum;
+    LocationFlagMap["labes"]             = Location::Labes;
+    LocationFlagMap["labyrinthus"]       = Location::Labyrinthus;
+    LocationFlagMap["lacuna"]            = Location::Lacuna;
+    LocationFlagMap["lacus"]             = Location::Lacus;
+    LocationFlagMap["largeringed"]       = Location::LargeRinged;
+    LocationFlagMap["lenticula"]         = Location::Lenticula;
+    LocationFlagMap["lingula"]           = Location::Lingula;
+    LocationFlagMap["macula"]            = Location::Macula;
+    LocationFlagMap["oceanus"]           = Location::Oceanus;
+    LocationFlagMap["palus"]             = Location::Palus;
+    LocationFlagMap["plume"]             = Location::Plume;
+    LocationFlagMap["promontorium"]      = Location::Promontorium;
+    LocationFlagMap["satellite"]         = Location::Satellite;
+    LocationFlagMap["scopulus"]          = Location::Scopulus;
+    LocationFlagMap["serpens"]           = Location::Serpens;
+    LocationFlagMap["sinus"]             = Location::Sinus;
+    LocationFlagMap["sulcus"]            = Location::Sulcus;
+    LocationFlagMap["vastitas"]          = Location::Vastitas;
+    LocationFlagMap["virga"]             = Location::Virga;
+    LocationFlagMap["other"]             = Location::Other;
+    LocationFlagMap["saxum"]             = Location::Saxum;
+    LocationFlagMap["capital"]           = Location::Capital;
+    LocationFlagMap["cosmodrome"]        = Location::Cosmodrome;
+    LocationFlagMap["ring"]              = Location::Ring;
+    LocationFlagMap["historical"]        = Location::Historical;
+}
+
+void initOverlayElementMap(FlagMap &OverlayElementMap)
+{
+    OverlayElementMap["Time"]            = CelestiaCore::ShowTime;
+    OverlayElementMap["Velocity"]        = CelestiaCore::ShowVelocity;
+    OverlayElementMap["Selection"]       = CelestiaCore::ShowSelection;
+    OverlayElementMap["Frame"]           = CelestiaCore::ShowFrame;
+}
+
+void initOrbitVisibilityMap(FlagMap &OrbitVisibilityMap)
+{
+    OrbitVisibilityMap["never"]          = Body::NeverVisible;
+    OrbitVisibilityMap["normal"]         = Body::UseClassVisibility;
+    OrbitVisibilityMap["always"]         = Body::AlwaysVisible;
+}
+
+void initLabelColorMap(ColorMap &LabelColorMap)
+{
+    LabelColorMap["stars"]               = &Renderer::StarLabelColor;
+    LabelColorMap["planets"]             = &Renderer::PlanetLabelColor;
+    LabelColorMap["dwarfplanets"]        = &Renderer::DwarfPlanetLabelColor;
+    LabelColorMap["moons"]               = &Renderer::MoonLabelColor;
+    LabelColorMap["minormoons"]          = &Renderer::MinorMoonLabelColor;
+    LabelColorMap["asteroids"]           = &Renderer::AsteroidLabelColor;
+    LabelColorMap["comets"]              = &Renderer::CometLabelColor;
+    LabelColorMap["spacecraft"]          = &Renderer::SpacecraftLabelColor;
+    LabelColorMap["locations"]           = &Renderer::LocationLabelColor;
+    LabelColorMap["galaxies"]            = &Renderer::GalaxyLabelColor;
+    LabelColorMap["globulars"]           = &Renderer::GlobularLabelColor;
+    LabelColorMap["nebulae"]             = &Renderer::NebulaLabelColor;
+    LabelColorMap["openclusters"]        = &Renderer::OpenClusterLabelColor;
+    LabelColorMap["constellations"]      = &Renderer::ConstellationLabelColor;
+    LabelColorMap["equatorialgrid"]      = &Renderer::EquatorialGridLabelColor;
+    LabelColorMap["galacticgrid"]        = &Renderer::GalacticGridLabelColor;
+    LabelColorMap["eclipticgrid"]        = &Renderer::EclipticGridLabelColor;
+    LabelColorMap["horizontalgrid"]      = &Renderer::HorizonGridLabelColor;
+    LabelColorMap["planetographicgrid"]  = &Renderer::PlanetographicGridLabelColor;
+
+}
+
+void initLineColorMap(ColorMap &LineColorMap)
+{
+    LineColorMap["starorbits"]           = &Renderer::StarOrbitColor;
+    LineColorMap["planetorbits"]         = &Renderer::PlanetOrbitColor;
+    LineColorMap["dwarfplanetorbits"]    = &Renderer::DwarfPlanetOrbitColor;
+    LineColorMap["moonorbits"]           = &Renderer::MoonOrbitColor;
+    LineColorMap["minormoonorbits"]      = &Renderer::MinorMoonOrbitColor;
+    LineColorMap["asteroidorbits"]       = &Renderer::AsteroidOrbitColor;
+    LineColorMap["cometorbits"]          = &Renderer::CometOrbitColor;
+    LineColorMap["spacecraftorbits"]     = &Renderer::SpacecraftOrbitColor;
+    LineColorMap["constellations"]       = &Renderer::ConstellationColor;
+    LineColorMap["boundaries"]           = &Renderer::BoundaryColor;
+    LineColorMap["equatorialgrid"]       = &Renderer::EquatorialGridColor;
+    LineColorMap["galacticgrid"]         = &Renderer::GalacticGridColor;
+    LineColorMap["eclipticgrid"]         = &Renderer::EclipticGridColor;
+    LineColorMap["horizontalgrid"]       = &Renderer::HorizonGridColor;
+    LineColorMap["planetographicgrid"]   = &Renderer::PlanetographicGridColor;
+    LineColorMap["planetequator"]        = &Renderer::PlanetEquatorColor;
+    LineColorMap["ecliptic"]             = &Renderer::EclipticColor;
+    LineColorMap["selectioncursor"]      = &Renderer::SelectionCursorColor;
+}
+
+ScriptMaps::ScriptMaps()
+{
+    initRenderFlagMap(RenderFlagMap);
+    initLabelFlagMap(LabelFlagMap);
+    initBodyTypeMap(BodyTypeMap);
+    initLocationFlagMap(LocationFlagMap);
+    initOverlayElementMap(OverlayElementMap);
+    initOrbitVisibilityMap(OrbitVisibilityMap);
+    initLabelColorMap(LabelColorMap);
+    initLineColorMap(LineColorMap);
+}
+
+}
+}

--- a/src/celscript/common/scriptmaps.h
+++ b/src/celscript/common/scriptmaps.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <celutil/color.h>
+
+namespace celestia
+{
+namespace scripts
+{
+// String to flag mappings
+typedef std::map<std::string, uint32_t> FlagMap;
+typedef std::map<std::string, uint64_t> FlagMap64;
+typedef std::map<std::string, Color*>   ColorMap;
+
+class ScriptMaps
+{
+ public:
+    ScriptMaps();
+    ~ScriptMaps() = default;
+    ScriptMaps(const ScriptMaps&) = delete;
+    ScriptMaps(ScriptMaps&&) = delete;
+    ScriptMaps& operator=(const ScriptMaps&) = delete;
+    ScriptMaps& operator=(ScriptMaps&&) = delete;
+
+    FlagMap64 RenderFlagMap;
+    FlagMap   LabelFlagMap;
+    FlagMap64 LocationFlagMap;
+    FlagMap   BodyTypeMap;
+    FlagMap   OverlayElementMap;
+    FlagMap   OrbitVisibilityMap;
+    ColorMap  LineColorMap;
+    ColorMap  LabelColorMap;
+};
+}
+}

--- a/src/celscript/legacy/cmdparser.h
+++ b/src/celscript/legacy/cmdparser.h
@@ -13,16 +13,17 @@
 #define _CMDPARSER_H_
 
 #include "command.h"
+#include <iostream>
 #include <celengine/parser.h>
 #include <celengine/render.h>
-#include <iostream>
+#include <celscript/common/scriptmaps.h>
 
 
 class CommandParser
 {
  public:
-    CommandParser(std::istream&);
-    CommandParser(Tokenizer&);
+    CommandParser(std::istream&, const std::shared_ptr<celestia::scripts::ScriptMaps> &sm);
+    CommandParser(Tokenizer&, const std::shared_ptr<celestia::scripts::ScriptMaps> &sm);
     ~CommandParser();
 
     CommandSequence* parse();
@@ -35,6 +36,7 @@ class CommandParser
     Parser* parser;
     Tokenizer* tokenizer;
     std::vector<std::string> errorList;
+    std::shared_ptr<celestia::scripts::ScriptMaps> scriptMaps;
 };
 
 #endif // _CMDPARSER_H_

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -16,9 +16,6 @@
 #endif
 #include <celestia/celestiacore.h>
 #include <celestia/imagecapture.h>
-#ifdef CELX
-#include <celscript/lua/celx_internal.h>
-#endif
 #include <celengine/multitexture.h>
 #include <celutil/util.h>
 #include <celmath/mathlib.h>
@@ -723,18 +720,14 @@ CommandSplitView::CommandSplitView(unsigned int _view, string _splitType, double
 
 void CommandSplitView::process(ExecutionEnvironment& env)
 {
-#ifdef CELX // because of getObservers
-    vector<Observer*> observer_list;
-    getObservers(env.getCelestiaCore(), observer_list);
-
+    vector<Observer*> observer_list = env.getCelestiaCore()->getObservers();
     if (view >= 1 && view <= observer_list.size())
     {
         Observer* obs = observer_list[view - 1];
-        View* view = getViewByObserver(env.getCelestiaCore(), obs);
+        View* view = env.getCelestiaCore()->getViewByObserver(obs);
         View::Type type = (compareIgnoringCase(splitType, "h") == 0) ? View::HorizontalSplit : View::VerticalSplit;
         env.getCelestiaCore()->splitView(type, view, (float)splitPos);
     }
-#endif
 }
 
 
@@ -748,17 +741,14 @@ CommandDeleteView::CommandDeleteView(unsigned int _view) :
 
 void CommandDeleteView::process(ExecutionEnvironment& env)
 {
-#ifdef CELX
-    vector<Observer*> observer_list;
-    getObservers(env.getCelestiaCore(), observer_list);
+    vector<Observer*> observer_list = env.getCelestiaCore()->getObservers();
 
     if (view >= 1 && view <= observer_list.size())
     {
         Observer* obs = observer_list[view - 1];
-        View* view = getViewByObserver(env.getCelestiaCore(), obs);
+        View* view = env.getCelestiaCore()->getViewByObserver(obs);
         env.getCelestiaCore()->deleteView(view);
     }
-#endif
 }
 
 
@@ -767,10 +757,8 @@ void CommandDeleteView::process(ExecutionEnvironment& env)
 
 void CommandSingleView::process(ExecutionEnvironment& env)
 {
-#ifdef CELX
-    View* view = getViewByObserver(env.getCelestiaCore(), env.getSimulation()->getActiveObserver());
+    View* view = env.getCelestiaCore()->getViewByObserver(env.getSimulation()->getActiveObserver());
     env.getCelestiaCore()->singleView(view);
-#endif
 }
 
 
@@ -784,17 +772,14 @@ CommandSetActiveView::CommandSetActiveView(unsigned int _view) :
 
 void CommandSetActiveView::process(ExecutionEnvironment& env)
 {
-#ifdef CELX
-    vector<Observer*> observer_list;
-    getObservers(env.getCelestiaCore(), observer_list);
+    vector<Observer*> observer_list = env.getCelestiaCore()->getObservers();
 
     if (view >= 1 && view <= observer_list.size())
     {
         Observer* obs = observer_list[view - 1];
-        View* view = getViewByObserver(env.getCelestiaCore(), obs);
+        View* view = env.getCelestiaCore()->getViewByObserver(obs);
         env.getCelestiaCore()->setActiveView(view);
     }
-#endif
 }
 
 
@@ -842,18 +827,17 @@ CommandSetLineColor::CommandSetLineColor(string _item, Color _color) :
 {
 }
 
-void CommandSetLineColor::process(ExecutionEnvironment& /* env */)
+void CommandSetLineColor::process(ExecutionEnvironment& env)
 {
-#ifdef CELX
-    if (CelxLua::LineColorMap.count(item) == 0)
+    auto &LineColorMap = env.getCelestiaCore()->scriptMaps()->LineColorMap;
+    if (LineColorMap.count(item) == 0)
     {
         cerr << "Unknown line style: " << item << "\n";
     }
     else
     {
-        *CelxLua::LineColorMap[item] = color;
+        *LineColorMap[item] = color;
     }
-#endif
 }
 
 
@@ -866,18 +850,17 @@ CommandSetLabelColor::CommandSetLabelColor(string _item, Color _color) :
 {
 }
 
-void CommandSetLabelColor::process(ExecutionEnvironment& /* env */)
+void CommandSetLabelColor::process(ExecutionEnvironment& env)
 {
-#ifdef CELX
-    if (CelxLua::LabelColorMap.count(item) == 0)
+    auto &LabelColorMap = env.getCelestiaCore()->scriptMaps()->LabelColorMap;
+    if (LabelColorMap.count(item) == 0)
     {
         cerr << "Unknown label style: " << item << "\n";
     }
     else
     {
-        *CelxLua::LabelColorMap[item] = color;
+        *LabelColorMap[item] = color;
     }
-#endif
 }
 
 

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -62,17 +62,6 @@ const char* CelxLua::ClassNames[] =
     "class_category"
 };
 
-CelxLua::FlagMap64 CelxLua::RenderFlagMap;
-CelxLua::FlagMap CelxLua::LabelFlagMap;
-CelxLua::FlagMap64 CelxLua::LocationFlagMap;
-CelxLua::FlagMap CelxLua::BodyTypeMap;
-CelxLua::FlagMap CelxLua::OverlayElementMap;
-CelxLua::FlagMap CelxLua::OrbitVisibilityMap;
-CelxLua::ColorMap CelxLua::LineColorMap;
-CelxLua::ColorMap CelxLua::LabelColorMap;
-bool CelxLua::mapsInitialized = false;
-
-
 #define CLASS(i) ClassNames[(i)]
 
 // Maximum timeslice a script may run without
@@ -104,208 +93,6 @@ int lua_isinteger(lua_State *L, int index)
 #endif
 
 
-// Initialize various maps from named keywords to numeric flags used within celestia:
-void CelxLua::initRenderFlagMap()
-{
-    RenderFlagMap["orbits"]              = Renderer::ShowOrbits;
-    RenderFlagMap["fadingorbits"]        = Renderer::ShowFadingOrbits;
-    RenderFlagMap["cloudmaps"]           = Renderer::ShowCloudMaps;
-    RenderFlagMap["constellations"]      = Renderer::ShowDiagrams;
-    RenderFlagMap["galaxies"]            = Renderer::ShowGalaxies;
-    RenderFlagMap["globulars"]           = Renderer::ShowGlobulars;
-    RenderFlagMap["planets"]             = Renderer::ShowPlanets;
-    RenderFlagMap["dwarfplanets"]        = Renderer::ShowDwarfPlanets;
-    RenderFlagMap["moons"]               = Renderer::ShowMoons;
-    RenderFlagMap["minormoons"]          = Renderer::ShowMinorMoons;
-    RenderFlagMap["asteroids"]           = Renderer::ShowAsteroids;
-    RenderFlagMap["comets"]              = Renderer::ShowComets;
-    RenderFlagMap["spasecrafts"]         = Renderer::ShowSpacecrafts;
-    RenderFlagMap["stars"]               = Renderer::ShowStars;
-    RenderFlagMap["nightmaps"]           = Renderer::ShowNightMaps;
-    RenderFlagMap["eclipseshadows"]      = Renderer::ShowEclipseShadows;
-    RenderFlagMap["planetrings"]         = Renderer::ShowPlanetRings;
-    RenderFlagMap["ringshadows"]         = Renderer::ShowRingShadows;
-    RenderFlagMap["comettails"]          = Renderer::ShowCometTails;
-    RenderFlagMap["boundaries"]          = Renderer::ShowBoundaries;
-    RenderFlagMap["markers"]             = Renderer::ShowMarkers;
-    RenderFlagMap["automag"]             = Renderer::ShowAutoMag;
-    RenderFlagMap["atmospheres"]         = Renderer::ShowAtmospheres;
-    RenderFlagMap["grid"]                = Renderer::ShowCelestialSphere;
-    RenderFlagMap["equatorialgrid"]      = Renderer::ShowCelestialSphere;
-    RenderFlagMap["galacticgrid"]        = Renderer::ShowGalacticGrid;
-    RenderFlagMap["eclipticgrid"]        = Renderer::ShowEclipticGrid;
-    RenderFlagMap["horizontalgrid"]      = Renderer::ShowHorizonGrid;
-    RenderFlagMap["smoothlines"]         = Renderer::ShowSmoothLines;
-    RenderFlagMap["partialtrajectories"] = Renderer::ShowPartialTrajectories;
-    RenderFlagMap["nebulae"]             = Renderer::ShowNebulae;
-    RenderFlagMap["openclusters"]        = Renderer::ShowOpenClusters;
-    RenderFlagMap["cloudshadows"]        = Renderer::ShowCloudShadows;
-    RenderFlagMap["ecliptic"]            = Renderer::ShowEcliptic;
-}
-
-void CelxLua::initLabelFlagMap()
-{
-    LabelFlagMap["planets"] = Renderer::PlanetLabels;
-    LabelFlagMap["dwarfplanets"] = Renderer::DwarfPlanetLabels;
-    LabelFlagMap["moons"] = Renderer::MoonLabels;
-    LabelFlagMap["minormoons"] = Renderer::MinorMoonLabels;
-    LabelFlagMap["spacecraft"] = Renderer::SpacecraftLabels;
-    LabelFlagMap["asteroids"] = Renderer::AsteroidLabels;
-    LabelFlagMap["comets"] = Renderer::CometLabels;
-    LabelFlagMap["constellations"] = Renderer::ConstellationLabels;
-    LabelFlagMap["stars"] = Renderer::StarLabels;
-    LabelFlagMap["galaxies"] = Renderer::GalaxyLabels;
-    LabelFlagMap["globulars"] = Renderer::GlobularLabels;
-    LabelFlagMap["locations"] = Renderer::LocationLabels;
-    LabelFlagMap["nebulae"] = Renderer::NebulaLabels;
-    LabelFlagMap["openclusters"] = Renderer::OpenClusterLabels;
-    LabelFlagMap["i18nconstellations"] = Renderer::I18nConstellationLabels;
-}
-
-void CelxLua::initBodyTypeMap()
-{
-    BodyTypeMap["Planet"] = Body::Planet;
-    BodyTypeMap["DwarfPlanet"] = Body::DwarfPlanet;
-    BodyTypeMap["Moon"] = Body::Moon;
-    BodyTypeMap["MinorMoon"] = Body::MinorMoon;
-    BodyTypeMap["Asteroid"] = Body::Asteroid;
-    BodyTypeMap["Comet"] = Body::Comet;
-    BodyTypeMap["Spacecraft"] = Body::Spacecraft;
-    BodyTypeMap["Invisible"] = Body::Invisible;
-    BodyTypeMap["Star"] = Body::Stellar;
-    BodyTypeMap["Unknown"] = Body::Unknown;
-}
-
-void CelxLua::initLocationFlagMap()
-{
-    LocationFlagMap["city"] = Location::City;
-    LocationFlagMap["observatory"] = Location::Observatory;
-    LocationFlagMap["landingsite"] = Location::LandingSite;
-    LocationFlagMap["crater"] = Location::Crater;
-    LocationFlagMap["vallis"] = Location::Vallis;
-    LocationFlagMap["mons"] = Location::Mons;
-    LocationFlagMap["planum"] = Location::Planum;
-    LocationFlagMap["chasma"] = Location::Chasma;
-    LocationFlagMap["patera"] = Location::Patera;
-    LocationFlagMap["mare"] = Location::Mare;
-    LocationFlagMap["rupes"] = Location::Rupes;
-    LocationFlagMap["tessera"] = Location::Tessera;
-    LocationFlagMap["regio"] = Location::Regio;
-    LocationFlagMap["chaos"] = Location::Chaos;
-    LocationFlagMap["terra"] = Location::Terra;
-    LocationFlagMap["volcano"] = Location::EruptiveCenter;
-    LocationFlagMap["astrum"] = Location::Astrum;
-    LocationFlagMap["corona"] = Location::Corona;
-    LocationFlagMap["dorsum"] = Location::Dorsum;
-    LocationFlagMap["fossa"] = Location::Fossa;
-    LocationFlagMap["catena"] = Location::Catena;
-    LocationFlagMap["mensa"] = Location::Mensa;
-    LocationFlagMap["rima"] = Location::Rima;
-    LocationFlagMap["undae"] = Location::Undae;
-    LocationFlagMap["tholus"] = Location::Tholus;
-    LocationFlagMap["reticulum"] = Location::Reticulum;
-    LocationFlagMap["planitia"] = Location::Planitia;
-    LocationFlagMap["linea"] = Location::Linea;
-    LocationFlagMap["fluctus"] = Location::Fluctus;
-    LocationFlagMap["farrum"] = Location::Farrum;
-    LocationFlagMap["insula"] = Location::Insula;
-    LocationFlagMap["albedo"] = Location::Albedo;
-    LocationFlagMap["arcus"] = Location::Arcus;
-    LocationFlagMap["cavus"] = Location::Cavus;
-    LocationFlagMap["colles"] = Location::Colles;
-    LocationFlagMap["facula"] = Location::Facula;
-    LocationFlagMap["flexus"] = Location::Flexus;
-    LocationFlagMap["flumen"] = Location::Flumen;
-    LocationFlagMap["fretum"] = Location::Fretum;
-    LocationFlagMap["labes"] = Location::Labes;
-    LocationFlagMap["labyrinthus"] = Location::Labyrinthus;
-    LocationFlagMap["lacuna"] = Location::Lacuna;
-    LocationFlagMap["lacus"] = Location::Lacus;
-    LocationFlagMap["largeringed"] = Location::LargeRinged;
-    LocationFlagMap["lenticula"] = Location::Lenticula;
-    LocationFlagMap["lingula"] = Location::Lingula;
-    LocationFlagMap["macula"] = Location::Macula;
-    LocationFlagMap["oceanus"] = Location::Oceanus;
-    LocationFlagMap["palus"] = Location::Palus;
-    LocationFlagMap["plume"] = Location::Plume;
-    LocationFlagMap["promontorium"] = Location::Promontorium;
-    LocationFlagMap["satellite"] = Location::Satellite;
-    LocationFlagMap["scopulus"] = Location::Scopulus;
-    LocationFlagMap["serpens"] = Location::Serpens;
-    LocationFlagMap["sinus"] = Location::Sinus;
-    LocationFlagMap["sulcus"] = Location::Sulcus;
-    LocationFlagMap["vastitas"] = Location::Vastitas;
-    LocationFlagMap["virga"] = Location::Virga;
-    LocationFlagMap["other"] = Location::Other;
-    LocationFlagMap["saxum"] = Location::Saxum;
-    LocationFlagMap["capital"] = Location::Capital;
-    LocationFlagMap["cosmodrome"] = Location::Cosmodrome;
-    LocationFlagMap["ring"] = Location::Ring;
-    LocationFlagMap["historical"] = Location::Historical;
-}
-
-void CelxLua::initOverlayElementMap()
-{
-    OverlayElementMap["Time"] = CelestiaCore::ShowTime;
-    OverlayElementMap["Velocity"] = CelestiaCore::ShowVelocity;
-    OverlayElementMap["Selection"] = CelestiaCore::ShowSelection;
-    OverlayElementMap["Frame"] = CelestiaCore::ShowFrame;
-}
-
-void CelxLua::initOrbitVisibilityMap()
-{
-    OrbitVisibilityMap["never"] = Body::NeverVisible;
-    OrbitVisibilityMap["normal"] = Body::UseClassVisibility;
-    OrbitVisibilityMap["always"] = Body::AlwaysVisible;
-}
-
-
-void CelxLua::initLabelColorMap()
-{
-    LabelColorMap["stars"]          = &Renderer::StarLabelColor;
-    LabelColorMap["planets"]        = &Renderer::PlanetLabelColor;
-    LabelColorMap["dwarfplanets"]   = &Renderer::DwarfPlanetLabelColor;
-    LabelColorMap["moons"]          = &Renderer::MoonLabelColor;
-    LabelColorMap["minormoons"]     = &Renderer::MinorMoonLabelColor;
-    LabelColorMap["asteroids"]      = &Renderer::AsteroidLabelColor;
-    LabelColorMap["comets"]         = &Renderer::CometLabelColor;
-    LabelColorMap["spacecraft"]     = &Renderer::SpacecraftLabelColor;
-    LabelColorMap["locations"]      = &Renderer::LocationLabelColor;
-    LabelColorMap["galaxies"]       = &Renderer::GalaxyLabelColor;
-    LabelColorMap["globulars"]      = &Renderer::GlobularLabelColor;
-    LabelColorMap["nebulae"]        = &Renderer::NebulaLabelColor;
-    LabelColorMap["openclusters"]   = &Renderer::OpenClusterLabelColor;
-    LabelColorMap["constellations"] = &Renderer::ConstellationLabelColor;
-    LabelColorMap["equatorialgrid"] = &Renderer::EquatorialGridLabelColor;
-    LabelColorMap["galacticgrid"]   = &Renderer::GalacticGridLabelColor;
-    LabelColorMap["eclipticgrid"]   = &Renderer::EclipticGridLabelColor;
-    LabelColorMap["horizontalgrid"] = &Renderer::HorizonGridLabelColor;
-    LabelColorMap["planetographicgrid"] = &Renderer::PlanetographicGridLabelColor;
-}
-
-void CelxLua::initLineColorMap()
-{
-    LineColorMap["starorbits"]       = &Renderer::StarOrbitColor;
-    LineColorMap["planetorbits"]     = &Renderer::PlanetOrbitColor;
-    LineColorMap["dwarfplanetorbits"]= &Renderer::DwarfPlanetOrbitColor;
-    LineColorMap["moonorbits"]       = &Renderer::MoonOrbitColor;
-    LineColorMap["minormoonorbits"]  = &Renderer::MinorMoonOrbitColor;
-    LineColorMap["asteroidorbits"]   = &Renderer::AsteroidOrbitColor;
-    LineColorMap["cometorbits"]      = &Renderer::CometOrbitColor;
-    LineColorMap["spacecraftorbits"] = &Renderer::SpacecraftOrbitColor;
-    LineColorMap["constellations"]   = &Renderer::ConstellationColor;
-    LineColorMap["boundaries"]       = &Renderer::BoundaryColor;
-    LineColorMap["equatorialgrid"]   = &Renderer::EquatorialGridColor;
-    LineColorMap["galacticgrid"]     = &Renderer::GalacticGridColor;
-    LineColorMap["eclipticgrid"]     = &Renderer::EclipticGridColor;
-    LineColorMap["horizontalgrid"]   = &Renderer::HorizonGridColor;
-    LineColorMap["planetographicgrid"] = &Renderer::PlanetographicGridColor;
-    LineColorMap["planetequator"]    = &Renderer::PlanetEquatorColor;
-    LineColorMap["ecliptic"]         = &Renderer::EclipticColor;
-    LineColorMap["selectioncursor"]  = &Renderer::SelectionCursorColor;
-}
-
-
 static void openLuaLibrary(lua_State* l,
                            const char* name,
                            lua_CFunction func)
@@ -318,24 +105,6 @@ static void openLuaLibrary(lua_State* l,
     lua_call(l, 1, 0);
 #endif
 }
-
-
-void CelxLua::initMaps()
-{
-    if (!mapsInitialized)
-    {
-        initRenderFlagMap();
-        initLabelFlagMap();
-        initBodyTypeMap();
-        initLocationFlagMap();
-        initOverlayElementMap();
-        initOrbitVisibilityMap();
-        initLabelColorMap();
-        initLineColorMap();
-    }
-    mapsInitialized = true;
-}
-
 
 // Push a class name onto the Lua stack
 void PushClass(lua_State* l, int id)
@@ -1260,8 +1029,6 @@ static void loadLuaLibs(lua_State* state);
 // ==================== Initialization ====================
 bool LuaState::init(CelestiaCore* appCore)
 {
-    CelxLua::initMaps();
-
     // Import the base, table, string, and math libraries
     openLuaLibrary(state, "", luaopen_base);
     openLuaLibrary(state, LUA_MATHLIBNAME, luaopen_math);

--- a/src/celscript/lua/celx_internal.h
+++ b/src/celscript/lua/celx_internal.h
@@ -328,32 +328,6 @@ public:
     }
 
     LuaState* getLuaStateObject();
-
-    // String to flag mappings
-    typedef std::map<std::string, uint32_t> FlagMap;
-    typedef std::map<std::string, uint64_t> FlagMap64;
-    typedef std::map<std::string, Color*> ColorMap;
-
-    static void initMaps();
-    static void initRenderFlagMap();
-    static void initLabelFlagMap();
-    static void initBodyTypeMap();
-    static void initLocationFlagMap();
-    static void initOverlayElementMap();
-    static void initOrbitVisibilityMap();
-    static void initLabelColorMap();
-    static void initLineColorMap();
-
-    static FlagMap64 RenderFlagMap;
-    static FlagMap LabelFlagMap;
-    static FlagMap64 LocationFlagMap;
-    static FlagMap BodyTypeMap;
-    static FlagMap OverlayElementMap;
-    static FlagMap OrbitVisibilityMap;
-    static ColorMap LineColorMap;
-    static ColorMap LabelColorMap;
-    static bool mapsInitialized;
-
     static const char* ClassNames[];
 
 private:

--- a/src/celscript/lua/celx_misc.cpp
+++ b/src/celscript/lua/celx_misc.cpp
@@ -6,6 +6,8 @@
 #include <celscript/legacy/execution.h>
 #include <celestia/celestiacore.h>
 
+using namespace celestia::scripts;
+
 LuaState *getLuaStateObject(lua_State*);
 
 // Wrapper for a CEL-script, including the needed Execution Environment
@@ -15,7 +17,7 @@ class CelScriptWrapper : public ExecutionEnvironment
     CelScriptWrapper(CelestiaCore& appCore, istream& scriptfile):
         core(appCore)
     {
-        CommandParser parser(scriptfile);
+        CommandParser parser(scriptfile, appCore.scriptMaps());
         cmdSequence = parser.parse();
         if (cmdSequence != nullptr)
         {

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -21,6 +21,7 @@
 #include <celengine/planetgrid.h>
 #include <celengine/multitexture.h>
 #include <celestia/celestiacore.h>
+#include <celscript/common/scriptmaps.h>
 
 using namespace Eigen;
 using namespace std;
@@ -258,13 +259,14 @@ static int object_setorbitvisibility(lua_State* l)
     string key;
     key = lua_tostring(l, 2);
 
-    if (CelxLua::OrbitVisibilityMap.count(key) == 0)
+    auto &OrbitVisibilityMap = celx.appCore(AllErrors)->scriptMaps()->OrbitVisibilityMap;
+    if (OrbitVisibilityMap.count(key) == 0)
     {
         cerr << "Unknown visibility policy: " << key << endl;
     }
     else
     {
-        Body::VisibilityPolicy visibility = static_cast<Body::VisibilityPolicy>(CelxLua::OrbitVisibilityMap[key]);
+        auto visibility = static_cast<Body::VisibilityPolicy>(OrbitVisibilityMap[key]);
 
         if (sel->body() != nullptr)
         {
@@ -705,10 +707,11 @@ static int object_getinfo(lua_State* l)
 
         uint32_t featureType = location->getFeatureType();
         string featureName("Unknown");
-        auto iter = std::find_if(CelxLua::LocationFlagMap.begin(),
-                                 CelxLua::LocationFlagMap.end(),
+        auto &LocationFlagMap = celx.appCore(AllErrors)->scriptMaps()->LocationFlagMap;
+        auto iter = std::find_if(LocationFlagMap.begin(),
+                                 LocationFlagMap.end(),
                                  [&featureType](pair<const string, uint64_t>& it){ return it.second == featureType; });
-        if (iter != CelxLua::LocationFlagMap.end())
+        if (iter != LocationFlagMap.end())
             featureName = iter->first;
         celx.setTable("featureType", featureName.c_str());
 

--- a/src/celscript/lua/celx_observer.cpp
+++ b/src/celscript/lua/celx_observer.cpp
@@ -877,13 +877,14 @@ static int observer_setlocationflags(lua_State* l)
             celx.doError("Values in table-argument to observer:setlocationflags() must be boolean");
             return 0;
         }
-        if (CelxLua::LocationFlagMap.count(key) == 0)
+        auto &LocationFlagMap = celx.appCore(AllErrors)->scriptMaps()->LocationFlagMap;
+        if (LocationFlagMap.count(key) == 0)
         {
             cerr << "Unknown key: " << key << "\n";
         }
         else
         {
-            const auto flag = CelxLua::LocationFlagMap[key];
+            const auto flag = LocationFlagMap[key];
             if (value)
             {
                 locationFlags |= flag;
@@ -906,7 +907,8 @@ static int observer_getlocationflags(lua_State* l)
     Observer* obs = this_observer(l);
     lua_newtable(l);
     const auto locationFlags = obs->getLocationFilter();
-    for (const auto& it : CelxLua::LocationFlagMap)
+    auto &LocationFlagMap = celx.appCore(AllErrors)->scriptMaps()->LocationFlagMap;
+    for (const auto& it : LocationFlagMap)
     {
         lua_pushstring(l, it.first.c_str());
         lua_pushboolean(l, (it.second & locationFlags) != 0);


### PR DESCRIPTION
different maps used by celx and legacy scripts made common + 2 methods (getObservers & getViewByObserver) added to celestiacore to be available everywhere