### PR TITLE
Refactor TextureFont::render()

### DIFF
--- a/src/celscript/lua/celx_misc.cpp
+++ b/src/celscript/lua/celx_misc.cpp
@@ -189,7 +189,8 @@ static int font_render(lua_State* l)
 
     const char* s = celx.safeGetString(2, AllErrors, "First argument to font:render must be a string");
     auto font = *celx.getThis<TextureFont*>();
-    font->render(s);
+    float xoffset = font->render(s);
+    glTranslatef(xoffset, 0, 0);
 
     return 0;
 }

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -482,21 +482,6 @@ TextureFont::~TextureFont()
     delete impl;
 }
 
-
-/**
- * Render a single character and update the modelview transform
- *
- * Render a single character of the font. The modelview transform is
- * automatically updated to advance to the next character.
- *
- * @param ch -- wide character
- */
-void TextureFont::render(wchar_t ch) const
-{
-    float xoffset = impl->render(ch, 0, 0);
-    glTranslatef(xoffset, 0.0f, 0.0f);
-}
-
 /**
  * Render a single character of the font with offset
  *
@@ -507,9 +492,9 @@ void TextureFont::render(wchar_t ch) const
  * @param xoffset -- horizontal offset
  * @param yoffset -- vertical offset
  */
-void TextureFont::render(wchar_t ch, float xoffset, float yoffset) const
+float TextureFont::render(wchar_t ch, float xoffset, float yoffset) const
 {
-    impl->render(ch, xoffset, yoffset);
+    return impl->render(ch, xoffset, yoffset);
 }
 
 /**
@@ -522,23 +507,9 @@ void TextureFont::render(wchar_t ch, float xoffset, float yoffset) const
  * @param xoffset -- horizontal offset
  * @param yoffset -- vertical offset
  */
-void TextureFont::render(const string &s, float xoffset, float yoffset) const
+float TextureFont::render(const string &s, float xoffset, float yoffset) const
 {
-    impl->render(s, xoffset, yoffset);
-}
-
-/**
- * Render a string and update the modelview transform
- *
- * Render a string and automatically update the modelview transform for the
- * string width.
- *
- * @param s -- string to render
- */
-void TextureFont::render(const string& s) const
-{
-    float xoffset = impl->render(s, 0, 0);
-    glTranslatef(xoffset, 0.0f, 0.0f);
+    return impl->render(s, xoffset, yoffset);
 }
 
 /**

--- a/src/celttf/truetypefont.h
+++ b/src/celttf/truetypefont.h
@@ -26,11 +26,8 @@ class TextureFont
     TextureFont& operator=(const TextureFont&) = delete;
     TextureFont& operator=(TextureFont&&) = delete;
 
-    void render(wchar_t c) const;
-    void render(const std::string& str) const;
-
-    void render(wchar_t c, float xoffset, float yoffset) const;
-    void render(const std::string& str, float xoffset, float yoffset) const;
+    float render(wchar_t c, float xoffset = 0.0f, float yoffset = 0.0f) const;
+    float render(const std::string& str, float xoffset = 0.0f, float yoffset = 0.0f) const;
 
     int getWidth(const std::string&) const;
     int getWidth(int c) const;

--- a/src/celtxf/texturefont.cpp
+++ b/src/celtxf/texturefont.cpp
@@ -45,43 +45,11 @@ struct FontVertex
     float u, v;
 };
 
-/** Render a single character of the font. The modelview transform is
- *  automatically updated to advance to the next character.
- */
-void TextureFont::render(wchar_t ch) const
-{
-    const Glyph* glyph = getGlyph(ch);
-    if (glyph == nullptr) glyph = getGlyph((wchar_t)'?');
-    if (glyph != nullptr)
-    {
-        const float x1 = glyph->xoff;
-        const float y1 = glyph->yoff;
-        const float x2 = glyph->xoff + glyph->width;
-        const float y2 = glyph->yoff + glyph->height;
-        FontVertex vertices[4] = {
-            {x1, y1, glyph->texCoords[0].u, glyph->texCoords[0].v},
-            {x2, y1, glyph->texCoords[1].u, glyph->texCoords[1].v},
-            {x2, y2, glyph->texCoords[2].u, glyph->texCoords[2].v},
-            {x1, y2, glyph->texCoords[3].u, glyph->texCoords[3].v}
-        };
-        glEnableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
-        glEnableVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex);
-        glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
-                              2, GL_FLOAT, GL_FALSE, sizeof(FontVertex), &vertices[0].x);
-        glVertexAttribPointer(CelestiaGLProgram::TextureCoord0AttributeIndex,
-                              2, GL_FLOAT, GL_FALSE, sizeof(FontVertex), &vertices[0].u);
-        glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
-        glDisableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
-        glDisableVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex);
-        glTranslatef(glyph->advance, 0.0f, 0.0f);
-    }
-}
-
 
 /** Render a single character of the font, adding the specified offset
  *  to the location.
  */
