### PR TITLE
Allow toggling visibility for stars #745

### DIFF
--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -159,6 +159,10 @@ static int object_setvisible(lua_State* l)
     {
         sel->deepsky()->setVisible(visible);
     }
+    else if (sel->star() != nullptr)
+    {
+        sel->star()->getDetails()->setVisibility(visible);
+    }
 
     return 0;
 }


### PR DESCRIPTION
For toggling star visibility.  I don't think that I need to check getDetails for null, since it looks like the star won't be loaded from the binary in src/celengine/stardb.cpp without details, but I can change that if necessary, or anything else.