### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -281,7 +281,7 @@ Install Homebrew
 Install required packages:
 
 ```
-brew install cmake fmt gettext libepoxy libpng lua qt5 jpeg eigen
+brew install cmake fmt gettext libepoxy libpng lua qt5 jpeg eigen freetype
 ```
 
 Install optional packages:


### PR DESCRIPTION
freetype was missing in the list of "required packages" on macOS (tried to compile on 10.15.6 Catalina yesterday).