### PR TITLE
Add callback for text display

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2402,6 +2402,8 @@ void CelestiaCore::showText(string s,
     messageVOffset = voff;
     messageStart = currentTime;
     messageDuration = duration;
+    if (textDisplayCallback)
+        textDisplayCallback->willShowText(s, duration);
 }
 
 int CelestiaCore::getTextWidth(string s) const
@@ -4146,6 +4148,16 @@ void CelestiaCore::setContextMenuHandler(ContextMenuHandler* handler)
 CelestiaCore::ContextMenuHandler* CelestiaCore::getContextMenuHandler() const
 {
     return contextMenuHandler;
+}
+
+void CelestiaCore::setTextDisplayCallback(CelestiaCore::TextDisplayCallback* handler)
+{
+    textDisplayCallback = handler;
+}
+
+CelestiaCore::TextDisplayCallback* CelestiaCore::getTextDisplayCallback() const
+{
+    return textDisplayCallback;
 }
 
 void CelestiaCore::setFont(const fs::path& fontPath, int collectionIndex, int fontSize)

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -329,6 +329,16 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     void setContextMenuHandler(ContextMenuHandler*);
     ContextMenuHandler* getContextMenuHandler() const;
 
+    class TextDisplayCallback
+    {
+    public:
+        virtual ~TextDisplayCallback() = default;
+        virtual void willShowText(const std::string&, double) = 0;
+    };
+
+    void setTextDisplayCallback(TextDisplayCallback*);
+    TextDisplayCallback* getTextDisplayCallback() const;
+
     void setFont(const fs::path& fontPath, int collectionIndex, int fontSize);
     void setTitleFont(const fs::path& fontPath, int collectionIndex, int fontSize);
     void setRendererFont(const fs::path& fontPath, int collectionIndex, int fontSize, Renderer::FontStyle fontStyle);
@@ -455,6 +465,7 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     CursorHandler* cursorHandler{ nullptr };
     CursorShape defaultCursorShape{ CelestiaCore::CrossCursor };
     ContextMenuHandler* contextMenuHandler{ nullptr };
+    TextDisplayCallback* textDisplayCallback{ nullptr };
 
     std::vector<Url*> history;
     std::vector<Url*>::size_type historyCurrent{ 0 };


### PR DESCRIPTION
In this way, we can get notified when texts are about to display on screen. Frontend can use text to speech libraries (as I know Android/iOS/Mac all have builtin support for text to speech and are easy to implement) to speak the text.