### PR TITLE
Remove old "simple" shaders

### DIFF
--- a/shaders/marker_frag.glsl
+++ b/shaders/marker_frag.glsl
@@ -1,7 +1,0 @@
-#version 120
-uniform vec4 color;
-
-void main(void)
-{
-    gl_FragColor = color;
-}

--- a/shaders/marker_vert.glsl
+++ b/shaders/marker_vert.glsl
@@ -1,8 +1,0 @@
-#version 120
-uniform float s;
-
-void main(void)
-{
-    vec4 p = vec4(gl_Vertex.xy * s, 0.0f, 1.0f);
-    gl_Position = gl_ModelViewProjectionMatrix * p;
-}

--- a/shaders/uniform_color_frag.glsl
+++ b/shaders/uniform_color_frag.glsl
@@ -1,8 +1,0 @@
-#version 110
-
-uniform vec4 color;
-
-void main(void)
-{
-    gl_FragColor = color;
-}

--- a/shaders/uniform_color_vert.glsl
+++ b/shaders/uniform_color_vert.glsl
@@ -1,6 +1,0 @@
-#version 110
-
-void main(void)
-{
-    gl_Position = ftransform();
-}

--- a/src/celengine/asterismrenderer.cpp
+++ b/src/celengine/asterismrenderer.cpp
@@ -10,12 +10,15 @@
 #include <cassert>
 #include "asterismrenderer.h"
 #include "render.h"
+#include "vecgl.h"
 
 using namespace std;
 
 AsterismRenderer::AsterismRenderer(const AsterismList *asterisms) :
     m_asterisms(asterisms)
 {
+    m_shadprop.texUsage = ShaderProperties::VertexColors;
+    m_shadprop.lightModel = ShaderProperties::UnlitModel;
 }
 
 bool AsterismRenderer::sameAsterisms(const AsterismList *asterisms) const
@@ -47,7 +50,7 @@ void AsterismRenderer::render(const Renderer &renderer, const Color &defaultColo
     }
 
     prog->use();
-    prog->color = defaultColor.toVector4();
+    glColor(defaultColor);
     m_vo.draw(GL_LINES, m_vtxTotal);
 
     assert(m_asterisms->size() == m_vtxCount.size());
@@ -63,7 +66,7 @@ void AsterismRenderer::render(const Renderer &renderer, const Color &defaultColo
             continue;
         }
 
-        prog->color = Color(ast->getOverrideColor(), opacity).toVector4();
+        glColor(ast->getOverrideColor(), opacity);
         m_vo.draw(GL_LINES, m_vtxCount[i], offset);
         offset += m_vtxCount[i];
     }

--- a/src/celengine/asterismrenderer.h
+++ b/src/celengine/asterismrenderer.h
@@ -35,7 +35,7 @@ class AsterismRenderer
     GLfloat* prepare();
 
     celgl::VertexObject     m_vo        { GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW };
-    ShaderProperties        m_shadprop  { ShaderProperties::UniformColor };
+    ShaderProperties        m_shadprop;
     std::vector<GLsizei>    m_vtxCount;
 
     const AsterismList     *m_asterisms { nullptr };

--- a/src/celengine/axisarrow.cpp
+++ b/src/celengine/axisarrow.cpp
@@ -220,6 +220,8 @@ ArrowReferenceMark::ArrowReferenceMark(const Body& _body) :
     opacity(1.0f)
 #endif
 {
+    shadprop.texUsage = ShaderProperties::VertexColors;
+    shadprop.lightModel = ShaderProperties::UnlitModel;
 }
 
 
