### PR TITLE
Separate modelview and projection

### DIFF
--- a/src/celengine/asterismrenderer.cpp
+++ b/src/celengine/asterismrenderer.cpp
@@ -28,7 +28,7 @@ bool AsterismRenderer::sameAsterisms(const AsterismList *asterisms) const
 
 /*! Draw visible asterisms.
  */
-void AsterismRenderer::render(const Renderer &renderer, const Color &defaultColor, const Eigen::Matrix4f &mvp)
+void AsterismRenderer::render(const Renderer &renderer, const Color &defaultColor, const Matrices &mvp)
 {
     auto *prog = renderer.getShaderManager().getShader(m_shadprop);
     if (prog == nullptr)
@@ -50,7 +50,7 @@ void AsterismRenderer::render(const Renderer &renderer, const Color &defaultColo
     }
 
     prog->use();
-    prog->MVPMatrix = mvp;
+    prog->setMVPMatrices(*mvp.projection, *mvp.modelview);
     glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, defaultColor);
     m_vo.draw(GL_LINES, m_vtxTotal);
 

--- a/src/celengine/asterismrenderer.h
+++ b/src/celengine/asterismrenderer.h
@@ -16,6 +16,7 @@
 #include "vertexobject.h"
 
 class Renderer;
+struct Matrices;
 
 class AsterismRenderer
 {
@@ -28,7 +29,7 @@ class AsterismRenderer
     AsterismRenderer& operator=(const AsterismRenderer&) = delete;
     AsterismRenderer& operator=(AsterismRenderer&&) = delete;
 
-    void render(const Renderer &renderer, const Color &color, const Eigen::Matrix4f &mvp);
+    void render(const Renderer &renderer, const Color &color, const Matrices &mvp);
     bool sameAsterisms(const AsterismList *asterisms) const;
 
  private:

--- a/src/celengine/axisarrow.cpp
+++ b/src/celengine/axisarrow.cpp
@@ -283,7 +283,7 @@ ArrowReferenceMark::render(Renderer* renderer,
     if (prog == nullptr)
         return;
     prog->use();
-    prog->MVPMatrix = (*m.projection) * mv;
+    prog->setMVPMatrices(*m.projection, mv);
 
     glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex,
 		     color.red(), color.green(), color.blue(), opacity);
@@ -358,7 +358,8 @@ AxesReferenceMark::render(Renderer* renderer,
     }
 
     Affine3f transform = Translation3f(position) * q.cast<float>() * Scaling(size);
-    Matrix4f mvp = (*m.projection) * (*m.modelview) * transform.matrix();
+    Matrix4f projection = *m.projection;
+    Matrix4f modelView = (*m.modelview) * transform.matrix();
 
 #if 0
     // Simple line axes
@@ -390,30 +391,30 @@ AxesReferenceMark::render(Renderer* renderer,
 
     Affine3f labelTransform = Translation3f(Vector3f(0.1f, 0.0f, 0.75f)) * Scaling(labelScale);
     Matrix4f labelTransformMatrix = labelTransform.matrix();
-    Matrix4f t;
+    Matrix4f tModelView;
 
     // x-axis
-    t = mvp * vecgl::rotate(AngleAxisf(90.0_deg, Vector3f::UnitY()));
+    tModelView = modelView * vecgl::rotate(AngleAxisf(90.0_deg, Vector3f::UnitY()));
     glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex, 1.0f, 0.0f, 0.0f, opacity);
-    prog->MVPMatrix = t;
+    prog->setMVPMatrices(projection, tModelView);
     RenderArrow(vo);
-    prog->MVPMatrix = t * labelTransformMatrix;
+    prog->setMVPMatrices(projection, tModelView * labelTransformMatrix);
     RenderX(vo);
 
     // y-axis
-    t = mvp * vecgl::rotate(AngleAxisf(180.0_deg, Vector3f::UnitY()));
+    tModelView = modelView * vecgl::rotate(AngleAxisf(180.0_deg, Vector3f::UnitY()));
     glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex, 0.0f, 1.0f, 0.0f, opacity);
-    prog->MVPMatrix = t;
+    prog->setMVPMatrices(projection, tModelView);
     RenderArrow(vo);
