### PR TITLE
Increase star render distance

### DIFF
--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -45,7 +45,7 @@ constexpr const char SAOCatalogPrefix[]       = "SAO ";
 // local group of galaxies. A larger value should be OK, but the
 // performance implications for octree traversal still need to be
 // investigated.
-constexpr const float STAR_OCTREE_ROOT_SIZE   = 10000000.0f;
+constexpr const float STAR_OCTREE_ROOT_SIZE   = 1000000000.0f;
 
 constexpr const float STAR_OCTREE_MAGNITUDE   = 6.0f;
 //constexpr const float STAR_EXTRA_ROOM        = 0.01f; // Reserve 1% capacity for extra stars


### PR DESCRIPTION
Based on [this thread](https://celestia.space/forum/viewtopic.php?f=3&t=17783) and [this one](https://celestia.space/forum/viewtopic.php?f=23&t=20030&start=20), I've increased the maximum star render distance to 1 billion light-years. Now Celestia should be able to render M87*, and other such distant objects.