-void TextureFont::render(wchar_t ch, float xoffset, float yoffset) const
+float TextureFont::render(wchar_t ch, float xoffset, float yoffset) const
 {
     const Glyph* glyph = getGlyph(ch);
     if (glyph == nullptr) glyph = getGlyph((wchar_t)'?');
@@ -106,46 +74,21 @@ void TextureFont::render(wchar_t ch, float xoffset, float yoffset) const
         glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
         glDisableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
         glDisableVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex);
+        return glyph->advance;
     }
-}
-
-
-/** Render a string and automatically update the modelview transform for the
-  * string width.
-  */
-void TextureFont::render(const string& s) const
-{
-    int len = s.length();
-    bool validChar = true;
-    int i = 0;
-
-    float xoffset = 0.0f;
-
-    while (i < len && validChar) {
-        wchar_t ch = 0;
-        validChar = UTF8Decode(s, i, ch);
-        i += UTF8EncodedSize(ch);
-
-        render(ch, xoffset, 0.0f);
-
-        const Glyph* glyph = getGlyph(ch);
-        if (glyph == nullptr)
-            glyph = getGlyph((wchar_t)'?');
-        xoffset += glyph->advance;
-    }
-
-    glTranslatef(xoffset, 0.0f, 0.0f);
+    return 0;
 }
 
 
 /** Render a string with the specified offset. Do *not* automatically update
  *  the modelview transform.
  */
-void TextureFont::render(const string& s, float xoffset, float yoffset) const
+float TextureFont::render(const string& s, float xoffset, float yoffset) const
 {
     int len = s.length();
     bool validChar = true;
     int i = 0;
+    float width = 0;
 
     while (i < len && validChar) {
         wchar_t ch = 0;
@@ -158,7 +101,9 @@ void TextureFont::render(const string& s, float xoffset, float yoffset) const
         if (glyph == nullptr)
             glyph = getGlyph((wchar_t)'?');
         xoffset += glyph->advance;
+        width += glyph->advance;
     }
+    return width;
 }
 
 

--- a/src/celtxf/texturefont.h
+++ b/src/celtxf/texturefont.h
@@ -25,11 +25,8 @@ class TextureFont
     TextureFont() = delete;
     ~TextureFont();
 
-    void render(wchar_t ch) const;
-    void render(const std::string& s) const;
-
-    void render(wchar_t ch, float xoffset, float yoffset) const;
-    void render(const std::string& s, float xoffset, float yoffset) const;
+    float render(wchar_t ch, float xoffset = 0.0f, float yoffset = 0.0f) const;
+    float render(const std::string& s, float xoffset = 0.0f, float yoffset = 0.0f) const;
 
     int getWidth(const std::string&) const;
     int getWidth(int c) const;


### PR DESCRIPTION
  1. Don't update ModelView Matrix in TextureFont::render()
  2. Remove variants without offset


Generally for compatibility with GL ES.