### PR TITLE
New celx methods

### DIFF
--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -2132,6 +2132,12 @@ static int celestia_loadfragment(lua_State* l)
     return 1;
 }
 
+static int celestia_version(lua_State* l)
+{
+    lua_pushstring(l, "1.7.0");
+    return 1;
+}
+
 void CreateCelestiaMetaTable(lua_State* l)
 {
     Celx_CreateClassMetatable(l, Celx_Celestia);
@@ -2235,6 +2241,8 @@ void CreateCelestiaMetaTable(lua_State* l)
     Celx_RegisterMethod(l, "play", celestia_play);
 
     Celx_RegisterMethod(l, "loadfragment", celestia_loadfragment);
+
+    Celx_RegisterMethod(l, "version", celestia_version);
 
     lua_pop(l, 1);
 }

--- a/src/celscript/lua/celx_gl.cpp
+++ b/src/celscript/lua/celx_gl.cpp
@@ -13,6 +13,7 @@
 #include "celx_internal.h"
 #include "celx_object.h"
 #include <celengine/glsupport.h>
+#include <celengine/shadermanager.h>
 
 
 // ==================== OpenGL ====================
@@ -118,6 +119,7 @@ static int gl_Color(lua_State* l)
     float a = (float)celx.safeGetNumber(4, WrongType, "argument 4 to gl.Color must be a number", 0.0);
     glColor4f(r,g,b,a);
     //    glColor4f(0.8f, 0.5f, 0.5f, 1.0f);
+    glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex, r, g, b, a);
     return 0;
 }
 

--- a/src/celscript/lua/celx_misc.cpp
+++ b/src/celscript/lua/celx_misc.cpp
@@ -200,10 +200,7 @@ static int font_render(lua_State* l)
 
     const char* s = celx.safeGetString(2, AllErrors, "First argument to font:render must be a string");
     auto font = *celx.getThis<TextureFont*>();
-    float xoffset = font->render(s);
-    glTranslatef(xoffset, 0, 0);
-
-    return 0;
+    return celx.push(font->render(s));
 }
 
 static int font_getwidth(lua_State* l)

--- a/src/celscript/lua/celx_misc.cpp
+++ b/src/celscript/lua/celx_misc.cpp
@@ -181,6 +181,17 @@ static int font_bind(lua_State* l)
     return 0;
 }
 
+static int font_unbind(lua_State* l)
+{
+    CelxLua celx(l);
+
+    celx.checkArgs(1, 1, "No arguments expected for font:unbind()");
+
+    auto font = *celx.getThis<TextureFont*>();
+    font->unbind();
+    return 0;
+}
+
 static int font_render(lua_State* l)
 {
     CelxLua celx(l);
@@ -231,6 +242,7 @@ void CreateFontMetaTable(lua_State* l)
     celx.registerMethod("__tostring", font_tostring);
     celx.registerMethod("bind", font_bind);
     celx.registerMethod("render", font_render);
+    celx.registerMethod("unbind", font_unbind);
     celx.registerMethod("getwidth", font_getwidth);
     celx.registerMethod("getheight", font_getheight);
 

--- a/test/scripts/version.celx
+++ b/test/scripts/version.celx
@@ -1,3 +1,9 @@
 print(_VERSION)
 print(_RELEASE)
 print(_LUAJIT_VERSION)
+
+if type(celestia['version']) == 'function' then
+  print(celestia:version())
+else
+  print("No celestia:version defined")
+end


### PR DESCRIPTION
`celestia:version()` is optional, can be used to distinguish Celestia 1.7.0 and earlier versions.
`font:unbind()` is mandatory because `TextureFont::unbind()` is mandatory, without it LUT will show garbage. I suppose this one is worth backporting to prepare for 1.6