### PR TITLE
update ambiguous licensing

### DIFF
--- a/README
+++ b/README
@@ -278,6 +278,72 @@ Scientific Data Base
 
        CHARM2 stellar radii (charm2.stc)
 
+Note on content from JPL
+------------------------
+Some content in Celestia, including texture maps and models, comes from JPL
+websites. That content is subject to the JPL Image Use Policy, a copy of which
+appears below (as captured on 2020-July-13). The latest version of this policy
+can be found at https://www.jpl.nasa.gov/imagepolicy/. Also refer to
+https://space.jpl.nasa.gov/faq.html for clarity on how textures/models are
+covered.
+
+# JPL Image Use Policy
+# Unless otherwise noted, images and video on JPL public web sites (public
+# sites ending with a jpl.nasa.gov address) may be used for any purpose
+# without prior permission, subject to the special cases noted below.
+# Publishers who wish to have authorization may print this page and
+# retain it for their records; JPL does not issue image permissions on an
+# image by image basis.
+#
+# By electing to download the material from this web site the user agrees:
+# 1. that Caltech makes no representations or warranties with respect to
+# ownership of copyrights in the images, and does not represent others who
+# may claim to be authors or owners of copyright of any of the images, and
+# makes no warranties as to the quality of the images. Caltech shall not be
+# responsible for any loss or expenses resulting from the use of the images,
+# and you release and hold Caltech harmless from all liability arising from
+# such use.
+#
+# 2. to use a credit line in connection with images. Unless otherwise noted
+# in the caption information for an image, the credit line should be
+# "Courtesy NASA/JPL-Caltech."
+#
+# 3. that the endorsement of any product or service by Caltech, JPL or NASA
+# must not be claimed or implied.
+#
+# Special Cases:
+# * Prior written approval must be obtained to use the NASA insignia logo
+# (the blue "meatball" insignia), the NASA logotype (the red "worm" logo)
+# and the NASA seal. These images may not be used by persons who are not
+# NASA employees or on products (including Web pages) that are not NASA
+# sponsored. In addition, no image may be used to explicitly or implicitly
+# suggest endorsement by NASA, JPL or Caltech of commercial goods or
+# services. Requests to use NASA logos may be directed to Bert Ulrich, Public
+# Services Division, NASA Headquarters, Code POS, Washington, DC 20546,
+# telephone (202) 358-1713, fax (202) 358-4331, email bert.ulrich@hq.nasa.gov.
+#
+# * Prior written approval must be obtained to use the JPL logo (stylized JPL
+# letters in red or other colors). Requests to use the JPL logo may be
+# directed to the Institutional Communications Office, email
+# instcomm@jpl.nasa.gov.
+#
+# * If an image includes an identifiable person, using the image for
+# commercial purposes may infringe that person's right of privacy or publicity,
+# and permission should be obtained from the person. NASA and JPL generally do
+# not permit likenesses of current employees to appear on commercial products.
+# For more information, consult the NASA and JPL points of contact listed above.
+#
+# * JPL/Caltech contractors and vendors who wish to use JPL images in
+# advertising or public relation materials should direct requests to the
+# Institutional Communications Office, email instcomm@jpl.nasa.gov.
+#
+# * Some image and video materials on JPL public web sites are owned by
+# organizations other than JPL or NASA. These owners have agreed to make their
+# images and video available for journalistic, educational and personal uses,
+# but restrictions are placed on commercial uses. To obtain permission for
+# commercial use, contact the copyright owner listed in each image caption.
+# Ownership of images and video by parties other than JPL and NASA is noted in
+# the caption material with each image.
 
 Texture maps
 ------------
@@ -385,6 +451,9 @@ https://www.deviantart.com/celestiaofficial/gallery/68412929/Release-Textures
 
 # Models of Mars Global Surveyor and Mars Odyssey were created by Shrox:
     http://www.shrox.com/
+  They are included under the Creative Commons Attribution 4.0 International
+  License (CC BY 4.0):
+    https://creativecommons.org/licenses/by/4.0/
 
 # The Cassini and Huygens models are by Jack Higgins:
     http://homepage.eircom.net/~jackcelestia/
@@ -400,7 +469,10 @@ https://www.deviantart.com/celestiaofficial/gallery/68412929/Release-Textures
 
 # 3D asteroid models of Toutatis, Kleopatra, Geographos, 1998 KY26, Bacchus,
   Castalia and Golevka are courtesy of Scott Hudson, Washington State
