### PR TITLE
Allow building without NLS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,7 +48,6 @@ init:
 
 install:
 - cd c:\tools\vcpkg
-- git pull
 - vcpkg install libpng:x86-windows
 - vcpkg install gettext:x86-windows
 - vcpkg install libjpeg-turbo:x86-windows
@@ -58,6 +57,7 @@ install:
 - vcpkg install glew:x86-windows
 - vcpkg install eigen3:x86-windows
 - vcpkg install freetype:x86-windows
+- git pull
 - vcpkg install cspice:x86-windows
 - vcpkg integrate install
 - cd %APPVEYOR_BUILD_FOLDER%

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ if(ENABLE_NLS)
   find_package(Intl REQUIRED)
   include_directories(${Intl_INCLUDE_DIRS})
   link_libraries(${Intl_LIBRARIES})
+  add_definitions(-DENABLE_NLS)
 endif()
 
 if(ENABLE_SPICE)

--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -9,7 +9,7 @@
 
 #include <config.h>
 #include <GL/glew.h>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include <celutil/debug.h>
 #include "stardb.h"
 #include "asterism.h"
@@ -22,12 +22,18 @@ using namespace std;
 Asterism::Asterism(string _name) :
     name(_name)
 {
+#ifdef ENABLE_NLS
     i18nName = dgettext("celestia_constellations", _name.c_str());
+#endif
 }
 
 string Asterism::getName(bool i18n) const
 {
+#ifdef ENABLE_NLS
     return i18n ? i18nName : name;
+#else
+    return name;
+#endif
 }
 
 int Asterism::getChainCount() const

--- a/src/celengine/astro.cpp
+++ b/src/celengine/astro.cpp
@@ -8,18 +8,19 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <config.h>
 #include <cstring>
 #include <cmath>
 #include <iomanip>
 #include <cstdio>
 #include <utility>
 #include <ctime>
-#include <celmath/mathlib.h>
-#include <config.h>
 #include "astro.h"
 #include "univcoord.h"
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include <celmath/geomutil.h>
+#include <celmath/mathlib.h>
+
 
 using namespace Eigen;
 using namespace std;

--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <algorithm>
 #include <celmath/mathlib.h>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include <celutil/utf8.h>
 #include "geometry.h"
 #include "meshmanager.h"

--- a/src/celengine/category.cpp
+++ b/src/celengine/category.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include <celutil/debug.h>
 #include <celengine/catentry.h>
 #include "category.h"
