### PR TITLE
Fix crash in DDS and galaxy picking

### DIFF
--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -230,6 +230,9 @@ bool Galaxy::pick(const Ray3d& ray,
                   double& distanceToPicker,
                   double& cosAngleToBoundCenter) const
 {
+    if (form == nullptr)
+        return false;
+
     if (!isVisible())
         return false;
 


### PR DESCRIPTION
`uintptr_t *block = (uintptr_t *)malloc(sizeof(blocksize));` this was stupid 😅, we don't need to handle SRGB ones, so did a little cleaning here

https://appcenter.ms/orgs/CelestiaProject/apps/Celestia-1/crashes/errors/2752384131u/overview
https://appcenter.ms/orgs/CelestiaProject/apps/Celestia-1/crashes/errors/2482730621u/overview

Galaxy picking, it has been there for a long time, I'm guessing form is null here

https://appcenter.ms/orgs/CelestiaProject/apps/Celestia-1/crashes/errors/3120907760u/overview
https://appcenter.ms/orgs/CelestiaProject/apps/Celestia-1/crashes/errors/956565877u/overview
https://appcenter.ms/orgs/CelestiaProject/apps/Celestia-1/crashes/errors/2715921738u/overview