-  University.
+  University. Originally found here:
+    http://users.tricity.wsu.edu/~hudson/Research/Asteroids/index.htm
+  On August 20, 2020, Scott Hudson waived the commercial use restrictions on
+  these models, permitting unrestricted use of them.
 
 # 3D models of Amalthea, Janus, Epimetheus, Prometheus, Pandora,
   Hyperion, Larissa, Proteus, Vesta, Ida, Gaspra and Halley are derived from


### PR DESCRIPTION
Since 2008, Debian and Fedora have been removing some content files from the releases of Celestia due to non-free or ambiguous licensing. Specifically, these files:

1. JPL textures

textures/hires/iapetus.jpg textures/hires/moon.jpg textures/hires/phoebe.jpg textures/hires/tethys.jpg 
textures/hires/titan.jpg textures/lores/amalthea.jpg textures/lores/ariel* textures/lores/callisto* 
textures/lores/charon* textures/lores/deimos.jpg textures/lores/dione.jpg textures/lores/epimetheus* 
textures/lores/eros.jpg textures/lores/europa* textures/lores/ganymede* textures/lores/gaspramosaic.jpg 
textures/lores/hyperion* textures/lores/iapetus.jpg textures/lores/idamosaic.jpg textures/lores/io* 
textures/lores/janus.jpg textures/lores/jupiter.jpg textures/lores/mars* textures/lores/mercury.jpg 
textures/lores/mimas.jpg textures/lores/miranda* textures/lores/moon* textures/lores/neptune.jpg 
textures/lores/oberon* textures/lores/phobos.jpg textures/lores/phoebe.jpg textures/lores/pluto-lok* 
textures/lores/prometheus.jpg textures/lores/proteus.jpg textures/lores/rhea.jpg textures/lores/tethys.jpg 
textures/lores/titan* textures/lores/triton* textures/lores/umbriel* textures/lores/uranus*
textures/medres/amalthea.jpg textures/medres/ariel.jpg textures/medres/callisto.jpg 
textures/medres/charon-lok* textures/medres/deimos.jpg textures/medres/dione.jpg textures/medres/epimetheus* 
textures/medres/eros.jpg textures/medres/europa.jpg textures/medres/ganymede.jpg 
textures/medres/gaspramosaic.jpg textures/medres/hyperion* textures/medres/iapetus.jpg 
textures/medres/idamosaic.jpg textures/medres/io.jpg textures/medres/janus.jpg textures/medres/jupiter.jpg 
textures/medres/mars* textures/medres/mercury.jpg textures/medres/mimas.jpg textures/medres/miranda.jpg 
textures/medres/moon* textures/medres/neptune.jpg textures/medres/oberon.jpg textures/medres/pho* 
textures/medres/pluto-lok* textures/medres/prometheus.jpg textures/medres/proteus.jpg 
textures/medres/rhea.jpg textures/medres/tethys.jpg textures/medres/titan* textures/medres/triton.jpg 
textures/medres/umbriel.jpg

At the time of the original Debian audit, the JPL content licensing was ... a bit of a hot mess, and it was determined that the JPL licensing made them non-free. However, in 2020, the JPL content licensing is much simpler and clearly Free.

2. Scott Hudson's Asteroid Models

models/bacchus.*
models/castalia.*
models/geographos.*
models/golevka.*
models/kleopatra.*
models/ky26.*
models/toutatis.*

Professor Hudson released these models under a license which restricted commercial use. I reached out to him via email and he agreed to waive the commercial use restrictions, making these models available for unrestricted use. I can provide a copy of that email on request.

3. Shrox's Mars Rover Models

models/marsglobalsurvr.3ds
models/marsodyssey.3ds

I reached out to Shrox via email and he agreed to permit these models to be used under the terms of the Creative Commons 4.0 International (CC BY 4.0) License - https://creativecommons.org/licenses/by/4.0/. I can provide a copy of that email on request

******

This changeset amends README to document the resolution of these concerns by
* Adding a copy of the current JPL content licensing policy
* Pointing to the original source for Scott Hudson's models and indicating the amended license
* Indicating the amended license for Shrox's models

With these changes, Fedora has moved to using an unmodified tarball of Celestia (and Debian should be able to do so if they choose).