-    prog->MVPMatrix = t * labelTransformMatrix;
+    prog->setMVPMatrices(projection, tModelView * labelTransformMatrix);
     RenderY(vo);
 
     // z-axis
-    t = mvp *vecgl::rotate(AngleAxisf(-90.0_deg, Vector3f::UnitX()));
+    tModelView = modelView *vecgl::rotate(AngleAxisf(-90.0_deg, Vector3f::UnitX()));
     glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex, 0.0f, 0.0f, 1.0f, opacity);
-    prog->MVPMatrix = t;
+    prog->setMVPMatrices(projection, tModelView);
     RenderArrow(vo);
-    prog->MVPMatrix = t * labelTransformMatrix;
+    prog->setMVPMatrices(projection, tModelView * labelTransformMatrix);
     RenderZ(vo);
 
     renderer->enableBlending();

--- a/src/celengine/boundariesrenderer.cpp
+++ b/src/celengine/boundariesrenderer.cpp
@@ -30,7 +30,7 @@ bool BoundariesRenderer::sameBoundaries(const ConstellationBoundaries *boundarie
     return m_boundaries == boundaries;
 }
 
-void BoundariesRenderer::render(const Renderer &renderer, const Color &color, const Eigen::Matrix4f &mvp)
+void BoundariesRenderer::render(const Renderer &renderer, const Color &color, const Matrices &mvp)
 {
     auto *prog = renderer.getShaderManager().getShader(m_shadprop);
     if (prog == nullptr)
@@ -51,7 +51,7 @@ void BoundariesRenderer::render(const Renderer &renderer, const Color &color, co
     }
 
     prog->use();
-    prog->MVPMatrix = mvp;
+    prog->setMVPMatrices(*mvp.projection, *mvp.modelview);
     glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, color);
     m_vo.draw(GL_LINES, m_vtxTotal);
 

--- a/src/celengine/boundariesrenderer.h
+++ b/src/celengine/boundariesrenderer.h
@@ -15,6 +15,7 @@
 class Color;
 class ConstellationBoundaries;
 class Renderer;
