### PR TITLE
GLUtil lib removal, part 1

### DIFF
--- a/src/celengine/console.cpp
+++ b/src/celengine/console.cpp
@@ -11,13 +11,14 @@
 #include <cstdarg>
 #include <cassert>
 #include <algorithm>
-#include "celutil/utf8.h"
+#include <celutil/utf8.h>
+#include <celmath/geomutil.h>
 #include <GL/glew.h>
 #include "vecgl.h"
 #include "console.h"
 
 using namespace std;
-
+using namespace celmath;
 
 static int pmod(int n, int m)
 {
@@ -74,8 +75,7 @@ void Console::begin()
 {
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
-    glLoadIdentity();
-    gluOrtho2D(0, xscale, 0, yscale);
+    glLoadMatrix(Ortho2D(0.0f, (float)xscale, 0.0f, (float)yscale));
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();

--- a/src/celengine/overlay.cpp
+++ b/src/celengine/overlay.cpp
@@ -13,6 +13,7 @@
 #include <GL/glew.h>
 #include <Eigen/Core>
 #include <celutil/debug.h>
+#include <celmath/geomutil.h>
 #include "vecgl.h"
 #include "overlay.h"
 #include "rectangle.h"
@@ -21,7 +22,7 @@
 
 using namespace std;
 using namespace Eigen;
-
+using namespace celmath;
 
 Overlay::Overlay(const Renderer& r) :
     ostream(&sbuf),
@@ -34,8 +35,7 @@ void Overlay::begin()
 {
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
-    glLoadIdentity();
-    gluOrtho2D(0, windowWidth, 0, windowHeight);
+    glLoadMatrix(Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight));
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2479,9 +2479,7 @@ void Renderer::draw(const Observer& observer,
     pixelSize = calcPixelSize(fov, (float) windowHeight);
 
     // Set up the projection we'll use for rendering stars.
-    gluPerspective(fov,
-                   (float) windowWidth / (float) windowHeight,
-                   NEAR_DIST, FAR_DIST);
+    glMatrix(Perspective(fov, getAspectRatio(), NEAR_DIST, FAR_DIST));
 
     // Set the modelview matrix
     glMatrixMode(GL_MODELVIEW);
@@ -3337,11 +3335,9 @@ void Renderer::draw(const Observer& observer,
             // Set up a perspective projection using the current interval's near and
             // far clip planes.
             glMatrixMode(GL_PROJECTION);
-            glLoadIdentity();
-            gluPerspective(fov,
-                           (float) windowWidth / (float) windowHeight,
-                           nearPlaneDistance,
-                           farPlaneDistance);
+            glLoadMatrix(Perspective(fov, getAspectRatio(),
+                                     nearPlaneDistance,
+                                     farPlaneDistance));
             glMatrixMode(GL_MODELVIEW);
 
             Frustum intervalFrustum(degToRad(fov),
@@ -3494,10 +3490,7 @@ void Renderer::draw(const Observer& observer,
     renderForegroundAnnotations(FontNormal);
 
     glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    gluPerspective(fov,
-                   (float) windowWidth / (float) windowHeight,
-                   NEAR_DIST, FAR_DIST);
+    glLoadMatrix(Perspective(fov, getAspectRatio(), NEAR_DIST, FAR_DIST));
     glMatrixMode(GL_MODELVIEW);
 
     if (!selectionVisible && (renderFlags & ShowMarkers))
@@ -6747,11 +6740,8 @@ void DSORenderer::process(DeepSkyObject* const & dso,
 
                     glMatrixMode(GL_PROJECTION);
                     glPushMatrix();
-                    glLoadIdentity();
-                    gluPerspective(fov,
-                                   (float) wWidth / (float) wHeight,
-                                   nearZ,
-                                   farZ);
+                    float t = (float) wWidth / (float) wHeight;
+                    glLoadMatrix(Perspective(fov, t, nearZ, farZ));
                     glMatrixMode(GL_MODELVIEW);
                 }
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -3340,7 +3340,7 @@ void Renderer::draw(const Observer& observer,
             glMatrixMode(GL_MODELVIEW);
 
             Frustum intervalFrustum(degToRad(fov),
-                                    (float) windowWidth / (float) windowHeight,
+                                    getAspectRatio(),
                                     -depthPartitions[interval].nearZ,
                                     -depthPartitions[interval].farZ);
 
@@ -4559,7 +4559,7 @@ void Renderer::renderObject(const Vector3f& pos,
     // radius (for an ellipsoidal planet, radius is taken to be
     // largest semiaxis.)
     Frustum viewFrustum(degToRad(fov),
-                        (float) windowWidth / (float) windowHeight,
+                        getAspectRatio(),
                         nearPlaneDistance / radius, frustumFarPlane / radius);
     viewFrustum.transform(invMV);
 
@@ -6554,7 +6554,7 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
     starRenderer.starVertexBuffer  = pointStarVertexBuffer;
     starRenderer.glareVertexBuffer = glareVertexBuffer;
     starRenderer.fov               = fov;
-    starRenderer.cosFOV            = (float) cos(degToRad(calcMaxFOV(fov, (float) windowWidth / (float) windowHeight)) / 2.0f);
+    starRenderer.cosFOV            = (float) cos(degToRad(calcMaxFOV(fov, getAspectRatio())) / 2.0f);
 
     starRenderer.pixelSize         = pixelSize;
     starRenderer.brightnessScale   = brightnessScale * corrFac;
@@ -6617,7 +6617,7 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
                             obsPos.cast<float>(),
                             observer.getOrientationf(),
                             degToRad(fov),
-                            (float) windowWidth / (float) windowHeight,
+                            getAspectRatio(),
                             faintestMagNight,
 #ifdef OCTREE_DEBUG
                             &m_starProcStats);
@@ -6868,8 +6868,8 @@ void Renderer::renderDeepSkyObjects(const Universe&  universe,
     dsoRenderer.wHeight          = windowHeight;
 
     dsoRenderer.frustum = Frustum(degToRad(fov),
-                        (float) windowWidth / (float) windowHeight,
-                        MinNearPlaneDistance);
+                                  getAspectRatio(),
+                                  MinNearPlaneDistance);
     // Use pixelSize * screenDpi instead of FoV, to eliminate windowHeight dependence.
     // = 1.0 at startup
     float effDistanceToScreen = mmToInches((float) REF_DISTANCE_TO_SCREEN) * pixelSize * getScreenDpi();
@@ -6896,7 +6896,7 @@ void Renderer::renderDeepSkyObjects(const Universe&  universe,
                            obsPos,
                            observer.getOrientationf(),
                            degToRad(fov),
-                           (float) windowWidth / (float) windowHeight,
+                           getAspectRatio(),
                            2 * faintestMagNight,
 #ifdef OCTREE_DEBUG
                            &m_dsoProcStats);
@@ -7398,7 +7398,7 @@ void Renderer::renderMarkers(const MarkerList& markers,
     // vertical field of view; we want the field of view as measured on the
     // diagonal between viewport corners.
     double h = tan(degToRad(fov / 2));
-    double diag = sqrt(1.0 + square(h) + square(h * (double) windowWidth / (double) windowHeight));
+    double diag = sqrt(1.0 + square(h) + square(h * (double) getAspectRatio()));
     double cosFOV = 1.0 / diag;
 
     Vector3d viewVector = cameraOrientation.conjugate() * -Vector3d::UnitZ();

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1298,30 +1298,22 @@ void Renderer::addAnnotation(vector<Annotation>& annotations,
                              float size,
                              bool special)
 {
-    double winX, winY, winZ;
     GLint view[4] = { 0, 0, windowWidth, windowHeight };
-    float depth = (float) (pos.x() * modelMatrix[2] +
-                           pos.y() * modelMatrix[6] +
-                           pos.z() * modelMatrix[10]);
-    if (gluProject(pos.x(), pos.y(), pos.z(),
-                   modelMatrix,
-                   projMatrix,
-                   view,
-                   &winX, &winY, &winZ) != GL_FALSE)
+    Vector3d win;
+    Vector3d posd = pos.cast<double>();
+    if (Project(posd, modelMatrix, projMatrix, view, win))
     {
+        double depth = pos.x() * modelMatrix(2, 0) +
+                       pos.y() * modelMatrix(2, 1) +
+                       pos.z() * modelMatrix(2, 2);
+        win.z() = -depth;
+
         Annotation a;
-        if (special)
-        {
-            if (markerRep == nullptr)
-                a.labelText = labelText;
-        }
-        else
-        {
-            a.labelText = labelText;
-        }
+        if (!special || markerRep == nullptr)
+             a.labelText = labelText;
         a.markerRep = markerRep;
         a.color = color;
-        a.position = Vector3f((float) winX, (float) winY, -depth);
+        a.position = win.cast<float>();
         a.halign = halign;
         a.valign = valign;
         a.size = size;
@@ -2522,8 +2514,8 @@ void Renderer::draw(const Observer& observer,
 
     // Get the model matrix *before* translation.  We'll use this for
     // positioning star and planet labels.
-    glGetDoublev(GL_MODELVIEW_MATRIX, modelMatrix);
-    glGetDoublev(GL_PROJECTION_MATRIX, projMatrix);
+    glGetDoublev(GL_MODELVIEW_MATRIX, modelMatrix.data());
+    glGetDoublev(GL_PROJECTION_MATRIX, projMatrix.data());
 
     clearSortedAnnotations();
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2423,8 +2423,7 @@ void Renderer::render(const Observer& observer,
 
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
-    glLoadIdentity();
-    glOrtho( 0.0, 1.0, 0.0, 1.0, -1.0, 1.0 );
+    glLoadMatrix(Ortho2D(0.0f, 1.0f, 0.0f, 1.0f));
     glMatrixMode (GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();
@@ -7095,8 +7094,7 @@ void Renderer::renderAnnotations(const vector<Annotation>& annotations, FontStyl
 
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
-    glLoadIdentity();
-    gluOrtho2D(0, windowWidth, 0, windowHeight);
+    glLoadMatrix(Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight));
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();
@@ -7229,8 +7227,7 @@ Renderer::renderSortedAnnotations(vector<Annotation>::iterator iter,
 
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
-    glLoadIdentity();
-    gluOrtho2D(0, windowWidth, 0, windowHeight);
+    glLoadMatrix(Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight));
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();
@@ -7316,8 +7313,7 @@ Renderer::renderAnnotations(vector<Annotation>::iterator startIter,
 
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
-    glLoadIdentity();
-    gluOrtho2D(0, windowWidth, 0, windowHeight);
+    glLoadMatrix(Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight));
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -719,8 +719,8 @@ class Renderer
 
     std::vector<LightSource> lightSourceList;
 
-    double modelMatrix[16];
-    double projMatrix[16];
+    Eigen::Matrix4d modelMatrix;
+    Eigen::Matrix4d projMatrix;
 
     bool useCompressedTextures{ false };
     unsigned int textureResolution;

--- a/src/celengine/vecgl.h
+++ b/src/celengine/vecgl.h
@@ -77,6 +77,16 @@ inline void glMatrix(const Eigen::Matrix4d& m)
     glMultMatrixd(m.data());
 }
 
+inline void glLoadMatrix(const Eigen::Matrix4f& m)
+{
+    glLoadMatrixf(m.data());
+}
+
+inline void glLoadMatrix(const Eigen::Matrix4d& m)
+{
+    glLoadMatrixd(m.data());
+}
+
 inline void glScale(const Eigen::Vector3f& scale)
 {
     glScalef(scale.x(), scale.y(), scale.z());

--- a/src/celmath/geomutil.h
+++ b/src/celmath/geomutil.h
@@ -62,6 +62,31 @@ LookAt(const Eigen::Matrix<T, 3, 1>& from, const Eigen::Matrix<T, 3, 1>& to, con
     return Eigen::Quaternion<T>(m).conjugate();
 }
 
+/*! Project to screen space
+ */
+template<class T> bool
+Project(const Eigen::Matrix<T, 3, 1>& from,
+        const Eigen::Matrix<T, 4, 4>& modelViewMatrix,
+        const Eigen::Matrix<T, 4, 4>& projMatrix,
+        const int viewport[4],
+        Eigen::Matrix<T, 3, 1>& to)
+{
+    Eigen::Matrix<T, 4, 1> in(from.x(), from.y(), from.z(), T(1.0));
+    Eigen::Matrix<T, 4, 1> out = projMatrix * modelViewMatrix * in;
+    if (out.w() == T(0.0))
+        return false;
+
+    out = out.array() / out.w();
+    // Map x, y and z to range 0-1
+    out = T(0.5) + out.array() * T(0.5);
+    // Map x,y to viewport
+    out.x() = viewport[0] + out.x() * viewport[2];
+    out.y() = viewport[1] + out.y() * viewport[3];
+
+    to = { out.x(), out.y(), out.z() };
+    return true;
+}
+
 }; // namespace celmath
 
 #endif // _CELMATH_GEOMUTIL_H_

--- a/src/celmath/geomutil.h
+++ b/src/celmath/geomutil.h
@@ -87,6 +87,34 @@ Project(const Eigen::Matrix<T, 3, 1>& from,
     return true;
 }
 
+/*! Return an perspective projection matrix
+ */
+template<class T> Eigen::Matrix<T, 4, 4>
+Perspective(T fovy, T aspect, T nearZ, T farZ)
+{
+    if (aspect == T(0.0))
+        return Eigen::Matrix<T, 4, 4>::Identity();
+
+    T deltaZ = farZ - nearZ;
+    if (deltaZ == T(0.0))
+        return Eigen::Matrix<T, 4, 4>::Identity();
+
+    T angle = degToRad(fovy / 2);
+    T sine = sin(angle);
+    if (sine == T(0.0))
+        return Eigen::Matrix<T, 4, 4>::Identity();
+    T ctg = cos(angle) / sine;
+
+    Eigen::Matrix<T, 4, 4> m = Eigen::Matrix<T, 4, 4>::Identity();
+    m(0, 0) = ctg / aspect;
+    m(1, 1) = ctg;
+    m(2, 2) = -(farZ + nearZ) / deltaZ;
+    m(2, 3) = T(-2.0) * nearZ * farZ / deltaZ;
+    m(3, 2) = T(-1.0);
+    m(3, 3) = T(0.0);
+    return m;
+}
+
 }; // namespace celmath
 
 #endif // _CELMATH_GEOMUTIL_H_

--- a/src/celmath/geomutil.h
+++ b/src/celmath/geomutil.h
@@ -115,6 +115,27 @@ Perspective(T fovy, T aspect, T nearZ, T farZ)
     return m;
 }
 
-}; // namespace celmath
+/*! Return an orthographic projection matrix
+ */
+template<class T> Eigen::Matrix<T, 4, 4>
+Ortho(T left, T right, T bottom, T top, T nearZ, T farZ)
+{
+    T rl = right - left;
+    T tb = top - bottom;
+    T fn = farZ - nearZ;
+    Eigen::Matrix<T, 4, 4> m;
+    m << 2/rl,    0,     0, - (right + left) / rl,
+            0, 2/tb,     0, - (top + bottom) / tb,
+            0,    0, -2/fn, - (farZ + nearZ) / fn,
+            0,    0,     0,                     1;
+    return m;
+}
 
+template<class T> Eigen::Matrix<T, 4, 4>
+Ortho2D(T left, T right, T bottom, T top)
+{
+    return Ortho(left, right, bottom, top, T(-1), T(1));
+}
+
+}; // namespace celmath
 #endif // _CELMATH_GEOMUTIL_H_


### PR DESCRIPTION
so far only 2 calls are left: gluErrorString (hardly useful) and gluBuild2DMipmaps which has 2 alternatives but still should left as a fallback, but it can be removed in macos builds