### PR TITLE
fix space between star/dso name and description

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3185,8 +3185,9 @@ void CelestiaCore::renderOverlay()
                 }
 
                 overlay->setFont(titleFont);
-                *overlay << selectionNames << '\n';
+                *overlay << selectionNames;
                 overlay->setFont(font);
+                *overlay << '\n';
                 displayStarInfo(*overlay,
                                 hudDetail,
                                 *(sel.star()),
@@ -3212,8 +3213,9 @@ void CelestiaCore::renderOverlay()
                 }
 
                 overlay->setFont(titleFont);
-                *overlay << selectionNames << '\n';
+                *overlay << selectionNames;
                 overlay->setFont(font);
+                *overlay << '\n';
                 displayDSOinfo(*overlay,
                                *sel.deepsky(),
                                astro::kilometersToLightYears(v.norm()) - sel.deepsky()->getRadius());


### PR DESCRIPTION
the line break should be inserted after change of the font so there is no space in between, just like the Body/Location branch in this switch.