+struct Matrices;
 
 class BoundariesRenderer
 {
@@ -27,7 +28,7 @@ class BoundariesRenderer
     BoundariesRenderer& operator=(const BoundariesRenderer&) = delete;
     BoundariesRenderer& operator=(BoundariesRenderer&&) = delete;
 
-    void render(const Renderer &renderer, const Color &color, const Eigen::Matrix4f &mvp);
+    void render(const Renderer &renderer, const Color &color, const Matrices &mvp);
     bool sameBoundaries(const ConstellationBoundaries*) const;
 
  private:

--- a/src/celengine/console.cpp
+++ b/src/celengine/console.cpp
@@ -76,7 +76,7 @@ bool Console::setRowCount(int _nRows)
 
 void Console::begin()
 {
-    mpv = Ortho2D(0.0f, (float)xscale, 0.0f, (float)yscale);
+    projection = Ortho2D(0.0f, (float)xscale, 0.0f, (float)yscale);
 
     renderer.enableBlending();
     renderer.setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -98,7 +98,7 @@ void Console::render(int rowHeight)
         return;
 
     font->bind();
-    font->setMVPMatrix(mpv);
+    font->setMVPMatrices(projection);
     savePos();
     for (int i = 0; i < rowHeight; i++)
     {

--- a/src/celengine/console.h
+++ b/src/celengine/console.h
@@ -117,7 +117,7 @@ class Console : public std::ostream
     };
     CursorPosition global { 0.0f, 0.0f };
     std::vector<CursorPosition> posStack;
-    Eigen::Matrix4f mpv;
+    Eigen::Matrix4f projection;
 };
 
 #endif // _CELENGINE_CONSOLE_H_

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -414,7 +414,7 @@ void Galaxy::renderGalaxyPointSprites(const Vector3f& offset,
     GLushort j = 0;
 
     prog->use();
-    prog->mat4Param("MVPMatrix") = (*ms.projection) * mv;
+    prog->setMVPMatrices(*ms.projection, mv);
     prog->samplerParam("galaxyTex") = 0;
     prog->samplerParam("colorTex") = 1;
 

--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -238,7 +238,7 @@ void Renderer::renderMarker(MarkerRepresentation::Symbol symbol,
 
     prog->use();
     float s = size / 2.0f;
-    prog->MVPMatrix = (*m.projection) * (*m.modelview) * vecgl::scale(Vector3f(s, s, 0));
+    prog->setMVPMatrices(*m.projection, (*m.modelview) * vecgl::scale(Vector3f(s, s, 0)));
 
     switch (symbol)
     {
@@ -362,7 +362,7 @@ void Renderer::renderSelectionPointer(const Observer& observer,
 
     prog->use();
     const Vector3f &center = cameraMatrix.col(2);
-    prog->mat4Param("MVPMatrix") = getProjectionMatrix() * getModelViewMatrix() * vecgl::translate(Vector3f(-center));
+    prog->setMVPMatrices(getProjectionMatrix(), getModelViewMatrix() * vecgl::translate(Vector3f(-center)));
     prog->vec4Param("color") = Color(SelectionCursorColor, 0.6f).toVector4();
     prog->floatParam("pixelSize") = pixelSize;
     prog->floatParam("s") = s;
@@ -400,7 +400,7 @@ void Renderer::renderEclipticLine()
         initVO(markerVO);
 
     prog->use();
-    prog->mat4Param("MVPMatrix") = getProjectionMatrix() * getModelViewMatrix();
+    prog->setMVPMatrices(getProjectionMatrix(), getModelViewMatrix());
     prog->vec4Param("color") = EclipticColor.toVector4();
     markerVO.draw(GL_LINE_LOOP, EclipticCount, EclipticOffset);
 
@@ -435,7 +435,7 @@ void Renderer::renderCrosshair(float selectionSizeInPixels,
     float cursorGrow = max(1.0f, min(2.5f, (selectionSizeInPixels - 10.0f) / 100.0f));
 
     prog->use();
-    prog->mat4Param("MVPMatrix") = (*m.projection) * (*m.modelview);
+    prog->setMVPMatrices(*m.projection, *m.modelview);
     prog->vec4Param("color") = color.toVector4();
     prog->floatParam("radius") = cursorRadius;
     prog->floatParam("width") = minCursorWidth * cursorGrow;

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -467,8 +467,7 @@ void Globular::renderGlobularPointSprites(
     tidalProg->use();
     centerTex[ic]->bind();
 
-    Matrix4f mvp = (*m.projection) * (*m.modelview);
-    tidalProg->mat4Param("MVPMatrix") = mvp;
+    tidalProg->setMVPMatrices(*m.projection, *m.modelview);
 
     Matrix3f viewMat = viewerOrientation.conjugate().toRotationMatrix();
     tidalProg->vec4Param("color")       = Vector4f(Rr, Gg, Bb, min(2 * brightness * pixelWeight, 1.0f));
@@ -492,8 +491,9 @@ void Globular::renderGlobularPointSprites(
     globProg->use();
 
     globularTex->bind();
-    globProg->mat4Param("MVPMatrix") = mvp;
-    globProg->mat4Param("ModelViewMatrix") = vecgl::translate(*m.modelview, offset);
+    globProg->setMVPMatrices(*m.projection, *m.modelview);
+    // TODO: model view matrix should not be reset here
+    globProg->ModelViewMatrix = vecgl::translate(*m.modelview, offset);
     Matrix3f mx = Scaling(form->scale) * getOrientation().toRotationMatrix() * Scaling(tidalSize);
     globProg->mat3Param("m")            = mx;
     globProg->vec3Param("offset")       = offset;

--- a/src/celengine/overlay.cpp
+++ b/src/celengine/overlay.cpp
@@ -34,7 +34,7 @@ Overlay::Overlay(Renderer& r) :
 
 void Overlay::begin()
 {
-    mvp = Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight);
+    projection = Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight);
     // ModelView is Identity
 
     renderer.enableBlending();
@@ -74,7 +74,7 @@ void Overlay::beginText()
     if (font != nullptr)
     {
         font->bind();
-        font->setMVPMatrix(mvp);
+        font->setMVPMatrices(projection);
         useTexture = true;
         fontChanged = false;
     }
@@ -98,7 +98,7 @@ void Overlay::print(wchar_t c)
         if (!useTexture || fontChanged)
         {
             font->bind();
-            font->setMVPMatrix(mvp);
+            font->setMVPMatrices(projection);
             useTexture = true;
             fontChanged = false;
         }
@@ -129,7 +129,7 @@ void Overlay::print(char c)
         if (!useTexture || fontChanged)
         {
             font->bind();
-            font->setMVPMatrix(mvp);
+            font->setMVPMatrices(projection);
             useTexture = true;
             fontChanged = false;
         }
@@ -171,7 +171,7 @@ void Overlay::drawRectangle(const Rect& r)
     if (useTexture && r.tex == nullptr)
         useTexture = false;
 
-    renderer.drawRectangle(r, mvp);
+    renderer.drawRectangle(r, projection);
 }
 
 void Overlay::setColor(float r, float g, float b, float a)

--- a/src/celengine/overlay.h
+++ b/src/celengine/overlay.h
@@ -108,7 +108,7 @@ class Overlay : public std::ostream
     };
     CursorPosition global { 0.0f, 0.0f };
     std::vector<CursorPosition> posStack;
-    Eigen::Matrix4f mvp;
+    Eigen::Matrix4f projection;
 };
 
 #endif // _OVERLAY_H_

--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -125,7 +125,8 @@ PlanetographicGrid::render(Renderer* renderer,
     renderer->disableBlending();
 
     Affine3f transform = Translation3f(pos) * qf.conjugate() * Scaling(scale * semiAxes);
-    Matrix4f mvp = (*m.projection) * (*m.modelview) * transform.matrix();
+    Matrix4f projection = *m.projection;
+    Matrix4f modelView = *m.modelview * transform.matrix();
 
     glEnableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
     glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
@@ -162,7 +163,7 @@ PlanetographicGrid::render(Renderer* renderer,
             glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex,
                            Renderer::PlanetographicGridColor);
         }
-        prog->MVPMatrix = mvp * vecgl::translate(0.0f, sin(phi), 0.0f) * vecgl::scale(r);;
+        prog->setMVPMatrices(projection, modelView * vecgl::translate(0.0f, sin(phi), 0.0f) * vecgl::scale(r));
         glDrawArrays(GL_LINE_LOOP, 0, circleSubdivisions);
 
         glLineWidth(1.0f);
@@ -191,7 +192,7 @@ PlanetographicGrid::render(Renderer* renderer,
                    Renderer::PlanetographicGridColor);
     for (float longitude = 0.0f; longitude <= 180.0f; longitude += longitudeStep)
     {
-        prog->MVPMatrix = mvp * vecgl::rotate(AngleAxisf(degToRad(longitude), Vector3f::UnitY()));
+        prog->setMVPMatrices(projection, modelView * vecgl::rotate(AngleAxisf(degToRad(longitude), Vector3f::UnitY())));
         glDrawArrays(GL_LINE_LOOP, 0, circleSubdivisions);
 
         if (showCoordinateLabels)

--- a/src/celengine/pointstarvertexbuffer.cpp
+++ b/src/celengine/pointstarvertexbuffer.cpp
@@ -36,7 +36,7 @@ void PointStarVertexBuffer::startSprites()
     if (prog == nullptr)
         return;
     prog->use();
-    prog->mat4Param("MVPMatrix") = renderer.getProjectionMatrix() * renderer.getModelViewMatrix();
+    prog->setMVPMatrices(renderer.getProjectionMatrix(), renderer.getModelViewMatrix());
     prog->samplerParam("starTex") = 0;
 
     unsigned int stride = sizeof(StarVertex);
@@ -70,7 +70,7 @@ void PointStarVertexBuffer::startPoints()
     if (prog == nullptr)
         return;
     prog->use();
-    prog->MVPMatrix = renderer.getProjectionMatrix() * renderer.getModelViewMatrix();
+    prog->setMVPMatrices(renderer.getProjectionMatrix(), renderer.getModelViewMatrix());
 
     unsigned int stride = sizeof(StarVertex);
     glEnableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);

--- a/src/celengine/rendcontext.cpp
+++ b/src/celengine/rendcontext.cpp
@@ -558,7 +558,7 @@ GLSL_RenderContext::makeCurrent(const Material& m)
         return;
 
     prog->use();
-    prog->MVPMatrix = (*projectionMatrix) * (*modelViewMatrix);
+    prog->setMVPMatrices(*projectionMatrix, *modelViewMatrix);
 
     for (unsigned int i = 0; i < nTextures; i++)
     {
@@ -772,9 +772,7 @@ GLSLUnlit_RenderContext::makeCurrent(const Material& m)
         return;
 
     prog->use();
-    prog->MVPMatrix = (*projectionMatrix) * (*modelViewMatrix);
-    if (usePointSize)
-        prog->ModelViewMatrix = *modelViewMatrix;
+    prog->setMVPMatrices(*projectionMatrix, *modelViewMatrix);
 
     for (unsigned int i = 0; i < nTextures; i++)
     {

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -44,8 +44,8 @@ class Frustum;
 
 struct Matrices
 {
-    Eigen::Matrix4f *projection;
-    Eigen::Matrix4f *modelview;
+    const Eigen::Matrix4f *projection;
+    const Eigen::Matrix4f *modelview;
 };
 
 struct LightSource
@@ -267,7 +267,7 @@ class Renderer
     void enableDepthTest() noexcept;
     void disableDepthTest() noexcept;
 
-    void drawRectangle(const Rect& r, const Eigen::Matrix4f& mvp);
+    void drawRectangle(const Rect& r, const Eigen::Matrix4f& p, const Eigen::Matrix4f& m = Eigen::Matrix4f::Identity());
     void setRenderRegion(int x, int y, int width, int height, bool withScissor = true);
 
     const ColorTemperatureTable* getStarColorTable() const;
@@ -527,8 +527,8 @@ class Renderer
                                 const celmath::Frustum& viewFrustum,
                                 const Selection& sel);
 
-    void renderAsterisms(const Universe&, float, const Eigen::Matrix4f&);
-    void renderBoundaries(const Universe&, float, const Eigen::Matrix4f&);
+    void renderAsterisms(const Universe&, float, const Matrices&);
+    void renderBoundaries(const Universe&, float, const Matrices&);
     void renderEclipticLine();
     void renderCrosshair(float size, double tsec, const Color &color, const Matrices &m);
 

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -237,7 +237,7 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
         return;
 
     prog->use();
-    prog->MVPMatrix = (*m.projection) * (*m.modelview);
+    prog->setMVPMatrices(*m.projection, *m.modelview);
 
 #ifdef USE_HDR
     prog->setLightParameters(ls, ri.color, ri.specularColor, Color::Black, ri.nightLightScale);
@@ -555,7 +555,7 @@ void renderClouds_GLSL(const RenderInfo& ri,
         return;
 
     prog->use();
-    prog->MVPMatrix = (*m.projection) * (*m.modelview);
+    prog->setMVPMatrices(*m.projection, *m.modelview);
 
     prog->setLightParameters(ls, ri.color, ri.specularColor, Color::Black);
     prog->eyePosition = ls.eyePos_obj;
@@ -640,7 +640,7 @@ renderAtmosphere_GLSL(const RenderInfo& ri,
         prog->setEclipseShadowParameters(ls, radius, planetOrientation);
 #endif
 
-    prog->MVPMatrix = (*m.projection) * (*m.modelview) * vecgl::scale(atmScale);
+    prog->setMVPMatrices(*m.projection, (*m.modelview) * vecgl::scale(atmScale));
 
     glFrontFace(GL_CW);
     renderer->enableBlending();
@@ -785,7 +785,7 @@ void renderRings_GLSL(RingSystem& rings,
         return;
 
     prog->use();
-    prog->MVPMatrix = (*m.projection) * (*m.modelview);
+    prog->setMVPMatrices(*m.projection, *m.modelview);
 
     prog->eyePosition = ls.eyePos_obj;
     prog->ambientColor = ri.ambientColor.toVector3();
@@ -932,8 +932,7 @@ void renderGeometryShadow_GLSL(Geometry* geometry,
     Matrix4f projMat = Ortho(-1.f, 1.f, -1.f, 1.f, -1.f, 1.f);
     Matrix4f modelViewMat = directionalLightMatrix(ls.lights[lightIndex].direction_obj);
     *lightMatrix = projMat * modelViewMat;
-    prog->mat4Param("MVPMatrix") = *lightMatrix;
-
+    prog->setMVPMatrices(projMat, modelViewMat);
     geometry->render(rc, tsec);
 
     glDisable(GL_POLYGON_OFFSET_FILL);

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -66,6 +66,7 @@ static const char* CommonHeader = "#version 100\nprecision highp float;\n";
 #endif
 static const char* VertexHeader = R"glsl(
 uniform mat4 ModelViewMatrix;
+uniform mat4 ProjectionMatrix;
 uniform mat4 MVPMatrix;
 
 invariant gl_Position;
@@ -3352,6 +3353,7 @@ CelestiaGLProgram::CelestiaGLProgram(GLProgram& _program,
 CelestiaGLProgram::CelestiaGLProgram(GLProgram& _program) :
     program(&_program)
 {
+    initCommonParameters();
 }
 
 CelestiaGLProgram::~CelestiaGLProgram()
@@ -3415,13 +3417,18 @@ CelestiaGLProgram::attribIndex(const std::string& paramName) const
     return glGetAttribLocation(program->getID(), paramName.c_str());
 }
 
+void
+CelestiaGLProgram::initCommonParameters()
+{
+    ModelViewMatrix = mat4Param("ModelViewMatrix");
+    ProjectionMatrix = mat4Param("ProjectionMatrix");
+    MVPMatrix = mat4Param("MVPMatrix");
+}
 
 void
 CelestiaGLProgram::initParameters()
 {
-    ModelViewMatrix = mat4Param("ModelViewMatrix");
-    MVPMatrix       = mat4Param("MVPMatrix");
-
+    initCommonParameters();
     for (unsigned int i = 0; i < props.nLights; i++)
     {
         lights[i].direction  = vec3Param(LightProperty(i, "direction"));
@@ -3765,3 +3772,12 @@ CelestiaGLProgram::setAtmosphereParameters(const Atmosphere& atmosphere,
     invScatterCoeffSum = tScatterCoeffSum.cwiseInverse();
     extinctionCoeff = tScatterCoeffSum + tAbsorptionCoeff;
 }
+
+void
+CelestiaGLProgram::setMVPMatrices(const Matrix4f& p, const Matrix4f& m)
+{
+    ProjectionMatrix = p;
+    ModelViewMatrix = m;
+    MVPMatrix = p * m;
+}
+

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -170,6 +170,7 @@ class CelestiaGLProgram
     void setAtmosphereParameters(const Atmosphere& atmosphere,
                                  float atmPlanetRadius,
                                  float objRadius);
+    void setMVPMatrices(const Eigen::Matrix4f& p, const Eigen::Matrix4f& m = Eigen::Matrix4f::Identity());
 
     enum
     {
@@ -265,11 +266,13 @@ class CelestiaGLProgram
     Mat4ShaderParameter mat4Param(const std::string&);
 
     Mat4ShaderParameter ModelViewMatrix;
+    Mat4ShaderParameter ProjectionMatrix;
     Mat4ShaderParameter MVPMatrix;
 
     int attribIndex(const std::string&) const;
 
  private:
+    void initCommonParameters();
     void initParameters();
     void initSamplers();
 

--- a/src/celengine/skygrid.cpp
+++ b/src/celengine/skygrid.cpp
@@ -555,7 +555,7 @@ SkyGrid::render(Renderer& renderer,
     Matrix4f m = renderer.getModelViewMatrix() *
                  vecgl::rotate((xrot90 * m_orientation.conjugate() * xrot90.conjugate()).cast<float>()) *
                  vecgl::scale(1000.0f);
-    prog->MVPMatrix = renderer.getProjectionMatrix() * m;
+    prog->setMVPMatrices(renderer.getProjectionMatrix(), m);
 
     double arcStep = (maxTheta - minTheta) / (double) ARC_SUBDIVISIONS;
     double theta0 = minTheta;

--- a/src/celengine/visibleregion.cpp
+++ b/src/celengine/visibleregion.cpp
@@ -86,7 +86,7 @@ static void
 renderTerminator(Renderer* renderer,
                  const vector<Vector3f>& pos,
                  const Color& color,
-                 const Matrix4f& mvp)
+                 const Matrices& mvp)
 {
     /*!
      * Proper terminator calculation requires double precision floats in GLSL
@@ -114,7 +114,7 @@ renderTerminator(Renderer* renderer,
     vo.setBufferData(pos.data(), 0, pos.size() * sizeof(Vector3f));
 
     prog->use();
-    prog->MVPMatrix = mvp;
+    prog->setMVPMatrices(*mvp.projection, *mvp.modelview);
     glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, color);
 
     vo.draw(GL_LINE_LOOP, pos.size());
@@ -212,8 +212,8 @@ VisibleRegion::render(Renderer* renderer,
     }
 
     Affine3f transform = Translation3f(position) * qf.conjugate();
-    Matrix4f mvp = (*m.projection) * (*m.modelview) * transform.matrix();
-    renderTerminator(renderer, pos, Color(m_color, opacity), mvp);
+    Matrix4f modelView = (*m.modelview) * transform.matrix();
+    renderTerminator(renderer, pos, Color(m_color, opacity), { m.projection, &modelView });
 
     renderer->enableBlending();
     renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE);

--- a/src/celscript/lua/celx_misc.cpp
+++ b/src/celscript/lua/celx_misc.cpp
@@ -200,7 +200,7 @@ static int font_render(lua_State* l)
     Eigen::Matrix4f p, m;
     glGetFloatv(GL_PROJECTION_MATRIX, p.data());
     glGetFloatv(GL_MODELVIEW_MATRIX, m.data());
-    font->setMVPMatrix(p * m);
+    font->setMVPMatrices(p, m);
 #endif
     return celx.push(font->render(s));
 }

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -108,7 +108,8 @@ struct TextureFontPrivate
 
     int m_inserted { 0 };
 
-    Eigen::Matrix4f m_MVP;
+    Eigen::Matrix4f m_projection;
+    Eigen::Matrix4f m_modelView;
     bool m_shaderInUse { false };
     vector<FontVertex> m_fontVertices;
 };
@@ -595,18 +596,19 @@ void TextureFont::bind()
         prog->use();
         prog->samplerParam("atlasTex") = 0;
         impl->m_shaderInUse = true;
-        prog->mat4Param("MVPMatrix") = impl->m_MVP;
+        prog->setMVPMatrices(impl->m_projection, impl->m_modelView);
     }
 }
 
-void TextureFont::setMVPMatrix(const Eigen::Matrix4f& mvp)
+void TextureFont::setMVPMatrices(const Eigen::Matrix4f& p, const Eigen::Matrix4f& m)
 {
-    impl->m_MVP = mvp;
+    impl->m_projection = p;
+    impl->m_modelView = m;
     auto *prog = impl->getProgram();
     if (prog != nullptr && impl->m_shaderInUse)
     {
         flush();
-        prog->mat4Param("MVPMatrix") = mvp;
+        prog->setMVPMatrices(p, m);
     }
 }
 

--- a/src/celttf/truetypefont.h
+++ b/src/celttf/truetypefont.h
@@ -27,7 +27,7 @@ class TextureFont
     TextureFont& operator=(const TextureFont&) = delete;
     TextureFont& operator=(TextureFont&&) = delete;
 
-    void setMVPMatrix(const Eigen::Matrix4f& m);
+    void setMVPMatrices(const Eigen::Matrix4f& p, const Eigen::Matrix4f& m = Eigen::Matrix4f::Identity());
 
     float render(wchar_t c, float xoffset = 0.0f, float yoffset = 0.0f) const;
     float render(const std::string& str, float xoffset = 0.0f, float yoffset = 0.0f) const;


### PR DESCRIPTION
by looking at the dome version code, we need to separate projection matrix and model view matrix in shaders.