### PR TITLE
Better fix for label jittering + optimization (precalculate mvp matrix once)

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -866,6 +866,12 @@ void Renderer::addAnnotation(vector<Annotation>& annotations,
                       pos.y() * m_modelMatrix(2, 1) +
                       pos.z() * m_modelMatrix(2, 2);
         win.z() = -depth;
+        // use round to remove precision error (+/- 0.0000x)
+        // which causes label jittering
+        float x = round(win.x());
+        float y = round(win.y());
+        if (abs(x - win.x()) < 0.001) win.x() = x;
+        if (abs(y - win.y()) < 0.001) win.y() = y;
 
         Annotation a;
         if (!special || markerRep == nullptr)

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -860,7 +860,7 @@ void Renderer::addAnnotation(vector<Annotation>& annotations,
 {
     GLint view[4] = { 0, 0, windowWidth, windowHeight };
     Vector3f win;
-    if (Project(pos, m_modelMatrix, m_projMatrix, view, win))
+    if (Project(pos, m_MVPMatrix, view, win))
     {
         float depth = pos.x() * m_modelMatrix(2, 0) +
                       pos.y() * m_modelMatrix(2, 1) +
@@ -1577,6 +1577,7 @@ void Renderer::draw(const Observer& observer,
     // We'll usethem for positioning star and planet labels.
     m_projMatrix = Perspective(fov, getAspectRatio(), NEAR_DIST, FAR_DIST);
     m_modelMatrix = Affine3f(getCameraOrientation()).matrix();
+    m_MVPMatrix = m_projMatrix * m_modelMatrix;
 
     depthSortedAnnotations.clear();
     foregroundAnnotations.clear();
@@ -5017,10 +5018,10 @@ void Renderer::markersToAnnotations(const MarkerList& markers,
     {
         Vector3d offset = marker.position(jd).offsetFromKm(cameraPosition);
 
+        double distance = offset.norm();
         // Only render those markers that lie withing the field of view.
-        if ((offset.dot(viewVector)) > cosViewConeAngle * offset.norm())
+        if ((offset.dot(viewVector)) > cosViewConeAngle * distance)
         {
-            double distance = offset.norm();
             float symbolSize = 0.0f;
             if (marker.sizing() == DistanceBasedSize)
             {

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4784,7 +4784,7 @@ Renderer::renderAnnotationMarker(const Annotation &a,
 
     glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, a.color);
     glPushMatrix();
-    glTranslatef(a.position.x(), a.position.y(), depth);
+    glTranslatef((int)a.position.x(), (int)a.position.y(), depth);
 
     if (markerRep.symbol() == MarkerRepresentation::Crosshair)
         renderCrosshair(size, realTime, a.color);
@@ -4812,8 +4812,8 @@ Renderer::renderAnnotationLabel(const Annotation &a,
 {
     glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, a.color);
     glPushMatrix();
-    glTranslatef(a.position.x() + hOffset + PixelOffset,
-                 a.position.y() + vOffset + PixelOffset,
+    glTranslatef((int)a.position.x() + hOffset + PixelOffset,
+                 (int)a.position.y() + vOffset + PixelOffset,
                  depth);
     font[fs]->bind();
     font[fs]->render(a.labelText, 0.0f, 0.0f);

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -454,9 +454,6 @@ class Renderer
 
  private:
     void setFieldOfView(float);
-    void renderStars(const StarDatabase& starDB,
-                     float faintestVisible,
-                     const Observer& observer);
     void renderPointStars(const StarDatabase& starDB,
                           float faintestVisible,
                           const Observer& observer);
@@ -724,6 +721,7 @@ class Renderer
 
     Eigen::Matrix4f m_modelMatrix;
     Eigen::Matrix4f m_projMatrix;
+    Eigen::Matrix4f m_MVPMatrix;
     Eigen::Matrix4f m_orthoProjMatrix;
 
     bool useCompressedTextures{ false };

--- a/src/celmath/geomutil.h
+++ b/src/celmath/geomutil.h
@@ -66,13 +66,12 @@ LookAt(const Eigen::Matrix<T, 3, 1>& from, const Eigen::Matrix<T, 3, 1>& to, con
  */
 template<class T> bool
 Project(const Eigen::Matrix<T, 3, 1>& from,
-        const Eigen::Matrix<T, 4, 4>& modelViewMatrix,
-        const Eigen::Matrix<T, 4, 4>& projMatrix,
+        const Eigen::Matrix<T, 4, 4>& modelViewProjectionMatrix,
         const int viewport[4],
         Eigen::Matrix<T, 3, 1>& to)
 {
     Eigen::Matrix<T, 4, 1> in(from.x(), from.y(), from.z(), T(1.0));
-    Eigen::Matrix<T, 4, 1> out = projMatrix * modelViewMatrix * in;
+    Eigen::Matrix<T, 4, 1> out = modelViewProjectionMatrix * in;
     if (out.w() == T(0.0))
         return false;
 
@@ -86,6 +85,18 @@ Project(const Eigen::Matrix<T, 3, 1>& from,
     to = { out.x(), out.y(), out.z() };
     return true;
 }
+
+template<class T> bool
+Project(const Eigen::Matrix<T, 3, 1>& from,
+        const Eigen::Matrix<T, 4, 4>& modelViewMatrix,
+        const Eigen::Matrix<T, 4, 4>& projMatrix,
+        const int viewport[4],
+        Eigen::Matrix<T, 3, 1>& to)
+{
+    Eigen::Matrix<T, 4, 4> m = projMatrix * modelViewMatrix;
+    return Project(from, m, viewport, to);
+}
+
 
 /*! Return an perspective projection matrix
  */


### PR DESCRIPTION
It looks like final screen coordinates are produced by dropping a fractional part, so with precision error +/- 0.000061 we have not only 642.0 but 642.000061 and 642.999939 also (sometimes other values but these are the most often), so we have +/- 1 pixel jittering. My original fix helped planet labels but made locations and spacecraft labels blurry.