### PR TITLE
C++17-like features plus fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,9 @@ if((NOT HAVE_FILESYSTEM) AND HAVE_EXPERIMENTAL_FILESYSTEM)
   endif()
 endif()
 
+try_compile(HAVE_STRING_VIEW ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/checks/cxxsv.cpp")
+try_compile(HAVE_EXPERIMENTAL_STRING_VIEW ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/checks/cxxsvexp.cpp")
+
 configure_file("config.h.in" "config.h")
 
 set(BASE_DATA_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,12 @@ if(NOT WIN32)
   add_compile_options(-fPIC)
 endif()
 
+if(MINGW)
+  # MinGW has a bug which causes too many false-positive warnings
+  # for 'operator!='
+  add_compile_options(-Wno-attributes)
+endif()
+
 EnableFastMath(${FAST_MATH})
 
 #

--- a/checks/cxxsv.cpp
+++ b/checks/cxxsv.cpp
@@ -1,0 +1,6 @@
+#include <string_view>
+
+int main()
+{
+    std::string_view sv("test");
+}

--- a/checks/cxxsvexp.cpp
+++ b/checks/cxxsvexp.cpp
@@ -1,0 +1,6 @@
+#include <experimental/string_view>
+
+int main()
+{
+    std::experimental::string_view sv("test");
+}

--- a/config.h.in
+++ b/config.h.in
@@ -1,4 +1,6 @@
 #cmakedefine HAVE_BYTESWAP_H
 #cmakedefine HAVE_FILESYSTEM
 #cmakedefine HAVE_EXPERIMENTAL_FILESYSTEM
+#cmakedefine HAVE_STRING_VIEW
+#cmakedefine HAVE_EXPERIMENTAL_STRING_VIEW
 #cmakedefine HAVE_WORDEXP

--- a/src/celcompat/CMakeLists.txt
+++ b/src/celcompat/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(CELCOMPAT_SOURCES
+  cc.cpp
+  cc.h
   fs.cpp
   fs.h
 )

--- a/src/celcompat/cc.cpp
+++ b/src/celcompat/cc.cpp
@@ -1,0 +1,71 @@
+// cc.cpp
+//
+// Copyright (C) 2021-present, Celestia Development Team.
+//
+// from_chars() functions family as in C++17.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "cc.h"
+
+namespace std
+{
+
+auto from_chars(const char* first, const char* last, float &value,
+                std::chars_format fmt)
+    -> std::from_chars_result
+{
+    char *end;
+    errno = 0;
+    float result = strtof(first, &end);
+    if (result == 0.0f && end == first)
+        return { first, std::errc::invalid_argument };
+    if (errno == ERANGE)
+    {
+        errno = 0;
+        return { first, std::errc::invalid_argument };
+    }
+    value = result;
+    return { end, std::errc() };
+}
+
+auto from_chars(const char* first, const char* last, double &value,
+                std::chars_format fmt)
+    -> std::from_chars_result
+{
+    char *end;
+    errno = 0;
+    double result = strtod(first, &end);
+    if (result == 0.0 && end == first)
+        return { first, std::errc::invalid_argument };
+    if (errno == ERANGE)
+    {
+        errno = 0;
+        return { first, std::errc::invalid_argument };
+    }
+    value = result;
+    return { end, std::errc() };
+}
+
+auto from_chars(const char* first, const char* last, long double &value,
+                std::chars_format fmt)
+    -> std::from_chars_result
+{
+    char *end;
+    errno = 0;
+    double result = strtold(first, &end);
+    if (result == 0.0l && end == first)
+        return { first, std::errc::invalid_argument };
+    if (errno == ERANGE)
+    {
+        errno = 0;
+        return { first, std::errc::invalid_argument };
+    }
+    value = result;
+    return { end, std::errc() };
+}
+
+}

--- a/src/celcompat/cc.h
+++ b/src/celcompat/cc.h
@@ -1,0 +1,132 @@
+// cc.h
+//
+// Copyright (C) 2021-present, Celestia Development Team.
+//
+// from_chars() functions family as in C++17.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <limits>
+#include <system_error>
+#include <type_traits>
+
+namespace std
+{
+struct from_chars_result
+{
+    const char* ptr;
+    std::errc ec;
+};
+
+enum class chars_format
+{
+    scientific  = 1,
+    fixed       = 2,
+    hex         = 4,
+    general     = fixed | scientific
+};
+
+template <typename T, typename std::enable_if<std::numeric_limits<T>::is_integer, T>::type = 0>
+auto from_chars(const char* first, const char* last, T& value, int base = 10)
+    -> std::from_chars_result;
+
+auto from_chars(const char* first, const char* last, float &value,
+                std::chars_format fmt = std::chars_format::general)
+    -> std::from_chars_result;
+
+auto from_chars(const char* first, const char* last, double &value,
+                std::chars_format fmt = std::chars_format::general)
+    -> std::from_chars_result;
+
+auto from_chars(const char* first, const char* last, long double &value,
+                std::chars_format fmt = std::chars_format::general)
+    -> std::from_chars_result;
+
+namespace
+{
+template <typename T>
+auto int_from_chars(const char* first, const char* last, T& value, int base) noexcept
+    -> std::from_chars_result
+{
+    auto p = first;
+    bool has_minus = false;
+    if (std::numeric_limits<T>::is_signed && *p == '-')
+    {
+        has_minus = true;
+        p++;
+    }
+
+    using U = typename make_unsigned<T>::type;
+
+    U risky_value;
+    U max_digit;
+    if (has_minus)
+    {
+        risky_value = (static_cast<U>(std::numeric_limits<T>::max()) + 1) / base;
+        max_digit = (static_cast<U>(std::numeric_limits<T>::max()) + 1) % base;
+    }
+    else
+    {
+        risky_value = static_cast<U>(std::numeric_limits<T>::max() / base);
+        max_digit = static_cast<U>(std::numeric_limits<T>::max() % base);
+    }
+
+    char last_n  = '0' + base;
+    char last_ll = 'a' + base - 10;
+    char last_ul = 'A' + base - 10;
+
+    bool overflow = false;
+    T result = 0;
+    for (; p < last; p++)
+    {
+        U digit;
+        if (base <= 10)
+        {
+            if (*p < '0' || *p >= last_n)
+                break;
+            digit = static_cast<U>(*p - '0');
+        }
+        else
+        {
+            if (*p >= '0' && *p <= '9')
+                digit = static_cast<U>(*p - '0');
+            else if (*p >= 'a' && *p < last_ll)
+                digit = static_cast<U>(*p - 'a' + 10);
+            else if (*p >= 'A' && *p < last_ul)
+                digit = static_cast<U>(*p - 'A' + 10);
+            else
+                break;
+        }
+
+        if (result > risky_value || (result == risky_value && digit > max_digit))
+            overflow = true;
+
+        result = result * base + digit;
+    }
+    if (p == first || (has_minus && p == first + 1))
+        return { first, std::errc::invalid_argument };
+
+    if (overflow)
+        return { p, std::errc::result_out_of_range };
+
+    if (has_minus)
+        value = -1 - static_cast<T>(result - 1);
+    else
+        value = static_cast<T>(result);
+    return { p, std::errc() };
+}
+
+} // anon namespace
+
+template <typename T, typename std::enable_if<std::numeric_limits<T>::is_integer, T>::type>
+auto from_chars(const char* first, const char* last, T& value, int base)
+    -> std::from_chars_result
+{
+    return int_from_chars(first, last, value, base);
+}
+}

--- a/src/celcompat/charconv.h
+++ b/src/celcompat/charconv.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <config.h>
+
+#ifdef HAVE_CHARCONV
+#include <charconv>
+#else
+#include "cc.h"
+#endif

--- a/src/celcompat/string_view.h
+++ b/src/celcompat/string_view.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <config.h>
+
+#ifdef HAVE_STRING_VIEW
+#include <string_view>
+#elif defined(HAVE_EXPERIMENTAL_STRING_VIEW)
+#include <experimental/string_view>
+namespace std
+{
+    using string_view = std::experimental::string_view;
+}
+#else
+#include "sv.h"
+#endif

--- a/src/celcompat/sv.h
+++ b/src/celcompat/sv.h
@@ -1,0 +1,537 @@
+// sv.h
+//
+// Copyright (C) 2021-present, Celestia Development Team.
+//
+// Read-only view of C/C++ strings.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <string>
+#include <stdexcept>
+#include <algorithm>
+
+#if defined(_MSC_VER) && !defined(__clang__)
+// M$VC++ 2015 doesn't have required features
+#define CEL_CPP_VER (_MSC_VER == 1900 ? 201103L : _MSVC_LANG)
+#else
+#define CEL_CPP_VER __cplusplus
+#endif
+
+#if CEL_CPP_VER == 201402L
+#define CEL_constexpr constexpr
+#else
+#define CEL_constexpr /* constexpr */
+#endif
+
+namespace std
+{
+template<
+    typename CharT,
+    typename Traits = std::char_traits<CharT>
+> class basic_string_view
+{
+ public:
+    using traits_type            = Traits;
+    using value_type             = CharT;
+    using pointer                = CharT*;
+    using const_pointer          = const CharT*;
+    using reference              = CharT&;
+    using const_reference        = const CharT&;
+    using const_iterator         = const CharT*;
+    using iterator               = const_iterator;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using reverse_iterator       = const_reverse_iterator;
+    using size_type              = std::size_t;
+    using difference_type        = std::ptrdiff_t;
+
+    enum : size_type
+    {
+        npos = size_type(-1)
+    };
+
+    constexpr basic_string_view() noexcept = default;
+    constexpr basic_string_view(const basic_string_view& other) noexcept = default;
+    constexpr basic_string_view(const CharT* s, size_type count) :
+        m_data { s },
+        m_size { count }
+    {}
+    constexpr basic_string_view(const std::basic_string<CharT, Traits> &s) :
+        m_data { s.data() },
+        m_size { s.size() }
+    {}
+
+    constexpr basic_string_view(const CharT* s) :
+        m_data { s },
+        m_size { Traits::length(s) }
+    {}
+
+    CEL_constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
+
+    explicit operator basic_string<CharT, Traits>() const
+    {
+        return { m_data, m_size };
+    }
+
+    constexpr const_pointer data() const noexcept
+    {
+        return m_data;
+    }
+    constexpr size_type size() const noexcept
+    {
+        return m_size;
+    }
+    constexpr size_type length() const noexcept
+    {
+        return size();
+    }
+    constexpr bool empty() const noexcept
+    {
+        return size() == 0;
+    }
+    constexpr const_reference operator[](size_type pos) const
+    {
+        return m_data[pos];
+    }
+    CEL_constexpr const_reference at(size_type pos) const
+    {
+        if (pos < size())
+            return m_data[pos];
+
+        throw std::out_of_range("pos >= size()");
+    }
+    constexpr const_reference front() const
+    {
+        return *m_data;
+    }
+    constexpr const_reference back() const
+    {
+        return *(m_data + m_size - 1);
+    }
+    constexpr size_type max_size() const noexcept
+    {
+        return (npos - sizeof(size_type) - sizeof(pointer)) / sizeof(value_type) / 4;
+    }
+    constexpr const_iterator begin() const noexcept
+    {
+        return m_data;
+    }
+    constexpr const_iterator cbegin() const noexcept
+    {
+        return begin();
+    }
+    constexpr const_iterator end() const noexcept
+    {
+        return m_data + m_size;
+    }
+    constexpr const_iterator cend() const noexcept
+    {
+        return end();
+    }
+    constexpr const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+    constexpr const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+    constexpr const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+    constexpr const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+    CEL_constexpr void remove_prefix(size_type n)
+    {
+        m_data += n;
+	m_size -= n;
+    }
+    CEL_constexpr void remove_suffix(size_type n)
+    {
+	m_size -= n;
+    }
+    CEL_constexpr void swap(basic_string_view& v) noexcept
+    {
+        auto t = *this;
+        this = v;
+        v = t;
+    }
+    size_type copy(CharT* dest, size_type count, size_type pos = 0) const
+    {
+        if (pos > m_size)
+            throw std::out_of_range("pos >= size()");
+
+        auto rcount = std::min(count, m_size - pos);
+        return Traits::copy(dest, m_data + pos, rcount);
+    }
+    CEL_constexpr basic_string_view substr(size_type pos = 0, size_type count = npos ) const
+    {
+        if (pos > m_size)
+            throw std::out_of_range("pos >= size()");
+
+        auto rcount = std::min(count, m_size - pos);
+        return { m_data + pos, rcount };
+    }
+    CEL_constexpr int compare(basic_string_view v) const noexcept
+    {
+        auto r = Traits::compare(data(), v.data(), std::min(size(), v.size()));
+        return r == 0 ? size() - v.size() : r;
+    }
+    constexpr int compare(size_type pos1, size_type count1, basic_string_view v) const
+    {
+        return substr(pos1, count1).compare(v);
+    }
+    constexpr int compare(size_type pos1, size_type count1, basic_string_view v, size_type pos2, size_type count2) const
+    {
+        return substr(pos1, count1).compare(v.substr(pos2, count2));
+    }
+    constexpr int compare(const CharT* s) const
+    {
+        return compare(basic_string_view(s));
+    }
+    constexpr int compare(size_type pos1, size_type count1, const CharT* s) const
+    {
+        return substr(pos1, count1).compare(basic_string_view(s));
+    }
+    constexpr int compare(size_type pos1, size_type count1, const CharT* s, size_type count2) const
+    {
+        return substr(pos1, count1).compare(basic_string_view(s, count2));
+    }
+    constexpr size_type find(basic_string_view v, size_type pos = 0) const noexcept
+    {
+        return (pos >= m_size ? npos : (basic_string_view(m_data + pos, v.size()).compare(v) == 0 ? pos : find(v, pos + 1)));
+    }
+    constexpr size_type find(CharT ch, size_type pos = 0) const noexcept
+    {
+        return find(basic_string_view(std::addressof(ch), 1), pos);
+    }
+    constexpr size_type find(const CharT* s, size_type pos, size_type count) const
+    {
+        return find(basic_string_view(s, count), pos);
+    }
+    constexpr size_type find(const CharT* s, size_type pos = 0) const
+    {
+        return find(basic_string_view(s), pos);
+    }
+    CEL_constexpr size_type rfind(basic_string_view v, size_type pos = npos) const noexcept
+    {
+        if (v.size() > size())
+            return npos;
+        if (v.size() == 0)
+            return std::min(size(), pos);
+        auto last = begin() + std::min(pos, size());
+        auto r = std::find_end(begin(), last, v.begin(), v.end());
+        if (r != last)
+            return r - begin();
+        return npos;
+    }
+    constexpr size_type rfind(CharT c, size_type pos = npos) const noexcept
+    {
+        return rfind(basic_string_view(std::addressof(c), 1), pos);
+    }
+    constexpr size_type rfind(const CharT* s, size_type pos, size_type count) const
+    {
+        return rfind(basic_string_view(s, count), pos);
+    }
+    constexpr size_type rfind(const CharT* s, size_type pos = npos) const
+    {
+        return rfind(basic_string_view(s), pos);
+    }
+    CEL_constexpr size_type find_first_of(basic_string_view v, size_type pos = 0) const noexcept
+    {
+        for (size_type i = pos; i < m_size; i++)
+            for (auto c : v)
+                if (c == m_data[i])
+                    return i;
+        return npos;
+    }
+    CEL_constexpr size_type find_first_of(CharT c, size_type pos = 0) const noexcept
+    {
+        return find_first_of(basic_string_view(std::addressof(c), 1), pos);
+    }
+    CEL_constexpr size_type find_first_of(const CharT* s, size_type pos, size_type count) const
+    {
+        return find_first_of(basic_string_view(s, count), pos);
+    }
+    CEL_constexpr size_type find_first_of(const CharT* s, size_type pos = 0) const
+    {
+        return find_first_of(basic_string_view(s), pos);
+    }
+    CEL_constexpr size_type find_last_of(basic_string_view v, size_type pos = npos) const noexcept
+    {
+        for (auto iter = cbegin() + std::min(m_size - 1, pos); iter >= cbegin(); iter--)
+            for (auto c : v)
+                if (c == *iter)
+                    return iter - cbegin();
+        return npos;
+    }
+    CEL_constexpr size_type find_last_of(CharT c, size_type pos = npos) const noexcept
+    {
+        return find_last_of(basic_string_view(std::addressof(c), 1), pos);
+    }
+    CEL_constexpr size_type find_last_of(const CharT* s, size_type pos, size_type count) const
+    {
+        return find_last_of(basic_string_view(s, count), pos);
+    }
+    CEL_constexpr size_type find_last_of(const CharT* s, size_type pos = npos) const
+    {
+        return find_last_of(basic_string_view(s), pos);
+    }
+    CEL_constexpr size_type find_first_not_of(basic_string_view v, size_type pos = 0) const noexcept
+    {
+        for (size_type i = pos; i < m_size; i++)
+            if (v.find(m_data[i]) == npos)
+                return i;
+        return npos;
+    }
+    CEL_constexpr size_type find_first_not_of(CharT c, size_type pos = 0) const noexcept
+    {
+        return find_first_not_of(basic_string_view(std::addressof(c), 1), pos);
+    }
+    CEL_constexpr size_type find_first_not_of(const CharT* s, size_type pos, size_type count) const
+    {
+        return find_first_not_of(basic_string_view(s, count), pos);
+    }
+    CEL_constexpr size_type find_first_not_of(const CharT* s, size_type pos = 0) const
+    {
+        return find_first_not_of(basic_string_view(s), pos);
+    }
+    CEL_constexpr size_type find_last_not_of(basic_string_view v, size_type pos = npos) const noexcept
+    {
+        for (auto iter = cbegin() + std::min(m_size - 1, pos); iter >= cbegin(); iter--)
+            if (v.find(*iter) == npos)
+                return iter - cbegin();
+        return npos;
+    }
+    CEL_constexpr size_type find_last_not_of(CharT c, size_type pos = npos) const noexcept
+    {
+        return find_last_not_of(basic_string_view(std::addressof(c), 1), pos);
+    }
+    CEL_constexpr size_type find_last_not_of(const CharT* s, size_type pos, size_type count) const
+    {
+        return find_last_not_of(basic_string_view(s, count), pos);
+    }
+    CEL_constexpr size_type find_last_not_of(const CharT* s, size_type pos = npos) const
+    {
+        return find_last_not_of(basic_string_view(s), pos);
+    }
+
+ private:
+    const_pointer   m_data { nullptr };
+    size_type       m_size { 0 };
+};
+
+using string_view = basic_string_view<char>;
+using wstring_view = basic_string_view<wchar_t>;
+
+template<class CharT, class Traits>
+constexpr bool operator==(basic_string_view <CharT, Traits> lhs,
+                          basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return lhs.compare(rhs) == 0;
+}
+
+/*!
+ * Helpers missing in C++17 for compatibility with C++11/C++14
+ */
+template<class CharT, class Traits>
+constexpr bool operator==(basic_string_view <CharT, Traits> lhs,
+                          basic_string <CharT, Traits> rhs) noexcept
+{
+    return lhs == basic_string_view<CharT, Traits>(rhs);
+}
+template<class CharT, class Traits>
+constexpr bool operator==(basic_string <CharT, Traits> lhs,
+                          basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return rhs == lhs;
+}
+template<class CharT, class Traits, size_t N>
+constexpr bool operator==(basic_string_view <CharT, Traits> lhs,
+                          const CharT (&rhs)[N]) noexcept
+{
+    return lhs == basic_string_view<CharT, Traits>(rhs, N-1);
+}
+template<class CharT, class Traits, size_t N>
+constexpr bool operator==(const CharT (&lhs)[N],
+                          basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return rhs == lhs;
+}
+template<class CharT, class Traits, size_t N>
+constexpr bool operator==(basic_string_view <CharT, Traits> lhs,
+                          const CharT* rhs) noexcept
+{
+    return lhs.compare(rhs) == 0;
+}
+template<class CharT, class Traits, size_t N>
+constexpr bool operator==(const CharT* lhs,
+                          basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return rhs == lhs;
+}
+
+template<class CharT, class Traits>
+constexpr bool operator!=(basic_string_view <CharT, Traits> lhs,
+                          basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return lhs.compare(rhs) != 0;
+}
+
+/*!
+ * Helpers missing in C++17 for compatibility with C++11/C++14
+ */
+template<class CharT, class Traits>
+constexpr bool operator!=(basic_string_view <CharT, Traits> lhs,
+                          basic_string <CharT, Traits> rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+template<class CharT, class Traits>
+constexpr bool operator!=(basic_string <CharT, Traits> lhs,
+                          basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+template<class CharT, class Traits, size_t N>
+constexpr bool operator!=(basic_string_view <CharT, Traits> lhs,
+                          const CharT* rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+template<class CharT, class Traits, size_t N>
+constexpr bool operator!=(const CharT* lhs,
+                          basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+
+template<class CharT, class Traits>
+constexpr bool operator<(basic_string_view <CharT, Traits> lhs,
+                         basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return lhs.compare(rhs) < 0;
+}
+template<class CharT, class Traits>
+constexpr bool operator<=(basic_string_view <CharT, Traits> lhs,
+                          basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return lhs.compare(rhs) <= 0;
+}
+template<class CharT, class Traits>
+constexpr bool operator>(basic_string_view <CharT, Traits> lhs,
+                         basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return lhs.compare(rhs) > 0;
+}
+template<class CharT, class Traits>
+constexpr bool operator>=(basic_string_view <CharT, Traits> lhs,
+                          basic_string_view <CharT, Traits> rhs) noexcept
+{
+    return lhs.compare(rhs) >= 0;
+}
+
+template <class CharT, class Traits>
+std::basic_ostream <CharT, Traits>& operator<<(std::basic_ostream <CharT, Traits>& os,
+                                              std::basic_string_view <CharT, Traits> v)
+{
+    os.write(v.data(), v.size());
+    return os;
+}
+
+namespace
+{
+template<size_t size = sizeof(size_t)>
+struct fnv;
+
+template<>
+struct fnv<4>
+{
+    enum : uint32_t
+    {
+        offset = 2166136261ul,
+        prime  = 16777619ul
+    };
+};
+
+template<>
+struct fnv<8>
+{
+    enum : uint64_t
+    {
+        offset = 14695981039346656037ull,
+        prime  = 1099511628211ull
+    };
+};
+
+constexpr size_t fnv1a_loop_helper(const char *begin, const char *end, size_t hash = fnv<>::offset)
+{
+    return begin < end ? fnv1a_loop_helper(begin + 1, end, (hash ^ size_t(*begin)) * fnv<>::prime) : hash;
+}
+}
+
+template<typename T>
+struct hash;
+
+template<>
+struct hash<string_view>
+{
+    size_t operator()(const string_view& sv) const noexcept
+    {
+#if 0
+        size_t _hash = fnv<>::offset;
+        for (char c : sv)
+        {
+            _hash ^= size_t(c);
+            _hash *= fnv<>::prime;
+        }
+        return _hash;
+#else
+        fnv1a_loop_helper(sv.data(), sv.data() + sv.length());
+#endif
+    }
+};
+}
+
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wreserved-user-defined-literal"
+//#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wuser-defined-literals"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wliteral-suffix"
+#endif
+constexpr std::string_view operator "" sv(const char *str, size_t len)
+{
+    return { str, len };
+}
+
+constexpr std::wstring_view operator "" sv(const wchar_t *str, size_t len)
+{
+    return { str, len };
+}
+
+constexpr std::string_view operator "" _sv(const char *str, size_t len)
+{
+    return { str, len };
+}
+
+constexpr std::wstring_view operator "" _sv(const wchar_t *str, size_t len)
+{
+    return { str, len };
+}
+#if defined(__clang__)
+//#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+
+#undef CEL_constexpr

--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -1,4 +1,5 @@
 #include "glsupport.h"
+#include <algorithm>
 
 namespace celestia
 {
@@ -15,7 +16,7 @@ bool ARB_shader_texture_lod         = false;
 bool EXT_texture_compression_s3tc   = false;
 bool EXT_texture_filter_anisotropic = false;
 GLint maxPointSize                  = 0;
-GLfloat maxLineWidth                = 0;
+GLfloat maxLineWidth                = 0.0f;
 
 namespace
 {
@@ -23,19 +24,24 @@ namespace
     {
         return epoxy_has_gl_extension(name);
     }
+
+    bool check_extension(util::array_view<std::string> list, const char* name) noexcept
+    {
+        return std::find(list.begin(), list.end(), std::string(name)) == list.end() && has_extension(name);
+    }
 }
 
-bool init() noexcept
+bool init(util::array_view<std::string> ignore) noexcept
 {
 #ifdef GL_ES
-    OES_vertex_array_object        = has_extension("GL_OES_vertex_array_object");
+    OES_vertex_array_object        = check_extension(ignore, "GL_OES_vertex_array_object");
 #else
-    ARB_vertex_array_object        = has_extension("GL_ARB_vertex_array_object");
-    EXT_framebuffer_object         = has_extension("GL_EXT_framebuffer_object");
+    ARB_vertex_array_object        = check_extension(ignore, "GL_ARB_vertex_array_object");
+    EXT_framebuffer_object         = check_extension(ignore, "GL_EXT_framebuffer_object");
 #endif
-    ARB_shader_texture_lod         = has_extension("GL_ARB_shader_texture_lod");
-    EXT_texture_compression_s3tc   = has_extension("GL_EXT_texture_compression_s3tc");
-    EXT_texture_filter_anisotropic = has_extension("GL_EXT_texture_filter_anisotropic");
+    ARB_shader_texture_lod         = check_extension(ignore, "GL_ARB_shader_texture_lod");
+    EXT_texture_compression_s3tc   = check_extension(ignore, "GL_EXT_texture_compression_s3tc");
+    EXT_texture_filter_anisotropic = check_extension(ignore, "GL_EXT_texture_filter_anisotropic");
 
     GLint pointSizeRange[2];
     GLfloat lineWidthRange[2];

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <celutil/array_view.h>
+
 #ifdef GL_ES
 #include <epoxy/gl.h>
 /*
@@ -45,7 +48,7 @@ extern bool EXT_framebuffer_object;
 extern GLint maxPointSize;
 extern GLfloat maxLineWidth;
 
-bool init() noexcept;
+bool init(util::array_view<std::string> = {}) noexcept;
 bool checkVersion(int) noexcept;
 } // gl
 } // celestia

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -185,7 +185,8 @@ class Renderer
         ShowAtmospheres         = 0x0000000000000100,
         ShowSmoothLines         = 0x0000000000000200,
         ShowEclipseShadows      = 0x0000000000000400,
-        ShowPlanetRings         = 0x0000000000000800,
+        // the next one is unused in 1.7, kept for compatibility with 1.6
+        ShowStarsAsPoints       = 0x0000000000000800,
         ShowRingShadows         = 0x0000000000001000,
         ShowBoundaries          = 0x0000000000002000,
         ShowAutoMag             = 0x0000000000004000,
@@ -201,6 +202,7 @@ class Renderer
         ShowHorizonGrid         = 0x0000000001000000,
         ShowEcliptic            = 0x0000000002000000,
         ShowTintedIllumination  = 0x0000000004000000,
+        // options added in 1.7
         ShowDwarfPlanets        = 0x0000000008000000,
         ShowMoons               = 0x0000000010000000,
         ShowMinorMoons          = 0x0000000020000000,
@@ -208,6 +210,7 @@ class Renderer
         ShowComets              = 0x0000000080000000,
         ShowSpacecrafts         = 0x0000000100000000,
         ShowFadingOrbits        = 0x0000000200000000,
+        ShowPlanetRings         = 0x0000000400000000,
         ShowSolarSystemObjects  = ShowPlanets           |
                                   ShowDwarfPlanets      |
                                   ShowMoons             |
@@ -231,6 +234,7 @@ class Renderer
                                   ShowCloudShadows      |
                                   ShowCometTails        |
                                   ShowAutoMag           |
+                                  ShowPlanetRings       |
                                   ShowFadingOrbits      |
                                   ShowSmoothLines
     };

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <tuple>
 #include <Eigen/Geometry>
 #include <celcompat/filesystem.h>
 #include <celmath/geomutil.h>
@@ -324,32 +325,8 @@ bool ShaderProperties::usePointSize() const
 
 bool operator<(const ShaderProperties& p0, const ShaderProperties& p1)
 {
-    if (p0.texUsage < p1.texUsage)
-        return true;
-    if (p1.texUsage < p0.texUsage)
-        return false;
-
-    if (p0.nLights < p1.nLights)
-        return true;
-    if (p1.nLights < p0.nLights)
-        return false;
-
-    if (p0.shadowCounts < p1.shadowCounts)
-        return true;
-    if (p1.shadowCounts < p0.shadowCounts)
-        return false;
-
-    if (p0.effects < p1.effects)
-        return true;
-    if (p1.effects < p0.effects)
-        return false;
-
-    if (p0.fishEyeOverride < p1.fishEyeOverride)
-        return true;
-    if (p1.fishEyeOverride < p0.fishEyeOverride)
-        return false;
-
-    return (p0.lightModel < p1.lightModel);
+    return std::tie(p0.texUsage, p0.nLights, p0.shadowCounts, p0.effects, p0.fishEyeOverride, p0.lightModel)
+         < std::tie(p1.texUsage, p1.nLights, p1.shadowCounts, p1.effects, p1.fishEyeOverride, p1.lightModel);
 }
 
 

--- a/src/celestia/glut/glutmain.cpp
+++ b/src/celestia/glut/glutmain.cpp
@@ -516,10 +516,10 @@ int main(int argc, char* argv[])
     initMenus();
     #endif
 
-    if (!gl::init() || !gl::checkVersion(gl::GL_2_1))
+    if (!gl::init(appCore->getConfig()->ignoreGLExtensions) || !gl::checkVersion(gl::GL_2_1))
     {
         cout << _("Celestia was unable to initialize OpenGL 2.1.\n");
-	return 1;
+        return 1;
     }
 
     // GL should be all set up, now initialize the renderer.

--- a/src/celestia/gtk/main.cpp
+++ b/src/celestia/gtk/main.cpp
@@ -244,7 +244,7 @@ public:
  *           that require the glArea to be set up. */
 static void initRealize(GtkWidget* widget, AppData* app)
 {
-    if (!gl::init() || !gl::checkVersion(gl::GL_2_1))
+    if (!gl::init(app->core->getConfig()->ignoreGLExtensions) || !gl::checkVersion(gl::GL_2_1))
     {
         GtkWidget *message;
         message = gtk_message_dialog_new(GTK_WINDOW(app->mainWindow),
@@ -254,7 +254,7 @@ static void initRealize(GtkWidget* widget, AppData* app)
                                          "Celestia was unable to initialize OpenGL 2.1.");
         gtk_dialog_run(GTK_DIALOG(message));
         gtk_widget_destroy(message);
-	exit(1);
+        exit(1);
     }
 
     app->core->setAlerter(new GtkAlerter(app));

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -265,7 +265,7 @@ void CelestiaAppWindow::init(const QString& qConfigFileName,
     glWidget = new CelestiaGlWidget(nullptr, "Celestia", m_appCore);
     glWidget->makeCurrent();
 
-    if (!gl::init() || !gl::checkVersion(gl::GL_2_1))
+    if (!gl::init(m_appCore->getConfig()->ignoreGLExtensions) || !gl::checkVersion(gl::GL_2_1))
     {
         QMessageBox::critical(0, "Celestia", _("Celestia was unable to initialize OpenGL 2.1."));
         exit(1);

--- a/src/celestia/win32/winbookmarks.cpp
+++ b/src/celestia/win32/winbookmarks.cpp
@@ -62,8 +62,8 @@ HTREEITEM PopulateBookmarksTree(HWND hTree, CelestiaCore* appCore, HINSTANCE app
         tvis.hParent = TVI_ROOT;
         tvis.hInsertAfter = TVI_LAST;
         tvis.item.mask = StdItemMask;
-        tvis.item.pszText = "Bookmarks";
-        tvis.item.lParam = NULL;
+        tvis.item.pszText = const_cast<char*>("Bookmarks");
+        tvis.item.lParam = 0;
         tvis.item.iImage = 2;
         tvis.item.iSelectedImage = 2;
         if (hParent = TreeView_InsertItem(hTree, &tvis))
@@ -167,7 +167,7 @@ HTREEITEM PopulateBookmarkFolders(HWND hTree, CelestiaCore* appCore, HINSTANCE a
         tvis.hParent = TVI_ROOT;
         tvis.hInsertAfter = TVI_LAST;
         tvis.item.mask = TVIF_TEXT | TVIF_PARAM | TVIF_IMAGE | TVIF_SELECTEDIMAGE;
-        tvis.item.pszText = "Bookmarks";
+        tvis.item.pszText = const_cast<char*>("Bookmarks");
         tvis.item.lParam = 0;
         tvis.item.iImage = 2;
         tvis.item.iSelectedImage = 2;
@@ -319,7 +319,7 @@ void BuildFavoritesMenu(HMENU menuBar,
                             menuInfo.fMask = MIIM_TYPE | MIIM_STATE;
                             menuInfo.fType = MFT_STRING;
                             menuInfo.fState = MFS_DISABLED;
-                            menuInfo.dwTypeData = "(empty)";
+                            menuInfo.dwTypeData = const_cast<char*>("(empty)");
                             if (InsertMenuItem(subMenu, subMenuIndex, TRUE, &menuInfo))
                             {
                                 odMenu->AddItem(subMenu, subMenuIndex);
@@ -653,7 +653,7 @@ void MoveBookmarkInFavorites(HWND hTree, CelestiaCore* appCore)
         dropFolderName[0] = '\0';
 
     // Get the dragged item text
-    tvItem.lParam = NULL;
+    tvItem.lParam = 0;
     tvItem.hItem = hDragItem;
     tvItem.mask = TVIF_TEXT | TVIF_HANDLE;
     tvItem.pszText = dragItemName;

--- a/src/celestia/win32/windatepicker.cpp
+++ b/src/celestia/win32/windatepicker.cpp
@@ -37,7 +37,7 @@
 // - No invalid date is permitted, including the skipped days in
 //   October 1582.
 
-static char* Months[12] =
+static const char* Months[12] =
 {
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
@@ -479,7 +479,7 @@ DatePicker::notifyDateChanged()
 int
 DatePicker::getFieldWidth(DatePickerField field, HDC hdc)
 {
-    char* maxWidthText = "\0";
+    const char* maxWidthText = "\0";
 
     switch (field)
     {

--- a/src/celestia/win32/wineclipses.cpp
+++ b/src/celestia/win32/wineclipses.cpp
@@ -32,7 +32,7 @@ static vector<Eclipse> eclipseList;
 
 extern void SetMouseCursor(LPCTSTR lpCursor);
 
-char* MonthNames[12] =
+const char* MonthNames[12] =
 {
     "Jan", "Feb", "Mar", "Apr",
     "May", "Jun", "Jul", "Aug",
@@ -46,7 +46,7 @@ bool InitEclipseFinderColumns(HWND listView)
 
     lvc.mask = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;
     lvc.fmt = LVCFMT_CENTER;
-    lvc.pszText = "";
+    lvc.pszText = const_cast<char*>("");
 
     int nColumns = sizeof(columns) / sizeof(columns[0]);
     int i;
@@ -110,7 +110,7 @@ void EclipseFinderDisplayItem(LPNMLVDISPINFOA nm)
     Eclipse* eclipse = reinterpret_cast<Eclipse*>(nm->item.lParam);
     if (eclipse == NULL)
     {
-        nm->item.pszText = "";
+        nm->item.pszText = const_cast<char*>("");
         return;
     }
 
@@ -253,7 +253,7 @@ LRESULT CALLBACK EclipseListViewProc(HWND hWnd,
             int listIndex = ListView_HitTest(hWnd, &lvHit);
             if (listIndex >= 0)
             {
-                SendMessage(GetParent(hWnd), WM_COMMAND, MAKEWPARAM(IDSETDATEANDGO, 0), NULL);
+                SendMessage(GetParent(hWnd), WM_COMMAND, MAKEWPARAM(IDSETDATEANDGO, 0), 0);
             }
         }
         break;

--- a/src/celestia/win32/wingotodlg.cpp
+++ b/src/celestia/win32/wingotodlg.cpp
@@ -31,7 +31,7 @@ static bool GetDialogFloat(HWND hDlg, int id, float& f)
         return false;
 }
 
-static bool SetDialogFloat(HWND hDlg, int id, char* format, float f)
+static bool SetDialogFloat(HWND hDlg, int id, const char* format, float f)
 {
     char buf[128];
 

--- a/src/celestia/win32/winhyperlinks.cpp
+++ b/src/celestia/win32/winhyperlinks.cpp
@@ -12,10 +12,10 @@
 #include "winhyperlinks.h"
 #include "res/resource.h"
 
-static LPTSTR hyperLinkFromStatic = "_Hyperlink_From_Static_";
-static LPTSTR hyperLinkOriginalProc = "_Hyperlink_Original_Proc_";
-static LPTSTR hyperLinkOriginalFont = "_Hyperlink_Original_Font_";
-static LPTSTR hyperLinkUnderlineFont = "_Hyperlink_Underline_Font_";
+static LPCTSTR hyperLinkFromStatic = "_Hyperlink_From_Static_";
+static LPCTSTR hyperLinkOriginalProc = "_Hyperlink_Original_Proc_";
+static LPCTSTR hyperLinkOriginalFont = "_Hyperlink_Original_Font_";
+static LPCTSTR hyperLinkUnderlineFont = "_Hyperlink_Underline_Font_";
 
 bool GetTextRect(HWND hWnd, RECT* rectText)
 {

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -91,7 +91,7 @@ static HDC deviceContext;
 
 static bool bReady = false;
 
-static LPTSTR CelestiaRegKey = "Software\\celestia.space\\Celestia1.7-dev";
+static LPCTSTR CelestiaRegKey = "Software\\celestia.space\\Celestia1.7-dev";
 
 HINSTANCE appInstance;
 HMODULE hRes;
@@ -1571,7 +1571,7 @@ VOID APIENTRY handlePopupMenu(HWND hwnd,
             vector<string>* altSurfaces = sel.body()->getAlternateSurfaceNames();
             if (altSurfaces != NULL)
             {
-                if (altSurfaces->size() != NULL)
+                if (!altSurfaces->empty())
                 {
                     HMENU surfMenu = CreateAlternateSurfaceMenu(*altSurfaces);
                     AppendMenu(hMenu, MF_POPUP | MF_STRING, (UINT_PTR) surfMenu,
@@ -2316,7 +2316,7 @@ static void HandleJoystick()
     }
 }
 
-static bool GetRegistryValue(HKEY hKey, LPSTR cpValueName, LPVOID lpBuf, DWORD iBufSize)
+static bool GetRegistryValue(HKEY hKey, LPCTSTR cpValueName, LPVOID lpBuf, DWORD iBufSize)
 {
 /*
     Function retrieves a value from the registry.
@@ -2381,7 +2381,7 @@ static bool SetRegistry(HKEY key, LPCTSTR value, const string& strVal)
     return err == ERROR_SUCCESS;
 }
 
-static bool SetRegistryBin(HKEY hKey, LPSTR cpValueName, LPVOID lpData, int iDataSize)
+static bool SetRegistryBin(HKEY hKey, LPCTSTR cpValueName, LPVOID lpData, int iDataSize)
 {
 /*
     Function sets BINARY data in the registry.
@@ -2413,7 +2413,7 @@ static bool SetRegistryBin(HKEY hKey, LPSTR cpValueName, LPVOID lpData, int iDat
 }
 
 
-static bool LoadPreferencesFromRegistry(LPTSTR regkey, AppPreferences& prefs)
+static bool LoadPreferencesFromRegistry(LPCTSTR regkey, AppPreferences& prefs)
 {
     LONG err;
     HKEY key;
@@ -2477,7 +2477,7 @@ static bool LoadPreferencesFromRegistry(LPTSTR regkey, AppPreferences& prefs)
 }
 
 
-static bool SavePreferencesToRegistry(LPTSTR regkey, AppPreferences& prefs)
+static bool SavePreferencesToRegistry(LPCTSTR regkey, AppPreferences& prefs)
 {
     LONG err;
     HKEY key;
@@ -3951,7 +3951,7 @@ LRESULT CALLBACK MainWindowProc(HWND hWnd,
                               MAKEINTRESOURCE(IDD_DISPLAYMODE),
                               hWnd,
                               (DLGPROC)SelectDisplayModeProc,
-                              NULL);
+                              0);
             break;
 
         case ID_RENDER_FULLSCREEN:
@@ -4155,7 +4155,7 @@ LRESULT CALLBACK MainWindowProc(HWND hWnd,
                               MAKEINTRESOURCE(IDD_CONTROLSHELP),
                               hWnd,
                               (DLGPROC)ControlsHelpProc,
-                              NULL);
+                              0);
             break;
 
         case ID_HELP_ABOUT:

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -19,6 +19,7 @@
 #include <cctype>
 #include <cstring>
 #include <cassert>
+#include <tuple>
 #include <process.h>
 #include <time.h>
 #include <windows.h>
@@ -2792,13 +2793,8 @@ static void HandleOpenScript(HWND hWnd, CelestiaCore* appCore)
 
 bool operator<(const DEVMODE& a, const DEVMODE& b)
 {
-    if (a.dmBitsPerPel != b.dmBitsPerPel)
-        return a.dmBitsPerPel < b.dmBitsPerPel;
-    if (a.dmPelsWidth != b.dmPelsWidth)
-        return a.dmPelsWidth < b.dmPelsWidth;
-    if (a.dmPelsHeight != b.dmPelsHeight)
-        return a.dmPelsHeight < b.dmPelsHeight;
-    return a.dmDisplayFrequency < b.dmDisplayFrequency;
+    return std::tie(a.dmBitsPerPel, a.dmPelsWidth, a.dmPelsHeight, a.dmDisplayFrequency)
+         < std::tie(b.dmBitsPerPel, b.dmPelsWidth, b.dmPelsHeight, b.dmDisplayFrequency);
 }
 
 vector<DEVMODE>* EnumerateDisplayModes(unsigned int minBPP)

--- a/src/celestia/win32/winsplash.h
+++ b/src/celestia/win32/winsplash.h
@@ -34,7 +34,7 @@ public:
 
 private:
     HWND hwnd;
-    char* className;
+    const char* className;
     std::string imageFileName;
     Image* image;
     HBITMAP hBitmap;

--- a/src/celestia/win32/winstarbrowser.cpp
+++ b/src/celestia/win32/winstarbrowser.cpp
@@ -49,7 +49,7 @@ bool InitStarBrowserColumns(HWND listView)
     lvc.mask = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;
     lvc.fmt = LVCFMT_LEFT;
     lvc.cx = 60;
-    lvc.pszText = "";
+    lvc.pszText = const_cast<char*>("");
 
     int nColumns = sizeof(columns) / sizeof(columns[0]);
     int i;
@@ -328,7 +328,7 @@ void StarBrowserDisplayItem(LPNMLVDISPINFOA nm, StarBrowser* browser)
     Star* star = reinterpret_cast<Star*>(nm->item.lParam);
     if (star == NULL)
     {
-        nm->item.pszText = "";
+        nm->item.pszText = const_cast<char*>("");
         return;
     }
 

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -651,9 +651,9 @@ int LuaState::loadScript(istream& in, const fs::path& streamname)
     return status;
 }
 
-int LuaState::loadScript(const fs::path& s)
+int LuaState::loadScript(const std::string& s)
 {
-    istringstream in(s.string());
+    istringstream in(s);
     return loadScript(in, "string");
 }
 

--- a/src/celscript/lua/celx.h
+++ b/src/celscript/lua/celx.h
@@ -40,7 +40,7 @@ public:
     lua_State* getState() const;
 
     int loadScript(std::istream&, const fs::path&);
-    int loadScript(const fs::path&);
+    int loadScript(const std::string&);
     bool init(CelestiaCore*);
 
     std::string getErrorMessage();

--- a/src/celscript/lua/luascript.cpp
+++ b/src/celscript/lua/luascript.cpp
@@ -40,7 +40,7 @@ LuaScript::~LuaScript()
 
 bool LuaScript::load(ifstream &scriptfile, const fs::path &path, string &errorMsg)
 {
-    if (m_celxScript->loadScript(scriptfile, path.string()) != 0)
+    if (m_celxScript->loadScript(scriptfile, path) != 0)
     {
         errorMsg = m_celxScript->getErrorMessage();
         return false;

--- a/src/celutil/array_view.h
+++ b/src/celutil/array_view.h
@@ -1,0 +1,149 @@
+// array_view.h
+//
+// Copyright (C) 2021-present, Celestia Development Team.
+//
+// Read-only view of array-like containers.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+namespace celestia
+{
+namespace util
+{
+
+/**
+ * Read-only view of array-like containers similar to C++20's std::span.
+ */
+template<typename T>
+class array_view
+{
+ public:
+    using element_type = typename std::remove_cv<T>::type;
+
+    /**
+     * Create an empty array view.
+     */
+    constexpr array_view() noexcept :
+        m_ptr(nullptr),
+        m_size(0)
+    {};
+
+    /**
+     * Wrap a C-style array.
+     */
+    template<size_t N> constexpr array_view(const T (&ary)[N]) noexcept :
+        m_ptr(ary),
+        m_size(N)
+    {};
+
+    /**
+     * Wrap a std::array or std::vector or other classes which have the same
+     * memory layout and interface.
+     */
+    template<typename C> constexpr array_view(const C &ary) noexcept :
+        m_ptr(ary.data()),
+        m_size(ary.size())
+    {};
+
+    /**
+     * Direct access to the underlying array.
+     */
+    constexpr const element_type* data() const noexcept
+    {
+        return m_ptr;
+    };
+
+    /**
+     * Return the number of elements.
+     */
+    constexpr size_t size() const noexcept
+    {
+        return m_size;
+    };
+
+    /**
+     * Check whether the view is empty.
+     */
+    constexpr bool empty() const noexcept
+    {
+        return m_size == 0;
+    }
+
+    /**
+     * Return the first element.
+     *
+     * Calling front on an empty container is undefined.
+     */
+    constexpr T front() const noexcept
+    {
+        return *m_ptr;
+    }
+
+    /**
+     * Return the last element.
+     *
+     * Calling back on an empty container is undefined.
+     */
+    constexpr T back() const noexcept
+    {
+        return m_ptr[m_size - 1];
+    }
+
+    /**
+     * Return array element at specified position. No bounds checking
+     * performed.
+     *
+     * Accessing a nonexistent element through this operator is
+     * undefined behavior.
+     *
+     * @param pos - position of the element to return
+     * @return the requested element
+     */
+    constexpr element_type operator[](std::size_t pos) const noexcept
+    {
+        return m_ptr[pos];
+    }
+
+    /**
+     * Return an iterator to the beginning.
+     */
+    constexpr const element_type* begin() const noexcept
+    {
+        return m_ptr;
+    }
+
+    /**
+     * Return an iterator to the beginning.
+     */
+    constexpr const element_type* cbegin() const noexcept
+    {
+        return m_ptr;
+    }
+
+    /**
+     * Return an iterator to the end.
+     */
+    constexpr const element_type* end() const noexcept
+    {
+        return m_ptr + m_size;
+    }
+
+    /**
+     * Return an iterator to the end.
+     */
+    constexpr const element_type* cend() const noexcept
+    {
+        return m_ptr + m_size;
+    }
+
+ private:
+    const element_type* m_ptr;
+    const size_t m_size;
+};
+}
+}


### PR DESCRIPTION
This PR provides some C++17-compatible libraries:
 * `string_view`, very useful as non-owning, non-allocation "view" of strings, both std::string and char[]. Safer replacement for `const char*`.
 * `charconv`, which provides `from_chars` function to convert numbers from strings. `to_chars` are not implemented yet.

One small utility library `array_view`. Like `string_view` but for arrays. With it we can have a single function which accepts C-style arrays, `std::array` and `std::vector`.

Then, use `std::tie` to compare structures. With `-O2` generated code looks the same but the sources are more readable and less error prune.

Fix for `LuaState::loadScript()`. This method accepts a string with a Lua script, but when transition to `fs` was made the string was replaced with `fs::path`.

Fix for `RenderFlags`. `ShowPlanetRings` was added instead of removed `ShowStarsAsPoints`, so compatibility with 1.6 version was lost. Let's restore it.

Old Celestia versions were able to blacklist GL extensions in `celestia.cfg`. When transition to `GLEW` was made this feature was lost. Let's restore it.

And at last fix warnings shown by `MinGW`, I use it to cross-compile windows backend.