### PR TITLE
Add WO spectral class

### DIFF
--- a/celestia.cfg
+++ b/celestia.cfg
@@ -101,6 +101,7 @@ StarTextures
 	# Wolf-Rayet stars
 	WC "bstar.*"
 	WN "bstar.*"
+	WO "bstar.*"
 
 	# brown dwarfs
 	L "browndwarf.*"

--- a/src/celengine/star.cpp
+++ b/src/celengine/star.cpp
@@ -106,7 +106,8 @@ static float tempM[3][10] =
 };
 
 // Wolf-Rayet temperatures. From Lang's Astrophysical Data: Planets and
-// Stars.
+// Stars. WO2 to WO4 temperatures taken from a sample of 6 WO stars.
+// Unused spectral types are filled in based on the closest type with data.
 static float tempWN[10] =
 {
     50000, 50000, 50000, 50000, 47000, 43000, 39000, 32000, 29000, 29000
@@ -115,6 +116,11 @@ static float tempWN[10] =
 static float tempWC[10] =
 {
     60000, 60000, 60000, 60000, 60000, 60000, 60000, 54000, 46000, 38000
+};
+
+static float tempWO[10] =
+{
+    210000, 210000, 200000, 160000, 140000, 130000, 130000, 130000, 130000, 130000
 };
 
 // Brown dwarf temperatures. From this website:
@@ -385,8 +391,8 @@ const char* SubclassNames[11] = {
 };
 
 const char* SpectralClassNames[StellarClass::NormalClassCount] = {
-    "O", "B", "A", "F", "G", "K", "M", "R",
-    "S", "N", "WC", "WN", "?", "L", "T", "Y", "C",
+    "O", "B", "A", "F", "G", "K", "M", "R", "S", "N",
+    "WC", "WN", "WO", "?", "L", "T", "Y", "C",
 };
 
 const char* WDSpectralClassNames[StellarClass::WDClassCount] = {
@@ -488,6 +494,7 @@ StarDetails::GetNormalStarDetails(StellarClass::SpectralClass specClass,
             case StellarClass::Spectral_O:
             case StellarClass::Spectral_WN:
             case StellarClass::Spectral_WC:
+            case StellarClass::Spectral_WO:
                 subclass = 9;
                 break;
             case StellarClass::Spectral_Y:
@@ -564,6 +571,9 @@ StarDetails::GetNormalStarDetails(StellarClass::SpectralClass specClass,
         case StellarClass::Spectral_WC:
             temp = tempWC[subclass];
             break;
+        case StellarClass::Spectral_WO:
+            temp = tempWO[subclass];
+            break;
         case StellarClass::Spectral_L:
             temp = tempL[subclass];
             break;
@@ -621,6 +631,7 @@ StarDetails::GetNormalStarDetails(StellarClass::SpectralClass specClass,
 
         case StellarClass::Spectral_WC:
         case StellarClass::Spectral_WN:
+        case StellarClass::Spectral_WO:
             period = rotperiod_O[lumIndex][subclass];
             bmagCorrection = bmag_correctionO[lumIndex][subclass];
             break;

--- a/src/celengine/stellarclass.cpp
+++ b/src/celengine/stellarclass.cpp
@@ -76,7 +76,7 @@ string StellarClass::str() const
     case StellarClass::BlackHole:
         return "X";
     case StellarClass::NormalStar:
-        s0 = "OBAFGKMRSNWW?LTYC"[(unsigned int) getSpectralClass()];
+        s0 = "OBAFGKMRSNWWW?LTYC"[(unsigned int) getSpectralClass()];
         s1 = "0123456789"[getSubclass()];
         switch (getLuminosityClass())
         {
@@ -317,6 +317,11 @@ StellarClass::parse(const string& st)
                 break;
             case 'N':
                 specClass = StellarClass::Spectral_WN;
+                state = NormalStarSubclassState;
+                i++;
+                break;
+            case 'O':
+                specClass = StellarClass::Spectral_WO;
                 state = NormalStarSubclassState;
                 i++;
                 break;

--- a/src/celengine/stellarclass.h
+++ b/src/celengine/stellarclass.h
@@ -40,28 +40,29 @@ public:
         Spectral_N     = 9, // superceded by class C
         Spectral_WC    = 10,
         Spectral_WN    = 11,
-        Spectral_Unknown = 12,
-        Spectral_L     = 13,
-        Spectral_T     = 14,
-        Spectral_Y     = 15, // brown dwarf
-        Spectral_C     = 16,
-        Spectral_DA    = 17, // white dwarf A (Balmer lines, no He I or metals)
-        Spectral_DB    = 18, // white dwarf B (He I lines, no H or metals)
-        Spectral_DC    = 19, // white dwarf C, continuous spectrum
-        Spectral_DO    = 20, // white dwarf O, He II strong, He I or H
-        Spectral_DQ    = 21, // white dwarf Q, carbon features
-        Spectral_DZ    = 22, // white dwarf Z, metal lines only, no H or He
-        Spectral_D     = 23, // generic white dwarf, no additional data
-        Spectral_DX    = 24,
-        Spectral_Count = 25,
+        Spectral_WO    = 12,
+        Spectral_Unknown = 13,
+        Spectral_L     = 14,
+        Spectral_T     = 15,
+        Spectral_Y     = 16, // brown dwarf
+        Spectral_C     = 17,
+        Spectral_DA    = 18, // white dwarf A (Balmer lines, no He I or metals)
+        Spectral_DB    = 19, // white dwarf B (He I lines, no H or metals)
+        Spectral_DC    = 20, // white dwarf C, continuous spectrum
+        Spectral_DO    = 21, // white dwarf O, He II strong, He I or H
+        Spectral_DQ    = 22, // white dwarf Q, carbon features
+        Spectral_DZ    = 23, // white dwarf Z, metal lines only, no H or He
+        Spectral_D     = 24, // generic white dwarf, no additional data
+        Spectral_DX    = 25,
+        Spectral_Count = 26,
     };
 
     enum
     {
-        FirstWDClass = 17,
+        FirstWDClass = 18,
         WDClassCount = 8,
         SubclassCount = 11,
-        NormalClassCount = 17,
+        NormalClassCount = 18,
     };
 
     enum LuminosityClass

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -291,6 +291,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
             starTexTable->getString("N", starTexNames[StellarClass::Spectral_N]);
             starTexTable->getString("WC", starTexNames[StellarClass::Spectral_WC]);
             starTexTable->getString("WN", starTexNames[StellarClass::Spectral_WN]);
+            starTexTable->getString("WO", starTexNames[StellarClass::Spectral_WO]);
             starTexTable->getString("Unknown", starTexNames[StellarClass::Spectral_Unknown]);
             starTexTable->getString("L", starTexNames[StellarClass::Spectral_L]);
             starTexTable->getString("T", starTexNames[StellarClass::Spectral_T]);


### PR DESCRIPTION
Now Celestia supports *all* spectral classes (with the exception of late-type white dwarfs...)

Code changes already tested by me; [here](https://drive.google.com/file/d/1Wcy8OefYhfvrQE5jeqgJhE_ERmMCxgDJ/view) is an stc file with all 9 known WO stars.

This is the data I used to estimate WO temperatures:

```
Name		Type	Temp
WR 93b		WO3	160000
WR 142		WO2	200000
Brey 93		WO3	???
LH 41-1042	WO4	150000
WR 30a		WO4	129500
SMC AB 8	WO4	141000
LMC195-1	WO2	???
WR 102		WO2	210000
IC 1613 DR1	WO3	???
```