### PR TITLE
Refactor renderer.cpp

### DIFF
--- a/src/celengine/CMakeLists.txt
+++ b/src/celengine/CMakeLists.txt
@@ -37,6 +37,8 @@ set(CELENGINE_SOURCES
   dsoname.h
   dsooctree.cpp
   dsooctree.h
+  dsorenderer.cpp
+  dsorenderer.h
   frame.cpp
   frame.h
   framebuffer.cpp

--- a/src/celengine/atmosphere.h
+++ b/src/celengine/atmosphere.h
@@ -67,7 +67,7 @@ class Atmosphere
 // to render. The radius of the sphere is the height at which the
 // density of the atmosphere falls to the extinction threshold, i.e.
 // -H * ln(extinctionThreshold)
-extern const double AtmosphereExtinctionThreshold;
+constexpr const float AtmosphereExtinctionThreshold = 0.05f;
 
 #endif // _CELENGINE_ATMOSPHERE_H_
 

--- a/src/celengine/dsorenderer.cpp
+++ b/src/celengine/dsorenderer.cpp
@@ -1,0 +1,190 @@
+// dsorenderer.cpp
+//
+// Copyright (C) 2001-2020, the Celestia Development Team
+// Original version by Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <celengine/dsodb.h>
+#include <celengine/deepskyobj.h>
+#include <celmath/geomutil.h>
+#include "glsupport.h"
+#include "render.h"
+#include "vecgl.h"
+#include "dsorenderer.h"
+
+using namespace Eigen;
+using namespace celmath;
+
+// The parameter 'enhance' adjusts the DSO brightness as viewed from "inside"
+// (e.g. MilkyWay as seen from Earth). It provides an enhanced apparent  core
+// brightness appMag  ~ absMag - enhance. 'enhance' thus serves to uniformly
+// enhance the too low sprite luminosity at close distance.
+constexpr const double enhance = 4.0;
+constexpr const double pc10 = 32.6167; // 10 parsecs
+static const float CubeCornerToCenterDistance = sqrt(3.0f);
+
+DSORenderer::DSORenderer() :
+    ObjectRenderer<DeepSkyObject*, double>(DSO_OCTREE_ROOT_SIZE)
+{
+}
+
+void DSORenderer::process(DeepSkyObject* const &dso,
+                          double distanceToDSO,
+                          float absMag)
+{
+    if (distanceToDSO > distanceLimit || !dso->isVisible())
+        return;
+
+    Vector3f relPos = (dso->getPosition() - obsPos).cast<float>();
+    Vector3f center = orientationMatrix.transpose() * relPos;
+
+    // Test the object's bounding sphere against the view frustum. If we
+    // avoid this stage, overcrowded octree cells may hit performance badly:
+    // each object (even if it's not visible) would be sent to the OpenGL
+    // pipeline.
+    double dsoRadius = dso->getBoundingSphereRadius();
+    if (frustum.testSphere(center, (float) dsoRadius) == Frustum::Outside)
+        return;
+
+    float appMag;
+    if (distanceToDSO >= pc10)
+        appMag = (float) astro::absToAppMag((double) absMag, distanceToDSO);
+    else
+        appMag = absMag + (float) (enhance * tanh(distanceToDSO/pc10 - 1.0));
+
+    if ((renderFlags & dso->getRenderMask()) != 0)
+    {
+        dsosProcessed++;
+
+        // Input: display looks satisfactory for 0.2 < brightness < O(1.0)
+        // Ansatz: brightness = a - b * appMag(distanceToDSO), emulating eye sensitivity...
+        // determine a,b such that
+        // a - b * absMag = absMag / avgAbsMag ~ 1; a - b * faintestMag = 0.2.
+        // The 2nd eq. guarantees that the faintest galaxies are still visible.
+
+        if (!strcmp(dso->getObjTypeName(), "globular"))
+            avgAbsMag = -6.86; // average over 150 globulars in globulars.dsc.
+        else if (!strcmp(dso->getObjTypeName(), "galaxy"))
+            avgAbsMag = -19.04; // average over 10937 galaxies in galaxies.dsc.
+
+        float r = absMag / (float)avgAbsMag;
+        float brightness = r - (r - 0.2f) * (absMag - appMag) / (absMag - faintestMag);
+
+        // obviously, brightness(appMag = absMag) = r and
+        // brightness(appMag = faintestMag) = 0.2, as desired.
+
+        brightness *= 2.3f * (faintestMag - 4.75f) / renderer->getFaintestAM45deg();
+
+#ifdef USE_HDR
+        brightness *= exposure;
+#endif
+        if (brightness < 0)
+            brightness = 0;
+
+        if (dsoRadius < 1000.0)
+        {
+            // Small objects may be prone to clipping; give them special
+            // handling.  We don't want to always set the projection
+            // matrix, since that could be expensive with large galaxy
+            // catalogs.
+            auto nearZ = (float)(distanceToDSO / 2);
+            auto farZ = (float)(distanceToDSO + dsoRadius * 2 * CubeCornerToCenterDistance);
+            if (nearZ < dsoRadius * 0.001)
+            {
+                nearZ = (float)(dsoRadius * 0.001);
+                farZ = nearZ * 10000.0f;
+            }
+
+            glMatrixMode(GL_PROJECTION);
+            glPushMatrix();
+            float t = (float)wWidth / (float)wHeight;
+            glLoadMatrix(Perspective(fov, t, nearZ, farZ));
+            glMatrixMode(GL_MODELVIEW);
+        }
+
+        glPushMatrix();
+        glTranslate(relPos);
+
+        dso->render(relPos, observer->getOrientationf(), brightness,
+                    pixelSize, renderer);
+        glPopMatrix();
+
+        if (dsoRadius < 1000.0)
+        {
+            glMatrixMode(GL_PROJECTION);
+            glPopMatrix();
+            glMatrixMode(GL_MODELVIEW);
+        }
+    } // renderFlags check
+
+    // Only render those labels that are in front of the camera:
+    // Place labels for DSOs brighter than the specified label threshold brightness
+    //
+    unsigned int labelMask = dso->getLabelMask();
+
+    if ((labelMask & labelMode) != 0)
+    {
+        Color labelColor;
+        float appMagEff = 6.0f;
+        float step = 6.0f;
+        float symbolSize = 0.0f;
+        MarkerRepresentation* rep = nullptr;
+
+        // Use magnitude based fading for galaxies, and distance based
+        // fading for nebulae and open clusters.
+        switch (labelMask)
+        {
+        case Renderer::NebulaLabels:
+            rep = &renderer->nebulaRep;
+            labelColor = Renderer::NebulaLabelColor;
+            appMagEff = astro::absToAppMag(-7.5f, (float)distanceToDSO);
+            symbolSize = (float)(dso->getRadius() / distanceToDSO) / pixelSize;
+            step = 6.0f;
+            break;
+        case Renderer::OpenClusterLabels:
+            rep = &renderer->openClusterRep;
+            labelColor = Renderer::OpenClusterLabelColor;
+            appMagEff = astro::absToAppMag(-6.0f, (float)distanceToDSO);
+            symbolSize = (float)(dso->getRadius() / distanceToDSO) / pixelSize;
+            step = 4.0f;
+            break;
+        case Renderer::GalaxyLabels:
+            labelColor = Renderer::GalaxyLabelColor;
+            appMagEff = appMag;
+            step = 6.0f;
+            break;
+        case Renderer::GlobularLabels:
+            labelColor = Renderer::GlobularLabelColor;
+            appMagEff = appMag;
+            step = 3.0f;
+            break;
+        default:
+            // Unrecognized object class
+            labelColor = Color::White;
+            appMagEff = appMag;
+            step = 6.0f;
+            break;
+        }
+
+        if (appMagEff < labelThresholdMag)
+        {
+            // introduce distance dependent label transparency.
+            float distr = step * (labelThresholdMag - appMagEff) / labelThresholdMag;
+            if (distr > 1.0f)
+                distr = 1.0f;
+            labelColor.alpha(distr * labelColor.alpha());
+
+            renderer->addBackgroundAnnotation(rep,
+                                              dsoDB->getDSOName(dso, true),
+                                              labelColor,
+                                              relPos,
+                                              Renderer::AlignLeft,
+                                              Renderer::VerticalAlignCenter,
+                                              symbolSize);
+        }
+    }     // labels enabled
+}

--- a/src/celengine/dsorenderer.h
+++ b/src/celengine/dsorenderer.h
@@ -1,0 +1,36 @@
+// dsorenderer.h
+//
+// Copyright (C) 2001-2020, the Celestia Development Team
+// Original version by Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <Eigen/Core>
+#include <celmath/frustum.h>
+#include "objectrenderer.h"
+
+class DeepSkyObject;
+
+class DSORenderer : public ObjectRenderer<DeepSkyObject*, double>
+{
+ public:
+    DSORenderer();
+
+    void process(DeepSkyObject* const &, double, float);
+
+ public:
+    Eigen::Vector3d     obsPos;
+    Eigen::Matrix3f     orientationMatrix;
+    celmath::Frustum    frustum         { 45.0_deg, 1.0f, 1.0f };
+    DSODatabase*        dsoDB           { nullptr };
+
+    int                 wWidth          { 0 };
+    int                 wHeight         { 0 };
+    double              avgAbsMag       { 0.0 };
+    uint32_t            dsosProcessed   { 0 };
+};

--- a/src/celengine/lodspheremesh.cpp
+++ b/src/celengine/lodspheremesh.cpp
@@ -805,7 +805,7 @@ void LODSphereMesh::renderSection(int phi0, int theta0, int extent,
     unsigned short* indexBase = useVertexBuffers ? (unsigned short*) nullptr : indices;
     for (int i = 0; i < nRings; i++)
     {
-        glDrawElements(GL_QUAD_STRIP,
+        glDrawElements(GL_TRIANGLE_STRIP,
                        (nSlices + 1) * 2,
                        GL_UNSIGNED_SHORT,
                        indexBase + (nSlices + 1) * 2 * i);

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -688,6 +688,7 @@ void Renderer::resize(int width, int height)
     windowHeight = height;
     cosViewConeAngle = computeCosViewConeAngle(fov, windowWidth, windowHeight);
     // glViewport(windowWidth, windowHeight);
+    m_orthoProjMatrix = Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight);
 
 #ifdef USE_HDR
     if (commonDataInitialized)
@@ -5868,7 +5869,7 @@ void Renderer::renderAnnotations(const vector<Annotation>& annotations, FontStyl
 
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
-    glLoadMatrix(Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight));
+    glLoadMatrix(m_orthoProjMatrix);
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();
@@ -5982,7 +5983,7 @@ Renderer::renderAnnotations(vector<Annotation>::iterator startIter,
 
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
-    glLoadMatrix(Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight));
+    glLoadMatrix(m_orthoProjMatrix);
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -3056,7 +3056,7 @@ void Renderer::renderEllipsoidAtmosphere(const Atmosphere& atmosphere,
     prog->use();
     for (int i = 0; i < nRings; i++)
     {
-        glDrawElements(GL_QUAD_STRIP,
+        glDrawElements(GL_TRIANGLE_STRIP,
                        (nSlices + 1) * 2,
                        GL_UNSIGNED_INT,
                        &skyIndices[(nSlices + 1) * 2 * i]);

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4584,7 +4584,6 @@ void Renderer::renderCometTail(const Body& body,
             glVertexAttribPointer(brightness, 1, GL_FLOAT, GL_FALSE, stride, &p->brightness);
         glDrawElements(GL_TRIANGLE_STRIP, indices.size(), GL_UNSIGNED_SHORT, indices.data());
     }
-    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_NORMAL_ARRAY);
     if (brightness != -1)

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -5816,7 +5816,7 @@ Renderer::renderAnnotationMarker(const Annotation &a,
 
     glColor(a.color);
     glPushMatrix();
-    glTranslatef((int)a.position.x(), (int)a.position.y(), depth);
+    glTranslatef(a.position.x(), a.position.y(), depth);
 
     if (markerRep.symbol() == MarkerRepresentation::Crosshair)
         renderCrosshair(size, realTime, a.color);
@@ -5843,8 +5843,8 @@ Renderer::renderAnnotationLabel(const Annotation &a,
 {
     glColor(a.color);
     glPushMatrix();
-    glTranslatef((int)a.position.x() + hOffset + PixelOffset,
-                 (int)a.position.y() + vOffset + PixelOffset,
+    glTranslatef(a.position.x() + hOffset + PixelOffset,
+                 a.position.y() + vOffset + PixelOffset,
                  depth);
     font[fs]->bind();
     font[fs]->render(a.labelText, 0.0f, 0.0f);

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1813,50 +1813,7 @@ void Renderer::draw(const Observer& observer,
         int nEntries = renderList.size();
 
 #ifdef USE_HDR
-        // Compute 1 eclipse between eye - closest body - brightest star
-        // This prevents an eclipsed star from increasing exposure
-        bool eyeNotEclipsed = true;
-        closestBody = renderList.empty() ? renderList.end() : renderList.begin();
-        if (foundClosestBody &&
-            closestBody != renderList.end() &&
-            closestBody->renderableType == RenderListEntry::RenderableBody &&
-            closestBody->body && brightestStar)
-        {
-            const Body *body = closestBody->body;
-            double scale = astro::microLightYearsToKilometers(1.0);
-            Vector3d posBody = body->getAstrocentricPosition(now);
-            Vector3d posStar;
-            Vector3d posEye = astrocentricPosition(observer.getPosition(), *brightestStar, now);
-
-            if (body->getSystem() &&
-                body->getSystem()->getStar() &&
-                body->getSystem()->getStar() != brightestStar)
-            {
-                UniversalCoord center = body->getSystem()->getStar()->getPosition(now);
-                posStar = brightestStar->getPosition(now) - center;
-            }
-            else
-            {
-                posStar = brightestStar->getPosition(now);
-            }
-
-            posStar /= scale;
-            Vec3d lightToBodyDir = posBody - posStar;
-            Vec3d bodyToEyeDir = posEye - posBody;
-
-            if (lightToBodyDir * bodyToEyeDir > 0.0)
-            {
-                double dist = distance(posEye,
-                                       Ray3d(posBody, lightToBodyDir));
-                if (dist < body->getRadius())
-                    eyeNotEclipsed = false;
-            }
-        }
-
-        if (eyeNotEclipsed)
-        {
-            maxBodyMag = min(maxBodyMag, starMaxMag);
-        }
+    adjustEclipsedStarExposure(now);
 #endif
 
         // Since we're rendering objects of a huge range of sizes spread over

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -211,21 +211,6 @@ Color Renderer::EclipticColor           (0.5f,   0.1f,   0.1f);
 
 Color Renderer::SelectionCursorColor    (1.0f,   0.0f,   0.0f);
 
-// Solar system objects
-constexpr const uint64_t ShowSSO = Renderer::ShowPlanets      |
-                                   Renderer::ShowDwarfPlanets |
-                                   Renderer::ShowMoons        |
-                                   Renderer::ShowMinorMoons   |
-                                   Renderer::ShowAsteroids    |
-                                   Renderer::ShowComets       |
-                                   Renderer::ShowPlanetRings  |
-                                   Renderer::ShowSpacecrafts;
-// Deep Sky Objects
-constexpr const uint64_t ShowDSO = Renderer::ShowGalaxies     |
-                                   Renderer::ShowGlobulars    |
-                                   Renderer::ShowNebulae      |
-                                   Renderer::ShowOpenClusters;
-
 // Some useful unit conversions
 inline float mmToInches(float mm)
 {
@@ -1676,14 +1661,14 @@ void Renderer::draw(const Observer& observer,
     bool foundBrightestStar = false;
 #endif
 
-    if ((renderFlags & (ShowSSO | ShowOrbits)) != 0)
+    if ((renderFlags & (ShowSolarSystemObjects | ShowOrbits)) != 0)
     {
         nearStars.clear();
         universe.getNearStars(observer.getPosition(), SolarSystemMaxDistance, nearStars);
 
         // Set up direct light sources (i.e. just stars at the moment)
         // Skip if only star orbits to be shown
-        if ((renderFlags & ShowSSO) != 0)
+        if ((renderFlags & ShowSolarSystemObjects) != 0)
             setupLightSources(nearStars, observer.getPosition(), now, lightSourceList, renderFlags);
 
         // Traverse the frame trees of each nearby solar system and
@@ -1692,7 +1677,7 @@ void Renderer::draw(const Observer& observer,
         {
             addStarOrbitToRenderList(*sun, observer, now);
             // Skip if only star orbits to be shown
-            if ((renderFlags & ShowSSO) == 0)
+            if ((renderFlags & ShowSolarSystemObjects) == 0)
                 continue;
 
             SolarSystem* solarSystem = universe.getSolarSystem(sun);
@@ -1966,7 +1951,7 @@ void Renderer::draw(const Observer& observer,
     glEnable(GL_BLEND);
 
     // Render deep sky objects
-    if ((renderFlags & ShowDSO) != 0 && universe.getDSOCatalog() != nullptr)
+    if ((renderFlags & ShowDeepSpaceObjects) != 0 && universe.getDSOCatalog() != nullptr)
     {
         renderDeepSkyObjects(universe, observer, faintestMag);
     }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1801,165 +1801,26 @@ void Renderer::draw(const Observer& observer,
 
     glPolygonMode(GL_FRONT_AND_BACK, (GLenum) renderMode);
 
-    {
-        removeInvisibleItems(frustum);
+    removeInvisibleItems(frustum);
 
-        // Sort the annotations
-        sort(depthSortedAnnotations.begin(), depthSortedAnnotations.end());
+    // Sort the annotations
+    sort(depthSortedAnnotations.begin(), depthSortedAnnotations.end());
 
-        // Sort the orbit paths
-        sort(orbitPathList.begin(), orbitPathList.end());
-
-        int nEntries = renderList.size();
+    // Sort the orbit paths
+    sort(orbitPathList.begin(), orbitPathList.end());
 
 #ifdef USE_HDR
     adjustEclipsedStarExposure(now);
 #endif
 
-        // Since we're rendering objects of a huge range of sizes spread over
-        // vast distances, we can't just rely on the hardware depth buffer to
-        // handle hidden surface removal without a little help. We'll partition
-        // the depth buffer into spans that can be rendered without running
-        // into terrible depth buffer precision problems. Typically, each body
-        // with an apparent size greater than one pixel is allocated its own
-        // depth buffer interval. However, this will not correctly handle
-        // overlapping objects.  If two objects overlap in depth, we must
-        // assign them to the same interval.
+    int nIntervals = buildDepthPartitions();
 
-        depthPartitions.clear();
-        int nIntervals = 0;
-        float prevNear = -1e12f;  // ~ 1 light year
-        if (nEntries > 0)
-            prevNear = renderList[nEntries - 1].farZ * 1.01f;
+    vector<Annotation>::iterator annotation = depthSortedAnnotations.begin();
 
-        int i;
-
-        // Completely partition the depth buffer. Scan from back to front
-        // through all the renderable items that passed the culling test.
-        for (i = nEntries - 1; i >= 0; i--)
-        {
-            // Only consider renderables that will occupy more than one pixel.
-            if (renderList[i].discSizeInPixels > 1)
-            {
-                if (nIntervals == 0 || renderList[i].farZ >= depthPartitions[nIntervals - 1].nearZ)
-                {
-                    // This object spans a depth interval that's disjoint with
-                    // the current interval, so create a new one for it, and
-                    // another interval to fill the gap between the last
-                    // interval.
-                    DepthBufferPartition partition;
-                    partition.index = nIntervals;
-                    partition.nearZ = renderList[i].farZ;
-                    partition.farZ = prevNear;
-
-                    // Omit null intervals
-                    // TODO: Is this necessary? Shouldn't the >= test prevent this?
-                    if (partition.nearZ != partition.farZ)
-                    {
-                        depthPartitions.push_back(partition);
-                        nIntervals++;
-                    }
-
-                    partition.index = nIntervals;
-                    partition.nearZ = renderList[i].nearZ;
-                    partition.farZ = renderList[i].farZ;
-                    depthPartitions.push_back(partition);
-                    nIntervals++;
-
-                    prevNear = partition.nearZ;
-                }
-                else
-                {
-                    // This object overlaps the current span; expand the
-                    // interval so that it completely contains the object.
-                    DepthBufferPartition& partition = depthPartitions[nIntervals - 1];
-                    partition.nearZ = max(partition.nearZ, renderList[i].nearZ);
-                    partition.farZ = min(partition.farZ, renderList[i].farZ);
-                    prevNear = partition.nearZ;
-                }
-            }
-        }
-
-        // Scan the list of orbit paths and find the closest one. We'll need
-        // adjust the nearest interval to accommodate it.
-        float zNearest = prevNear;
-        for (i = 0; i < (int) orbitPathList.size(); i++)
-        {
-            const OrbitPathListEntry& o = orbitPathList[i];
-            float minNearDistance = min(-MinNearPlaneDistance, o.centerZ + o.radius);
-            if (minNearDistance > zNearest)
-                zNearest = minNearDistance;
-        }
-
-        // Adjust the nearest interval to include the closest marker (if it's
-        // closer to the observer than anything else
-        if (!depthSortedAnnotations.empty())
-        {
-            // Factor of 0.999 makes sure ensures that the near plane does not fall
-            // exactly at the marker's z coordinate (in which case the marker
-            // would be susceptible to getting clipped.)
-            if (-depthSortedAnnotations[0].position.z() > zNearest)
-                zNearest = -depthSortedAnnotations[0].position.z() * 0.999f;
-        }
-
-
-#if DEBUG_COALESCE
-        clog << "nEntries: " << nEntries << ",   zNearest: " << zNearest << ",   prevNear: " << prevNear << "\n";
-#endif
-
-        // If the nearest distance wasn't set, nothing should appear
-        // in the frontmost depth buffer interval (so we can set the near plane
-        // of the front interval to whatever we want as long as it's less than
-        // the far plane distance.
-        if (zNearest == prevNear)
-            zNearest = 0.0f;
-
-        // Add one last interval for the span from 0 to the front of the
-        // nearest object
-        {
-            // TODO: closest object may not be at entry 0, since objects are
-            // sorted by far distance.
-            float closest = zNearest;
-            if (nEntries > 0)
-            {
-                closest = max(closest, renderList[0].nearZ);
-
-                // Setting a the near plane distance to zero results in unreliable rendering, even
-                // if we don't care about the depth buffer. Compromise and set the near plane
-                // distance to a small fraction of distance to the nearest object.
-                if (closest == 0.0f)
-                {
-                    closest = renderList[0].nearZ * 0.01f;
-                }
-            }
-
-            DepthBufferPartition partition;
-            partition.index = nIntervals;
-            partition.nearZ = closest;
-            partition.farZ = prevNear;
-            depthPartitions.push_back(partition);
-
-            nIntervals++;
-        }
-
-        // If orbits are enabled, adjust the farthest partition so that it
-        // can contain the orbit.
-        if (!orbitPathList.empty())
-        {
-            depthPartitions[0].farZ = min(depthPartitions[0].farZ,
-                                           orbitPathList[orbitPathList.size() - 1].centerZ -
-                                           orbitPathList[orbitPathList.size() - 1].radius);
-        }
-
-        // We want to avoid overpartitioning the depth buffer. In this stage, we coalesce
-        // partitions that have small spans in the depth buffer.
-        // TODO: Implement this step!
-
-        vector<Annotation>::iterator annotation = depthSortedAnnotations.begin();
-
+    {
         // Render everything that wasn't culled.
         float intervalSize = 1.0f / (float) max(1, nIntervals);
-        i = nEntries - 1;
+        int i = (int) renderList.size() - 1;
         for (int interval = 0; interval < nIntervals; interval++)
         {
             currentIntervalIndex = interval;
@@ -6166,4 +6027,147 @@ Renderer::buildNearSystemsLists(const Universe &universe,
 
     if ((labelMode & BodyLabelMask) != 0)
         buildLabelLists(xfrustum, now);
+}
+
+int
+Renderer::buildDepthPartitions()
+{
+    // Since we're rendering objects of a huge range of sizes spread over
+    // vast distances, we can't just rely on the hardware depth buffer to
+    // handle hidden surface removal without a little help. We'll partition
+    // the depth buffer into spans that can be rendered without running
+    // into terrible depth buffer precision problems. Typically, each body
+    // with an apparent size greater than one pixel is allocated its own
+    // depth buffer interval. However, this will not correctly handle
+    // overlapping objects.  If two objects overlap in depth, we must
+    // assign them to the same interval.
+
+    depthPartitions.clear();
+    int nIntervals = 0;
+    int nEntries = (int)renderList.size();
+    float prevNear = -1e12f; // ~ 1 light year
+    if (nEntries > 0)
+        prevNear = renderList[nEntries - 1].farZ * 1.01f;
+
+    int i;
+
+    // Completely partition the depth buffer. Scan from back to front
+    // through all the renderable items that passed the culling test.
+    for (i = nEntries - 1; i >= 0; i--)
+    {
+        // Only consider renderables that will occupy more than one pixel.
+        if (renderList[i].discSizeInPixels > 1)
+        {
+            if (nIntervals == 0 ||
+                renderList[i].farZ >= depthPartitions[nIntervals - 1].nearZ)
+            {
+                // This object spans a depth interval that's disjoint with
+                // the current interval, so create a new one for it, and
+                // another interval to fill the gap between the last
+                // interval.
+                DepthBufferPartition partition;
+                partition.index = nIntervals;
+                partition.nearZ = renderList[i].farZ;
+                partition.farZ = prevNear;
+
+                // Omit null intervals
+                // TODO: Is this necessary? Shouldn't the >= test prevent this?
+                if (partition.nearZ != partition.farZ)
+                {
+                    depthPartitions.push_back(partition);
+                    nIntervals++;
+                }
+
+                partition.index = nIntervals;
+                partition.nearZ = renderList[i].nearZ;
+                partition.farZ = renderList[i].farZ;
+                depthPartitions.push_back(partition);
+                nIntervals++;
+
+                prevNear = partition.nearZ;
+            }
+            else
+            {
+                // This object overlaps the current span; expand the
+                // interval so that it completely contains the object.
+                DepthBufferPartition& partition = depthPartitions[nIntervals - 1];
+                partition.nearZ = max(partition.nearZ, renderList[i].nearZ);
+                partition.farZ = min(partition.farZ, renderList[i].farZ);
+                prevNear = partition.nearZ;
+            }
+        }
+    }
+
+    // Scan the list of orbit paths and find the closest one. We'll need
+    // adjust the nearest interval to accommodate it.
+    float zNearest = prevNear;
+    for (i = 0; i < (int)orbitPathList.size(); i++)
+    {
+        const OrbitPathListEntry& o = orbitPathList[i];
+        float minNearDistance = min(-MinNearPlaneDistance, o.centerZ + o.radius);
+        if (minNearDistance > zNearest)
+            zNearest = minNearDistance;
+    }
+
+    // Adjust the nearest interval to include the closest marker (if it's
+    // closer to the observer than anything else
+    if (!depthSortedAnnotations.empty())
+    {
+        // Factor of 0.999 makes sure ensures that the near plane does not fall
+        // exactly at the marker's z coordinate (in which case the marker
+        // would be susceptible to getting clipped.)
+        if (-depthSortedAnnotations[0].position.z() > zNearest)
+            zNearest = -depthSortedAnnotations[0].position.z() * 0.999f;
+    }
+
+#if DEBUG_COALESCE
+    clog << "nEntries: " << nEntries << ",   zNearest: " << zNearest
+         << ",   prevNear: " << prevNear << "\n";
+#endif
+
+    // If the nearest distance wasn't set, nothing should appear
+    // in the frontmost depth buffer interval (so we can set the near plane
+    // of the front interval to whatever we want as long as it's less than
+    // the far plane distance.
+    if (zNearest == prevNear)
+        zNearest = 0.0f;
+
+    // Add one last interval for the span from 0 to the front of the
+    // nearest object
+    // TODO: closest object may not be at entry 0, since objects are
+    // sorted by far distance.
+    float closest = zNearest;
+    if (nEntries > 0)
+    {
+        closest = max(closest, renderList[0].nearZ);
+
+        // Setting a the near plane distance to zero results in unreliable rendering, even
+        // if we don't care about the depth buffer. Compromise and set the near plane
+        // distance to a small fraction of distance to the nearest object.
+        if (closest == 0.0f)
+        {
+            closest = renderList[0].nearZ * 0.01f;
+        }
+    }
+
+    DepthBufferPartition partition;
+    partition.index = nIntervals;
+    partition.nearZ = closest;
+    partition.farZ = prevNear;
+    depthPartitions.push_back(partition);
+
+    nIntervals++;
+
+    // If orbits are enabled, adjust the farthest partition so that it
+    // can contain the orbit.
+    if (!orbitPathList.empty())
+    {
+        depthPartitions[0].farZ = min(depthPartitions[0].farZ,
+                                      orbitPathList.back().centerZ - orbitPathList.back().radius);
+    }
+
+    // We want to avoid overpartitioning the depth buffer. In this stage, we
+    // coalesce partitions that have small spans in the depth buffer.
+    // TODO: Implement this step!
+    return nIntervals;
 }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -5021,14 +5021,6 @@ void Renderer::markersToAnnotations(const MarkerList& markers,
 {
     const UniversalCoord& cameraPosition = observer.getPosition();
     const Quaterniond& cameraOrientation = observer.getOrientation();
-    // Calculate the cosine of half the maximum field of view. We'll use this for
-    // fast testing of marker visibility. The stored field of view is the
-    // vertical field of view; we want the field of view as measured on the
-    // diagonal between viewport corners.
-    double h = tan(degToRad(fov / 2));
-    double diag = sqrt(1.0 + square(h) + square(h * (double) getAspectRatio()));
-    double cosFOV = 1.0 / diag;
-
     Vector3d viewVector = cameraOrientation.conjugate() * -Vector3d::UnitZ();
 
     for (const auto& marker : markers)
@@ -5036,7 +5028,7 @@ void Renderer::markersToAnnotations(const MarkerList& markers,
         Vector3d offset = marker.position(jd).offsetFromKm(cameraPosition);
 
         // Only render those markers that lie withing the field of view.
-        if ((offset.dot(viewVector)) > cosFOV * offset.norm())
+        if ((offset.dot(viewVector)) > cosViewConeAngle * offset.norm())
         {
             double distance = offset.norm();
             float symbolSize = 0.0f;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -31,7 +31,6 @@ std::ofstream hdrlog;
 #define BLUR_SIZE           128
 #define DEFAULT_EXPOSURE    -23.35f
 #define EXPOSURE_HALFLIFE   0.4f
-//#define USE_BLOOM_LISTS
 #endif
 
 #include <config.h>
@@ -299,12 +298,6 @@ Renderer::Renderer() :
         blurTextures[i] = nullptr;
     }
 #endif
-#ifdef USE_BLOOM_LISTS
-    for (size_t i = 0; i < (sizeof gaussianLists/sizeof(GLuint)); ++i)
-    {
-        gaussianLists[i] = 0;
-    }
-#endif
 
     for (int i = 0; i < (int) FontCount; i++)
     {
@@ -323,13 +316,7 @@ Renderer::~Renderer()
     delete[] skyVertices;
     delete[] skyIndices;
     delete[] skyContour;
-#ifdef USE_BLOOM_LISTS
-    for (size_t i = 0; i < (sizeof gaussianLists/sizeof(GLuint)); ++i)
-    {
-        if (gaussianLists[i] != 0)
-            glDeleteLists(gaussianLists[i], 1);
-    }
-#endif
+
 #ifdef USE_HDR
     for (size_t i = 0; i < BLUR_PASS_COUNT; ++i)
     {
@@ -615,19 +602,6 @@ bool Renderer::init(
 
         commonDataInitialized = true;
     }
-
-#if 0
-    int nSamples = 0;
-    int sampleBuffers = 0;
-    int enabled = (int) glIsEnabled(GL_MULTISAMPLE);
-    glGetIntegerv(GL_SAMPLE_BUFFERS, &sampleBuffers);
-    glGetIntegerv(GL_SAMPLES, &nSamples);
-    clog << "AA samples: " << nSamples
-         << ", enabled=" << (int) enabled
-         << ", sample buffers=" << (sampleBuffers)
-         << "\n";
-    glEnable(GL_MULTISAMPLE);
-#endif
 
 #ifdef USE_HDR
     Image        *testImg = new Image(GL_LUMINANCE_ALPHA, 1, 1);
@@ -1818,14 +1792,6 @@ void Renderer::draw(const Observer& observer,
 
     glDisable(GL_BLEND);
     glDepthMask(GL_TRUE);
-
-#if 0
-    int errCode = glGetError();
-    if (errCode != GL_NO_ERROR)
-    {
-        cout << "glError: " << (char*) gluErrorString(errCode) << '\n';
-    }
-#endif
 }
 
 void renderPoint(const Renderer &renderer,
@@ -2028,9 +1994,6 @@ void Renderer::renderEllipsoidAtmosphere(const Atmosphere& atmosphere,
     float height = atmosphere.height / radius;
     Vector3f recipSemiAxes = semiAxes.cwiseInverse();
 
-#if 0
-    Vector3f recipAtmSemiAxes = recipSemiAxes / (1.0f + height);
-#endif
     // ellipDist is not the true distance from the surface unless the
     // planet is spherical.  Computing the true distance requires finding
     // the roots of a sixth degree polynomial, and isn't actually what we
@@ -3016,15 +2979,8 @@ void Renderer::renderObject(const Vector3f& pos,
             }
 
             glDisable(GL_POLYGON_OFFSET_FILL);
-
-            // Reset the texture matrix
-            glMatrixMode(GL_TEXTURE);
-            glLoadIdentity();
-            glMatrixMode(GL_MODELVIEW);
-
             glDepthMask(GL_TRUE);
             glFrontFace(GL_CCW);
-
             glPopMatrix();
         }
     }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1011,9 +1011,12 @@ void Renderer::addObjectAnnotation(const MarkerRepresentation* markerRep,
     }
 }
 
-
-static void enableSmoothLines()
+void
+Renderer::enableSmoothLines() const
 {
+    if ((renderFlags & ShowSmoothLines) == 0)
+        return;
+
     // glEnable(GL_BLEND);
 #ifdef USE_HDR
     glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA);
@@ -1024,26 +1027,16 @@ static void enableSmoothLines()
     glLineWidth(1.5f);
 }
 
-static void disableSmoothLines()
+void
+Renderer::disableSmoothLines() const
 {
+    if ((renderFlags & Renderer::ShowSmoothLines) == 0)
+        return;
+
     // glDisable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
     glDisable(GL_LINE_SMOOTH);
     glLineWidth(1.0f);
-}
-
-
-inline void enableSmoothLines(uint64_t renderFlags)
-{
-    if ((renderFlags & Renderer::ShowSmoothLines) != 0)
-        enableSmoothLines();
-}
-
-
-inline void disableSmoothLines(uint64_t renderFlags)
-{
-    if ((renderFlags & Renderer::ShowSmoothLines) != 0)
-        disableSmoothLines();
 }
 
 Vector4f renderOrbitColor(const Body *body, bool selected, float opacity)
@@ -1721,9 +1714,9 @@ void Renderer::draw(const Observer& observer,
     glDepthMask(GL_FALSE);
 
     // Render sky grids first--these will always be in the background
-    enableSmoothLines(renderFlags);
+    enableSmoothLines();
     renderSkyGrids(observer);
-    disableSmoothLines(renderFlags);
+    disableSmoothLines();
     glEnable(GL_BLEND);
 
     // Render deep sky objects
@@ -3865,9 +3858,9 @@ void Renderer::renderAsterisms(const Universe& universe, float dist)
                         (MaxAsterismLinesDist - MaxAsterismLinesConstDist) + 1);
     }
 
-    enableSmoothLines(renderFlags);
+    enableSmoothLines();
     m_asterismRenderer->render(*this, Color(ConstellationColor, opacity));
-    disableSmoothLines(renderFlags);
+    disableSmoothLines();
 }
 
 
@@ -3896,9 +3889,9 @@ void Renderer::renderBoundaries(const Universe& universe, float dist)
                         (MaxAsterismLabelsDist - MaxAsterismLabelsConstDist) + 1);
     }
 
-    enableSmoothLines(renderFlags);
+    enableSmoothLines();
     m_boundariesRenderer->render(*this, Color(BoundaryColor, opacity));
-    disableSmoothLines(renderFlags);
+    disableSmoothLines();
 }
 
 
@@ -4681,7 +4674,7 @@ void Renderer::renderDeepSkyObjects(const Universe& universe,
 
     // Render any line primitives with smooth lines
     // (mostly to make graticules look good.)
-    enableSmoothLines(renderFlags);
+    enableSmoothLines();
 
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
@@ -4704,7 +4697,7 @@ void Renderer::renderDeepSkyObjects(const Universe& universe,
 
     // clog << "DSOs processed: " << dsoRenderer.dsosProcessed << endl;
 
-    disableSmoothLines(renderFlags);
+    disableSmoothLines();
 }
 
 
@@ -4926,7 +4919,7 @@ void Renderer::renderAnnotations(const vector<Annotation>& annotations, FontStyl
         return;
 
     // Enable line smoothing for rendering symbols
-    enableSmoothLines(renderFlags);
+    enableSmoothLines();
 
 #ifdef USE_HDR
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
@@ -4997,7 +4990,7 @@ void Renderer::renderAnnotations(const vector<Annotation>& annotations, FontStyl
 #endif
 
     font[fs]->unbind();
-    disableSmoothLines(renderFlags);
+    disableSmoothLines();
 }
 
 
@@ -6057,7 +6050,7 @@ Renderer::renderSolarSystemObjects(const Observer &observer,
 #else
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 #endif
-            enableSmoothLines(renderFlags);
+            enableSmoothLines();
 
             // Scan through the list of orbits and render any that overlap this interval
             for (const auto& orbit : orbitPathList)
@@ -6078,7 +6071,7 @@ Renderer::renderSolarSystemObjects(const Observer &observer,
                 }
             }
 
-            disableSmoothLines(renderFlags);
+            disableSmoothLines();
             glDepthMask(GL_FALSE);
         }
 
@@ -6093,13 +6086,13 @@ Renderer::renderSolarSystemObjects(const Observer &observer,
         }
 
         // Render annotations in this interval
-        enableSmoothLines(renderFlags);
+        enableSmoothLines();
         annotation = renderSortedAnnotations(annotation,
                                              nearPlaneDistance,
                                              farPlaneDistance,
                                              FontNormal);
         endObjectAnnotations();
-        disableSmoothLines(renderFlags);
+        disableSmoothLines();
         glDisable(GL_DEPTH_TEST);
     }
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1104,11 +1104,6 @@ Vector4f renderOrbitColor(const Body *body, bool selected, float opacity)
 #endif
 }
 
-
-static int orbitsRendered = 0;
-static int orbitsSkipped = 0;
-static int sectionsCulled = 0;
-
 void Renderer::renderOrbit(const OrbitPathListEntry& orbitPath,
                            double t,
                            const Quaterniond& cameraOrientation,
@@ -1814,178 +1809,7 @@ void Renderer::draw(const Observer& observer,
 #endif
 
     int nIntervals = buildDepthPartitions();
-
-    vector<Annotation>::iterator annotation = depthSortedAnnotations.begin();
-
-    {
-        // Render everything that wasn't culled.
-        float intervalSize = 1.0f / (float) max(1, nIntervals);
-        int i = (int) renderList.size() - 1;
-        for (int interval = 0; interval < nIntervals; interval++)
-        {
-            currentIntervalIndex = interval;
-            beginObjectAnnotations();
-
-            float nearPlaneDistance = -depthPartitions[interval].nearZ;
-            float farPlaneDistance  = -depthPartitions[interval].farZ;
-
-            // Set the depth range for this interval--each interval is allocated an
-            // equal section of the depth buffer.
-            glDepthRange(1.0f - (float) (interval + 1) * intervalSize,
-                         1.0f - (float) interval * intervalSize);
-
-            // Set up a perspective projection using the current interval's near and
-            // far clip planes.
-            glMatrixMode(GL_PROJECTION);
-            glLoadMatrix(Perspective(fov, getAspectRatio(),
-                                     nearPlaneDistance,
-                                     farPlaneDistance));
-            glMatrixMode(GL_MODELVIEW);
-
-            Frustum intervalFrustum(degToRad(fov),
-                                    getAspectRatio(),
-                                    -depthPartitions[interval].nearZ,
-                                    -depthPartitions[interval].farZ);
-
-
-#if DEBUG_COALESCE
-            clog << "interval: " << interval <<
-                    ", near: " << -depthPartitions[interval].nearZ <<
-                    ", far: " << -depthPartitions[interval].farZ <<
-                    "\n";
-#endif
-            int firstInInterval = i;
-
-            // Render just the opaque objects in the first pass
-            while (i >= 0 && renderList[i].farZ < depthPartitions[interval].nearZ)
-            {
-                // This interval should completely contain the item
-                // Unless it's just a point?
-                //assert(renderList[i].nearZ <= depthPartitions[interval].near);
-
-#if DEBUG_COALESCE
-                switch (renderList[i].renderableType)
-                {
-                case RenderListEntry::RenderableBody:
-                    if (renderList[i].discSizeInPixels > 1)
-                    {
-                        clog << renderList[i].body->getName() << "\n";
-                    }
-                    else
-                    {
-                        clog << "point: " << renderList[i].body->getName() << "\n";
-                    }
-                    break;
-
-                case RenderListEntry::RenderableStar:
-                    if (renderList[i].discSizeInPixels > 1)
-                    {
-                        clog << "Star\n";
-                    }
-                    else
-                    {
-                        clog << "point: " << "Star" << "\n";
-                    }
-                    break;
-
-                default:
-                    break;
-                }
-#endif
-                // Treat objects that are smaller than one pixel as transparent and render
-                // them in the second pass.
-                if (renderList[i].isOpaque && renderList[i].discSizeInPixels > 1.0f)
-                    renderItem(renderList[i], observer, m_cameraOrientation, nearPlaneDistance, farPlaneDistance);
-
-                i--;
-            }
-
-            // Render orbit paths
-            if (!orbitPathList.empty())
-            {
-                glEnable(GL_DEPTH_TEST);
-                glDepthMask(GL_FALSE);
-#ifdef USE_HDR
-                glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA);
-#else
-                glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-#endif
-                enableSmoothLines(renderFlags);
-
-                // Scan through the list of orbits and render any that overlap this interval
-                for (const auto& orbit : orbitPathList)
-                {
-                    // Test for overlap
-                    float nearZ = -orbit.centerZ - orbit.radius;
-                    float farZ = -orbit.centerZ + orbit.radius;
-
-                    // Don't render orbits when they're completely outside this
-                    // depth interval.
-                    if (nearZ < farPlaneDistance && farZ > nearPlaneDistance)
-                    {
-#ifdef DEBUG_COALESCE
-                        switch (interval % 6)
-                        {
-                            case 0: glColor4f(1.0f, 0.0f, 0.0f, 1.0f); break;
-                            case 1: glColor4f(1.0f, 1.0f, 0.0f, 1.0f); break;
-                            case 2: glColor4f(0.0f, 1.0f, 0.0f, 1.0f); break;
-                            case 3: glColor4f(0.0f, 1.0f, 1.0f, 1.0f); break;
-                            case 4: glColor4f(0.0f, 0.0f, 1.0f, 1.0f); break;
-                            case 5: glColor4f(1.0f, 0.0f, 1.0f, 1.0f); break;
-                            default: glColor4f(1.0f, 1.0f, 1.0f, 1.0f); break;
-                        }
-#endif
-                        orbitsRendered++;
-                        renderOrbit(orbit, now, m_cameraOrientation.cast<double>(), intervalFrustum, nearPlaneDistance, farPlaneDistance);
-
-#if DEBUG_COALESCE
-                        if (highlightObject.body() == orbit.body)
-                        {
-                            clog << "orbit, radius=" << orbit.radius << "\n";
-                        }
-#endif
-                    }
-                    else
-                    {
-                        orbitsSkipped++;
-                    }
-                }
-
-                disableSmoothLines(renderFlags);
-                glDepthMask(GL_FALSE);
-            }
-
-            // Render transparent objects in the second pass
-            i = firstInInterval;
-            while (i >= 0 && renderList[i].farZ < depthPartitions[interval].nearZ)
-            {
-                if (!renderList[i].isOpaque || renderList[i].discSizeInPixels <= 1.0f)
-                    renderItem(renderList[i], observer, m_cameraOrientation, nearPlaneDistance, farPlaneDistance);
-
-                i--;
-            }
-
-            // Render annotations in this interval
-            enableSmoothLines(renderFlags);
-            annotation = renderSortedAnnotations(annotation, -depthPartitions[interval].nearZ, -depthPartitions[interval].farZ, FontNormal);
-            endObjectAnnotations();
-            disableSmoothLines(renderFlags);
-            glDisable(GL_DEPTH_TEST);
-        }
-#if 0
-        // TODO: Debugging output for new orbit code; remove when development is complete
-        clog << "orbits: " << orbitsRendered
-             << ", skipped: " << orbitsSkipped
-             << ", sections culled: " << sectionsCulled
-             << ", nIntervals: " << nIntervals << "\n";
-#endif
-        orbitsRendered = 0;
-        orbitsSkipped = 0;
-        sectionsCulled = 0;
-
-        // reset the depth range
-        glDepthRange(0, 1);
-    }
+    renderSolarSystemObjects(observer, nIntervals, now);
 
     renderForegroundAnnotations(FontNormal);
 
@@ -6171,4 +5995,114 @@ Renderer::buildDepthPartitions()
     // coalesce partitions that have small spans in the depth buffer.
     // TODO: Implement this step!
     return nIntervals;
+}
+
+void
+Renderer::renderSolarSystemObjects(const Observer &observer,
+                                   int nIntervals,
+                                   double now)
+{
+    // Render everything that wasn't culled.
+    auto annotation = depthSortedAnnotations.begin();
+    float intervalSize = 1.0f / static_cast<float>(max(1, nIntervals));
+    int i = static_cast<int>(renderList.size()) - 1;
+    for (int interval = 0; interval < nIntervals; interval++)
+    {
+        currentIntervalIndex = interval;
+        beginObjectAnnotations();
+
+        const float nearPlaneDistance = -depthPartitions[interval].nearZ;
+        const float farPlaneDistance = -depthPartitions[interval].farZ;
+
+        // Set the depth range for this interval--each interval is allocated an
+        // equal section of the depth buffer.
+        glDepthRange(1.0f - (interval + 1) * intervalSize,
+                     1.0f - interval * intervalSize);
+
+        // Set up a perspective projection using the current interval's near and
+        // far clip planes.
+        glMatrixMode(GL_PROJECTION);
+        glLoadMatrix(Perspective(fov, getAspectRatio(), nearPlaneDistance, farPlaneDistance));
+        glMatrixMode(GL_MODELVIEW);
+
+        Frustum intervalFrustum(degToRad(fov),
+                                getAspectRatio(),
+                                nearPlaneDistance,
+                                farPlaneDistance);
+
+        int firstInInterval = i;
+
+        // Render just the opaque objects in the first pass
+        while (i >= 0 && renderList[i].farZ < depthPartitions[interval].nearZ)
+        {
+            // This interval should completely contain the item
+            // Unless it's just a point?
+            // assert(renderList[i].nearZ <= depthPartitions[interval].near);
+
+            // Treat objects that are smaller than one pixel as transparent and
+            // render them in the second pass.
+            if (renderList[i].isOpaque && renderList[i].discSizeInPixels > 1.0f)
+                renderItem(renderList[i], observer, getCameraOrientation(), nearPlaneDistance, farPlaneDistance);
+
+            i--;
+        }
+
+        // Render orbit paths
+        if (!orbitPathList.empty())
+        {
+            glEnable(GL_DEPTH_TEST);
+            glDepthMask(GL_FALSE);
+#ifdef USE_HDR
+            glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA);
+#else
+            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+#endif
+            enableSmoothLines(renderFlags);
+
+            // Scan through the list of orbits and render any that overlap this interval
+            for (const auto& orbit : orbitPathList)
+            {
+                // Test for overlap
+                float nearZ = -orbit.centerZ - orbit.radius;
+                float farZ = -orbit.centerZ + orbit.radius;
+
+                // Don't render orbits when they're completely outside this
+                // depth interval.
+                if (nearZ < farPlaneDistance && farZ > nearPlaneDistance)
+                {
+                    renderOrbit(orbit, now,
+                                observer.getOrientation(),
+                                intervalFrustum,
+                                nearPlaneDistance,
+                                farPlaneDistance);
+                }
+            }
+
+            disableSmoothLines(renderFlags);
+            glDepthMask(GL_FALSE);
+        }
+
+        // Render transparent objects in the second pass
+        i = firstInInterval;
+        while (i >= 0 && renderList[i].farZ < depthPartitions[interval].nearZ)
+        {
+            if (!renderList[i].isOpaque || renderList[i].discSizeInPixels <= 1.0f)
+                renderItem(renderList[i], observer, getCameraOrientation(), nearPlaneDistance, farPlaneDistance);
+
+            i--;
+        }
+
+        // Render annotations in this interval
+        enableSmoothLines(renderFlags);
+        annotation = renderSortedAnnotations(annotation,
+                                             nearPlaneDistance,
+                                             farPlaneDistance,
+                                             FontNormal);
+        endObjectAnnotations();
+        disableSmoothLines(renderFlags);
+        glDisable(GL_DEPTH_TEST);
+    }
+
+    // reset the depth range
+    glDepthRange(0, 1);
 }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -3587,7 +3587,7 @@ void Renderer::renderObject(const Vector3f& pos,
         if (obj.atmosphere != nullptr)
         {
             float atmosphereHeight = max(obj.atmosphere->cloudHeight,
-                                         obj.atmosphere->mieScaleHeight * (float) -log(AtmosphereExtinctionThreshold));
+                                         obj.atmosphere->mieScaleHeight * -log(AtmosphereExtinctionThreshold));
             if (atmosphereHeight > 0.0f)
             {
                 // If there's an atmosphere, we need to move the far plane

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4677,7 +4677,7 @@ void Renderer::renderDeepSkyObjects(const Universe& universe,
     galaxyRep      = MarkerRepresentation(MarkerRepresentation::Triangle, 8.0f, GalaxyLabelColor);
     nebulaRep      = MarkerRepresentation(MarkerRepresentation::Square,   8.0f, NebulaLabelColor);
     openClusterRep = MarkerRepresentation(MarkerRepresentation::Circle,   8.0f, OpenClusterLabelColor);
-    globularRep    = MarkerRepresentation(MarkerRepresentation::Circle,   8.0f, OpenClusterLabelColor);
+    globularRep    = MarkerRepresentation(MarkerRepresentation::Circle,   8.0f, GlobularLabelColor);
 
     // Render any line primitives with smooth lines
     // (mostly to make graticules look good.)

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2521,9 +2521,10 @@ static void renderCloudsUnlit(const RenderInfo& ri,
     glUseProgram(0);
 }
 
-void Renderer::renderLocations(const Body& body,
-                               const Vector3d& bodyPosition,
-                               const Quaterniond& bodyOrientation)
+void
+Renderer::locationsToAnnotations(const Body& body,
+                                 const Vector3d& bodyPosition,
+                                 const Quaterniond& bodyOrientation)
 {
     const vector<Location*>* locations = body.getLocations();
 
@@ -3654,7 +3655,7 @@ void Renderer::renderPlanet(Body& body,
             // We need a double precision body-relative position of the
             // observer, otherwise location labels will tend to jitter.
             Vector3d posd = body.getPosition(observer.getTime()).offsetFromKm(observer.getPosition());
-            renderLocations(body, posd, q);
+            locationsToAnnotations(body, posd, q);
 
             glDisable(GL_DEPTH_TEST);
         }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1668,122 +1668,6 @@ void Renderer::draw(const Observer& observer,
 
     setupSecondaryLightSources(secondaryIlluminators, lightSourceList);
 
-#ifdef USE_HDR
-    Matrix3f viewMat = observer.getOrientationf().conjugate().toRotationMatrix();
-    float maxSpan = (float) sqrt(square((float) windowWidth) +
-                                 square((float) windowHeight));
-    float nearZcoeff = (float) cos(degToRad(fov / 2)) *
-        ((float) windowHeight / maxSpan);
-
-    // Remove objects from the render list that lie completely outside the
-    // view frustum.
-    auto notCulled = renderList.begin();
-    for (const auto& render_item : renderList)
-    {
-        Vector3f center = viewMat * render_item.position;
-
-        bool convex = true;
-        float radius = 1.0f;
-        float cullRadius = 1.0f;
-        float cloudHeight = 0.0f;
-
-        switch (render_item.renderableType)
-        {
-        case RenderListEntry::RenderableStar:
-            continue;
-
-        case RenderListEntry::RenderableCometTail:
-        case RenderListEntry::RenderableReferenceMark:
-            radius = render_item.radius;
-            cullRadius = radius;
-            convex = false;
-            break;
-
-        case RenderListEntry::RenderableBody:
-        default:
-            radius = render_item.body->getBoundingRadius();
-            if (render_item.body->getRings() != nullptr)
-            {
-                radius = render_item.body->getRings()->outerRadius;
-                convex = false;
-            }
-
-            if (!render_item.body->isEllipsoid())
-                convex = false;
-
-            cullRadius = radius;
-            if (render_item.body->getAtmosphere() != nullptr)
-            {
-                cullRadius += render_item.body->getAtmosphere()->height;
-                cloudHeight = max(render_item.body->getAtmosphere()->cloudHeight,
-                                  render_item.body->getAtmosphere()->mieScaleHeight * (float) -log(AtmosphereExtinctionThreshold));
-            }
-            break;
-        }
-
-        // Test the object's bounding sphere against the view frustum
-        if (frustum.testSphere(center, cullRadius) != Frustum::Outside)
-        {
-            float nearZ = center.norm() - radius;
-            nearZ = -nearZ * nearZcoeff;
-
-            if (nearZ > -MinNearPlaneDistance)
-                render_item.nearZ = -max(MinNearPlaneDistance, radius / 2000.0f);
-            else
-                render_item.nearZ = nearZ;
-
-            if (!convex)
-            {
-                render_item.farZ = center.z() - radius;
-                if (render_item.farZ / render_item.nearZ > MaxFarNearRatio * 0.5f)
-                    render_item.nearZ = render_item.farZ / (MaxFarNearRatio * 0.5f);
-            }
-            else
-            {
-                // Make the far plane as close as possible
-                float d = center.norm();
-                // Account for ellipsoidal objects
-                float eradius = radius;
-                if (render_item.body != nullptr) // XXX: not checked before
-                {
-                    Vector3f semiAxes = render_item.body->getSemiAxes();
-                    float minSemiAxis = min(semiAxes.x(), min(semiAxes.y(), semiAxes.z()));
-                    eradius *= minSemiAxis / radius;
-                }
-
-                if (d > eradius)
-                {
-                    render_item.farZ = render_item.centerZ - render_item.radius;
-                }
-                else
-                {
-                    // We're inside the bounding sphere (and, if the planet
-                    // is spherical, inside the planet.)
-                    render_item.farZ = render_item.nearZ * 2.0f;
-                }
-
-                if (cloudHeight > 0.0f)
-                {
-                    // If there's a cloud layer, we need to move the
-                    // far plane out so that the clouds aren't clipped
-                    float cloudLayerRadius = eradius + cloudHeight;
-                    render_item.farZ -= (float) sqrt(square(cloudLayerRadius) -
-                                               square(eradius));
-                }
-            }
-
-            *notCulled = render_item;
-            notCulled++;
-
-            maxBodyMag = min(maxBodyMag, render_item.appMag);
-            foundClosestBody = true;
-        }
-    }
-
-    renderList.resize(notCulled - renderList.begin());
-    saturationMag = maxBodyMag;
-#endif // USE_HDR
-
     Color skyColor(0.0f, 0.0f, 0.0f);
 
     // Scan through the render list to see if we're inside a planetary
@@ -1918,164 +1802,7 @@ void Renderer::draw(const Observer& observer,
     glPolygonMode(GL_FRONT_AND_BACK, (GLenum) renderMode);
 
     {
-        Matrix3f viewMat = observer.getOrientationf().conjugate().toRotationMatrix();
-
-        // Remove objects from the render list that lie completely outside the
-        // view frustum.
-        auto notCulled = renderList.begin();
-#ifdef USE_HDR
-        maxBodyMag = maxBodyMagPrev;
-        float starMaxMag = maxBodyMagPrev;
-#endif
-        for (auto& render_item : renderList)
-        {
-#ifdef USE_HDR
-            switch (render_item.renderableType)
-            {
-            case RenderListEntry::RenderableStar:
-                break;
-            default:
-                *notCulled = render_item;
-                notCulled++;
-                continue;
-            }
-#endif
-            Vector3f center = viewMat.transpose() * render_item.position;
-
-            bool convex = true;
-            float radius = 1.0f;
-            float cullRadius = 1.0f;
-            float cloudHeight = 0.0f;
-
-#ifndef USE_HDR
-            switch (render_item.renderableType)
-            {
-            case RenderListEntry::RenderableStar:
-                radius = render_item.star->getRadius();
-                cullRadius = radius * (1.0f + CoronaHeight);
-                break;
-
-            case RenderListEntry::RenderableCometTail:
-                radius = render_item.radius;
-                cullRadius = radius;
-                convex = false;
-                break;
-
-            case RenderListEntry::RenderableBody:
-                radius = render_item.body->getBoundingRadius();
-                if (render_item.body->getRings() != nullptr)
-                {
-                    radius = render_item.body->getRings()->outerRadius;
-                    convex = false;
-                }
-
-                if (!render_item.body->isEllipsoid())
-                    convex = false;
-
-                cullRadius = radius;
-                if (render_item.body->getAtmosphere() != nullptr)
-                {
-                    cullRadius += render_item.body->getAtmosphere()->height;
-                    cloudHeight = max(render_item.body->getAtmosphere()->cloudHeight,
-                                      render_item.body->getAtmosphere()->mieScaleHeight * (float) -log(AtmosphereExtinctionThreshold));
-                }
-                break;
-
-            case RenderListEntry::RenderableReferenceMark:
-                radius = render_item.radius;
-                cullRadius = radius;
-                convex = false;
-                break;
-
-            default:
-                break;
-            }
-#else
-            radius = render_item.star->getRadius();
-            cullRadius = radius * (1.0f + CoronaHeight);
-#endif // USE_HDR
-
-            // Test the object's bounding sphere against the view frustum
-            if (frustum.testSphere(center, cullRadius) != Frustum::Outside)
-            {
-                float nearZ = center.norm() - radius;
-#ifdef USE_HDR
-                nearZ = -nearZ * nearZcoeff;
-#else
-                float maxSpan = (float) sqrt(square((float) windowWidth) +
-                                             square((float) windowHeight));
-
-                nearZ = -nearZ * (float) cos(degToRad(fov / 2)) *
-                    ((float) windowHeight / maxSpan);
-#endif
-                if (nearZ > -MinNearPlaneDistance)
-                    render_item.nearZ = -max(MinNearPlaneDistance, radius / 2000.0f);
-                else
-                    render_item.nearZ = nearZ;
-
-                if (!convex)
-                {
-                    render_item.farZ = center.z() - radius;
-                    if (render_item.farZ / render_item.nearZ > MaxFarNearRatio * 0.5f)
-                        render_item.nearZ = render_item.farZ / (MaxFarNearRatio * 0.5f);
-                }
-                else
-                {
-                    // Make the far plane as close as possible
-                    float d = center.norm();
-
-                    // Account for ellipsoidal objects
-                    float eradius = radius;
-                    if (render_item.renderableType == RenderListEntry::RenderableBody)
-                    {
-                        float minSemiAxis = render_item.body->getSemiAxes().minCoeff();
-                        eradius *= minSemiAxis / radius;
-                    }
-
-                    if (d > eradius)
-                    {
-                        render_item.farZ = render_item.centerZ - render_item.radius;
-                    }
-                    else
-                    {
-                        // We're inside the bounding sphere (and, if the planet
-                        // is spherical, inside the planet.)
-                        render_item.farZ = render_item.nearZ * 2.0f;
-                    }
-
-                    if (cloudHeight > 0.0f)
-                    {
-                        // If there's a cloud layer, we need to move the
-                        // far plane out so that the clouds aren't clipped
-                        float cloudLayerRadius = eradius + cloudHeight;
-                        render_item.farZ -= (float) sqrt(square(cloudLayerRadius) -
-                                                   square(eradius));
-                    }
-                }
-
-                *notCulled = render_item;
-                notCulled++;
-#ifdef USE_HDR
-                if (render_item.discSizeInPixels > 1.0f &&
-                    render_item.appMag < starMaxMag)
-                {
-                    starMaxMag = render_item.appMag;
-                    brightestStar = render_item.star;
-                    foundBrightestStar = true;
-                }
-#endif
-            }
-        }
-
-        renderList.resize(notCulled - renderList.begin());
-
-        // The calls to buildRenderLists/renderStars filled renderList
-        // with visible bodies.  Sort it front to back, then
-        // render each entry in reverse order (TODO: convenient, but not
-        // ideal for performance; should render opaque objects front to
-        // back, then translucent objects back to front. However, the
-        // amount of overdraw in Celestia is typically low.)
-        sort(renderList.begin(), renderList.end());
+        removeInvisibleItems(frustum);
 
         // Sort the annotations
         sort(depthSortedAnnotations.begin(), depthSortedAnnotations.end());
@@ -6180,6 +5907,144 @@ Renderer::setShadowMapSize(unsigned size)
         m_shadowFBO = nullptr;
     else
         createShadowFBO();
+}
+
+void
+Renderer::removeInvisibleItems(const Frustum &frustum)
+{
+    // Remove objects from the render list that lie completely outside the
+    // view frustum.
+    auto notCulled = renderList.begin();
+#ifdef USE_HDR
+    maxBodyMag = maxBodyMagPrev;
+    float starMaxMag = maxBodyMagPrev;
+#endif
+    for (auto &ri : renderList)
+    {
+        bool convex = true;
+        float radius = 1.0f;
+        float cullRadius = 1.0f;
+        float cloudHeight = 0.0f;
+
+        switch (ri.renderableType)
+        {
+        case RenderListEntry::RenderableStar:
+            radius = ri.star->getRadius();
+            cullRadius = radius * (1.0f + CoronaHeight);
+            break;
+
+        case RenderListEntry::RenderableCometTail:
+        case RenderListEntry::RenderableReferenceMark:
+            radius = ri.radius;
+            cullRadius = radius;
+            convex = false;
+            break;
+
+        case RenderListEntry::RenderableBody:
+            radius = ri.body->getBoundingRadius();
+            if (ri.body->getRings() != nullptr)
+            {
+                radius = ri.body->getRings()->outerRadius;
+                convex = false;
+            }
+
+            if (!ri.body->isEllipsoid())
+                convex = false;
+
+            cullRadius = radius;
+            if (ri.body->getAtmosphere() != nullptr)
+            {
+                auto *a = ri.body->getAtmosphere();
+                cullRadius += a->height;
+                cloudHeight = max(a->cloudHeight,
+                                  a->mieScaleHeight * -log(AtmosphereExtinctionThreshold));
+            }
+            break;
+
+        default:
+            break;
+        }
+
+        Vector3f center = getCameraOrientation().toRotationMatrix() * ri.position;
+        // Test the object's bounding sphere against the view frustum
+        if (frustum.testSphere(center, cullRadius) != Frustum::Outside)
+        {
+            float nearZ = center.norm() - radius;
+            float maxSpan = hypot((float) windowWidth, (float) windowHeight);
+            float nearZcoeff = cos(degToRad(fov / 2.0f)) * ((float) windowHeight / maxSpan);
+            nearZ = -nearZ * nearZcoeff;
+
+            if (nearZ > -MinNearPlaneDistance)
+                ri.nearZ = -max(MinNearPlaneDistance, radius / 2000.0f);
+            else
+                ri.nearZ = nearZ;
+
+            if (!convex)
+            {
+                ri.farZ = center.z() - radius;
+                if (ri.farZ / ri.nearZ > MaxFarNearRatio * 0.5f)
+                    ri.nearZ = ri.farZ / (MaxFarNearRatio * 0.5f);
+            }
+            else
+            {
+                // Make the far plane as close as possible
+                float d = center.norm();
+
+                // Account for ellipsoidal objects
+                float eradius = radius;
+                if (ri.renderableType == RenderListEntry::RenderableBody)
+                {
+                    float minSemiAxis = ri.body->getSemiAxes().minCoeff();
+                    eradius *= minSemiAxis / radius;
+                }
+
+                if (d > eradius)
+                {
+                    ri.farZ = ri.centerZ - ri.radius;
+                }
+                else
+                {
+                    // We're inside the bounding sphere (and, if the planet
+                    // is spherical, inside the planet.)
+                    ri.farZ = ri.nearZ * 2.0f;
+                }
+
+                if (cloudHeight > 0.0f)
+                {
+                    // If there's a cloud layer, we need to move the
+                    // far plane out so that the clouds aren't clipped
+                    float cloudLayerRadius = eradius + cloudHeight;
+                    ri.farZ -= sqrt(square(cloudLayerRadius) - square(eradius));
+                }
+            }
+
+            *notCulled = ri;
+            notCulled++;
+#ifdef USE_HDR
+            if (ri.discSizeInPixels > 1.0f && ri.appMag < starMaxMag)
+            {
+                starMaxMag = ri.appMag;
+                brightestStar = ri.star;
+                foundBrightestStar = true;
+            }
+            maxBodyMag = min(maxBodyMag, starMaxMag);
+            foundClosestBody = true;
+#endif
+        }
+    }
+
+    renderList.resize(notCulled - renderList.begin());
+#ifdef USE_HDR
+    saturationMag = maxBodyMag;
+#endif // USE_HDR
+
+    // The calls to buildRenderLists/renderStars filled renderList
+    // with visible bodies.  Sort it front to back, then
+    // render each entry in reverse order (TODO: convenient, but not
+    // ideal for performance; should render opaque objects front to
+    // back, then translucent objects back to front. However, the
+    // amount of overdraw in Celestia is typically low.)
+    sort(renderList.begin(), renderList.end());
 }
 
 bool

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -628,6 +628,10 @@ class Renderer
                                const celmath::Frustum &xfrustum,
                                double now);
 
+    void adjustMagnitudeInsideAtmosphere(float &faintestMag,
+                                         float &saturationMag,
+                                         double now);
+
     void renderOrbit(const OrbitPathListEntry&,
                      double now,
                      const Eigen::Quaterniond& cameraOrientation,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -722,8 +722,8 @@ class Renderer
 
     std::vector<LightSource> lightSourceList;
 
-    Eigen::Matrix4d modelMatrix;
-    Eigen::Matrix4d projMatrix;
+    Eigen::Matrix4f m_modelMatrix;
+    Eigen::Matrix4f m_projMatrix;
     Eigen::Matrix4f m_orthoProjMatrix;
 
     bool useCompressedTextures{ false };

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -593,6 +593,14 @@ class Renderer
                        LabelVerticalAlignment = VerticalAlignBottom,
                        float size = 0.0f,
                        bool special = false);
+    void renderAnnotationMarker(const Annotation &a,
+                                FontStyle fs,
+                                float depth);
+    void renderAnnotationLabel(const Annotation &a,
+                               FontStyle fs,
+                               int hOffset,
+                               int vOffset,
+                               float depth);
     void renderAnnotations(const std::vector<Annotation>&, FontStyle fs);
     void renderBackgroundAnnotations(FontStyle fs);
     void renderForegroundAnnotations(FontStyle fs);

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -606,10 +606,14 @@ class Renderer
                                                                   float farDist,
                                                                   FontStyle fs);
 
-    void renderMarkers(const MarkerList&,
-                       const UniversalCoord& cameraPosition,
-                       const Eigen::Quaterniond& cameraOrientation,
-                       double jd);
+    void markersToAnnotations(const MarkerList &markers,
+                              const Observer &observer,
+                              double now);
+
+    bool selectionToAnnotation(const Selection &sel,
+                               const Observer &observer,
+                               const celmath::Frustum &xfrustum,
+                               double now);
 
     void renderOrbit(const OrbitPathListEntry&,
                      double now,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -643,6 +643,10 @@ class Renderer
                      float nearDist,
                      float farDist);
 
+    void renderSolarSystemObjects(const Observer &observer,
+                                  int nIntervals,
+                                  double now);
+
     void updateBodyVisibilityMask();
 
     void createShadowFBO();

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -719,6 +719,7 @@ class Renderer
 
     Eigen::Matrix4d modelMatrix;
     Eigen::Matrix4d projMatrix;
+    Eigen::Matrix4f m_orthoProjMatrix;
 
     bool useCompressedTextures{ false };
     unsigned int textureResolution;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -494,6 +494,8 @@ class Renderer
                          double now);
     void buildLabelLists(const celmath::Frustum& viewFrustum,
                          double now);
+    int buildDepthPartitions();
+
 
     void addRenderListEntries(RenderListEntry& rle,
                               Body& body,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -338,7 +338,6 @@ class Renderer
     float getNearPlaneDistance() const;
 
     void clearAnnotations(std::vector<Annotation>&);
-    void clearSortedAnnotations();
 
     void invalidateOrbitCache();
 

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -570,9 +570,9 @@ class Renderer
                                    float fade,
                                    bool lit);
 
-    void renderLocations(const Body& body,
-                         const Eigen::Vector3d& bodyPosition,
-                         const Eigen::Quaterniond& bodyOrientation);
+    void locationsToAnnotations(const Body& body,
+                                const Eigen::Vector3d& bodyPosition,
+                                const Eigen::Quaterniond& bodyOrientation);
 
     // Render an item from the render list
     void renderItem(const RenderListEntry& rle,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -540,14 +540,6 @@ class Renderer
                          const Observer& observer,
                          float discSizeInPixels);
 
-    void renderObjectAsPoint_nosprite(const Eigen::Vector3f& center,
-                                      float radius,
-                                      float appMag,
-                                      float _faintestMag,
-                                      float discSizeInPixels,
-                                      Color color,
-                                      const Eigen::Quaternionf& cameraOrientation,
-                                      bool useHalos);
     void renderObjectAsPoint(const Eigen::Vector3f& center,
                              float radius,
                              float appMag,
@@ -749,31 +741,6 @@ class Renderer
     };
 
     int m_GLStateFlag { 0 };
-
- public:
-#if 0
-    struct OrbitSample
-    {
-        double t;
-        Point3d pos;
-
-        OrbitSample(const Eigen::Vector3d& _pos, double _t) : t(_t), pos(_pos.x(), _pos.y(), _pos.z()) { }
-        OrbitSample() { }
-    };
-
-    struct OrbitSection
-    {
-        Capsuled boundingVolume;
-        uint32_t firstSample;
-    };
-
-    struct CachedOrbit
-    {
-        std::vector<OrbitSample> trajectory;
-        std::vector<OrbitSection> sections;
-        uint32_t lastUsed;
-    };
-#endif
 
  private:
     typedef std::map<const Orbit*, CurvePlot*> OrbitCache;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -172,6 +172,31 @@ class Renderer
         ShowComets              = 0x0000000080000000,
         ShowSpacecrafts         = 0x0000000100000000,
         ShowFadingOrbits        = 0x0000000200000000,
+        ShowSolarSystemObjects  = ShowPlanets           |
+                                  ShowDwarfPlanets      |
+                                  ShowMoons             |
+                                  ShowMinorMoons        |
+                                  ShowAsteroids         |
+                                  ShowComets            |
+                                  ShowPlanetRings       |
+                                  ShowSpacecrafts,
+        ShowDeepSpaceObjects    = ShowGalaxies          |
+                                  ShowGlobulars         |
+                                  ShowNebulae           |
+                                  ShowOpenClusters,
+        DefaultRenderFlags      = ShowStars             |
+                                  ShowSolarSystemObjects|
+                                  ShowDeepSpaceObjects  |
+                                  ShowCloudMaps         |
+                                  ShowNightMaps         |
+                                  ShowAtmospheres       |
+                                  ShowEclipseShadows    |
+                                  ShowRingShadows       |
+                                  ShowCloudShadows      |
+                                  ShowCometTails        |
+                                  ShowAutoMag           |
+                                  ShowFadingOrbits      |
+                                  ShowSmoothLines
     };
 
     enum StarStyle
@@ -189,32 +214,6 @@ class Renderer
         RGB = GL_RGB,
         BGR_EXT = GL_BGR_EXT
     };
-
-    // constants
-    constexpr static const uint64_t DefaultRenderFlags =
-                                          Renderer::ShowStars          |
-                                          Renderer::ShowPlanets        |
-                                          Renderer::ShowDwarfPlanets   |
-                                          Renderer::ShowMoons          |
-                                          Renderer::ShowMinorMoons     |
-                                          Renderer::ShowAsteroids      |
-                                          Renderer::ShowComets         |
-                                          Renderer::ShowSpacecrafts    |
-                                          Renderer::ShowGalaxies       |
-                                          Renderer::ShowGlobulars      |
-                                          Renderer::ShowCloudMaps      |
-                                          Renderer::ShowNightMaps      |
-                                          Renderer::ShowAtmospheres    |
-                                          Renderer::ShowEclipseShadows |
-                                          Renderer::ShowPlanetRings    |
-                                          Renderer::ShowRingShadows    |
-                                          Renderer::ShowCloudShadows   |
-                                          Renderer::ShowCometTails     |
-                                          Renderer::ShowNebulae        |
-                                          Renderer::ShowOpenClusters   |
-                                          Renderer::ShowAutoMag        |
-                                          Renderer::ShowFadingOrbits   |
-                                          Renderer::ShowSmoothLines;
 
     uint64_t getRenderFlags() const;
     void setRenderFlags(uint64_t);

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -651,6 +651,9 @@ class Renderer
 
     void createShadowFBO();
 
+    void enableSmoothLines() const;
+    void disableSmoothLines() const;
+
 #ifdef USE_HDR
  private:
     int sceneTexWidth, sceneTexHeight;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -475,6 +475,11 @@ class Renderer
     void renderEclipticLine();
     void renderCrosshair(float size, double tsec, const Color &color);
 
+    void buildNearSystemsLists(const Universe &universe,
+                               const Observer &observer,
+                               const celmath::Frustum &xfrustum,
+                               double jd);
+
     void buildRenderLists(const Eigen::Vector3d& astrocentricObserverPos,
                           const celmath::Frustum& viewFrustum,
                           const Eigen::Vector3d& viewPlaneNormal,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -503,6 +503,8 @@ class Renderer
                                   const Observer& observer,
                                   double now);
 
+    void removeInvisibleItems(const celmath::Frustum &frustum);
+
     void renderObject(const Eigen::Vector3f& pos,
                       float distance,
                       double now,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -334,7 +334,7 @@ class Renderer
     void beginObjectAnnotations();
     void addObjectAnnotation(const MarkerRepresentation* markerRep, const std::string& labelText, Color, const Eigen::Vector3f&);
     void endObjectAnnotations();
-    Eigen::Quaternionf getCameraOrientation() const;
+    const Eigen::Quaternionf& getCameraOrientation() const;
     float getNearPlaneDistance() const;
 
     void clearAnnotations(std::vector<Annotation>&);
@@ -510,7 +510,6 @@ class Renderer
     void renderObject(const Eigen::Vector3f& pos,
                       float distance,
                       double now,
-                      const Eigen::Quaternionf& cameraOrientation,
                       float nearPlaneDistance,
                       float farPlaneDistance,
                       RenderProperties& obj,
@@ -521,14 +520,12 @@ class Renderer
                       float distance,
                       float appMag,
                       const Observer& observer,
-                      const Eigen::Quaternionf& cameraOrientation,
                       float, float);
 
     void renderStar(const Star& star,
                     const Eigen::Vector3f& pos,
                     float distance,
                     float appMag,
-                    const Eigen::Quaternionf& orientation,
                     double now,
                     float, float);
 
@@ -557,7 +554,6 @@ class Renderer
                              float _faintestMag,
                              float discSizeInPixels,
                              Color color,
-                             const Eigen::Quaternionf& cameraOrientation,
                              bool useHalos,
                              bool emissive);
 
@@ -577,7 +573,6 @@ class Renderer
     // Render an item from the render list
     void renderItem(const RenderListEntry& rle,
                     const Observer& observer,
-                    const Eigen::Quaternionf& cameraOrientation,
                     float nearPlaneDistance,
                     float farPlaneDistance);
 
@@ -589,8 +584,7 @@ class Renderer
 
     void labelConstellations(const AsterismList& asterisms,
                              const Observer& observer);
-    void renderParticles(const std::vector<Particle>& particles,
-                         const Eigen::Quaternionf& orientation);
+    void renderParticles(const std::vector<Particle>& particles);
 
 
     void addAnnotation(std::vector<Annotation>&,

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -41,8 +41,6 @@ using namespace celmath;
 #define GL_ONLY_SHADOWS 1
 #endif
 
-const double AtmosphereExtinctionThreshold = 0.05;
-
 static
 void renderGeometryShadow_GLSL(Geometry* geometry,
                                FramebufferObject* shadowFbo,
@@ -634,7 +632,7 @@ renderAtmosphere_GLSL(const RenderInfo& ri,
     prog->setLightParameters(ls, ri.color, ri.specularColor, Color::Black);
     prog->ambientColor = Vector3f::Zero();
 
-    float atmosphereRadius = radius + -atmosphere->mieScaleHeight * (float) log(AtmosphereExtinctionThreshold);
+    float atmosphereRadius = radius + -atmosphere->mieScaleHeight * log(AtmosphereExtinctionThreshold);
     float atmScale = atmosphereRadius / radius;
 
     prog->eyePosition = ls.eyePos_obj / atmScale;

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -3692,9 +3692,9 @@ CelestiaGLProgram::setAtmosphereParameters(const Atmosphere& atmosphere,
     // fallse off exponentially with height above the planet's surface, so the actual
     // radius is infinite. That's a bit impractical, so well just render the portion
     // out to the point where the density is some fraction of the surface density.
-    float skySphereRadius = atmPlanetRadius + -atmosphere.mieScaleHeight * (float) log(AtmosphereExtinctionThreshold);
+    float skySphereRadius = atmPlanetRadius + -atmosphere.mieScaleHeight * log(AtmosphereExtinctionThreshold);
 
-    float tMieCoeff        = atmosphere.mieCoeff * objRadius;
+    float tMieCoeff           = atmosphere.mieCoeff * objRadius;
     Vector3f tRayleighCoeff   = atmosphere.rayleighCoeff * objRadius;
     Vector3f tAbsorptionCoeff = atmosphere.absorptionCoeff * objRadius;
 

--- a/src/celmath/mathlib.h
+++ b/src/celmath/mathlib.h
@@ -160,4 +160,10 @@ namespace std
     using celmath::clamp;
 };
 #endif
+
+constexpr long double operator"" _deg (long double deg)
+{
+    return celmath::degToRad(deg);
+}
+
 #endif // _MATHLIB_H_

--- a/src/celutil/color.h
+++ b/src/celutil/color.h
@@ -58,12 +58,17 @@ class Color
     inline constexpr float green() const;
     inline constexpr float blue() const;
     inline constexpr float alpha() const;
+    inline Color& alpha(float a);
+
     inline void get(uint8_t*) const;
     inline const uint8_t* data() const;
 
     inline Eigen::Vector3f toVector3() const;
     inline Eigen::Vector4f toVector4() const;
+    inline operator Eigen::Vector3f() const;
+    inline operator Eigen::Vector4f() const;
 
+    inline Color operator*(float m) const;
     friend bool operator==(Color, Color);
     friend bool operator!=(Color, Color);
     friend Color operator*(Color, Color);
@@ -81,8 +86,6 @@ class Color
     typedef std::map<const std::string, Color> ColorMap;
     static ColorMap x11Colors;
 };
-#undef C
-
 
 constexpr float Color::red() const
 {
@@ -153,5 +156,27 @@ inline Color operator*(Color a, Color b)
                  a.blue() * b.blue(),
                  a.alpha() * b.alpha());
 }
+
+inline Color::operator Eigen::Vector3f() const
+{
+    return toVector3();
+}
+
+inline Color::operator Eigen::Vector4f() const
+{
+    return toVector4();
+}
+
+inline Color Color::operator*(float m) const
+{
+    return { red() * m, green() * m, blue() *m };
+}
+
+inline Color& Color::alpha(float a)
+{
+    c[Alpha] = C(a);
+    return *this;
+}
+#undef C
 
 #endif // _CELUTIL_COLOR_H_


### PR DESCRIPTION
This is a really huge thing, but there are not much changes actually.
1. Fixed wireframe mode, in certain cases it did not work because it was disabled in comet tail rendering code
1. Fixed color of globular markers, it was using open clusters' color
1. Fixed labels jittering. Noticeable when rotating planets or changing distance to them.
1. Changed `QUAD_STRIP` used in old GL versions to `TRIANGLE_STRIP`.
1. Added a few utility methods for `Color` and `degToRad`.
1. Refactored Annotation related code to simplify it.
1. DSO renderer extracted into its own files.

All other changes are refactoring of a huge unreadable (almost one thousand LoC!!!) `Renderer::draw()` into smaller logically independent pieces (at least now I can tell what it actually does :) ). Also some methods were renamed to better reflect their purpose.