### PR TITLE
Optimize font rendering

### DIFF
--- a/src/celengine/console.cpp
+++ b/src/celengine/console.cpp
@@ -143,7 +143,11 @@ void Console::setScale(int w, int h)
 void Console::setFont(TextureFont* f)
 {
     if (f != font)
+    {
+        if (font != nullptr)
+            font->flush();
         font = f;
+    }
 }
 
 
@@ -237,14 +241,18 @@ int Console::getHeight() const
 
 void Console::setColor(float r, float g, float b, float a) const
 {
+    if (font != nullptr)
+        font->flush();
     glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex, r, g, b, a);
 }
 
 
 void Console::setColor(const Color& c) const
 {
+    if (font != nullptr)
+        font->flush();
     glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex,
-		     c.red(), c.green(), c.blue(), c.alpha());
+                     c.red(), c.green(), c.blue(), c.alpha());
 
 }
 

--- a/src/celengine/overlay.cpp
+++ b/src/celengine/overlay.cpp
@@ -73,6 +73,8 @@ void Overlay::setFont(TextureFont* f)
 {
     if (f != font)
     {
+        if (font != nullptr)
+            font->flush();
         font = f;
         fontChanged = true;
     }
@@ -188,13 +190,17 @@ void Overlay::drawRectangle(const Rect& r)
 
 void Overlay::setColor(float r, float g, float b, float a)
 {
+    if (font != nullptr)
+        font->flush();
     glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex, r, g, b, a);
 }
 
 void Overlay::setColor(const Color& c)
 {
+    if (font != nullptr)
+        font->flush();
     glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex,
-		     c.red(), c.green(), c.blue(), c.alpha());
+                     c.red(), c.green(), c.blue(), c.alpha());
 }
 
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4798,6 +4798,7 @@ Renderer::renderAnnotationMarker(const Annotation &a,
                      -labelOffset - font[fs]->getHeight() + PixelOffset, 0.0f);
         font[fs]->bind();
         font[fs]->render(markerRep.label(), 0.0f, 0.0f);
+        font[fs]->flush();
     }
     glPopMatrix();
 }
@@ -4816,6 +4817,7 @@ Renderer::renderAnnotationLabel(const Annotation &a,
                  depth);
     font[fs]->bind();
     font[fs]->render(a.labelText, 0.0f, 0.0f);
+    font[fs]->flush();
     glPopMatrix();
 }
 

--- a/src/celttf/truetypefont.h
+++ b/src/celttf/truetypefont.h
@@ -48,6 +48,7 @@ class TextureFont
     void bind();
     void unbind();
     bool buildTexture();
+    void flush();
 
     static TextureFont* load(const Renderer*, const fs::path&, int size, int dpi);
 

--- a/src/celtxf/texturefont.h
+++ b/src/celtxf/texturefont.h
@@ -53,6 +53,7 @@ class TextureFont
 
     void bind();
     void unbind();
+    void flush() {};
 
     bool buildTexture();
 


### PR DESCRIPTION
overlay and console write char by char because they implement an iostream, so we have a lot of glDrawArray calls (one per char). With this commit N calls to glDrawArray are replaced with a single glDrawElements.