### PR TITLE
Initial implementation of self shadowing

### DIFF
--- a/src/celengine/framebuffer.cpp
+++ b/src/celengine/framebuffer.cpp
@@ -103,8 +103,9 @@ FramebufferObject::generateDepthTexture()
     glBindTexture(GL_TEXTURE_2D, m_depthTexId);
 
     // Only nearest sampling is appropriate for depth textures
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    // But we can use linear to decrease aliasing
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
     // Clamp to edge
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/src/celengine/rendcontext.h
+++ b/src/celengine/rendcontext.h
@@ -81,6 +81,7 @@ class GLSL_RenderContext : public RenderContext
     void makeCurrent(const cmod::Material&) override;
     void setLunarLambert(float);
     void setAtmosphere(const Atmosphere*);
+    void setShadowMap(GLuint, GLuint, const Eigen::Matrix4f*);
 
  private:
      void initLightingEnvironment();
@@ -99,6 +100,9 @@ class GLSL_RenderContext : public RenderContext
     float lunarLambert{ 0.0f };
 
     ShaderProperties shaderProps;
+    const Eigen::Matrix4f *lightMatrix { nullptr };
+    GLuint shadowMap { 0 };
+    GLuint shadowMapWidth { 0 };
 };
 
 

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -11,9 +11,10 @@
 #ifndef _CELENGINE_RENDER_H_
 #define _CELENGINE_RENDER_H_
 
-#include <vector>
 #include <list>
+#include <memory>
 #include <string>
+#include <vector>
 #include <Eigen/Core>
 #include <celengine/universe.h>
 #include <celengine/selection.h>
@@ -35,6 +36,7 @@ class AsterismRenderer;
 class BoundariesRenderer;
 class Observer;
 class TextureFont;
+class FramebufferObject;
 namespace celmath
 {
 class Frustum;
@@ -249,6 +251,7 @@ class Renderer
     bool getVideoSync() const;
     void setVideoSync(bool);
     void setSolarSystemMaxDistance(float);
+    void setShadowMapSize(unsigned);
 
     bool captureFrame(int, int, int, int, PixelFormat format, unsigned char*, bool = false) const;
 
@@ -368,6 +371,8 @@ class Renderer
     void addWatcher(RendererWatcher*);
     void removeWatcher(RendererWatcher*);
     void notifyWatchers() const;
+
+    FramebufferObject* getShadowFBO(int) const;
 
  public:
     // Internal types
@@ -616,6 +621,8 @@ class Renderer
 
     void updateBodyVisibilityMask();
 
+    void createShadowFBO();
+
 #ifdef USE_HDR
  private:
     int sceneTexWidth, sceneTexHeight;
@@ -775,6 +782,10 @@ class Renderer
     // will not necessarily be rendered correctly. This limit is used for
     // visibility culling of solar systems.
     float SolarSystemMaxDistance{ 1.0f };
+
+    // Size of a texture used in shadow mapping
+    unsigned m_shadowMapSize { 0 };
+    std::unique_ptr<FramebufferObject> m_shadowFBO;
 
     std::array<celgl::VertexObject*, static_cast<size_t>(VOType::Count)> m_VertexObjects;
 

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -41,6 +41,7 @@ class ShaderProperties
     void setCloudShadowForLight(unsigned int lightIndex, bool enabled);
     bool hasCloudShadowForLight(unsigned int lightIndex) const;
     bool hasCloudShadows() const;
+    bool hasShadowMap() const;
 
     bool hasShadowsForLight(unsigned int) const;
     bool hasSharedTextureCoords() const;
@@ -60,6 +61,7 @@ class ShaderProperties
      CloudShadowTexture      =   0x80,
      CompressedNormalTexture =  0x100,
      EmissiveTexture         =  0x200,
+     ShadowMapTexture        =  0x400,
      VertexOpacities         =  0x800,
      VertexColors            = 0x1000,
      Scattering              = 0x2000,
@@ -272,6 +274,9 @@ class CelestiaGLProgram
 
     // Color sent as a uniform
     Vec4ShaderParameter color;
+
+    // Matrix used to project to light space
+    Mat4ShaderParameter ShadowMatrix0;
 
     CelestiaGLProgramShadow shadows[MaxShaderLights][MaxShaderEclipseShadows];
 

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -98,6 +98,8 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
     configParams->getNumber("SolarSystemMaxDistance", maxDist);
     config->SolarSystemMaxDistance = min(max(maxDist, 1.0f), 10.0f);
 
+    config->ShadowMapSize = getUint(configParams, "ShadowMapSize", 0);
+
     double aaSamples = 1;
     configParams->getNumber("AntialiasingSamples", aaSamples);
     config->aaSamples = (unsigned int) aaSamples;

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -76,6 +76,7 @@ public:
     const std::string getStringValue(const std::string& name);
 
     float SolarSystemMaxDistance;
+    unsigned ShadowMapSize;
 };
 
 CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig* config = nullptr);

--- a/src/celestia/glut/glutmain.cpp
+++ b/src/celestia/glut/glutmain.cpp
@@ -526,6 +526,7 @@ int main(int argc, char* argv[])
     appCore->initRenderer();
 
     appCore->getRenderer()->setSolarSystemMaxDistance(appCore->getConfig()->SolarSystemMaxDistance);
+    appCore->getRenderer()->setShadowMapSize(appCore->getConfig()->ShadowMapSize);
 
     // Set the simulation starting time to the current system time
     appCore->start();

--- a/src/celestia/gtk/main.cpp
+++ b/src/celestia/gtk/main.cpp
@@ -411,6 +411,7 @@ int main(int argc, char* argv[])
     g_assert(app->simulation);
 
     app->renderer->setSolarSystemMaxDistance(app->core->getConfig()->SolarSystemMaxDistance);
+    app->renderer->setShadowMapSize(app->core->getConfig()->ShadowMapSize);
 
     #ifdef GNOME
     /* Create the main window (GNOME) */

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -160,6 +160,7 @@ void CelestiaGlWidget::initializeGL()
     appCore->setScreenDpi(logicalDpiY());
 
     appRenderer->setSolarSystemMaxDistance(appCore->getConfig()->SolarSystemMaxDistance);
+    appRenderer->setShadowMapSize(appCore->getConfig()->ShadowMapSize);
 }
 
 

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -3263,6 +3263,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
             hDefaultCursor = LoadCursor(hRes, MAKEINTRESOURCE(IDC_CROSSHAIR_OPAQUE));
 
         appCore->getRenderer()->setSolarSystemMaxDistance(appCore->getConfig()->SolarSystemMaxDistance);
+        appCore->getRenderer()->setShadowMapSize(appCore->getConfig()->ShadowMapSize);
     }
 
     cursorHandler = new WinCursorHandler(hDefaultCursor);


### PR DESCRIPTION
Known bugs and limitations:
  * Only the 1st light source casts shadows.
  * Thin objects have incorrect shadows, see ISS.

Disabled by default. Can be enabled by setting `ShadowMapSize` option in `celestia.cfg`/`~/.celestia.cfg`. I don't think that setting higher value that 4096 increases quality. I suggest 2048 for older hardware and 4096 for newer. If hardware allows then it's better enable MSAA: `AntialiasingSamples 1`.

For gl4es builds it's better to use `-DGL_ONLY_SHADOWS=0`.