### PR TITLE
Remove deprecated C++ features

### DIFF
--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -23,7 +23,7 @@
 #include <cstring>
 #include <fstream>
 #include <algorithm>
-#include <celutil/debug.h>
+#include <random>
 #include <cassert>
 
 using namespace Eigen;
@@ -658,7 +658,9 @@ GalacticForm* buildGalacticForms(const fs::path& filename)
     // reshuffle the galaxy points randomly...except the first kmin+1 in the center!
     // the higher that number the stronger the central "glow"
 
-    random_shuffle( galacticPoints->begin() + kmin, galacticPoints->end());
+    std::random_device rng;
+    std::mt19937 urng(rng());
+    shuffle(galacticPoints->begin() + kmin, galacticPoints->end(), urng);
 
     auto* galacticForm  = new GalacticForm();
     galacticForm->blobs = galacticPoints;

--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -498,7 +498,7 @@ void Observer::reverseOrientation()
 
 
 
-struct TravelExpFunc : public unary_function<double, double>
+struct TravelExpFunc
 {
     double dist, s;
 

--- a/src/celephem/orbit.cpp
+++ b/src/celephem/orbit.cpp
@@ -196,7 +196,7 @@ EllipticalOrbit::EllipticalOrbit(double _pericenterDistance,
 
 
 // Standard iteration for solving Kepler's Equation
-struct SolveKeplerFunc1 : public unary_function<double, double>
+struct SolveKeplerFunc1
 {
     double ecc;
     double M;
@@ -213,7 +213,7 @@ struct SolveKeplerFunc1 : public unary_function<double, double>
 // Faster converging iteration for Kepler's Equation; more efficient
 // than above for orbits with eccentricities greater than 0.3.  This
 // is from Jean Meeus's _Astronomical Algorithms_ (2nd ed), p. 199
-struct SolveKeplerFunc2 : public unary_function<double, double>
+struct SolveKeplerFunc2
 {
     double ecc;
     double M;
@@ -227,7 +227,7 @@ struct SolveKeplerFunc2 : public unary_function<double, double>
 };
 
 
-struct SolveKeplerLaguerreConway : public unary_function<double, double>
+struct SolveKeplerLaguerreConway
 {
     double ecc;
     double M;
@@ -247,7 +247,7 @@ struct SolveKeplerLaguerreConway : public unary_function<double, double>
     }
 };
 
-struct SolveKeplerLaguerreConwayHyp : public unary_function<double, double>
+struct SolveKeplerLaguerreConwayHyp
 {
     double ecc;
     double M;

--- a/src/celmodel/mesh.cpp
+++ b/src/celmodel/mesh.cpp
@@ -304,16 +304,12 @@ Mesh::remapMaterials(const vector<unsigned int>& materialMap)
 }
 
 
-class PrimitiveGroupComparator : public std::binary_function<const Mesh::PrimitiveGroup*, const Mesh::PrimitiveGroup*, bool>
+struct PrimitiveGroupComparator
 {
-public:
     bool operator()(const Mesh::PrimitiveGroup* g0, const Mesh::PrimitiveGroup* g1) const
     {
         return g0->materialIndex < g1->materialIndex;
     }
-
-private:
-    int unused;
 };
 
 

--- a/src/celmodel/model.cpp
+++ b/src/celmodel/model.cpp
@@ -381,7 +381,7 @@ Model::usesTextureType(Material::TextureSemantic t) const
 }
 
 
-class MeshComparatorAdapter : public std::binary_function<const Mesh*, const Mesh*, bool>
+class MeshComparatorAdapter
 {
 public:
     MeshComparatorAdapter(const Model::MeshComparator& c) :

--- a/src/celutil/util.h
+++ b/src/celutil/util.h
@@ -44,24 +44,21 @@ extern int compareIgnoringCase(const std::string& s1, const std::string& s2);
 extern int compareIgnoringCase(const std::string& s1, const std::string& s2, int n);
 extern fs::path LocaleFilename(const fs::path& filename);
 
-class CompareIgnoringCasePredicate : public std::binary_function<std::string, std::string, bool>
+struct CompareIgnoringCasePredicate
 {
- public:
     bool operator()(const std::string&, const std::string&) const;
 };
 
-template <class T> struct printlineFunc : public std::unary_function<T, void>
+template <class T> struct printlineFunc
 {
     printlineFunc(std::ostream& o) : out(o) {};
     void operator() (T x) { out << x << '\n'; };
     std::ostream& out;
 };
 
-template <class T> struct deleteFunc : public std::unary_function<T, void>
+template <class T> struct deleteFunc
 {
-    deleteFunc() {};
     void operator() (T x) { delete x; };
-    int dummy;
 };
 
 // size in bytes of memory required to store a container data

--- a/src/tools/cmod/cmodfix/cmodfix.cpp
+++ b/src/tools/cmod/cmodfix/cmodfix.cpp
@@ -79,7 +79,7 @@ struct Face
 };
 
 
-class VertexComparator : public std::binary_function<Vertex, Vertex, bool>
+class VertexComparator
 {
 public:
     virtual bool compare(const Vertex& a, const Vertex& b) const = 0;
@@ -390,19 +390,12 @@ bool operator<(const Mesh::VertexDescription& a,
 }
 
 
-class MeshVertexDescComparator :
-    public std::binary_function<const Mesh*, const Mesh*, bool>
+struct MeshVertexDescComparator
 {
-public:
-    MeshVertexDescComparator() = default;
-
     bool operator()(const Mesh* a, const Mesh* b) const
     {
         return a->getVertexDescription() < b->getVertexDescription();
     }
-
-private:
-    int ignore;
 };
 
 

--- a/src/tools/cmod/common/cmodops.cpp
+++ b/src/tools/cmod/common/cmodops.cpp
@@ -24,9 +24,8 @@ using namespace Eigen;
 using namespace std;
 
 
-class VertexComparator : public std::binary_function<Vertex, Vertex, bool>
+struct VertexComparator
 {
-public:
     virtual bool compare(const Vertex& a, const Vertex& b) const = 0;
 
     bool operator()(const Vertex& a, const Vertex& b) const
@@ -335,21 +334,13 @@ bool operator<(const Mesh::VertexDescription& a,
 }
 
 
-class MeshVertexDescComparator :
-    public std::binary_function<const Mesh*, const Mesh*, bool>
+struct MeshVertexDescComparator
 {
-public:
-    MeshVertexDescComparator() = default;
-
     bool operator()(const Mesh* a, const Mesh* b) const
     {
         return a->getVertexDescription() < b->getVertexDescription();
     }
-
-private:
-    int ignore;
 };
-
 
 
 bool

--- a/src/tools/stardb/buildstardb.cpp
+++ b/src/tools/stardb/buildstardb.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <iostream>
 #include <fstream>
+#include <random>
 #include <cstdio>
 #include <cassert>
 #include <unistd.h>
@@ -1130,7 +1131,9 @@ int main(int argc, char* argv[])
         // It may not even be necessary to sort the records, if the
         // HIPPARCOS catalog is strictly ordered by catalog number.  I'm not
         // sure about this however,
-        random_shuffle(starIndex.begin(), starIndex.end());
+        std::random_device rng;
+        std::mt19937 urng(rng());
+        shuffle(starIndex.begin(), starIndex.end(), urng);
         sort(starIndex.begin(), starIndex.end(), pred);
     }
 


### PR DESCRIPTION
std::unary_function & std::binary_function were deprecated in C++11
and removed in C++17