### PR TITLE
Fix missing header (GCC 4)

### DIFF
--- a/src/celephem/scriptobject.h
+++ b/src/celephem/scriptobject.h
@@ -17,6 +17,7 @@
 #endif
 
 #include "lua.hpp"
+#include <iostream>
 #include <string>
 #include <celengine/parser.h>
 


### PR DESCRIPTION
`clog` is no longer a built-in and requires iostream.

This bug was introduced in 4a38917e08a83314ca9d2cb8af3c0562acd29fb2.