### PR TITLE
Increase Star Render Distance FURTHER

### DIFF
--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -45,7 +45,7 @@ constexpr const char SAOCatalogPrefix[]       = "SAO ";
 // local group of galaxies. A larger value should be OK, but the
 // performance implications for octree traversal still need to be
 // investigated.
-constexpr const float STAR_OCTREE_ROOT_SIZE   = 1000000000.0f;
+constexpr const float STAR_OCTREE_ROOT_SIZE   = 100000000000.0f;
 
 constexpr const float STAR_OCTREE_MAGNITUDE   = 6.0f;
 //constexpr const float STAR_EXTRA_ROOM        = 0.01f; // Reserve 1% capacity for extra stars


### PR DESCRIPTION
I made a small change to the stardb.cpp file, increasing the star render distance from 1 GLY to 100 GLY. Would you mind checking if this works well with the current programming of Celestia? Thanks