### PR TITLE
Add include file for locale text

### DIFF
--- a/src/celestia/gtk/main.cpp
+++ b/src/celestia/gtk/main.cpp
@@ -20,6 +20,7 @@
 #include <cctype>
 #include <cstring>
 #include <time.h>
+#include <libintl.h>
 
 #ifdef WIN32
 #include <direct.h>


### PR DESCRIPTION
Add include for header file libintl.h on line 17
make version: GNU Make 4.1

error message:
[ 92%] Building CXX object src/celestia/gtk/CMakeFiles/celestia-gtk.dir/main.cpp.o
/home/william/Development/Celestia/src/celestia/gtk/main.cpp: In function ‘int main(int, char**)’:
/home/william/Development/Celestia/src/celestia/gtk/main.cpp:310:38: error: ‘bindtextdomain’ was not declared in this scope
     bindtextdomain(PACKAGE, LOCALEDIR);
                                      ^
/home/william/Development/Celestia/src/celestia/gtk/main.cpp:311:45: error: ‘bind_textdomain_codeset’ was not declared in this scope
     bind_textdomain_codeset(PACKAGE, "UTF-8");
                                             ^
/home/william/Development/Celestia/src/celestia/gtk/main.cpp:312:23: error: ‘textdomain’ was not declared in this scope
     textdomain(PACKAGE);
                       ^
src/celestia/gtk/CMakeFiles/celestia-gtk.dir/build.make:335: recipe for target 'src/celestia/gtk/CMakeFiles/celestia-gtk.dir/main.cpp.o' failed
make[2]: *** [src/celestia/gtk/CMakeFiles/celestia-gtk.dir/main.cpp.o] Error 1
CMakeFiles/Makefile2:801: recipe for target 'src/celestia/gtk/CMakeFiles/celestia-gtk.dir/all' failed
make[1]: *** [src/celestia/gtk/CMakeFiles/celestia-gtk.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
