### PR TITLE
[travis] pin fmt version 6.1.2 to workaroud build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ addons:
     packages:
     - eigen
     - cspice
-    - fmt
+    - fmt@6.1.2
     - jpeg
     - gettext
     - libpng


### PR DESCRIPTION
See https://github.com/fmtlib/fmt/issues/1631 for more information.