### PR TITLE
[qt] Process event sent before the event loop started

### DIFF
--- a/src/celestia/qt/qtmain.cpp
+++ b/src/celestia/qt/qtmain.cpp
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
 
     // TODO: resolve issues with pixmap alpha channel
     splash.show();
+    app.processEvents();
 
     // Gettext integration
     setlocale(LC_ALL, "");


### PR DESCRIPTION
currently if you abort Celestia loading files it will not stop actually as the qt event corresponding to SIGTERM is not processed. the patch fixes this misbehaviour.