### PR TITLE
Use libepoxy instead of GLEW

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,7 +54,7 @@ install:
 - vcpkg remove lua:x86-windows
 - vcpkg install luajit:x86-windows
 - vcpkg install fmt:x86-windows
-- vcpkg install glew:x86-windows
+- vcpkg install libepoxy:x86-windows
 - vcpkg install eigen3:x86-windows
 - vcpkg install freetype:x86-windows
 - git pull
@@ -70,7 +70,7 @@ build_script:
 
     cd build
 
-    cmake -DCMAKE_PREFIX_PATH=%Qt5_DIR% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DENABLE_SPICE=ON -DENABLE_TOOLS=ON -DENABLE_TTF=ON -DENABLE_TESTS=ON ..
+    cmake -DCMAKE_PREFIX_PATH=%Qt5_DIR% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DENABLE_SPICE=ON -DENABLE_TOOLS=ON -DENABLE_TTF=ON -DENABLE_TESTS=ON -DENABLE_GLEW=OFF ..
 
     cmake --build . --config Release -- /maxcpucount:4 /nologo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ matrix:
 
 before_script:
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt install -y liblua${LUA}-dev; fi
-- if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew install glew --build-from-source; brew link gettext --force; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew link gettext --force; fi
 - mkdir build
 - cd build
 
 script:
-- cmake -DENABLE_SPICE=ON -DENABLE_TOOLS=ON -DENABLE_TTF=ON -DENABLE_TESTS=ON ..
+- cmake -DENABLE_SPICE=ON -DENABLE_TOOLS=ON -DENABLE_TTF=ON -DENABLE_TESTS=ON -DENABLE_GLEW=OFF ..
 - make -j $(nproc || echo 4)
 - CTEST_OUTPUT_ON_FAILURE=1 ctest
 
@@ -43,7 +43,7 @@ addons:
   apt:
     packages:
     - libeigen3-dev
-    - libglew-dev
+    - libepoxy-dev
     - libtheora-dev
     - libjpeg-dev
     - libpng-dev
@@ -63,4 +63,5 @@ addons:
     - lua
     - qt5
     - freetype
+    - libepoxy
     update: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(NATIVE_OSX_APP "Support native OSX paths read data from (Default: off)" O
 option(FAST_MATH      "Build with unsafe fast-math compiller option (Default: off)" OFF)
 option(ENABLE_TTF     "Use TrueType fonts instead of TXF (Default: off)" OFF)
 option(ENABLE_TESTS   "Enable unit tests? (Default: off)" OFF)
+option(ENABLE_GLEW    "Use GLEW instead of libepoxy? (Default: on)" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type." FORCE)
@@ -144,9 +145,16 @@ find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIRS})
 link_libraries(${OPENGL_LIBRARIES})
 
-find_package(GLEW REQUIRED)
-link_libraries(GLEW::GLEW)
-include_directories(${GLEW_INCLUDE_DIRS})
+if(ENABLE_GLEW)
+  find_package(GLEW REQUIRED)
+  link_libraries(GLEW::GLEW)
+  include_directories(${GLEW_INCLUDE_DIRS})
+  add_definitions(-DUSE_GLEW)
+else()
+  find_package(Libepoxy REQUIRED)
+  link_libraries(libepoxy::libepoxy)
+  include_directories(${LIBEPOXY_INCLUDE_DIR})
+endif()
 
 find_package(Eigen3 3.3 NO_MODULE) # -DEigen3_DIR=...
 if(TARGET Eigen3::Eigen)

--- a/cmake/FindLibepoxy.cmake
+++ b/cmake/FindLibepoxy.cmake
@@ -1,0 +1,59 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindLibepoxy
+# --------
+#
+# Find the epoxy headers and libraries.
+#
+# This module reports information about the epoxy
+# installation in several variables.  General variables::
+#
+#   LIBEPOXY_FOUND - true if the epoxy headers and libraries were found
+#   LIBEPOXY_INCLUDE_DIRS - the directory containing the epoxy headers
+#   LIBEPOXY_LIBRARIES - epoxy libraries to be linked
+#
+# The following cache variables may also be set::
+#
+#   LIBEPOXY_INCLUDE_DIR - the directory containing the epoxy headers
+#   LIBEPOXY_LIBRARY - the epoxy library (if any)
+
+# Find include directory
+
+# TODO: use pkgconfig
+
+find_path(LIBEPOXY_INCLUDE_DIR
+          NAMES epoxy/gl.h
+          HINTS LIBEPOXY_DIR
+          DOC "epoxy headers")
+mark_as_advanced(LIBEPOXY_INCLUDE_DIR)
+
+find_library(LIBEPOXY_LIBRARY
+             NAMES epoxy
+             HINTS LIBEPOXY_DIR
+             DOC "epoxy libraries")
+mark_as_advanced(LIBEPOXY_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libepoxy
+                                  FOUND_VAR LIBEPOXY_FOUND
+                                  REQUIRED_VARS LIBEPOXY_INCLUDE_DIR LIBEPOXY_LIBRARY
+                                  FAIL_MESSAGE "Failed to find epoxy")
+
+if(LIBEPOXY_FOUND)
+  set(LIBEPOXY_INCLUDE_DIRS "${LIBEPOXY_INCLUDE_DIR}")
+  if(LIBEPOXY_LIBRARY)
+    set(LIBEPOXY_LIBRARIES "${LIBEPOXY_LIBRARY}")
+  else()
+    unset(LIBEPOXY_LIBRARIES)
+  endif()
+
+  if(NOT TARGET libepoxy::libepoxy)
+    add_library(libepoxy::libepoxy UNKNOWN IMPORTED)
+    set_target_properties(libepoxy::libepoxy PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LIBEPOXY_INCLUDE_DIRS}")
+    set_target_properties(libepoxy::libepoxy PROPERTIES
+      IMPORTED_LOCATION "${LIBEPOXY_LIBRARY}")
+  endif()
+endif()

