### PR TITLE
Update INSTALL.md, ENABLE_DATA set to ON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(FAST_MATH      "Build with unsafe fast-math compiller option (Default: of
 option(ENABLE_TTF     "Use TrueType fonts instead of TXF (Default: off)" OFF)
 option(ENABLE_TESTS   "Enable unit tests? (Default: off)" OFF)
 option(ENABLE_GLEW    "Use GLEW instead of libepoxy? (Default: on)" ON)
-option(ENABLE_DATA    "Install data from content submodule? (Default: off)" OFF)
+option(ENABLE_DATA    "Install data from content submodule? (Default: on)" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type." FORCE)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -274,23 +274,23 @@ Install Homebrew
 Install required packages:
 
 ```
-brew install cmake cspice fmt gettext libpng lua qt5 jpeg eigen
+brew install cmake glew fmt gettext libpng lua qt5 jpeg eigen
 ```
 
-Build GLEW from source (Homebrew's precompiled GLEW has wrong linking path):
+Install optional packages:
 
 ```
-brew install glew --build-from-source
+brew install cspice
 ```
 
-Clone the source and go to the source directory.
+Follow common building instructions to fetch the source.
 
 Configure and build:
 
 ```
 mkdir build
 cd build
-cmake -DENABLE_SPICE=ON ..
+cmake ..
 make -jN
 ```
 
@@ -303,8 +303,8 @@ make install
 ```
 
 Celestia will be installed into /usr/local by default, with data files landing
-in /usr/local/share/celestia, but you may specify a new location with the
-following option to cmake: `-DCMAKE_INSTALL_PREFIX=/another/path`.
+in /usr/local/share/celestia, but you may want to specify a new location with
+the following option to cmake: `-DCMAKE_INSTALL_PREFIX=/another/path`.
 
 To build the application bundle, pass -DNATIVE_OSX_APP=ON to the cmake command,
 the application bundle will be located in the "build" folder that you previously
@@ -329,6 +329,7 @@ List of supported parameters (passed as `-DPARAMETER=VALUE`):
 | ENABLE_THEORA        | bool | \*\*ON    | Support video capture to OGG Theora
 | ENABLE_TOOLS         | bool | OFF     | Build tools for Celestia data files
 | ENABLE_TTF           | bool | \*\*\*\*OFF | Build with FreeType support
+| ENABLE_DATA          | bool | OFF     | Use CelestiaContent submodule for data
 | NATIVE_OSX_APP       | bool | OFF     | Support native OSX data paths
 
 Notes:  

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,7 @@ override_dh_auto_configure:
 		-DENABLE_QT=ON		\
 		-DENABLE_TOOLS=ON	\
 		-DENABLE_TTF=ON		\
+		-DENABLE_DATA=OFF       \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DGIT_COMMIT="$$_git_commit"
 


### PR DESCRIPTION
Some changes the macosx build instruction and add ENABLE_DATA to supported parameters. 