### PR TITLE
macOS: allow more alternative surfaces in menu

### DIFF
--- a/macosx/Menu_Extensions.mm
+++ b/macosx/Menu_Extensions.mm
@@ -267,14 +267,14 @@
     NSMenu *surfaceMenu = [[NSMenu alloc ] initWithTitle: @"altsurf" ];
     [ self setEnabled: YES ];
     NSMenuItem *newItem = [[NSMenuItem alloc] initWithTitle: NSLocalizedString(@"default",@"") action: action keyEquivalent: @""];
-    [newItem setTag:    600 ];
+    [newItem setTag:    1100 ];
     [newItem setTarget: target ];
     [ surfaceMenu addItem: newItem ];
     unsigned i;
     for (i = 0; i < [surfaces count]; ++i)
     {
         newItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithUTF8String:_([[surfaces objectAtIndex: i] UTF8String])] action: action keyEquivalent: @""];
-        [newItem setTag:     601+i ];
+        [newItem setTag:     1101+i ];
         [newItem setTarget:  target ];
         [ surfaceMenu addItem: newItem ];
     }


### PR DESCRIPTION
there was a limit in the Cocoa version limiting number of alternative surfaces in menu (9 at max. tagged 601 to 609).
this pull request just increase the limit to 99 (tagged 1101 to 1199).

to remove the limit totally there needed to be some big change, so not worthwhile to do this for 1.6.x