--- a/src/celengine/CMakeLists.txt
+++ b/src/celengine/CMakeLists.txt
@@ -53,6 +53,8 @@ set(CELENGINE_SOURCES
   globular.h
   glshader.cpp
   glshader.h
+  glsupport.cpp
+  glsupport.h
   hash.cpp
   hash.h
   #hdrfuncrender.cpp

--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -8,7 +8,6 @@
 // of the License, or (at your option) any later version.
 
 #include <config.h>
-#include <GL/glew.h>
 #include <celutil/gettext.h>
 #include <celutil/debug.h>
 #include "stardb.h"

--- a/src/celengine/axisarrow.cpp
+++ b/src/celengine/axisarrow.cpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <vector>
 #include <celmath/mathlib.h>
-#include <GL/glew.h>
+#include "glsupport.h"
 #include "vecgl.h"
 #include "axisarrow.h"
 #include "selection.h"

--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -20,7 +20,7 @@
 #include <celutil/utf8.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <string>
 #include <vector>
 #include <array>

--- a/src/celengine/console.cpp
+++ b/src/celengine/console.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <celutil/utf8.h>
 #include <celmath/geomutil.h>
-#include <GL/glew.h>
+#include "glsupport.h"
 #include "vecgl.h"
 #include "console.h"
 #if NO_TTF

--- a/src/celengine/curveplot.cpp
+++ b/src/celengine/curveplot.cpp
@@ -34,8 +34,8 @@
 #define USE_VERTEX_BUFFER 1
 #endif
 
+#include "glsupport.h"
 #include "curveplot.h"
-#include "GL/glew.h"
 #include <vector>
 #include <iostream>
 

--- a/src/celengine/dds.cpp
+++ b/src/celengine/dds.cpp
@@ -13,10 +13,10 @@
 #include <celutil/debug.h>
 #include <celutil/bytes.h>
 #include <celengine/image.h>
-#include <GL/glew.h>
+#include "glsupport.h"
 
+using namespace celestia;
 using namespace std;
-
 
 
 struct DDPixelFormat
@@ -186,7 +186,7 @@ Image* LoadDDSImage(const fs::path& filename)
         format == GL_COMPRESSED_RGBA_S3TC_DXT3_EXT ||
         format == GL_COMPRESSED_RGBA_S3TC_DXT5_EXT)
     {
-        if (!GLEW_EXT_texture_compression_s3tc)
+        if (!gl::EXT_texture_compression_s3tc)
             return nullptr;
     }
 

