### PR TITLE
Partially revert "Remove fixed pipeline calls in glsl-based code"

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4646,6 +4646,15 @@ void Renderer::renderObject(const Vector3f& pos,
                                           astro::daysToSecs(now - astro::J2000),
                                           this);
             }
+
+            // XXX: this code should be removed
+            for (unsigned int i = 1; i < 8;/*context->getMaxTextures();*/ i++)
+            {
+                glActiveTexture(GL_TEXTURE0 + i);
+                glDisable(GL_TEXTURE_2D);
+            }
+            glActiveTexture(GL_TEXTURE0);
+            glEnable(GL_TEXTURE_2D);
         }
     }
 


### PR DESCRIPTION
Without this chunk garbage is shown on screen when rendering models

This reverts commit e363e9102f47b9d39baf2ac99793aa9330b7eaf1.

i'm unable to figure out what exactly breaks overlay, but let's keep this code until we port other parts to shaders