### PR TITLE
Fix crash due to use of uninitialized memory

### DIFF
--- a/src/celengine/boundariesrenderer.cpp
+++ b/src/celengine/boundariesrenderer.cpp
@@ -83,13 +83,13 @@ void BoundariesRenderer::render(const Renderer &renderer, const Color &color, co
 bool BoundariesRenderer::prepare(std::vector<LineEnds> &data)
 {
     auto chains = m_boundaries->getChains();
-    auto vtx_num = accumulate(chains.begin(), chains.end(), 0,
-                              [](int a, ConstellationBoundaries::Chain* b) { return a + b->size(); });
+    auto lineCount = accumulate(chains.begin(), chains.end(), 0,
+                                [](int a, ConstellationBoundaries::Chain* b) { return a + b->size() - 1; });
 
-    if (vtx_num == 0)
+    if (lineCount == 0)
         return false;
 
-    m_lineCount = vtx_num;
+    m_lineCount = lineCount;
 
     // we reserve 6 times the space so we can allow to
     // draw a line segment with two triangles

--- a/src/celengine/vertexobject.cpp
+++ b/src/celengine/vertexobject.cpp
@@ -61,7 +61,7 @@ void VertexObject::bind(AttributesType attributes) noexcept
         else
         {
             glBindBuffer(m_bufferType, m_vboId);
-            enableAttribArrays(attributes);
+            enableAttribArrays();
         }
     }
 }
@@ -118,12 +118,12 @@ bool VertexObject::setBufferData(const void* data, GLintptr offset, GLsizeiptr s
 void VertexObject::draw(GLenum primitive, GLsizei count, GLint first) noexcept
 {
     if ((m_state & State::Initialize) != 0)
-        enableAttribArrays(m_currentAttributes);
+        enableAttribArrays();
 
     glDrawArrays(primitive, first, count);
 }
 
-void VertexObject::enableAttribArrays(AttributesType attributes) noexcept
+void VertexObject::enableAttribArrays() noexcept
 {
     glBindBuffer(m_bufferType, m_vboId);
     for (const auto& t : m_attribParams[(unsigned int)m_currentAttributes])

--- a/src/celengine/vertexobject.h
+++ b/src/celengine/vertexobject.h
@@ -87,7 +87,7 @@ class VertexObject
         bool       normalized;
     };
 
-    void enableAttribArrays(AttributesType attributes) noexcept;
+    void enableAttribArrays() noexcept;
     void disableAttribArrays() noexcept;
 
     GLuint     m_vboId{ 0 };


### PR DESCRIPTION
This might be the real cause of issues mentioned in https://github.com/CelestiaProject/Celestia/pull/922 I can reliably reproduce by turning on boundary rendering