--- a/src/celengine/framebuffer.h
+++ b/src/celengine/framebuffer.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <GL/glew.h>
+#include "glsupport.h"
 
 class FramebufferObject
 {

--- a/src/celengine/glcontext.cpp
+++ b/src/celengine/glcontext.cpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <celutil/debug.h>
 #include "glcontext.h"
-#include <GL/glew.h>
+#include "glsupport.h"
 
 using namespace std;
 

--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -11,7 +11,7 @@
 #include <celmath/frustum.h>
 #include <celmath/mathlib.h>
 #include <celutil/util.h>
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <vector>
 #include "render.h"
 #include "vertexobject.h"

--- a/src/celengine/glshader.cpp
+++ b/src/celengine/glshader.cpp
@@ -9,7 +9,6 @@
 
 #include <iostream>
 #include "glshader.h"
-#include <GL/glew.h>
 
 using namespace std;
 

--- a/src/celengine/glshader.h
+++ b/src/celengine/glshader.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <GL/glew.h>
+#include "glsupport.h"
 
 class GLShaderLoader;
 

--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -1,0 +1,57 @@
+#include "glsupport.h"
+
+namespace celestia
+{
+namespace gl
+{
+
+bool ARB_shader_texture_lod         = false;
+bool ARB_vertex_array_object        = false;
+bool EXT_framebuffer_object         = false;
+bool EXT_texture_compression_s3tc   = false;
+bool EXT_texture_filter_anisotropic = false;
+
+namespace
+{
+    inline bool has_extension(const char* name) noexcept
+    {
+#ifdef USE_GLEW
+        return glewIsSupported(name);
+#else
+        return epoxy_has_gl_extension(name);
+#endif
+    }
+}
+
+bool init() noexcept
+{
+#ifdef USE_GLEW
+    GLenum glewErr = glewInit();
+    if (glewErr != GLEW_OK)
+        return false;
+#endif
+    ARB_shader_texture_lod         = has_extension("GL_ARB_shader_texture_lod");
+    ARB_vertex_array_object        = has_extension("GL_ARB_vertex_array_object");
+    EXT_framebuffer_object         = has_extension("GL_EXT_framebuffer_object");
+    EXT_texture_compression_s3tc   = has_extension("GL_EXT_texture_compression_s3tc");
+    EXT_texture_filter_anisotropic = has_extension("GL_EXT_texture_filter_anisotropic");
+
+    return true;
+}
+
+bool checkVersion(int v) noexcept
+{
+#ifdef USE_GLEW
+    switch (v)
+    {
+    case GL_2_1:
+        return GLEW_VERSION_2_1 != GL_FALSE;
+    default:
+        return false;
+    }
+#else
+    return epoxy_gl_version() >= v;
+#endif
+}
+} // gl
+} // celestia

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#ifdef USE_GLEW
+#include <GL/glew.h>
+#else
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#include <epoxy/gl.h>
+#ifdef __APPLE__
+#include <OpenGL/glu.h>
+#else
+#include <GL/glu.h>
+#endif
+#endif
+
+namespace celestia
+{
+namespace gl
+{
+
+constexpr const int GL_2_1 = 21;
+
+extern bool ARB_shader_texture_lod;
+extern bool ARB_vertex_array_object;
+extern bool EXT_framebuffer_object;
+extern bool EXT_texture_compression_s3tc;
+extern bool EXT_texture_filter_anisotropic;
+
+bool init() noexcept;
+bool checkVersion(int) noexcept;
+} // gl
+} // celestia

--- a/src/celengine/image.cpp
+++ b/src/celengine/image.cpp
@@ -21,7 +21,7 @@ extern "C" {
 }
 #include <png.h>
 
-#include <GL/glew.h>
+#include "glsupport.h"
 
 #include <celutil/debug.h>
 #include <celutil/filetype.h>

--- a/src/celengine/lodspheremesh.cpp
+++ b/src/celengine/lodspheremesh.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 #include <algorithm>
 #include <celmath/mathlib.h>
-#include <GL/glew.h>
+#include "glsupport.h"
 #include "lodspheremesh.h"
 #include "shadermanager.h"
 

--- a/src/celengine/overlay.cpp
+++ b/src/celengine/overlay.cpp
@@ -10,7 +10,7 @@
 #include <cstring>
 #include <cstdarg>
 #include <iostream>
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <Eigen/Core>
 #include <celutil/debug.h>
 #include <celutil/utf8.h>

--- a/src/celengine/particlesystem.cpp
+++ b/src/celengine/particlesystem.cpp
@@ -17,7 +17,7 @@
 #include <limits>
 #include "modelgeometry.h"
 #include "particlesystem.h"
-#include <GL/glew.h>
+#include "glsupport.h"
 #include "vecgl.h"
 #include "rendcontext.h"
 #include "texmanager.h"

--- a/src/celengine/pointstarvertexbuffer.cpp
+++ b/src/celengine/pointstarvertexbuffer.cpp
@@ -8,7 +8,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <celutil/color.h>
 #include "objectrenderer.h"
 #include "shadermanager.h"

--- a/src/celengine/rendcontext.cpp
+++ b/src/celengine/rendcontext.cpp
@@ -13,7 +13,7 @@
 #include "texmanager.h"
 #include "modelgeometry.h"
 #include "body.h"
-#include <GL/glew.h>
+#include "glsupport.h"
 #include "render.h"
 
 using namespace cmod;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -80,7 +80,7 @@ std::ofstream hdrlog;
 #else
 #include <celttf/truetypefont.h>
 #endif
-#include <GL/glew.h>
+#include "glsupport.h"
 #ifdef VIDEO_SYNC
 #ifdef _WIN32
 #include <GL/wglew.h>
@@ -103,6 +103,7 @@ std::ofstream hdrlog;
 using namespace cmod;
 using namespace Eigen;
 using namespace std;
+using namespace celestia;
 using namespace celmath;
 
 #define FOV           45.0f
@@ -778,7 +779,7 @@ bool Renderer::init(
 #endif
 
 #ifdef ENABLE_SELF_SHADOW
-        if (GLEW_EXT_framebuffer_object)
+        if (gl::EXT_framebuffer_object)
         {
             shadowFbo = new FramebufferObject(1024, 1024, FramebufferObject::DepthAttachment);
             if (!shadowFbo->isValid())
@@ -4414,7 +4415,7 @@ void Renderer::renderPlanet(Body& body,
                     // us explicitly set the LOD. But, they do all have an optional lodBias parameter
                     // for the textureXD instruction. The bias is just the difference between the
                     // area light LOD and the approximate GPU calculated LOD.
-                    if (!GLEW_ARB_shader_texture_lod)
+                    if (!gl::ARB_shader_texture_lod)
                         lod = max(0.0f, lod - gpuLod);
                     lights.ringShadows[li].texLod = lod;
                 }
@@ -6761,12 +6762,9 @@ bool Renderer::getInfo(map<string, string>& info) const
     glGetFloatv(GL_SMOOTH_POINT_SIZE_GRANULARITY, &pointSizeGran);
     info["PointSizeGran"] = to_string(pointSizeGran);
 
-    if (GLEW_EXT_texture_cube_map)
-    {
-        GLint maxCubeMapSize = 0;
-        glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE_ARB, &maxCubeMapSize);
-        info["MaxCubeMapSize"] = to_string(maxCubeMapSize);
-    }
+    GLint maxCubeMapSize = 0;
+    glGetIntegerv(GL_MAX_CUBE_MAP_TEXTURE_SIZE_ARB, &maxCubeMapSize);
+    info["MaxCubeMapSize"] = to_string(maxCubeMapSize);
 
     s = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
     if (s != nullptr)

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -11,7 +11,7 @@
 #include <celutil/util.h>
 #include <celcompat/filesystem.h>
 #include "shadermanager.h"
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <cmath>
 #include <iostream>
 #include <fstream>
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <Eigen/Geometry>
 
+using namespace celestia;
 using namespace Eigen;
 using namespace std;
 
@@ -1220,7 +1221,7 @@ BeginLightSourceShadows(const ShaderProperties& props, unsigned int light)
 
     if (props.hasRingShadowForLight(light))
     {
-        if (GLEW_ARB_shader_texture_lod)
+        if (gl::ARB_shader_texture_lod)
         {
             source += mulAssign("shadow",
                       (1.0f - texture2DLod(sampler2D("ringTex"), vec2(ringShadowTexCoord(light), 0.0f), indexedUniform("ringShadowLOD", light))["a"]));
@@ -1918,7 +1919,7 @@ ShaderManager::buildFragmentShader(const ShaderProperties& props)
 
     // Without GL_ARB_shader_texture_lod enabled one can use texture2DLod
     // in vertext shaders only
-    if (GLEW_ARB_shader_texture_lod)
+    if (gl::ARB_shader_texture_lod)
         source += "#extension GL_ARB_shader_texture_lod : enable\n";
 
     string diffTexCoord("diffTexCoord");

--- a/src/celengine/spheremesh.cpp
+++ b/src/celengine/spheremesh.cpp
@@ -14,7 +14,7 @@
 
 #include "spheremesh.h"
 #include <celmath/mathlib.h>
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <cmath>
 
 using namespace Eigen;

--- a/src/celengine/texture.cpp
+++ b/src/celengine/texture.cpp
@@ -16,7 +16,7 @@
 #include <iostream>
 
 #include <Eigen/Core>
-#include <GL/glew.h>
+#include "glsupport.h"
 
 #include <celutil/filetype.h>
 #include <celutil/debug.h>
@@ -25,6 +25,7 @@
 #include "virtualtex.h"
 
 
+using namespace celestia;
 using namespace Eigen;
 using namespace std;
 
@@ -94,7 +95,7 @@ static const TextureCaps& GetTextureCaps()
         glGetIntegerv(GL_MAX_TEXTURE_SIZE, &texCaps.maxTextureSize);
 
         texCaps.preferredAnisotropy = 1;
-        if (GLEW_EXT_texture_filter_anisotropic)
+        if (gl::EXT_texture_filter_anisotropic)
         {
             GLint maxAnisotropy = 1;
             glGetIntegerv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAnisotropy);
@@ -388,7 +389,7 @@ ImageTexture::ImageTexture(Image& img,
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
                     mipmap ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
 
-    if (GLEW_EXT_texture_filter_anisotropic && texCaps.preferredAnisotropy > 1)
+    if (gl::EXT_texture_filter_anisotropic && texCaps.preferredAnisotropy > 1)
     {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, texCaps.preferredAnisotropy);
     }
@@ -400,7 +401,7 @@ ImageTexture::ImageTexture(Image& img,
     bool genMipmaps = mipmap && !precomputedMipMaps;
 
 #ifdef NO_GLU
-    if (genMipmaps && !GLEW_EXT_framebuffer_object)
+    if (genMipmaps && !gl::EXT_framebuffer_object)
         glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
 #endif
 
@@ -434,7 +435,7 @@ ImageTexture::ImageTexture(Image& img,
         LoadMiplessTexture(img, GL_TEXTURE_2D);
     }
 #ifdef NO_GLU
-    if (genMipmaps && GLEW_EXT_framebuffer_object)
+    if (genMipmaps && gl::EXT_framebuffer_object)
         glGenerateMipmapEXT(GL_TEXTURE_2D);
 #endif
     DumpTextureMipmapInfo(GL_TEXTURE_2D);
@@ -538,7 +539,7 @@ TiledTexture::TiledTexture(Image& img,
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
                             mipmap ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
-            if (GLEW_EXT_texture_filter_anisotropic && texCaps.preferredAnisotropy > 1)
+            if (gl::EXT_texture_filter_anisotropic && texCaps.preferredAnisotropy > 1)
             {
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, texCaps.preferredAnisotropy);
             }
@@ -619,7 +620,7 @@ TiledTexture::TiledTexture(Image& img,
                 if (mipmap)
                 {
 #ifdef NO_GLU
-                    if (GLEW_EXT_framebuffer_object)
+                    if (gl::EXT_framebuffer_object)
                     {
                         LoadMiplessTexture(*tile, GL_TEXTURE_2D);
                         glGenerateMipmapEXT(GL_TEXTURE_2D);
@@ -749,7 +750,7 @@ CubeMap::CubeMap(Image* faces[]) :
     bool genMipmaps = mipmap && !precomputedMipMaps;
 
 #ifdef NO_GLU
-    if (genMipmaps && !GLEW_EXT_framebuffer_object)
+    if (genMipmaps && !gl::EXT_framebuffer_object)
         glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_GENERATE_MIPMAP, GL_TRUE);
 #endif
 
@@ -784,7 +785,7 @@ CubeMap::CubeMap(Image* faces[]) :
         }
     }
 #ifdef NO_GLU
-    if (genMipmaps && GLEW_EXT_framebuffer_object)
+    if (genMipmaps && gl::EXT_framebuffer_object)
         glGenerateMipmapEXT(GL_TEXTURE_CUBE_MAP);
 #endif
     DumpTextureMipmapInfo(GL_TEXTURE_CUBE_MAP_POSITIVE_X);

--- a/src/celengine/vecgl.h
+++ b/src/celengine/vecgl.h
@@ -14,7 +14,7 @@
 #define _CELENGINE_VECGL_H_
 
 #include <celutil/color.h>
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 

--- a/src/celengine/vertexobject.cpp
+++ b/src/celengine/vertexobject.cpp
@@ -11,6 +11,8 @@
 
 #include "vertexobject.h"
 
+using namespace celestia;
+
 namespace celgl
 {
 VertexObject::VertexObject(GLenum bufferType) :
@@ -29,7 +31,7 @@ VertexObject::~VertexObject()
 {
     delete m_attribParams;
 
-    if (m_vaoId != 0 && GLEW_ARB_vertex_array_object)
+    if (m_vaoId != 0 && gl::ARB_vertex_array_object)
         glDeleteVertexArrays(1, &m_vaoId);
 
     if (m_vboId != 0)
@@ -40,7 +42,7 @@ void VertexObject::bind() noexcept
 {
     if ((m_state & State::Initialize) != 0)
     {
-        if (GLEW_ARB_vertex_array_object)
+        if (gl::ARB_vertex_array_object)
         {
             glGenVertexArrays(1, &m_vaoId);
             glBindVertexArray(m_vaoId);
@@ -50,7 +52,7 @@ void VertexObject::bind() noexcept
     }
     else
     {
-        if (GLEW_ARB_vertex_array_object)
+        if (gl::ARB_vertex_array_object)
         {
             glBindVertexArray(m_vaoId);
             if ((m_state & State::Update) != 0)
@@ -72,7 +74,7 @@ void VertexObject::bindWritable() noexcept
 
 void VertexObject::unbind() noexcept
 {
-    if (GLEW_ARB_vertex_array_object)
+    if (gl::ARB_vertex_array_object)
     {
         if ((m_state & (State::Initialize | State::Update)) != 0)
             glBindBuffer(m_bufferType, 0);

--- a/src/celengine/vertexobject.h
+++ b/src/celengine/vertexobject.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <array>
 #include <map>
 

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <utility>
 #include <celutil/debug.h>
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <celutil/debug.h>
 #include <celcompat/filesystem.h>
 #include <celutil/filetype.h>

--- a/src/celestia/avicapture.cpp
+++ b/src/celestia/avicapture.cpp
@@ -9,7 +9,6 @@
 
 #include <cmath>
 
-#include <GL/glew.h>
 #include <windowsx.h>
 #include <celutil/debug.h>
 #include "avicapture.h"

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -40,7 +40,6 @@
 #include <celcompat/filesystem.h>
 #include <celcompat/memory.h>
 #include <Eigen/Geometry>
-#include <GL/glew.h>
 #include <iostream>
 #include <fstream>
 #include <iomanip>

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -21,7 +21,6 @@
 #include <celengine/render.h>
 #include <celengine/simulation.h>
 #include <celengine/overlayimage.h>
-#include <GL/glew.h>
 #include "configfile.h"
 #include "favorites.h"
 #include "destination.h"

--- a/src/celestia/glut/glutmain.cpp
+++ b/src/celestia/glut/glutmain.cpp
@@ -18,7 +18,9 @@
 #include <cstring>
 #include <ctime>
 #include <unistd.h>
-#include <GL/glew.h>
+
+// celengine/glsupport.h must be included before GL/glut.h / GL/gl.h
+#include <celengine/glsupport.h>
 #ifndef MACOSX
 #include <GL/glut.h>
 #else
@@ -35,6 +37,7 @@
 #include "popt.h"
 */
 
+using namespace celestia;
 using namespace std;
 
 
@@ -513,12 +516,10 @@ int main(int argc, char* argv[])
     initMenus();
     #endif
 
-    GLenum glewErr = glewInit();
-    if (glewErr != GLEW_OK)
+    if (!gl::init() || !gl::checkVersion(gl::GL_2_1))
     {
-        fmt::fprintf(std::cerr,
-                     _("Celestia was unable to initialize OpenGL extensions (error %i). Graphics quality will be reduced."),
-                     glewErr);
+        cout << _("Celestia was unable to initialize OpenGL 2.1.\n");
+	return 1;
     }
 
     // GL should be all set up, now initialize the renderer.

--- a/src/celestia/gtk/actions.cpp
+++ b/src/celestia/gtk/actions.cpp
@@ -11,7 +11,6 @@
  */
 
 #include <config.h>
-#include <GL/glew.h>
 #include <cstring>
 #include <fstream>
 #include <gtk/gtk.h>
@@ -22,7 +21,7 @@
 #endif /* GNOME */
 
 #include <celengine/body.h>
-
+#include <celengine/glsupport.h>
 #include <celengine/simulation.h>
 #include <celengine/render.h>
 #include <celestia/celestiacore.h>

--- a/src/celestia/gtk/main.cpp
+++ b/src/celestia/gtk/main.cpp
@@ -24,12 +24,12 @@
 #include <unistd.h>
 #endif /* WIN32 */
 
-#include <GL/glew.h>
 #include <gtk/gtk.h>
 #include <gtk/gtkgl.h>
 
 #include <celengine/astro.h>
 #include <celengine/galaxy.h>
+#include <celengine/glsupport.h>
 #include <celengine/simulation.h>
 #include <celestia/celestiacore.h>
 #include <celutil/debug.h>
@@ -60,6 +60,7 @@
 #endif /* DEBUG */
 
 
+using namespace celestia;
 using namespace std;
 
 
@@ -242,17 +243,17 @@ public:
  *           that require the glArea to be set up. */
 static void initRealize(GtkWidget* widget, AppData* app)
 {
-    GLenum glewErr = glewInit();
-    if (GLEW_OK != glewErr)
+    if (!gl::init() || !gl::checkVersion(gl::GL_2_1))
     {
         GtkWidget *message;
         message = gtk_message_dialog_new(GTK_WINDOW(app->mainWindow),
                                          GTK_DIALOG_DESTROY_WITH_PARENT,
                                          GTK_MESSAGE_ERROR,
                                          GTK_BUTTONS_CLOSE,
-                                         "Celestia was unable to initialize OpenGL.");
+                                         "Celestia was unable to initialize OpenGL 2.1.");
         gtk_dialog_run(GTK_DIALOG(message));
         gtk_widget_destroy(message);
+	exit(1);
     }
 
     app->core->setAlerter(new GtkAlerter(app));

--- a/src/celestia/oggtheoracapture.cpp
+++ b/src/celestia/oggtheoracapture.cpp
@@ -67,7 +67,6 @@
 #include <cmath>
 #include <celutil/debug.h>
 #include <celutil/gettext.h>
-#include <GL/glew.h>
 #include <string>
 #include <theora/theora.h>
 

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -74,6 +74,7 @@
 #define CONFIG_DATA_DIR "./"
 #endif
 
+using namespace celestia;
 using namespace std;
 
 
@@ -257,11 +258,10 @@ void CelestiaAppWindow::init(const QString& qConfigFileName,
     glWidget = new CelestiaGlWidget(nullptr, "Celestia", m_appCore);
     glWidget->makeCurrent();
 
-    GLenum glewErr = glewInit();
-    if (glewErr != GLEW_OK)
+    if (!gl::init() || !gl::checkVersion(gl::GL_2_1))
     {
-        QMessageBox::critical(0, "Celestia",
-                              QString(_("Celestia was unable to initialize OpenGL extensions (error %1). Graphics quality will be reduced.")).arg(glewErr));
+        QMessageBox::critical(0, "Celestia", _("Celestia was unable to initialize OpenGL 2.1."));
+	exit(1);
     }
 
     m_appCore->setCursorHandler(glWidget);

--- a/src/celestia/qt/qtglwidget.h
+++ b/src/celestia/qt/qtglwidget.h
@@ -14,8 +14,6 @@
 #ifndef QTGLWIDGET_H
 #define QTGLWIDGET_H
 
-#include <GL/glew.h>
-
 #include <QGLWidget>
 
 #include "celestia/celestiacore.h"

--- a/src/celestia/win32/wglext.cpp
+++ b/src/celestia/win32/wglext.cpp
@@ -9,7 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <GL/glew.h>
+#include <celengine/glsupport.h>
 //#define WGL_WGLEXT_PROTOTYPES 1
 #include "wglext.h"
 #include <windows.h>

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -3246,8 +3246,6 @@ int APIENTRY WinMain(HINSTANCE hInstance,
     if (!initSucceeded)
         return 1;
 
-    appCore->getRenderer()->setSolarSystemMaxDistance(appCore->getConfig()->SolarSystemMaxDistance);
-
     if (startURL != "")
         appCore->setStartURL(startURL);
 
@@ -3263,6 +3261,8 @@ int APIENTRY WinMain(HINSTANCE hInstance,
             hDefaultCursor = LoadCursor(hRes, MAKEINTRESOURCE(IDC_CROSSHAIR));
         else
             hDefaultCursor = LoadCursor(hRes, MAKEINTRESOURCE(IDC_CROSSHAIR_OPAQUE));
+
+        appCore->getRenderer()->setSolarSystemMaxDistance(appCore->getConfig()->SolarSystemMaxDistance);
     }
 
     cursorHandler = new WinCursorHandler(hDefaultCursor);

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -27,6 +27,8 @@
 #include <commdlg.h>
 #include <shellapi.h>
 
+#include <celengine/glsupport.h>
+
 #include <celmath/mathlib.h>
 #include <celutil/debug.h>
 #include <celutil/gettext.h>
@@ -34,10 +36,7 @@
 #include <celutil/filetype.h>
 #include <celengine/astro.h>
 #include <celscript/legacy/cmdparser.h>
-#include <celengine/axisarrow.h>
-#include <celengine/planetgrid.h>
 
-#include <GL/glew.h>
 #include "celestia/celestiacore.h"
 #include "celestia/avicapture.h"
 #include "celestia/helper.h"
@@ -62,6 +61,7 @@
 #include <locale.h>
 #include <fmt/printf.h>
 
+using namespace celestia;
 using namespace std;
 
 typedef pair<int,string> IntStrPair;
@@ -1947,10 +1947,11 @@ HWND CreateOpenGLWindow(int x, int y, int width, int height,
 
     if (firstContext)
     {
-        GLenum glewErr = glewInit();
-        if (glewErr != GLEW_OK)
+        if (!gl::init() || !gl::checkVersion(gl::GL_2_1))
         {
-            MessageBox(NULL, "Could not set up OpenGL extensions.", "Fatal Error",
+            MessageBox(NULL,
+                       _("You system doesn't support OpenGL 2.1!"),
+                       "Fatal Error",
                        MB_OK | MB_ICONERROR);
             return NULL;
         }

--- a/src/celscript/lua/celx_gl.cpp
+++ b/src/celscript/lua/celx_gl.cpp
@@ -12,7 +12,7 @@
 #include "celx.h"
 #include "celx_internal.h"
 #include "celx_object.h"
-#include <GL/glew.h>
+#include <celengine/glsupport.h>
 
 
 // ==================== OpenGL ====================

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -12,9 +12,9 @@
 #include <array>
 #include <iostream>
 #include <vector>
-#include <GL/glew.h>
 #include <fmt/printf.h>
 #include <celutil/utf8.h>
+#include <celengine/glsupport.h>
 #include <celengine/render.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H

--- a/src/celtxf/texturefont.cpp
+++ b/src/celtxf/texturefont.cpp
@@ -15,8 +15,8 @@
 #include <celutil/bytes.h>
 #include <celutil/utf8.h>
 #include <celutil/util.h>
+#include <celengine/glsupport.h>
 #include <celengine/render.h>
-#include <GL/glew.h>
 #include "texturefont.h"
 
 using namespace std;

--- a/src/tools/cmod/cmodview/CMakeLists.txt
+++ b/src/tools/cmod/cmodview/CMakeLists.txt
@@ -18,5 +18,5 @@ set(CMAKE_AUTOMOC ON)
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-build_cmod_tool(cmodview WIN32 cmodview.cpp glframebuffer.cpp  glshader.cpp  mainwindow.cpp  materialwidget.cpp  modelviewwidget.cpp)
+build_cmod_tool(cmodview WIN32 cmodview.cpp glframebuffer.cpp  glshader.cpp  mainwindow.cpp  materialwidget.cpp  modelviewwidget.cpp glsupport.cpp)
 qt5_use_modules(cmodview ${QT_LIBS})

--- a/src/tools/cmod/cmodview/glframebuffer.h
+++ b/src/tools/cmod/cmodview/glframebuffer.h
@@ -12,7 +12,7 @@
 #ifndef _GLFRAMEBUFFER_H_
 #define _GLFRAMEBUFFER_H_
 
-#include <GL/glew.h>
+#include "glsupport.h"
 
 
 class GLFrameBufferObject

--- a/src/tools/cmod/cmodview/glshader.cpp
+++ b/src/tools/cmod/cmodview/glshader.cpp
@@ -11,6 +11,7 @@
 
 #include "glshader.h"
 
+using namespace celestia;
 using namespace std;
 
 
@@ -177,7 +178,7 @@ GLShaderProgram::link()
 bool
 GLShaderProgram::hasOpenGLShaderPrograms()
 {
-    return GLEW_ARB_shader_objects && GLEW_ARB_shading_language_100;
+    return gl::ARB_shader_objects && gl::ARB_shading_language_100;
 }
 
 

--- a/src/tools/cmod/cmodview/glshader.h
+++ b/src/tools/cmod/cmodview/glshader.h
@@ -9,7 +9,7 @@
 //
 // C++ wrapper for OpenGL shaders and shader programs
 
-#include <GL/glew.h>
+#include "glsupport.h"
 #include <Eigen/Core>
 #include <string>
 

--- a/src/tools/cmod/cmodview/glsupport.cpp
+++ b/src/tools/cmod/cmodview/glsupport.cpp
@@ -1,0 +1,53 @@
+#include "glsupport.h"
+
+namespace celestia
+{
+namespace gl
+{
+
+bool ARB_shader_objects       = false;
+bool ARB_shading_language_100 = false;
+bool EXT_framebuffer_object   = false;
+
+namespace
+{
+    inline bool has_extension(const char* name) noexcept
+    {
+#ifdef USE_GLEW
+        return glewIsSupported(name);
+#else
+        return epoxy_has_gl_extension(name);
+#endif
+    }
+}
+
+bool init() noexcept
+{
+#ifdef USE_GLEW
+    GLenum glewErr = glewInit();
+    if (glewErr != GLEW_OK)
+        return false;
+#endif
+    ARB_shader_objects       = has_extension("GL_ARB_shader_objects");
+    ARB_shading_language_100 = has_extension("GL_ARB_shading_language_100");
+    EXT_framebuffer_object   = has_extension("GL_EXT_framebuffer_object");
+
+    return true;
+}
+
+bool checkVersion(int v) noexcept
+{
+#ifdef USE_GLEW
+    switch (v)
+    {
+    case GL_2_1:
+        return GLEW_VERSION_2_1 != GL_FALSE;
+    default:
+        return false;
+    }
+#else
+    return epoxy_gl_version() >= v;
+#endif
+}
+} // gl
+} // celestia

--- a/src/tools/cmod/cmodview/glsupport.h
+++ b/src/tools/cmod/cmodview/glsupport.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#ifdef USE_GLEW
+#include <GL/glew.h>
+#else
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#include <epoxy/gl.h>
+#ifdef __APPLE__
+#include <OpenGL/glu.h>
+#else
+#include <GL/glu.h>
+#endif
+#endif
+
+namespace celestia
+{
+namespace gl
+{
+
+constexpr const int GL_2_1 = 21;
+
+extern bool ARB_shader_objects;
+extern bool ARB_shading_language_100;
+extern bool EXT_framebuffer_object;
+
+bool init() noexcept;
+bool checkVersion(int) noexcept;
+} // gl
+} // celestia

--- a/src/tools/cmod/cmodview/materialwidget.cpp
+++ b/src/tools/cmod/cmodview/materialwidget.cpp
@@ -7,7 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <GL/glew.h>
+#include "glsupport.h"
 #include "materialwidget.h"
 #include <celmodel/material.h>
 #include <QGridLayout>

--- a/src/tools/cmod/cmodview/modelviewwidget.cpp
+++ b/src/tools/cmod/cmodview/modelviewwidget.cpp
@@ -8,7 +8,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <GL/glew.h>
+#include "glsupport.h"
 #include "modelviewwidget.h"
 #include "glframebuffer.h"
 #include <QFileInfo>
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <iostream>
 
+using namespace celestia;
 using namespace cmod;
 using namespace Eigen;
 
@@ -545,7 +546,7 @@ ModelViewWidget::setBackgroundColor(const QColor& color)
 void
 ModelViewWidget::initializeGL()
 {
-    glewInit();
+    gl::init();
     emit contextCreated();
 }
 
@@ -878,7 +879,7 @@ ModelViewWidget::setAmbientLight(bool enable)
 void
 ModelViewWidget::setShadows(bool enable)
 {
-    if (!GLEW_EXT_framebuffer_object)
+    if (!gl::EXT_framebuffer_object)
     {
         return;
     }


### PR DESCRIPTION
Unlike GLEW libepoxy supports OpenGL ES and better handles cases with
functions provided by different extensions, e.g. the same functions
provided by vendor/EXT/ARB/core.