### PR TITLE
Use system font on Mac/iOS/Android

### DIFF
--- a/src/celttf/truetypefont.h
+++ b/src/celttf/truetypefont.h
@@ -47,7 +47,7 @@ class TextureFont
     bool buildTexture();
     void flush();
 
-    static TextureFont* load(const Renderer*, const fs::path&, int size, int dpi);
+    static TextureFont* load(const Renderer*, const fs::path&, int index, int size, int dpi);
 
  private:
     TextureFontPrivate *impl;


### PR DESCRIPTION
Mac/iOS uses private API while Android requires Android 10.

Windows provides similar function https://docs.microsoft.com/en-us/windows/win32/api/dwrite_2/nn-dwrite_2-idwritefontfallback