@@ -8,7 +8,9 @@ UserCategory::UserCategory(const std::string &n, UserCategory *p, const std::str
         m_name(n), 
         m_parent(p)
 {
+#ifdef ENABLE_NLS
     m_i18n = dgettext(m_name.c_str(), domain.c_str());
+#endif
 }
 
 UserCategory::~UserCategory() { cleanup(); }

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -16,7 +16,7 @@
 #include <algorithm>
 #include <celutil/debug.h>
 #include <celmath/mathlib.h>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include <celutil/bytes.h>
 #include <celutil/utf8.h>
 #include <celengine/dsodb.h>
@@ -222,8 +222,10 @@ bool DSODatabase::load(istream& in, const fs::path& resourcePath)
     Tokenizer tokenizer(&in);
     Parser    parser(&tokenizer);
 
+#ifdef ENABLE_NLS
     const char *d = resourcePath.string().c_str();
     bindtextdomain(d, d); // domain name is the same as resource path
+#endif
 
     while (tokenizer.nextToken() != Tokenizer::TokenEnd)
     {

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -17,7 +17,7 @@
 #include <celmath/mathlib.h>
 #include <celmath/perlin.h>
 #include <celmath/intersect.h>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include <celutil/debug.h>
 #include <celcompat/filesystem.h>
 #include <cstring>

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -18,11 +18,12 @@
 #include "texture.h"
 #include <celmath/perlin.h>
 #include <celmath/intersect.h>
+#include <celutil/debug.h>
+#include <celutil/gettext.h>
 #include <cmath>
 #include <fstream>
 #include <algorithm>
 #include <cassert>
-#include <celutil/debug.h>
 
 using namespace Eigen;
 using namespace std;

--- a/src/celengine/image.cpp
+++ b/src/celengine/image.cpp
@@ -21,11 +21,11 @@ extern "C" {
 }
 #include <png.h>
 
-#include <celutil/debug.h>
-#include <celutil/util.h>
-#include <celutil/filetype.h>
 #include <GL/glew.h>
+
 #include <celutil/debug.h>
+#include <celutil/filetype.h>
+#include <celutil/gettext.h>
 #include "image.h"
 
 

--- a/src/celengine/location.cpp
+++ b/src/celengine/location.cpp
@@ -11,7 +11,7 @@
 #include <celengine/location.h>
 #include <celengine/body.h>
 #include <celengine/selection.h>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 
 using namespace Eigen;
 using namespace std;

--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -30,13 +30,13 @@
 #include <celmath/perlin.h>
 #include <celutil/debug.h>
 #include <celutil/filetype.h>
-#include <celutil/util.h>
+#include <celutil/debug.h>
+#include <celutil/gettext.h>
 
 #include <iostream>
 #include <fstream>
 #include <cassert>
 #include <utility>
-#include <celutil/debug.h>
 #include <memory>
 
 

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -15,8 +15,8 @@
 #include "meshmanager.h"
 #include "rendcontext.h"
 #include <celmath/mathlib.h>
-#include <celutil/util.h>
 #include <celutil/debug.h>
+#include <celutil/gettext.h>
 #include <algorithm>
 
 using namespace Eigen;

--- a/src/celengine/opencluster.cpp
+++ b/src/celengine/opencluster.cpp
@@ -13,8 +13,8 @@
 #include "opencluster.h"
 #include "meshmanager.h"
 #include <celmath/mathlib.h>
-#include <celutil/util.h>
 #include <celutil/debug.h>
+#include <celutil/gettext.h>
 #include <algorithm>
 
 using namespace Eigen;

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -10,13 +10,12 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <cassert>
 #include <config.h>
-#include <celutil/debug.h>
-#include <celmath/mathlib.h>
-#include <celutil/util.h>
+#include <cassert>
 #include <limits>
+#include <celmath/mathlib.h>
 #include <celutil/debug.h>
+#include <celutil/gettext.h>
 #include "astro.h"
 #include "parser.h"
 #include "tokenizer.h"
@@ -1084,8 +1083,10 @@ bool LoadSolarSystemObjects(istream& in,
     Tokenizer tokenizer(&in);
     Parser parser(&tokenizer);
 
+#ifdef ENABLE_NLS
     const char* d = directory.string().c_str();
     bindtextdomain(d, d); // domain name is the same as resource path
+#endif
 
     while (tokenizer.nextToken() != Tokenizer::TokenEnd)
     {

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -8,24 +8,23 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <config.h>
 #include <cstring>
 #include <cmath>
 #include <cstdlib>
-#include <celutil/debug.h>
 #include <cassert>
 #include <algorithm>
 #include <celmath/mathlib.h>
-#include <celutil/util.h>
 #include <celutil/bytes.h>
-#include <celengine/stardb.h>
-#include <config.h>
+#include <celutil/debug.h>
+#include <celutil/gettext.h>
+#include "stardb.h"
 #include "astro.h"
 #include "parser.h"
 #include "parseobject.h"
 #include "multitexture.h"
 #include "meshmanager.h"
 #include "tokenizer.h"
-#include <celutil/debug.h>
 
 using namespace Eigen;
 using namespace std;
@@ -1160,8 +1159,10 @@ bool StarDatabase::load(istream& in, const fs::path& resourcePath)
     Tokenizer tokenizer(&in);
     Parser parser(&tokenizer);
 
+#ifdef ENABLE_NLS
     const char *d = resourcePath.string().c_str();
     bindtextdomain(d, d); // domain name is the same as resource path
+#endif
 
     while (tokenizer.nextToken() != Tokenizer::TokenEnd)
     {

--- a/src/celengine/texture.cpp
+++ b/src/celengine/texture.cpp
@@ -20,12 +20,12 @@ extern "C" {
 }
 #include <png.h>
 
-#include <celutil/filetype.h>
-#include <celutil/debug.h>
-#include <celutil/util.h>
 #include <Eigen/Core>
 #include <GL/glew.h>
+
+#include <celutil/filetype.h>
 #include <celutil/debug.h>
+#include <celutil/gettext.h>
 #include "texture.h"
 #include "virtualtex.h"
 

--- a/src/celephem/samporbit.cpp
+++ b/src/celephem/samporbit.cpp
@@ -16,7 +16,8 @@
 #include <celengine/astro.h>
 #include <celmath/mathlib.h>
 #include <celutil/bytes.h>
-#include <celutil/util.h> // intl.h
+#include <celutil/gettext.h>
+#include <celutil/debug.h>
 #include <cmath>
 #include <string>
 #include <algorithm>
@@ -25,7 +26,6 @@
 #include <fstream>
 #include <limits>
 #include <iomanip>
-#include <celutil/debug.h>
 
 using namespace Eigen;
 using namespace std;

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -31,10 +31,11 @@
 #include <celengine/planetgrid.h>
 #include <celengine/visibleregion.h>
 #include <celmath/geomutil.h>
-#include <celutil/util.h>
+#include <celutil/color.h>
 #include <celutil/filetype.h>
 #include <celutil/formatnum.h>
 #include <celutil/debug.h>
+#include <celutil/gettext.h>
 #include <celutil/utf8.h>
 #include <celcompat/filesystem.h>
 #include <celcompat/memory.h>
@@ -50,9 +51,6 @@
 #include <cassert>
 #include <ctime>
 #include <set>
-#include <celutil/debug.h>
-#include <celutil/color.h>
-#include <celengine/vecgl.h>
 #include <celengine/rectangle.h>
 
 #ifdef CELX

--- a/src/celestia/oggtheoracapture.cpp
+++ b/src/celestia/oggtheoracapture.cpp
@@ -66,10 +66,9 @@
 #include <cstdlib>
 #include <cmath>
 #include <celutil/debug.h>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include <GL/glew.h>
 #include <string>
-#include <celutil/debug.h>
 #include <theora/theora.h>
 
 using namespace std;

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -42,6 +42,7 @@
 #include <vector>
 #include <string>
 #include <cassert>
+#include <celutil/gettext.h>
 #include "qtappwin.h"
 #include "qtglwidget.h"
 #include "qtpreferencesdialog.h"

--- a/src/celestia/qt/qtbookmark.cpp
+++ b/src/celestia/qt/qtbookmark.cpp
@@ -10,7 +10,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include "celestia/url.h"
+#include <celestia/url.h>
+#include <celutil/gettext.h>
 #include "qtbookmark.h"
 #include "xbel.h"
 #include <QAbstractItemModel>

--- a/src/celestia/qt/qtcelestiaactions.cpp
+++ b/src/celestia/qt/qtcelestiaactions.cpp
@@ -12,7 +12,8 @@
 
 #include <QAction>
 #include <QMenu>
-#include "celestia/celestiacore.h"
+#include <celestia/celestiacore.h>
+#include <celutil/gettext.h>
 #include "qtcelestiaactions.h"
 
 

--- a/src/celestia/qt/qtcelestialbrowser.cpp
+++ b/src/celestia/qt/qtcelestialbrowser.cpp
@@ -11,6 +11,7 @@
 // of the License, or (at your option) any later version.
 
 #include <celestia/celestiacore.h>
+#include <celutil/gettext.h>
 #include "qtcelestialbrowser.h"
 #include "qtcolorswatchwidget.h"
 #include "qtinfopanel.h"

--- a/src/celestia/qt/qtdeepskybrowser.cpp
+++ b/src/celestia/qt/qtdeepskybrowser.cpp
@@ -11,6 +11,7 @@
 // of the License, or (at your option) any later version.
 
 #include <celestia/celestiacore.h>
+#include <celutil/gettext.h>
 #include "qtdeepskybrowser.h"
 #include "qtcolorswatchwidget.h"
 #include "qtinfopanel.h"

--- a/src/celestia/qt/qteventfinder.cpp
+++ b/src/celestia/qt/qteventfinder.cpp
@@ -10,11 +10,6 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include "celestia/celestiacore.h"
-#include "qteventfinder.h"
-#include "celmath/distance.h"
-#include "celmath/intersect.h"
-#include "celmath/geomutil.h"
 #include <QRadioButton>
 #include <QTreeView>
 #include <QVBoxLayout>
@@ -31,7 +26,13 @@
 #include <vector>
 #include <algorithm>
 #include <cassert>
-#include "celestia/eclipsefinder.h"
+#include <celestia/celestiacore.h>
+#include <celestia/eclipsefinder.h>
+#include <celmath/distance.h>
+#include <celmath/intersect.h>
+#include <celmath/geomutil.h>
+#include <celutil/gettext.h>
+#include "qteventfinder.h"
 
 using namespace Eigen;
 using namespace std;

--- a/src/celestia/qt/qtgettext.h
+++ b/src/celestia/qt/qtgettext.h
@@ -9,7 +9,7 @@
 
 
 #include <QTranslator>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 
 class CelestiaQTranslator : public QTranslator
 {
@@ -25,5 +25,6 @@ CelestiaQTranslator::translate(const char*,
                                const char*,
                                int) const
 {
-    return QString(gettext(msgid));
+    return QString(_(msgid));
+    return QString(msgid);
 }

--- a/src/celestia/qt/qtinfopanel.cpp
+++ b/src/celestia/qt/qtinfopanel.cpp
@@ -13,6 +13,7 @@
 
 #include <celestia/celestiacore.h>
 #include <celengine/astro.h>
+#include <celutil/gettext.h>
 #include <celutil/utf8.h>
 #include <celengine/universe.h>
 #include <QTextBrowser>

--- a/src/celestia/qt/qtmain.cpp
+++ b/src/celestia/qt/qtmain.cpp
@@ -88,6 +88,7 @@ int main(int argc, char *argv[])
     // Gettext integration
     setlocale(LC_ALL, "");
     setlocale(LC_NUMERIC, "C");
+#ifdef ENABLE_NLS
 #ifdef NATIVE_OSX_APP
     // On macOS locale directory is in a fixed position relative to the application bundle
     QString localeDir = QApplication::applicationDirPath() + "/../Resources/locale";
@@ -99,6 +100,7 @@ int main(int argc, char *argv[])
     bindtextdomain("celestia_constellations", localeDir.toUtf8().data());
     bind_textdomain_codeset("celestia_constellations", "UTF-8");
     textdomain("celestia");
+#endif
 
     CelestiaAppWindow window;
 

--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -27,11 +27,12 @@
 
 #include "qtappwin.h"
 #include "qtpreferencesdialog.h"
-#include "celengine/render.h"
+#include <celengine/render.h>
 #ifdef USE_GLCONTEXT
-#include "celengine/glcontext.h"
+#include <celengine/glcontext.h>
 #endif
-#include "celestia/celestiacore.h"
+#include <celestia/celestiacore.h>
+#include <celutil/gettext.h>
 
 
 static void SetComboBoxValue(QComboBox* combo, const QVariant& value)

--- a/src/celestia/qt/qtselectionpopup.cpp
+++ b/src/celestia/qt/qtselectionpopup.cpp
@@ -16,6 +16,7 @@
 #include <celestia/helper.h>
 #include <celengine/axisarrow.h>
 #include <celengine/planetgrid.h>
+#include <celutil/gettext.h>
 #include <fmt/printf.h>
 #include "qtselectionpopup.h"
 #include "qtappwin.h"

--- a/src/celestia/qt/qtsettimedialog.cpp
+++ b/src/celestia/qt/qtsettimedialog.cpp
@@ -11,8 +11,8 @@
 // of the License, or (at your option) any later version.
 
 #include <celestia/celestiacore.h>
-#include "qtsettimedialog.h"
-#include "celengine/astro.h"
+#include <celengine/astro.h>
+#include <celutil/gettext.h>
 #include <QPushButton>
 #include <QDialogButtonBox>
 #include <QSpinBox>
@@ -22,6 +22,7 @@
 #include <QVBoxLayout>
 #include <QGroupBox>
 #include <QGridLayout>
+#include "qtsettimedialog.h"
 
 #ifdef _WIN32
 static const double minLocalTime = 2440587.5; // 1970 Jan 1 00:00:00

--- a/src/celestia/qt/qtsolarsystembrowser.cpp
+++ b/src/celestia/qt/qtsolarsystembrowser.cpp
@@ -11,6 +11,7 @@
 // of the License, or (at your option) any later version.
 
 #include <celestia/celestiacore.h>
+#include <celutil/gettext.h>
 #include "qtsolarsystembrowser.h"
 #include "qtinfopanel.h"
 #include "qtcolorswatchwidget.h"

--- a/src/celestia/qt/qttimetoolbar.cpp
+++ b/src/celestia/qt/qttimetoolbar.cpp
@@ -10,7 +10,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include "celestia/celestiacore.h"
+#include <celestia/celestiacore.h>
+#include <celutil/gettext.h>
 #include "qttimetoolbar.h"
 #include <QAction>
 #include <QIcon>

--- a/src/celestia/qt/xbel.cpp
+++ b/src/celestia/qt/xbel.cpp
@@ -10,7 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include "celutil/util.h"
+#include <celutil/gettext.h>
 #include "xbel.h"
 #include "qtbookmark.h"
 #include <QBuffer>

--- a/src/celestia/url.cpp
+++ b/src/celestia/url.cpp
@@ -20,10 +20,10 @@
 #include <sstream>
 #include <iomanip>
 #include <utility>
+#include <celengine/astro.h>
 #include <celutil/debug.h>
+#include <celutil/gettext.h>
 #include "celestiacore.h"
-#include "celutil/util.h"
-#include "celengine/astro.h"
 #include "url.h"
 
 using namespace Eigen;

--- a/src/celestia/win32/windatepicker.cpp
+++ b/src/celestia/win32/windatepicker.cpp
@@ -12,7 +12,7 @@
 #include <windows.h>
 #include <commctrl.h>
 #include "celengine/astro.h"
-#include "celutil/util.h"
+#include "celutil/gettext.h"
 #include "celutil/winutil.h"
 
 
@@ -157,11 +157,15 @@ DatePicker::redraw(HDC hdc)
     char monthBuf[32];
     char yearBuf[32];
 
+#ifdef ENABLE_NLS
     bind_textdomain_codeset("celestia", CurrentCP());
+#endif
     sprintf(dayBuf, "%02d", date.day);
     sprintf(monthBuf, "%s", _(Months[date.month - 1]));
     sprintf(yearBuf, "%5d", date.year);
+#ifdef ENABLE_NLS
     bind_textdomain_codeset("celestia", "UTF8");
+#endif
 
     char* fieldText[NumFields];
     fieldText[DayField] = dayBuf;

--- a/src/celestia/win32/wineclipses.cpp
+++ b/src/celestia/win32/wineclipses.cpp
@@ -19,7 +19,7 @@
 #include "wineclipses.h"
 #include "res/resource.h"
 #include "celmath/geomutil.h"
-#include "celutil/util.h"
+#include "celutil/gettext.h"
 #include "celutil/winutil.h"
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -56,7 +56,9 @@ bool InitEclipseFinderColumns(HWND listView)
     for (i = 0; i < nColumns; i++)
         columns[i] = lvc;
 
+#ifdef ENABLE_NLS
     bind_textdomain_codeset("celestia", CurrentCP());
+#endif
     columns[0].pszText = _("Planet");
     columns[0].cx = 65;
     columns[1].pszText = _("Satellite");
@@ -67,7 +69,9 @@ bool InitEclipseFinderColumns(HWND listView)
     columns[3].cx = 55;
     columns[4].pszText = _("Duration");
     columns[4].cx = 135;
+#ifdef ENABLE_NLS
     bind_textdomain_codeset("celestia", "UTF8");
+#endif
 
     for (i = 0; i < nColumns; i++)
     {
@@ -126,14 +130,18 @@ void EclipseFinderDisplayItem(LPNMLVDISPINFOA nm)
 
     case 2:
         {
+#ifdef ENABLE_NLS
             bind_textdomain_codeset("celestia", CurrentCP());
+#endif
             astro::Date startDate(eclipse->startTime);
             sprintf(callbackScratch, "%2d %s %4d",
                     startDate.day,
                     _(MonthNames[startDate.month - 1]),
                     startDate.year);
             nm->item.pszText = callbackScratch;
+#ifdef ENABLE_NLS
             bind_textdomain_codeset("celestia", "UTF8");
+#endif
         }
         break;
 
@@ -280,7 +288,9 @@ BOOL APIENTRY EclipseFinderProc(HWND hDlg,
             InitEclipseFinderColumns(hwnd);
             SendDlgItemMessage(hDlg, IDC_ECLIPSES_LIST, LVM_SETEXTENDEDLISTVIEWSTYLE, 0, LVS_EX_FULLROWSELECT);
 
+#ifdef ENABLE_NLS
             bind_textdomain_codeset("celestia", CurrentCP());
+#endif
             CheckRadioButton(hDlg, IDC_SOLARECLIPSE, IDC_LUNARECLIPSE, IDC_SOLARECLIPSE);
             efd->type = Eclipse::Solar;
 
@@ -292,7 +302,9 @@ BOOL APIENTRY EclipseFinderProc(HWND hDlg,
             SendDlgItemMessage(hDlg, IDC_ECLIPSETARGET, CB_ADDSTRING, 0, (LPARAM)_("Pluto"));
             SendDlgItemMessage(hDlg, IDC_ECLIPSETARGET, CB_SETCURSEL, 0, 0);
             efd->strPlaneteToFindOn = "Earth";
+#ifdef ENABLE_NLS
             bind_textdomain_codeset("celestia", "UTF8");
+#endif
 
             InitDateControls(hDlg, astro::Date(efd->appCore->getSimulation()->getTime()), efd->fromTime, efd->toTime);
 

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -29,7 +29,7 @@
 
 #include <celmath/mathlib.h>
 #include <celutil/debug.h>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include <celutil/winutil.h>
 #include <celutil/filetype.h>
 #include <celengine/astro.h>
@@ -1384,10 +1384,14 @@ BOOL APIENTRY SelectDisplayModeProc(HWND hDlg,
             HWND hwnd = GetDlgItem(hDlg, IDC_COMBO_RESOLUTION);
 
             // Add windowed mode as the first item on the menu
+#ifdef ENABLE_NLS
             bind_textdomain_codeset("celestia", CurrentCP());
+#endif
             SendMessage(hwnd, CB_INSERTSTRING, -1,
                         reinterpret_cast<LPARAM>(_("Windowed Mode")));
+#ifdef ENABLE_NLS
             bind_textdomain_codeset("celestia", "UTF8");
+#endif
 
             for (vector<DEVMODE>::const_iterator iter= displayModes->begin();
                  iter != displayModes->end(); iter++)
@@ -3276,6 +3280,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
     // Gettext integration
     setlocale(LC_ALL, "");
     setlocale(LC_NUMERIC, "C");
+#ifdef ENABLE_NLS
     bindtextdomain("celestia","locale");
     bind_textdomain_codeset("celestia", "UTF-8");
     bindtextdomain("celestia_constellations","locale");
@@ -3292,6 +3297,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
         cout << "Couldn't load localized resources: "<< res<< "\n";
         hRes = hInstance;
     }
+#endif
 
     appCore->setAlerter(new WinAlerter());
 

--- a/src/celestia/win32/winsplash.cpp
+++ b/src/celestia/win32/winsplash.cpp
@@ -10,7 +10,7 @@
 // of the License, or (at your option) any later version.
 
 #include "winsplash.h"
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include <celutil/winutil.h>
 #include <string>
 #include <winuser.h>

--- a/src/celestia/win32/winstarbrowser.cpp
+++ b/src/celestia/win32/winstarbrowser.cpp
@@ -15,10 +15,10 @@
 #include <windows.h>
 #include <commctrl.h>
 #include <cstring>
+#include <celutil/gettext.h>
+#include <celutil/winutil.h>
+#include <celmath/mathlib.h>
 #include "winstarbrowser.h"
-#include "celutil/winutil.h"
-#include "celmath/mathlib.h"
-
 #include "res/resource.h"
 
 extern void SetMouseCursor(LPCTSTR lpCursor);
@@ -57,7 +57,9 @@ bool InitStarBrowserColumns(HWND listView)
     for (i = 0; i < nColumns; i++)
         columns[i] = lvc;
 
+#ifdef ENABLE_NLS
     bind_textdomain_codeset("celestia", CurrentCP());
+#endif
 
     columns[0].pszText = _("Name");
     columns[0].cx = 100;
@@ -72,7 +74,9 @@ bool InitStarBrowserColumns(HWND listView)
     columns[3].cx = 65;
     columns[4].pszText = _("Type");
 
+#ifdef ENABLE_NLS
     bind_textdomain_codeset("celestia", "UTF8");
+#endif
 
     for (i = 0; i < nColumns; i++)
     {

--- a/src/celestia/win32/wintime.cpp
+++ b/src/celestia/win32/wintime.cpp
@@ -16,8 +16,8 @@
 #include <time.h>
 #include "res/resource.h"
 #include <celengine/astro.h>
-#include "celutil/util.h"
-#include "celutil/winutil.h"
+#include <celutil/gettext.h>
+#include <celutil/winutil.h>
 
 
 
@@ -91,12 +91,16 @@ SetTimeDialog::init(HWND _hDlg)
     useLocalTime = appCore->getTimeZoneBias() != 0;
     useUTCOffset = appCore->getDateFormat() == 2;
 
+#ifdef ENABLE_NLS
     bind_textdomain_codeset("celestia", CurrentCP());
+#endif
     SendDlgItemMessage(hDlg, IDC_COMBOBOX_TIMEZONE, CB_ADDSTRING, 0, (LPARAM) _("Universal Time"));
     SendDlgItemMessage(hDlg, IDC_COMBOBOX_TIMEZONE, CB_ADDSTRING, 0, (LPARAM) _("Local Time"));
     SendDlgItemMessage(hDlg, IDC_COMBOBOX_DATE_FORMAT, CB_ADDSTRING, 0, (LPARAM) _("Time Zone Name"));
     SendDlgItemMessage(hDlg, IDC_COMBOBOX_DATE_FORMAT, CB_ADDSTRING, 0, (LPARAM) _("UTC Offset"));
+#ifdef ENABLE_NLS
     bind_textdomain_codeset("celestia", "UTF8");
+#endif
 
     SendDlgItemMessage(hDlg, IDC_COMBOBOX_TIMEZONE, CB_SETCURSEL, useLocalTime ? 1 : 0, 0);
     SendDlgItemMessage(hDlg, IDC_COMBOBOX_DATE_FORMAT, CB_SETCURSEL, useUTCOffset ? 1 : 0, 0);

--- a/src/celscript/legacy/legacyscript.cpp
+++ b/src/celscript/legacy/legacyscript.cpp
@@ -12,7 +12,7 @@
 #include <celcompat/filesystem.h>
 #include <celcompat/memory.h>
 #include <celestia/celestiacore.h>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include "legacyscript.h"
 #include "cmdparser.h"
 #include "execution.h"

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -23,6 +23,7 @@
 #include <celengine/timeline.h>
 #include <celengine/timelinephase.h>
 #include <celutil/debug.h>
+#include <celutil/gettext.h>
 #include <celestia/celestiacore.h>
 #include <celestia/imagecapture.h>
 #include <celestia/url.h>

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -10,6 +10,7 @@
 // of the License, or (at your option) any later version.
 
 #include <celutil/debug.h>
+#include <celutil/gettext.h>
 #if NO_TTF
 #include "celtxf/texturefont.h"
 #else
@@ -2458,6 +2459,7 @@ static int celestia_getrootcategories(lua_State *l)
 
 static int celestia_bindtranslationdomain(lua_State *l)
 {
+#ifdef ENABLE_NLS
     CelxLua celx(l);
 
     const char *domain = celx.safeGetNonEmptyString(2, AllErrors, "First argument of celestia:bindtranslationdomain must be domain name string.");
@@ -2466,6 +2468,9 @@ static int celestia_bindtranslationdomain(lua_State *l)
     if (newdir == nullptr)
         return 0;
     return celx.push(newdir);
+#else
+    return 0;
+#endif
 }
 
 void ExtendCelestiaMetaTable(lua_State* l)

--- a/src/celscript/lua/luascript.cpp
+++ b/src/celscript/lua/luascript.cpp
@@ -16,7 +16,7 @@
 #include <celephem/scriptobject.h>
 #include <celestia/configfile.h>
 #include <celestia/celestiacore.h>
-#include <celutil/util.h>
+#include <celutil/gettext.h>
 #include "celx_internal.h"
 #include "luascript.h"
 

--- a/src/celutil/gettext.h
+++ b/src/celutil/gettext.h
@@ -1,0 +1,52 @@
+// gettext.h
+//
+// Copyright (C) 2001, Chris Laurel <claurel@shatters.net>
+// Copyright (C) 2020, the Celestia Development Team
+//
+// Miscellaneous useful functions.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#ifdef ENABLE_NLS
+
+#include <libintl.h>
+
+// gettext / libintl setup
+#ifndef _ /* unless somebody already took care of this */
+#define _(string) gettext (string)
+#endif
+
+#ifndef gettext_noop
+#define gettext_noop(string) string
+#endif
+
+#ifdef _WIN32
+// POSIX provides an extension to printf family to reorder their arguments,
+// so GNU GetText provides own replacement for them on windows platform
+#ifdef fprintf
+#undef fprintf
+#endif
+#ifdef printf
+#undef printf
+#endif
+#ifdef sprintf
+#undef sprintf
+#endif
+#endif // _WIN32
+
+#else // ENABLE_NLS
+
+#ifndef _
+#define _(string) string
+#endif
+
+#ifndef gettext_noop
+#define gettext_noop(string) string
+#endif
+
+#endif // ENABLE_NLS

--- a/src/celutil/util.cpp
+++ b/src/celutil/util.cpp
@@ -12,6 +12,7 @@
 #include <config.h>
 #include <celutil/debug.h>
 #include "util.h"
+#include "gettext.h"
 #ifdef _WIN32
 #include <shlobj.h>
 #include "winutil.h"

--- a/src/celutil/util.h
+++ b/src/celutil/util.h
@@ -15,30 +15,7 @@
 #include <string>
 #include <iostream>
 #include <functional>
-#include <libintl.h>
 #include <celcompat/filesystem.h>
-
-// gettext / libintl setup
-#ifndef _ /* unless somebody already took care of this */
-#define _(string) gettext (string)
-#endif
-#ifndef gettext_noop
-#define gettext_noop(string) string
-#endif
-
-#ifdef _WIN32
-// POSIX provides an extension to printf family to reorder their arguments,
-// so GNU GetText provides own replacement for them on windows platform
-#ifdef fprintf
-#undef fprintf
-#endif
-#ifdef printf
-#undef printf
-#endif
-#ifdef sprintf
-#undef sprintf
-#endif
-#endif
 
 extern int compareIgnoringCase(const std::string& s1, const std::string& s2);
 extern int compareIgnoringCase(const std::string& s1, const std::string& s2, int n);


### PR DESCRIPTION
Since the introduction of CMake we had `ENABLE_NLS` option but it was never properly implemented. It basically useless for end-users but I have a mingw & vcpkg based crosscompiling environment and it lacks gettext.