### PR TITLE
fix markers in multiview + small style fix for selection

### DIFF
--- a/src/celengine/category.h
+++ b/src/celengine/category.h
@@ -11,7 +11,7 @@ public:
     {
         size_t operator()(const Selection &s) const
         {
-            return (size_t)s.obj;
+            return (size_t)s.catEntry();
         }
     };
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2964,6 +2964,7 @@ void Renderer::draw(const Observer& observer,
                 addAnnotation(backgroundAnnotations, &cursorRep, "", Color(SelectionCursorColor, 1.0f),
                               offset.cast<float>(),
                               AlignLeft, VerticalAlignTop, symbolSize);
+                renderBackgroundAnnotations(FontNormal);
             }
 
             Color occludedCursorColor(SelectionCursorColor.red(), SelectionCursorColor.green() + 0.3f, SelectionCursorColor.blue());

--- a/src/celengine/selection.h
+++ b/src/celengine/selection.h
@@ -23,7 +23,8 @@ class DeepSkyObject;
 class Selection
 {
  public:
-    enum Type {
+    enum Type
+    {
         Type_Nil,
         Type_Star,
         Type_Body,
@@ -32,15 +33,14 @@ class Selection
         Type_Generic
     };
 
-public:
-    Selection() : type(Type_Nil), obj(nullptr) {};
+    Selection() = default;
     Selection(CatEntry *cat) : type(Type_Generic), obj(cat) { checkNull(); };
     Selection(Star* star) : type(Type_Star), obj(star) { checkNull(); };
     Selection(Body* body) : type(Type_Body), obj(body) { checkNull(); };
     Selection(DeepSkyObject* deepsky) : type(Type_DeepSky), obj(deepsky) {checkNull(); };
     Selection(Location* location) : type(Type_Location), obj(location) { checkNull(); };
     Selection(const Selection& sel) : type(sel.type), obj(sel.obj) {};
-    ~Selection() {};
+    ~Selection() = default;
 
     bool empty() const { return type == Type_Nil; }
     double radius() const;
@@ -78,11 +78,14 @@ public:
 
     Type getType() const { return type; }
 
-    // private:
-    Type type;
-    void* obj;
+ private:
+    Type type { Type_Nil };
+    void* obj { nullptr };
 
     void checkNull() { if (obj == nullptr) type = Type_Nil; }
+
+    friend bool operator==(const Selection& s0, const Selection& s1);
+    friend bool operator!=(const Selection& s0, const Selection& s1);
 };
 
 


### PR DESCRIPTION
see #486 
the problem with selection markers of distant objects is caused by the way they are drawn: they are composed by 2 dim markers actually, 1st is background and 2nd one is foreground. currently renderer clears vector of annotations (markers) every time they are rendered, and so we have several calls to draw them but the last call is missing. this means that when we render a new frame we first draw *old* background marker and only then the current foreground one, that's noticeable with frame rate set to 1. that's not a problem with only 1 view, but with several we draw a bg marker from the previous view.
so added missing call to renderBackgroundAnnotations fixes the issue.