### PR TITLE
Fix typos in bg.po causing build errors

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -878,7 +878,7 @@ msgstr "Грешка при създаване на ogg файла %s за пр�
 
 #: src/celestia/oggtheoracapture.cpp:256 src/celestia/oggtheoracapture.cpp:276
 msgid "Internal Ogg library error."
-msgstr "Вътрешна грешка на Ogg библиотеката.\n"
+msgstr "Вътрешна грешка на Ogg библиотеката."
 
 #: src/celestia/oggtheoracapture.cpp:311
 #, c-format
@@ -1274,7 +1274,7 @@ msgstr "Задай размер на изгледа..."
 
 #: src/celestia/gtk/actions.cpp:467
 msgid "Dimensions for Main Window:"
-msgstr "Размер на основния прозорец""
+msgstr "Размер на основния прозорец:"
 
 #: src/celestia/gtk/actions.cpp:479
 #, c-format
@@ -1284,7 +1284,7 @@ msgstr "%d x %d (текущ)"
 #: src/celestia/gtk/actions.cpp:484
 #, c-format
 msgid "%d x %d"
-msgstr "d x %d"
+msgstr "%d x %d"
 
 #: src/celestia/gtk/actions.cpp:648
 msgid "Mouse and Keyboard Controls"


### PR DESCRIPTION
A few typos in po/bg.po makes the build of 1.6.x fail as msgfmt 0.19.8.1 reports errors :

<pre>
rm -f bg.gmo && /usr/bin/msgfmt -c --statistics -o bg.gmo bg.po
bg.po:1278: end-of-line within string
/usr/bin/msgfmt: found 1 fatal error
make[3]: *** [Makefile:250: bg.gmo] Error 1
</pre>

and

<pre>
rm -f bg.gmo && /usr/bin/msgfmt -c --statistics -o bg.gmo bg.po
bg.po:881: 'msgid' and 'msgstr' entries do not both end with '\n'
bg.po:1287: number of format specifications in 'msgid' and 'msgstr' does not match
/usr/bin/msgfmt: found 2 fatal errors
1155 translated messages, 1 untranslated message.
make[3]: *** [Makefile:250: bg.gmo] Error 1
</pre>

With this PR the gmo generation (and hence the build) is successful.