@@ -281,7 +283,7 @@ ArrowReferenceMark::render(Renderer* renderer,
     if (prog == nullptr)
         return;
     prog->use();
-    prog->color = Color(color, opacity).toVector4();
+    glColor(color, opacity);
 
     auto &vo = renderer->getVertexObject(VOType::AxisArrow, GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW);
     RenderArrow(vo);
@@ -306,6 +308,8 @@ AxesReferenceMark::AxesReferenceMark(const Body& _body) :
     opacity(1.0f)
 #endif
 {
+    shadprop.texUsage = ShaderProperties::VertexColors;
+    shadprop.lightModel = ShaderProperties::UnlitModel;
 }
 
 
@@ -388,7 +392,7 @@ AxesReferenceMark::render(Renderer* renderer,
     // x-axis
     glPushMatrix();
     glRotatef(90.0f, 0.0f, 1.0f, 0.0f);
-    prog->color = { 1.0f, 0.0f, 0.0f, opacity };
+    glColor4f(1.0f, 0.0f, 0.0f, opacity);
     RenderArrow(vo);
     glTranslatef(0.1f, 0.0f, 0.75f);
     glScalef(labelScale, labelScale, labelScale);
@@ -398,7 +402,7 @@ AxesReferenceMark::render(Renderer* renderer,
     // y-axis
     glPushMatrix();
     glRotatef(180.0f, 0.0f, 1.0f, 0.0f);
-    prog->color = { 0.0f, 1.0f, 0.0f, opacity };
+    glColor4f(0.0f, 1.0f, 0.0f, opacity);
     RenderArrow(vo);
     glTranslatef(0.1f, 0.0f, 0.75f);
     glScalef(labelScale, labelScale, labelScale);
@@ -408,7 +412,7 @@ AxesReferenceMark::render(Renderer* renderer,
     // z-axis
     glPushMatrix();
     glRotatef(-90.0f, 1.0f, 0.0f, 0.0f);
-    prog->color = { 0.0f, 0.0f, 1.0f, opacity };
+    glColor4f(0.0f, 0.0f, 1.0f, opacity);
     RenderArrow(vo);
     glTranslatef(0.1f, 0.0f, 0.75f);
     glScalef(labelScale, labelScale, labelScale);

--- a/src/celengine/axisarrow.h
+++ b/src/celengine/axisarrow.h
@@ -49,7 +49,7 @@ class ArrowReferenceMark : public ReferenceMark
     float size;
     Color color;
     float opacity;
-    ShaderProperties shadprop{ ShaderProperties::UniformColor };
+    ShaderProperties shadprop;
 };
 
 
@@ -80,7 +80,7 @@ class AxesReferenceMark : public ReferenceMark
  private:
     float size;
     float opacity;
-    ShaderProperties shadprop{ ShaderProperties::UniformColor };
+    ShaderProperties shadprop;
 };
 
 

--- a/src/celengine/boundariesrenderer.cpp
+++ b/src/celengine/boundariesrenderer.cpp
@@ -13,6 +13,7 @@
 #include <celutil/color.h>
 #include "boundariesrenderer.h"
 #include "render.h"
+#include "vecgl.h"
 
 using namespace Eigen;
 using namespace std;
@@ -20,6 +21,8 @@ using namespace std;
 BoundariesRenderer::BoundariesRenderer(const ConstellationBoundaries *boundaries) :
     m_boundaries(boundaries)
 {
+    m_shadprop.texUsage = ShaderProperties::VertexColors;
+    m_shadprop.lightModel = ShaderProperties::UnlitModel;
 }
 
 bool BoundariesRenderer::sameBoundaries(const ConstellationBoundaries *boundaries) const
@@ -48,7 +51,7 @@ void BoundariesRenderer::render(const Renderer &renderer, const Color &color)
     }
 
     prog->use();
-    prog->color = color.toVector4();
+    glColor(color);
     m_vo.draw(GL_LINES, m_vtxTotal);
 
     glUseProgram(0);

--- a/src/celengine/boundariesrenderer.h
+++ b/src/celengine/boundariesrenderer.h
@@ -34,7 +34,7 @@ class BoundariesRenderer
     GLshort* prepare();
 
     celgl::VertexObject            m_vo         { GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW };
-    ShaderProperties               m_shadprop   { ShaderProperties::UniformColor };
+    ShaderProperties               m_shadprop;
     const ConstellationBoundaries *m_boundaries { nullptr };
     GLsizei                        m_vtxTotal   { 0 };
 };

--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -16,6 +16,7 @@
 #include "render.h"
 #include "vertexobject.h"
 #include "marker.h"
+#include "vecgl.h"
 
 
 using namespace std;
