### PR TITLE
Fix crash in rendering orbits again

### DIFF
--- a/src/celengine/curveplot.cpp
+++ b/src/celengine/curveplot.cpp
@@ -330,11 +330,11 @@ public:
 #if USE_VERTEX_BUFFER
         if (currentPosition > 0)
         {
-            glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(Vertex) * (currentPosition + 1) * 2, data);
-
             // Finish the current line strip
             if (endIfNeeded && currentStripLength > 1)
                 end(false);
+
+            glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(Vertex) * currentPosition * 2, data);
 
             unsigned int startIndex = 0;
             for (vector<unsigned int>::const_iterator iter = stripLengths.begin(); iter != stripLengths.end(); ++iter)


### PR DESCRIPTION
It seems the last fix is still problematic, we should grab the currentPosition after calling `end` instead of always adding 1 before `end`, since it does not necessarily add a line end in `end`, and always adding 1 may exceed the capacity of the buffer and cause crash...

I'm only seeing the crash on iOS tho, and on iOS multithreaded OpenGLES is enabled  so there is no clear backtrace, but I can infer from the internal ones that it should be crashing in glBufferSubData.

https://appcenter.ms/orgs/CelestiaProject/apps/Celestia/crashes/errors/3993446285u/overview
https://appcenter.ms/orgs/CelestiaProject/apps/Celestia/crashes/errors/1213229124u/overview
https://appcenter.ms/orgs/CelestiaProject/apps/Celestia/crashes/errors/4180550728u/overview
https://appcenter.ms/orgs/CelestiaProject/apps/Celestia/crashes/errors/1181049503u/overview
https://appcenter.ms/orgs/CelestiaProject/apps/Celestia/crashes/errors/2910451737u/overview