### PR TITLE
Fix largestar shader on some platforms

### DIFF
--- a/shaders/largestar_vert.glsl
+++ b/shaders/largestar_vert.glsl
@@ -11,6 +11,6 @@ void main(void)
 {
     texCoord = in_TexCoord0.st;
     set_vp(vec4(center, 1.0));
-    vec2 transformed = vec2((texCoord.x - 0.5) * pointWidth, (texCoord.y - 0.5) * pointHeight);
+    vec2 transformed = vec2((in_TexCoord0.x - 0.5) * pointWidth, (in_TexCoord0.y - 0.5) * pointHeight);
     gl_Position.xy += transformed * gl_Position.w;
 }


### PR DESCRIPTION
Originally, it might fail to link with an error like texCoord is invariant in vertex shader, but not declared invariant in fragment shader.