@@ -218,7 +219,10 @@ static void initVO(VertexObject& vo)
 void Renderer::renderMarker(MarkerRepresentation::Symbol symbol, float size, const Color& color)
 {
     assert(shaderManager != nullptr);
-    auto* prog = shaderManager->getShader("marker");
+    ShaderProperties shadprop;
+    shadprop.texUsage = ShaderProperties::VertexColors;
+    shadprop.lightModel = ShaderProperties::UnlitModel;
+    auto* prog = shaderManager->getShader(shadprop);
     if (prog == nullptr)
         return;
 
@@ -229,8 +233,8 @@ void Renderer::renderMarker(MarkerRepresentation::Symbol symbol, float size, con
 
     float s = size / 2.0f;
     prog->use();
-    prog->vec4Param("color") = color.toVector4();
-    prog->floatParam("s") = s;
+    glColor(color);
+    glScalef(s, s, 0);
 
     switch (symbol)
     {

--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -91,7 +91,10 @@ PlanetographicGrid::render(Renderer* renderer,
                            float discSizeInPixels,
                            double tdb) const
 {
-    auto *prog = renderer->getShaderManager().getShader("uniform_color");
+    ShaderProperties shadprop;
+    shadprop.texUsage = ShaderProperties::VertexColors;
+    shadprop.lightModel = ShaderProperties::UnlitModel;
+    auto *prog = renderer->getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
 
@@ -150,12 +153,12 @@ PlanetographicGrid::render(Renderer* renderer,
 
         if (latitude == 0.0f)
         {
-            prog->vec4Param("color") = Renderer::PlanetEquatorColor.toVector4();
+            glColor(Renderer::PlanetEquatorColor);
             glLineWidth(2.0f);
         }
         else
         {
-            prog->vec4Param("color") = Renderer::PlanetographicGridColor.toVector4();
+            glColor(Renderer::PlanetographicGridColor);
         }
         glPushMatrix();
         glTranslatef(0.0f, (float) std::sin(phi), 0.0f);

--- a/src/celengine/pointstarvertexbuffer.cpp
+++ b/src/celengine/pointstarvertexbuffer.cpp
@@ -59,7 +59,10 @@ void PointStarVertexBuffer::startSprites()
 
 void PointStarVertexBuffer::startPoints()
 {
-    auto *prog = renderer.getShaderManager().getShader(ShaderProperties::PerVertexColor);
+    ShaderProperties shadprop;
+    shadprop.texUsage = ShaderProperties::VertexColors;
+    shadprop.lightModel = ShaderProperties::UnlitModel;
+    auto *prog = renderer.getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
     prog->use();

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -238,6 +238,7 @@ ShaderProperties::isViewDependent() const
     case DiffuseModel:
     case ParticleDiffuseModel:
     case EmissiveModel:
+    case UnlitModel:
         return false;
     default:
         return true;
@@ -1724,8 +1725,11 @@ ShaderManager::buildVertexShader(const ShaderProperties& props)
     }
     else
     {
-        source += "uniform vec3 ambientColor;\n";
-        source += "uniform float opacity;\n";
+        if (props.lightModel != ShaderProperties::UnlitModel)
+        {
+            source += "uniform vec3 ambientColor;\n";
+            source += "uniform float opacity;\n";
+        }
         source += "varying vec4 diff;\n";
         if (props.lightModel == ShaderProperties::SpecularModel)
         {
@@ -1830,7 +1834,17 @@ ShaderManager::buildVertexShader(const ShaderProperties& props)
     }
     else
     {
-        source += "diff = vec4(ambientColor, opacity);\n";
+        if (props.lightModel == ShaderProperties::UnlitModel)
+        {
+            if ((props.texUsage & ShaderProperties::VertexColors) != 0)
+                source += "diff = gl_Color;\n";
+            else
+                source += "diff = vec4(1.0);\n";
+        }
+        else
+        {
+            source += "diff = vec4(ambientColor, opacity);\n";
+        }
         if (props.hasSpecular())
             source += "spec = vec4(0.0, 0.0, 0.0, 0.0);\n";
     }

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -255,11 +255,6 @@ ShaderProperties::usesTangentSpaceLighting() const
 
 bool operator<(const ShaderProperties& p0, const ShaderProperties& p1)
 {
-    if (p0.simpleProps < p1.simpleProps)
-        return true;
-    if (p1.simpleProps < p0.simpleProps)
-        return false;
-
     if (p0.texUsage < p1.texUsage)
         return true;
     if (p1.texUsage < p0.texUsage)
@@ -3093,80 +3088,6 @@ ShaderManager::buildParticleFragmentShader(const ShaderProperties& props)
     return status == ShaderStatus_OK ? fs : nullptr;
 }
 
-GLVertexShader*
-ShaderManager::buildSimpleVertexShader(uint32_t props)
-{
-    ostringstream source;
-
-    source << CommonHeader;
-
-    if (props & ShaderProperties::PerVertexColor)
-        source << DeclareVarying("color", Shader_Vector4);
-
-    if (props & ShaderProperties::HasTexture)
-        source << DeclareVarying("texCoord", Shader_Vector2);
-
-    // Begin main()
-    source << "\nvoid main(void)\n";
-    source << "{\n";
-
-    if (props & ShaderProperties::PerVertexColor)
-        source << "    color = gl_Color;\n";
-    if (props & ShaderProperties::HasTexture)
-        source << "    texCoord = gl_MultiTexCoord0.st;\n";
-    source << "    gl_Position = ftransform();\n";
-
-    source << "}\n";
-    // End of main()
-
-    DumpVSSource(source);
-
-    GLVertexShader* vs = nullptr;
-    GLShaderStatus status = GLShaderLoader::CreateVertexShader(source.str(), &vs);
-    return status == ShaderStatus_OK ? vs : nullptr;
-}
-
-
-GLFragmentShader*
-ShaderManager::buildSimpleFragmentShader(uint32_t props)
-{
-    ostringstream source;
-
-    source << CommonHeader;
-
-    if (props & ShaderProperties::UniformColor)
-        source << DeclareUniform("color", Shader_Vector4);
-
-    if (props & ShaderProperties::HasTexture)
-    {
-        source << DeclareUniform("tex", Shader_Sampler2D);
-        source << DeclareVarying("texCoord", Shader_Vector2);
-    }
-
-    if (props & ShaderProperties::PerVertexColor)
-        source << DeclareVarying("color", Shader_Vector4);
-
-    // Begin main()
-    source << "\nvoid main(void)\n";
-    source << "{\n";
-
-    if (props & ShaderProperties::HasTexture)
-        source << "    gl_FragColor = texture2D(tex, texCoord) * color;\n";
-    else
-        source << "    gl_FragColor = color;\n";
-
-    source << "}\n";
-    // End of main()
-
-    DumpFSSource(source);
-
-    GLFragmentShader* fs = nullptr;
-    GLShaderStatus status = GLShaderLoader::CreateFragmentShader(source.str(), &fs);
-    return status == ShaderStatus_OK ? fs : nullptr;
-}
-
-
-
 CelestiaGLProgram*
 ShaderManager::buildProgram(const ShaderProperties& props)
 {
@@ -3176,12 +3097,7 @@ ShaderManager::buildProgram(const ShaderProperties& props)
     GLVertexShader* vs = nullptr;
     GLFragmentShader* fs = nullptr;
 
-    if (props.simpleProps != 0)
-    {
-        vs = buildSimpleVertexShader(props.simpleProps);
-        fs = buildSimpleFragmentShader(props.simpleProps);
-    }
-    else if (props.lightModel == ShaderProperties::RingIllumModel)
+    if (props.lightModel == ShaderProperties::RingIllumModel)
     {
         vs = buildRingsVertexShader(props);
         fs = buildRingsFragmentShader(props);
@@ -3473,11 +3389,6 @@ CelestiaGLProgram::initParameters()
     if ((props.texUsage & ShaderProperties::PointSprite) != 0)
     {
         pointScale           = floatParam("pointScale");
-    }
-
-    if (props.simpleProps & ShaderProperties::UniformColor)
-    {
-        color                = vec4Param("color");
     }
 }
 

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -24,7 +24,6 @@ class ShaderProperties
 {
  public:
     ShaderProperties() = default;
-    ShaderProperties(uint32_t p) : simpleProps(p) {};
     bool usesShadows() const;
     bool usesFragmentLighting() const;
     bool usesTangentSpaceLighting() const;
@@ -91,13 +90,6 @@ class ShaderProperties
      VolumetricEmissionEffect        = 0x0004,
  };
 
- enum : uint32_t
- {
-     UniformColor   = 0x0001,
-     PerVertexColor = 0x0002,
-     HasTexture     = 0x0004
- };
-
  public:
     unsigned short nLights{ 0 };
     unsigned short texUsage{ 0 };
@@ -113,9 +105,6 @@ class ShaderProperties
     //   Bit  3,   on for self shadowing
     //   Bit  4,   on for cloud shadows
     uint32_t shadowCounts{ 0 };
-
-    // Properties of "simple" shaders. Other properties are ignored.
-    uint32_t simpleProps{ 0 };
 
  private:
     enum
@@ -308,9 +297,6 @@ class ShaderManager
 
     GLVertexShader* buildParticleVertexShader(const ShaderProperties&);
     GLFragmentShader* buildParticleFragmentShader(const ShaderProperties&);
-
-    GLVertexShader* buildSimpleVertexShader(uint32_t);
-    GLFragmentShader* buildSimpleFragmentShader(uint32_t);
 
     std::map<ShaderProperties, CelestiaGLProgram*> dynamicShaders;
     std::map<std::string, CelestiaGLProgram*> staticShaders;

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -81,6 +81,7 @@ class ShaderProperties
      ParticleDiffuseModel  = 7,
      EmissiveModel         = 8,
      ParticleModel         = 9,
+     UnlitModel            = 10,
  };
 
  enum

--- a/src/celengine/skygrid.cpp
+++ b/src/celengine/skygrid.cpp
@@ -390,7 +390,10 @@ SkyGrid::render(Renderer& renderer,
                 int windowWidth,
                 int windowHeight)
 {
-    auto *prog = renderer.getShaderManager().getShader("uniform_color");
+    ShaderProperties shadprop;
+    shadprop.texUsage = ShaderProperties::VertexColors;
+    shadprop.lightModel = ShaderProperties::UnlitModel;
+    auto *prog = renderer.getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
 
@@ -544,7 +547,7 @@ SkyGrid::render(Renderer& renderer,
     Quaternionf orientationf = q.cast<float>();
 
     prog->use();
-    prog->vec4Param("color") = m_lineColor.toVector4();
+    glColor(m_lineColor);
 
     // Render the parallels
     glPushMatrix();

--- a/src/celengine/visibleregion.cpp
+++ b/src/celengine/visibleregion.cpp
@@ -92,7 +92,10 @@ renderTerminator(Renderer* renderer, const vector<Vector3f>& pos, const Vector4f
      * Because of this we make calculations on a CPU and stream results to GPU.
      */
 
-    auto *prog = renderer->getShaderManager().getShader("uniform_color");
+    ShaderProperties shadprop;
+    shadprop.texUsage = ShaderProperties::VertexColors;
+    shadprop.lightModel = ShaderProperties::UnlitModel;
+    auto *prog = renderer->getShaderManager().getShader(shadprop);
     if (prog == nullptr)
         return;
 
@@ -109,10 +112,7 @@ renderTerminator(Renderer* renderer, const vector<Vector3f>& pos, const Vector4f
     vo.setBufferData(pos.data(), 0, pos.size() * sizeof(Vector3f));
 
     prog->use();
-    prog->vec4Param("color") = color;
-    Eigen::Matrix4f m = Eigen::Matrix4f::Identity();
-    m.topLeftCorner(3, 3) = qf.conjugate().toRotationMatrix();
-    prog->mat4Param("rotate") = m;
+    glColor(color);
 
     vo.draw(GL_LINE_LOOP, pos.size());
 


### PR DESCRIPTION
Once I added so called simple shaders to ShaderManager. Now with introduction of "Unlit" lighting model (not the best name for it, but I don't have a better one) we can remove that temporary "simple" shaders. Also we can remove some static shaders and use that "unlit" model instead. 