### PR TITLE
Update author list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,7 @@ Toti <>
 Da Woon Jung <dirkpitt2050@users.sf.net>
 Vincent Giangiulio <vince.gian@free.fr>
 Andrew Tribick
+Hleb Valoshka
+Li Linfeng
+Dmitry Brant
+Łukasz Buczyński


### PR DESCRIPTION
The AUTHORS file had been updated on the 1.6.2 branch but not on the master branch. I think Dmitry Brant should be replaced by Łukasz Buczyński (@pirogronian), but I left it as it is on the 1.6.2 branch.