### PR TITLE
Auto-update version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 | **`Release`** | **`Localized`** | **`License`** | **`Contribute`** |
 |-------------------|---------------|---------------|---------------|
-|[![GitHub release](https://img.shields.io/badge/Release-v1.6.2-blue)](https://celestia.space/download.html) | [![Localization](https://img.shields.io/badge/Localized-85%25-green.svg)](#) | [![License](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://github.com/CelestiaProject/Celestia/blob/master/COPYING) | [![Contribute](https://img.shields.io/badge/PRs-Welcome-brightgreen.svg)](#contributing) |
+|[![GitHub release](https://img.shields.io/github/v/release/CelestiaProject/Celestia?label=Release)](https://celestia.space/download.html) | [![Localization](https://img.shields.io/badge/Localized-85%25-green.svg)](#) | [![License](https://img.shields.io/github/license/CelestiaProject/Celestia?label=License)](https://github.com/CelestiaProject/Celestia/blob/master/COPYING) | [![Contribute](https://img.shields.io/badge/PRs-Welcome-brightgreen.svg)](#contributing) |
 
 # Celestia
 ![Celestia](celestia-logo.png)<br>


### PR DESCRIPTION
Follow-up to #889: looks like [shields.io](https://shields.io/) can automatically get the version number and license from GitHub.

The readme could potentially also have other "badges", for example:

![languages](https://img.shields.io/github/languages/count/CelestiaProject/Celestia) ![size](https://img.shields.io/github/languages/code-size/CelestiaProject/Celestia) ![issues](https://img.shields.io/github/issues/CelestiaProject/Celestia) ![pull-requests](https://img.shields.io/github/issues-pr/CelestiaProject/Celestia) ![contributors](https://img.shields.io/github/contributors/CelestiaProject/Celestia) [![discord](https://img.shields.io/discord/558624707147071489?label=discord)](https://discord.com/invite/WEWDcJh)
(I'm not suggesting these specific ones, just giving examples)