### PR TITLE
Use core/FBO function to generate mipmaps instead of glu

### DIFF
--- a/src/celengine/texture.cpp
+++ b/src/celengine/texture.cpp
@@ -15,11 +15,6 @@
 #include <fstream>
 #include <iostream>
 
-extern "C" {
-#include <jpeglib.h>
-}
-#include <png.h>
-
 #include <Eigen/Core>
 #include <GL/glew.h>
 
@@ -44,6 +39,26 @@ struct TextureCaps
 
 static TextureCaps texCaps;
 
+#define NO_GLU
+#undef DUMP_TEXTURE_MIPMAP_INFO
+
+#ifdef DUMP_TEXTURE_MIPMAP_INFO
+static void DumpTextureMipmapInfo(GLenum target)
+{
+    for (int i = 0; i < 16; i++)
+    {
+        GLint w = 0, h = 0;
+        glGetTexLevelParameteriv(target, i, GL_TEXTURE_HEIGHT, &h);
+        if (glGetError() != GL_NO_ERROR) break;
+        glGetTexLevelParameteriv(target, i, GL_TEXTURE_WIDTH, &w);
+        if (glGetError() != GL_NO_ERROR) break;
+        if (w == 0 || h == 0) break;
+        cout << w << 'x' << h << '\n';
+    }
+}
+#else
+#define DumpTextureMipmapInfo(target) (void)target
+#endif
 
 static bool testMaxLevel()
 {
@@ -382,6 +397,12 @@ ImageTexture::ImageTexture(Image& img,
         glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
 
     int internalFormat = getInternalFormat(img.getFormat());
+    bool genMipmaps = mipmap && !precomputedMipMaps;
+
+#ifdef NO_GLU
+    if (genMipmaps && !GLEW_EXT_framebuffer_object)
+        glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
+#endif
 
     if (mipmap)
     {
@@ -391,12 +412,16 @@ ImageTexture::ImageTexture(Image& img,
         }
         else if (mipMapMode == DefaultMipMaps)
         {
+#ifdef NO_GLU
+            LoadMiplessTexture(img, GL_TEXTURE_2D);
+#else
             gluBuild2DMipmaps(GL_TEXTURE_2D,
                               internalFormat,
                               getWidth(), getHeight(),
                               (GLenum) img.getFormat(),
                               GL_UNSIGNED_BYTE,
                               img.getPixels());
+#endif
         }
         else
         {
@@ -408,6 +433,11 @@ ImageTexture::ImageTexture(Image& img,
     {
         LoadMiplessTexture(img, GL_TEXTURE_2D);
     }
+#ifdef NO_GLU
+    if (genMipmaps && GLEW_EXT_framebuffer_object)
+        glGenerateMipmapEXT(GL_TEXTURE_2D);
+#endif
+    DumpTextureMipmapInfo(GL_TEXTURE_2D);
 
     alpha = img.hasAlpha();
     compressed = img.isCompressed();
@@ -588,17 +618,31 @@ TiledTexture::TiledTexture(Image& img,
 
                 if (mipmap)
                 {
+#ifdef NO_GLU
+                    if (GLEW_EXT_framebuffer_object)
+                    {
+                        LoadMiplessTexture(*tile, GL_TEXTURE_2D);
+                        glGenerateMipmapEXT(GL_TEXTURE_2D);
+                    }
+                    else
+                    {
+                        glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
+                        LoadMiplessTexture(*tile, GL_TEXTURE_2D);
+                    }
+#else
                     gluBuild2DMipmaps(GL_TEXTURE_2D,
                                       internalFormat,
                                       tileWidth, tileHeight,
                                       (GLenum) tile->getFormat(),
                                       GL_UNSIGNED_BYTE,
                                       tile->getPixels());
+#endif
                 }
                 else
                 {
                     LoadMiplessTexture(*tile, GL_TEXTURE_2D);
                 }
+                DumpTextureMipmapInfo(GL_TEXTURE_2D);
             }
         }
     }
@@ -702,6 +746,12 @@ CubeMap::CubeMap(Image* faces[]) :
                     mipmap ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
 
     int internalFormat = getInternalFormat(format);
+    bool genMipmaps = mipmap && !precomputedMipMaps;
+
+#ifdef NO_GLU
+    if (genMipmaps && !GLEW_EXT_framebuffer_object)
+        glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_GENERATE_MIPMAP, GL_TRUE);
+#endif
 
     for (i = 0; i < 6; i++)
     {
@@ -716,12 +766,16 @@ CubeMap::CubeMap(Image* faces[]) :
             }
             else
             {
+#ifdef NO_GLU
+                LoadMiplessTexture(*face, targetFace);
+#else
                 gluBuild2DMipmaps(targetFace,
                                   internalFormat,
                                   getWidth(), getHeight(),
                                   (GLenum) face->getFormat(),
                                   GL_UNSIGNED_BYTE,
                                   face->getPixels());
+#endif
             }
         }
         else
@@ -729,6 +783,11 @@ CubeMap::CubeMap(Image* faces[]) :
             LoadMiplessTexture(*face, targetFace);
         }
     }
+#ifdef NO_GLU
+    if (genMipmaps && GLEW_EXT_framebuffer_object)
+        glGenerateMipmapEXT(GL_TEXTURE_CUBE_MAP);
+#endif
+    DumpTextureMipmapInfo(GL_TEXTURE_CUBE_MAP_POSITIVE_X);
 }
 
 


### PR DESCRIPTION
Desktop GL 1.4 doesn't require glu to generate texture mip maps because it has `GL_GENERATE_MIPMAP`. GL ES 2 and GL 2 with FBO have `glGenerateMipmap`.

So in this PR `glGenerateMipmap` is a preferred method, and if FBO doesn't preset, then `GL_GENERATE_MIPMAP` is used.

This change may break something but actually I doubt it will. I want to have it merged to test it on wider audience. 