### PR TITLE
Always use gl_PointSize in shaders to set point size

### DIFF
--- a/shaders/largestar_vert.glsl
+++ b/shaders/largestar_vert.glsl
@@ -1,4 +1,4 @@
-attribute vec3 in_Position;
+attribute vec2 in_Position;
 attribute vec2 in_TexCoord0;
 
 uniform float pointWidth;
@@ -11,6 +11,6 @@ void main(void)
 {
     texCoord = in_TexCoord0.st;
     set_vp(vec4(center, 1.0));
-    vec2 transformed = vec2((in_TexCoord0.x - 0.5) * pointWidth, (in_TexCoord0.y - 0.5) * pointHeight);
+    vec2 transformed = vec2(in_Position.x * pointWidth, in_Position.y * pointHeight);
     gl_Position.xy += transformed * gl_Position.w;
 }

--- a/src/celengine/modelgeometry.cpp
+++ b/src/celengine/modelgeometry.cpp
@@ -136,6 +136,7 @@ ModelGeometry::render(RenderContext& rc, double /* t */)
         for (unsigned int groupIndex = 0; groupIndex < mesh->getGroupCount(); ++groupIndex)
         {
             const Mesh::PrimitiveGroup* group = mesh->getGroup(groupIndex);
+            rc.updateShader(mesh->getVertexDescription(), group->prim);
 
             // Set up the material
             const Material* material = nullptr;

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -101,7 +101,7 @@ void Nebula::render(const Vector3f& /*offset*/,
                                 getOrientation());
 
     GLSLUnlit_RenderContext rc(renderer, getRadius());
-    rc.setPointScale(2.0f * getRadius() / pixelSize);
+    rc.setPointScale(2.0f * getRadius() / pixelSize * renderer->getScreenDpi() / 96.0f);
     rc.setProjectionMatrix(m.projection);
     rc.setModelViewMatrix(&mv);
     g->render(rc);

--- a/src/celengine/pointstarvertexbuffer.h
+++ b/src/celengine/pointstarvertexbuffer.h
@@ -15,6 +15,7 @@
 class Color;
 class Renderer;
 class Texture;
+class CelestiaGLProgram;
 
 // PointStarVertexBuffer is used when hardware supports point sprites.
 class PointStarVertexBuffer
@@ -30,12 +31,16 @@ public:
     PointStarVertexBuffer& operator=(const PointStarVertexBuffer&) = delete;
     PointStarVertexBuffer& operator=(PointStarVertexBuffer&&) = delete;
 
-    void startPoints();
+    void startBasicPoints();
     void startSprites();
     void render();
     void finish();
     inline void addStar(const Eigen::Vector3f& pos, const Color&, float);
     void setTexture(Texture* /*_texture*/);
+    void setPointScale(float);
+
+    static void enable();
+    static void disable();
 
 private:
     struct StarVertex
@@ -49,10 +54,16 @@ private:
     const Renderer& renderer;
     capacity_t capacity;
 
-    capacity_t nStars       { 0 };
-    StarVertex* vertices    { nullptr };
-    Texture* texture        { nullptr };
-    bool useSprites         { false };
+    capacity_t nStars           { 0 };
+    StarVertex* vertices        { nullptr };
+    Texture* texture            { nullptr };
+    bool pointSizeFromVertex    { false };
+    float pointScale            { 1.0f };
+    CelestiaGLProgram* program  { nullptr };
+
+    static PointStarVertexBuffer* current;
+
+    void makeCurrent();
 };
 
 inline void PointStarVertexBuffer::addStar(const Eigen::Vector3f& pos,

--- a/src/celengine/rendcontext.h
+++ b/src/celengine/rendcontext.h
@@ -29,6 +29,7 @@ class RenderContext
     virtual void makeCurrent(const cmod::Material&) = 0;
     virtual void setVertexArrays(const cmod::Mesh::VertexDescription& desc,
                                  const void* vertexData);
+    virtual void updateShader(const cmod::Mesh::VertexDescription& desc, cmod::Mesh::PrimitiveGroupType primType);
     virtual void drawGroup(const cmod::Mesh::PrimitiveGroup& group);
 
     const cmod::Material* getMaterial() const;
@@ -65,6 +66,7 @@ class RenderContext
  protected:
     Renderer* renderer { nullptr };
     bool usePointSize{ false };
+    bool useStaticPointSize{ false };
     bool useNormals{ true };
     bool useColors{ false };
     bool useTexCoords{ true };

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -26,6 +26,7 @@ class ShaderProperties
     bool usesShadows() const;
     bool usesFragmentLighting() const;
     bool usesTangentSpaceLighting() const;
+    bool usePointSize() const;
 
     unsigned int getEclipseShadowCountForLight(unsigned int lightIndex) const;
     void setEclipseShadowCountForLight(unsigned int lightIndex, unsigned int shadowCount);
@@ -49,22 +50,23 @@ class ShaderProperties
 
  enum
  {
-     DiffuseTexture          =   0x01,
-     SpecularTexture         =   0x02,
-     NormalTexture           =   0x04,
-     NightTexture            =   0x08,
-     SpecularInDiffuseAlpha  =   0x10,
-     RingShadowTexture       =   0x20,
-     OverlayTexture          =   0x40,
-     CloudShadowTexture      =   0x80,
-     CompressedNormalTexture =  0x100,
-     EmissiveTexture         =  0x200,
-     ShadowMapTexture        =  0x400,
-     VertexOpacities         =  0x800,
-     VertexColors            = 0x1000,
-     Scattering              = 0x2000,
-     PointSprite             = 0x4000,
-     SharedTextureCoords     = 0x8000,
+     DiffuseTexture          =    0x01,
+     SpecularTexture         =    0x02,
+     NormalTexture           =    0x04,
+     NightTexture            =    0x08,
+     SpecularInDiffuseAlpha  =    0x10,
+     RingShadowTexture       =    0x20,
+     OverlayTexture          =    0x40,
+     CloudShadowTexture      =    0x80,
+     CompressedNormalTexture =   0x100,
+     EmissiveTexture         =   0x200,
+     ShadowMapTexture        =   0x400,
+     VertexOpacities         =   0x800,
+     VertexColors            =  0x1000,
+     Scattering              =  0x2000,
+     PointSprite             =  0x4000,
+     SharedTextureCoords     =  0x8000,
+     StaticPointSize         = 0x10000,
  };
 
  enum
@@ -98,8 +100,8 @@ class ShaderProperties
 
  public:
     unsigned short nLights{ 0 };
-    unsigned short texUsage{ 0 };
     unsigned short lightModel{ DiffuseModel };
+    unsigned long texUsage{ 0 };
 
     // Effects that may be applied with any light model
     unsigned short effects{ 0 };


### PR DESCRIPTION
On iOS, we have to set gl_PointSize in order to draw points, otherwise it will simply not display. In non-sprite model drawing and point star drawing, the shader did not set gl_PointSize. This should also fix the point rendering on HiDPI screens.