### PR TITLE
small render-related cleanup

### DIFF
--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -20,11 +20,10 @@
 #include <celutil/utf8.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include "glsupport.h"
 #include <string>
 #include <vector>
-#include <array>
 #include <map>
+#include <memory>
 #include <list>
 
 class Selection;
@@ -81,6 +80,18 @@ class PlanetarySystem
 };
 
 
+class RingRenderData
+{
+ public:
+    RingRenderData() = default;
+    virtual ~RingRenderData() = default;
+    RingRenderData(const RingRenderData&) = delete;
+    RingRenderData(RingRenderData&&) = delete;
+    RingRenderData& operator=(const RingRenderData&) = delete;
+    RingRenderData& operator=(RingRenderData&&) = delete;
+};
+
+
 class RingSystem
 {
  public:
@@ -88,7 +99,7 @@ class RingSystem
     float outerRadius;
     Color color;
     MultiResTexture texture;
-    std::array<GLuint, 4> vboId {{ 0, 0, 0, 0 }};
+    std::shared_ptr<RingRenderData> renderData;
 
     RingSystem(float inner, float outer) :
         innerRadius(inner), outerRadius(outer),

--- a/src/celengine/overlay.cpp
+++ b/src/celengine/overlay.cpp
@@ -188,19 +188,29 @@ void Overlay::drawRectangle(const Rect& r)
     renderer.drawRectangle(r);
 }
 
-void Overlay::setColor(float r, float g, float b, float a) const
+void Overlay::setColor(float r, float g, float b, float a)
 {
     glColor4f(r, g, b, a);
 }
 
-void Overlay::setColor(const Color& c) const
+void Overlay::setColor(const Color& c)
 {
     glColor4f(c.red(), c.green(), c.blue(), c.alpha());
 }
 
-void Overlay::moveBy(float dx, float dy, float dz) const
+void Overlay::moveBy(float dx, float dy, float dz)
 {
     glTranslatef(dx, dy, dz);
+}
+
+void Overlay::savePos()
+{
+    glPushMatrix();
+}
+
+void Overlay::restorePos()
+{
+    glPopMatrix();
 }
 
 //

--- a/src/celengine/overlay.h
+++ b/src/celengine/overlay.h
@@ -60,18 +60,13 @@ class Overlay : public std::ostream
     void setWindowSize(int, int);
     void setFont(TextureFont*);
 
-    void setColor(float r, float g, float b, float a) const;
-    void setColor(const Color& c) const;
+    void setColor(float r, float g, float b, float a);
+    void setColor(const Color& c);
 
-    void moveBy(float dx, float dy, float dz = 0.0f) const;
-    void savePos() const
-    {
-        glPushMatrix();
-    };
-    void restorePos() const
-    {
-        glPopMatrix();
-    };
+    void moveBy(float dx, float dy, float dz = 0.0f);
+    void savePos();
+    void restorePos();
+
     Renderer& getRenderer() const
     {
         return renderer;


### PR DESCRIPTION
just to decouple renderer from other engine.

`const` removed because with other renderers they won't be const potentially.