### PR TITLE
Fix scripted orbits and rotations (Closes: #576)

### DIFF
--- a/src/celephem/scriptorbit.cpp
+++ b/src/celephem/scriptorbit.cpp
@@ -115,7 +115,7 @@ ScriptedOrbit::initialize(const std::string& moduleName,
     luaOrbitObjectName = GenerateScriptObjectName();
 
     // Attach the name to the script orbit
-    lua_pushvalue(luaState, -2); // dup the orbit object on top of stack
+    lua_pushvalue(luaState, -1); // dup the orbit object on top of stack
     lua_setglobal(luaState, luaOrbitObjectName.c_str());
 
     // Now, call orbit object methods to get the bounding radius

--- a/src/celephem/scriptrotation.cpp
+++ b/src/celephem/scriptrotation.cpp
@@ -112,7 +112,7 @@ ScriptedRotation::initialize(const std::string& moduleName,
     luaRotationObjectName = GenerateScriptObjectName();
 
     // Attach the name to the script rotation
-    lua_pushvalue(luaState, -2); // dup the rotation object on top of stack
+    lua_pushvalue(luaState, -1); // dup the rotation object on top of stack
     lua_setglobal(luaState, luaRotationObjectName.c_str());
 
     // Get the rest of the rotation parameters; they are all optional.


### PR DESCRIPTION
The following change broke scripted orb/rot:
```
     // Attach the name to the script orbit
-    lua_pushstring(luaState, luaOrbitObjectName.c_str());
     lua_pushvalue(luaState, -2); // dup the orbit object on top of stack
-    lua_settable(luaState, LUA_GLOBALSINDEX);
+    lua_setglobal(luaState, luaOrbitObjectName.c_str());
```

I.e. in old code we had in lua stack:
```
........
required value // -2
luaOrbitObjectName // -1
```
in the new code we don't push `luaOrbitObjectName` so the index of `required value` must be -1.