### PR TITLE
Fix a bug where shader might not compile

### DIFF
--- a/shaders/globular_vert.glsl
+++ b/shaders/globular_vert.glsl
@@ -40,7 +40,7 @@ float relStarDensity(void)
 void main(void)
 {
     vec3 p = m * gl_Vertex.xyz;
-    float br = 2 * brightness;
+    float br = 2.0f * brightness;
 
     vec4 mod = vec4(gl_ModelViewMatrix * gl_Vertex);
     float s = 2000.0 / -mod.z * br * starSize;


### PR DESCRIPTION
it's discovered while using gl4es shim, the operands should be of the same value type