### PR TITLE
Fix crash due to improper initialization of TwoVectorFrame

### DIFF
--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -1522,25 +1522,25 @@ ObserverFrame::createFrame(CoordinateSystem _coordSys,
 
     case PhaseLock:
     {
-        return make_shared<TwoVectorFrame>(_refObject,
-                                  FrameVector::createRelativePositionVector(_refObject, _targetObject), 1,
-                                  FrameVector::createRelativeVelocityVector(_refObject, _targetObject), 2);
+        return shared_ptr<TwoVectorFrame>(new TwoVectorFrame(_refObject,
+                                                             FrameVector::createRelativePositionVector(_refObject, _targetObject), 1,
+                                                             FrameVector::createRelativeVelocityVector(_refObject, _targetObject), 2));
     }
 
     case Chase:
     {
-        return make_shared<TwoVectorFrame>(_refObject,
-                                  FrameVector::createRelativeVelocityVector(_refObject, _refObject.parent()), 1,
-                                  FrameVector::createRelativePositionVector(_refObject, _refObject.parent()), 2);
+        return shared_ptr<TwoVectorFrame>(new TwoVectorFrame(_refObject,
+                                                             FrameVector::createRelativeVelocityVector(_refObject, _refObject.parent()), 1,
+                                                             FrameVector::createRelativePositionVector(_refObject, _refObject.parent()), 2));
     }
 
     case PhaseLock_Old:
     {
         FrameVector rotAxis(FrameVector::createConstantVector(Vector3d::UnitY(),
                                                               make_shared<BodyMeanEquatorFrame>(_refObject, _refObject)));
-        return make_shared<TwoVectorFrame>(_refObject,
-                                  FrameVector::createRelativePositionVector(_refObject, _targetObject), 3,
-                                  rotAxis, 2);
+        return shared_ptr<TwoVectorFrame>(new TwoVectorFrame(_refObject,
+                                                             FrameVector::createRelativePositionVector(_refObject, _targetObject), 3,
+                                                             rotAxis, 2));
     }
 
     case Chase_Old:
@@ -1548,9 +1548,9 @@ ObserverFrame::createFrame(CoordinateSystem _coordSys,
         FrameVector rotAxis(FrameVector::createConstantVector(Vector3d::UnitY(),
                                                               make_shared<BodyMeanEquatorFrame>(_refObject, _refObject)));
 
-        return make_shared<TwoVectorFrame>(_refObject,
-                                  FrameVector::createRelativeVelocityVector(_refObject.parent(), _refObject), 3,
-                                  rotAxis, 2);
+        return shared_ptr<TwoVectorFrame>(new TwoVectorFrame(_refObject,
+                                                             FrameVector::createRelativeVelocityVector(_refObject.parent(), _refObject), 3,
+                                                             rotAxis, 2));
     }
 
     case ObserverLocal:

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -1626,9 +1626,9 @@ CreateTwoVectorFrame(const Universe& universe,
     shared_ptr<const TwoVectorFrame> frame;
     if (primaryVector != nullptr && secondaryVector != nullptr)
     {
-        frame = make_shared<TwoVectorFrame>(center,
-                                   *primaryVector, primaryAxis,
-                                   *secondaryVector, secondaryAxis);
+        frame = shared_ptr<TwoVectorFrame>(new TwoVectorFrame(center,
+                                                              *primaryVector, primaryAxis,
+                                                              *secondaryVector, secondaryAxis));
     }
 
     return frame;
@@ -1676,7 +1676,7 @@ CreateTopocentricFrame(const Selection& center,
     FrameVector north = FrameVector::createConstantVector(Vector3d::UnitY(), eqFrame);
     FrameVector up = FrameVector::createRelativePositionVector(observer, target);
 
-    return make_shared<TwoVectorFrame>(center, up, -2, north, -3);
+    return shared_ptr<TwoVectorFrame>(new TwoVectorFrame(center, up, -2, north, -3));
 }
 
 


### PR DESCRIPTION
use shared_ptr directly with new operator to ensure the Eigen allocator for alignment is called