### PR TITLE
Url refactoring, enable release builds without exceptions and RTTI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,11 +105,13 @@ if(MSVC)
   # C4244, C4267, C4503: implicit type conversion to a smaller type
   # C4786: long names in templates
   # C4800: forcing value to bool
+  # C4455: reserved literals (no undescore at the beginning)
+  # C5030: not recognized attribute
   # Additional options
   # bigobj: generate more object sections than allowed by default
   # Promoted to errors
   # C4316: object allocated on the heap may not be aligned 16
-  add_compile_options("/wd4244" "/wd4267" "/wd4503" "/wd4800" "/bigobj" "/we4316")
+  add_compile_options("/wd4244" "/wd4267" "/wd4503" "/wd4800" "/wd4455" "/wd5030" "/bigobj" "/we4316")
 endif()
 
 if(NOT WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,9 @@ if("${build_type_lc}" STREQUAL "debug")
   add_definitions(-D_DEBUG -DDEBUG)
 else()
   add_definitions(-DNO_DEBUG -DEIGEN_NO_DEBUG)
+  if(NOT MSVC)
+    add_compile_options(-fno-rtti -fno-exceptions)
+  endif()
 endif()
 
 # Turning all debug on dramatically decreases performance

--- a/src/celcompat/fs.cpp
+++ b/src/celcompat/fs.cpp
@@ -6,7 +6,14 @@
 #else
 #include <sys/stat.h>
 #endif
+#if defined(_MSC_VER) && !defined(__clang__)
+// M$VC++ build without C++ exceptions are not supported yet
+#define __cpp_exceptions 1
+#endif
 
+#if ! __cpp_exceptions
+#include <cstdlib>
+#endif
 
 namespace celestia
 {
@@ -339,7 +346,11 @@ uintmax_t file_size(const path& p)
     std::error_code ec;
     uintmax_t s = file_size(p, ec);
     if (ec)
+#if __cpp_exceptions
         throw filesystem_error(ec, "celfs::file_size error");
+#else
+        std::abort();
+#endif
     return s;
 }
 
@@ -383,7 +394,11 @@ bool exists(const path& p)
     std::error_code ec;
     bool r = exists(p, ec);
     if (ec)
+#if __cpp_exceptions
         throw filesystem_error(ec, "celfs::exists error");
+#else
+        std::abort();
+#endif
     return r;
 }
 
@@ -415,7 +430,11 @@ bool is_directory(const path& p)
     std::error_code ec;
     bool r = is_directory(p, ec);
     if (ec)
+#if __cpp_exceptions
         throw filesystem_error(ec, "celfs::is_directory error");
+#else
+        std::abort();
+#endif
     return r;
 }
 

--- a/src/celcompat/sv.h
+++ b/src/celcompat/sv.h
@@ -18,6 +18,8 @@
 #if defined(_MSC_VER) && !defined(__clang__)
 // M$VC++ 2015 doesn't have required features
 #define CEL_CPP_VER (_MSC_VER == 1900 ? 201103L : _MSVC_LANG)
+// M$VC++ build without C++ exceptions are not supported yet
+#define __cpp_exceptions 1
 #else
 #define CEL_CPP_VER __cplusplus
 #endif
@@ -26,6 +28,10 @@
 #define CEL_constexpr constexpr
 #else
 #define CEL_constexpr /* constexpr */
+#endif
+
+#if ! __cpp_exceptions
+#include <cstdlib>
 #endif
 
 namespace std
@@ -101,8 +107,11 @@ template<
     {
         if (pos < size())
             return m_data[pos];
-
+#if __cpp_exceptions
         throw std::out_of_range("pos >= size()");
+#else
+        std::abort();
+#endif
     }
     constexpr const_reference front() const
     {
@@ -166,7 +175,11 @@ template<
     size_type copy(CharT* dest, size_type count, size_type pos = 0) const
     {
         if (pos > m_size)
+#if __cpp_exceptions
             throw std::out_of_range("pos >= size()");
+#else
+            std::abort();
+#endif
 
         auto rcount = std::min(count, m_size - pos);
         return Traits::copy(dest, m_data + pos, rcount);
@@ -174,7 +187,11 @@ template<
     CEL_constexpr basic_string_view substr(size_type pos = 0, size_type count = npos ) const
     {
         if (pos > m_size)
+#if __cpp_exceptions
             throw std::out_of_range("pos >= size()");
+#else
+            std::abort();
+#endif
 
         auto rcount = std::min(count, m_size - pos);
         return { m_data + pos, rcount };

--- a/src/celcompat/sv.h
+++ b/src/celcompat/sv.h
@@ -511,7 +511,7 @@ struct hash<string_view>
         }
         return _hash;
 #else
-        fnv1a_loop_helper(sv.data(), sv.data() + sv.length());
+        return fnv1a_loop_helper(sv.data(), sv.data() + sv.length());
 #endif
     }
 };

--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -9,6 +9,7 @@
 
 #include <celutil/gettext.h>
 #include <celutil/debug.h>
+#include <celutil/util.h>
 #include "stardb.h"
 #include "asterism.h"
 #include "parser.h"

--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -7,7 +7,6 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <config.h>
 #include <celutil/gettext.h>
 #include <celutil/debug.h>
 #include "stardb.h"

--- a/src/celengine/astro.cpp
+++ b/src/celengine/astro.cpp
@@ -106,7 +106,7 @@ static const char* MonthAbbrList[12] =
 
 struct UnitDefinition
 {
-    const char* name;
+    string_view name;
     double conversion;
 };
 
@@ -759,7 +759,7 @@ astro::TAItoJDUTC(double tai)
 
 
 // Get scale of given length unit in kilometers
-bool astro::getLengthScale(const string& unitName, double& scale)
+bool astro::getLengthScale(string_view unitName, double& scale)
 {
     unsigned int nUnits = sizeof(lengthUnits) / sizeof(lengthUnits[0]);
     bool foundMatch = false;
@@ -778,7 +778,7 @@ bool astro::getLengthScale(const string& unitName, double& scale)
 
 
 // Get scale of given time unit in days
-bool astro::getTimeScale(const string& unitName, double& scale)
+bool astro::getTimeScale(string_view unitName, double& scale)
 {
     for (const auto& timeUnit : timeUnits)
     {
@@ -794,7 +794,7 @@ bool astro::getTimeScale(const string& unitName, double& scale)
 
 
 // Get scale of given angle unit in degrees
-bool astro::getAngleScale(const string& unitName, double& scale)
+bool astro::getAngleScale(string_view unitName, double& scale)
 {
     for (const auto& angleUnit : angleUnits)
     {
@@ -809,7 +809,7 @@ bool astro::getAngleScale(const string& unitName, double& scale)
 }
 
 
-bool astro::getMassScale(const string& unitName, double& scale)
+bool astro::getMassScale(string_view unitName, double& scale)
 {
     for (const auto& massUnit : massUnits)
     {
@@ -825,31 +825,31 @@ bool astro::getMassScale(const string& unitName, double& scale)
 
 
 // Check if unit is a length unit
-bool astro::isLengthUnit(string unitName)
+bool astro::isLengthUnit(string_view unitName)
 {
     double dummy;
-    return getLengthScale(std::move(unitName), dummy);
+    return getLengthScale(unitName, dummy);
 }
 
 
 // Check if unit is a time unit
-bool astro::isTimeUnit(string unitName)
+bool astro::isTimeUnit(string_view unitName)
 {
     double dummy;
-    return getTimeScale(std::move(unitName), dummy);
+    return getTimeScale(unitName, dummy);
 }
 
 
 // Check if unit is an angle unit
-bool astro::isAngleUnit(string unitName)
+bool astro::isAngleUnit(string_view unitName)
 {
     double dummy;
-    return getAngleScale(std::move(unitName), dummy);
+    return getAngleScale(unitName, dummy);
 }
 
 
-bool astro::isMassUnit(string unitName)
+bool astro::isMassUnit(string_view unitName)
 {
     double dummy;
-    return getMassScale(std::move(unitName), dummy);
+    return getMassScale(unitName, dummy);
 }

--- a/src/celengine/astro.cpp
+++ b/src/celengine/astro.cpp
@@ -382,11 +382,16 @@ const char* astro::Date::toCStr(Format format) const
 {
     static char date[255];
 
+    if (format == ISO8601)
+    {
+        snprintf(date, sizeof(date), "%04d-%02d-%02dT%02d:%02d:%08.5fZ",
+                 year, month, day, hour, minute, seconds);
+        return date;
+    }
     // MinGW's libraries don't have the tm_gmtoff and tm_zone fields for
     // struct tm.
 #if defined(__GNUC__) && !defined(_WIN32)
-    struct tm cal_time;
-    memset(&cal_time, 0, sizeof(cal_time));
+    struct tm cal_time {};
     cal_time.tm_year = year-1900;
     cal_time.tm_mon = month-1;
     cal_time.tm_mday = day;
@@ -477,7 +482,9 @@ bool astro::parseDate(const string& s, astro::Date& date)
     unsigned int minute = 0;
     double second = 0.0;
 
-    if (sscanf(s.c_str(), " %d %u %u %u:%u:%lf ",
+    if (sscanf(s.c_str(), "%d-%u-%uT%u:%u:%lf",
+               &year, &month, &day, &hour, &minute, &second) == 6 ||
+        sscanf(s.c_str(), " %d %u %u %u:%u:%lf ",
                &year, &month, &day, &hour, &minute, &second) == 6 ||
         sscanf(s.c_str(), " %d %u %u %u:%u ",
                &year, &month, &day, &hour, &minute) == 5 ||

--- a/src/celengine/astro.cpp
+++ b/src/celengine/astro.cpp
@@ -8,11 +8,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <cstring>
 #include <cmath>
 #include <iostream>
-#include <iomanip>
-#include <cstdio>
 #include <utility>
 #include <ctime>
 #include "astro.h"

--- a/src/celengine/astro.h
+++ b/src/celengine/astro.h
@@ -58,6 +58,7 @@ namespace astro
             Locale          = 0,
             TZName          = 1,
             UTCOffset       = 2,
+            ISO8601         = 3,
         };
 
         const char* toCStr(Format format = Locale) const;

--- a/src/celengine/astro.h
+++ b/src/celengine/astro.h
@@ -238,6 +238,23 @@ namespace astro
 
     constexpr const double SOLAR_IRRADIANCE = 1367.6; // Watts / m^2
     constexpr const double SOLAR_POWER      = 3.8462e26;  // in Watts
+
+
+    namespace literals
+    {
+    constexpr long double operator "" _au (long double au)
+    {
+        return AUtoKilometers(au);
+    }
+    constexpr long double operator "" _ly (long double ly)
+    {
+        return lightYearsToKilometers(ly);
+    }
+    constexpr long double operator "" _c (long double n)
+    {
+        return astro::speedOfLight * n;
+    }
+    }
 }
 
 // Convert a date structure to a Julian date

--- a/src/celengine/astro.h
+++ b/src/celengine/astro.h
@@ -42,8 +42,6 @@
 #define JUPITER_RADIUS 71492.0
 #define SOLAR_RADIUS   696000.0
 
-using namespace std;
-
 class UniversalCoord;
 
 namespace astro

--- a/src/celengine/astro.h
+++ b/src/celengine/astro.h
@@ -14,6 +14,7 @@
 #include <Eigen/Geometry>
 #include <iosfwd>
 #include <string>
+#include <celcompat/string_view.h>
 #include <celmath/mathlib.h>
 
 #define SOLAR_ABSMAG   4.83f
@@ -195,14 +196,14 @@ namespace astro
         return jd * SECONDS_PER_DAY;
     }
 
-    bool isLengthUnit(string unitName);
-    bool isTimeUnit(string unitName);
-    bool isAngleUnit(string unitName);
-    bool isMassUnit(string unitName);
-    bool getLengthScale(const string& unitName, double& scale);
-    bool getTimeScale(const string& unitName, double& scale);
-    bool getAngleScale(const string& unitName, double& scale);
-    bool getMassScale(const string& unitName, double& scale);
+    bool isLengthUnit(std::string_view unitName);
+    bool isTimeUnit(std::string_view unitName);
+    bool isAngleUnit(std::string_view unitName);
+    bool isMassUnit(std::string_view unitName);
+    bool getLengthScale(std::string_view unitName, double& scale);
+    bool getTimeScale(std::string_view unitName, double& scale);
+    bool getAngleScale(std::string_view unitName, double& scale);
+    bool getMassScale(std::string_view unitName, double& scale);
 
     void decimalToDegMinSec(double angle, int& degrees, int& minutes, double& seconds);
     double degMinSecToDecimal(int degrees, int minutes, double seconds);

--- a/src/celengine/constellation.cpp
+++ b/src/celengine/constellation.cpp
@@ -7,7 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <celutil/util.h>
+#include <celutil/stringutils.h>
 #include "constellation.h"
 
 using namespace std;

--- a/src/celengine/marker.cpp
+++ b/src/celengine/marker.cpp
@@ -108,9 +108,9 @@ void MarkerRepresentation::setSize(float size)
 }
 
 
-void MarkerRepresentation::setLabel(const std::string& label)
+void MarkerRepresentation::setLabel(std::string label)
 {
-    m_label = label;
+    m_label = std::move(label);
 }
 
 

--- a/src/celengine/marker.h
+++ b/src/celengine/marker.h
@@ -14,7 +14,6 @@
 #include <string>
 #include <celutil/color.h>
 #include <celengine/selection.h>
-#include <celutil/debug.h>
 
 class Renderer;
 struct Matrices;
@@ -42,11 +41,11 @@ public:
     MarkerRepresentation(Symbol symbol = MarkerRepresentation::Diamond,
                          float size = 10.0f,
                          Color color = Color::White,
-                         const std::string& label = "") :
+                         std::string label = {}) :
         m_symbol(symbol),
         m_size(size),
         m_color(color),
-        m_label(label)
+        m_label(std::move(label))
     {
     }
 
@@ -59,8 +58,8 @@ public:
     void setColor(Color);
     float size() const { return m_size; }
     void setSize(float size);
-    string label() const { return m_label; }
-    void setLabel(const std::string&);
+    const std::string& label() const { return m_label; }
+    void setLabel(std::string);
 
     void render(Renderer &r, float size, const Matrices &m) const;
 
@@ -68,7 +67,7 @@ private:
     Symbol m_symbol;
     float m_size;
     Color m_color;
-    string m_label;
+    std::string m_label;
 };
 
 

--- a/src/celengine/name.h
+++ b/src/celengine/name.h
@@ -17,7 +17,7 @@
 #include <map>
 #include <vector>
 #include <celutil/debug.h>
-#include <celutil/util.h>
+#include <celutil/stringutils.h>
 #include <celutil/utf8.h>
 #include <celengine/astroobj.h>
 

--- a/src/celengine/parseobject.h
+++ b/src/celengine/parseobject.h
@@ -34,7 +34,7 @@ enum class DataDisposition
 };
 
 
-bool ParseDate(Hash* hash, const string& name, double& jd);
+bool ParseDate(Hash* hash, const std::string& name, double& jd);
 
 Orbit* CreateOrbit(const Selection& centralObject,
                    Hash* planetData,

--- a/src/celengine/parser.cpp
+++ b/src/celengine/parser.cpp
@@ -13,6 +13,7 @@
 #include "tokenizer.h"
 #include "value.h"
 
+using namespace std;
 using namespace Eigen;
 using namespace celmath;
 

--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -19,6 +19,7 @@
 #include "render.h"
 #include "vecgl.h"
 
+using namespace std;
 using namespace Eigen;
 using namespace celmath;
 using namespace celestia;

--- a/src/celengine/timelinephase.cpp
+++ b/src/celengine/timelinephase.cpp
@@ -18,6 +18,7 @@
 #include "celephem/rotation.h"
 #include <cassert>
 
+using namespace std;
 
 TimelinePhase::TimelinePhase(Body* _body,
                              double _startTime,

--- a/src/celengine/tokenizer.cpp
+++ b/src/celengine/tokenizer.cpp
@@ -11,9 +11,12 @@
 #include <cctype>
 #include <cmath>
 #include <iomanip>
+#include <iostream>
 #include <celutil/utf8.h>
 #include "tokenizer.h"
 
+
+using namespace std;
 
 static bool issep(char c)
 {

--- a/src/celengine/tokenizer.h
+++ b/src/celengine/tokenizer.h
@@ -12,10 +12,7 @@
 #define _TOKENIZER_H_
 
 #include <string>
-#include <iostream>
-
-using namespace std;
-
+#include <iosfwd>
 
 class Tokenizer
 {
@@ -39,14 +36,14 @@ public:
         TokenEndUnits       = 14,
     };
 
-    Tokenizer(istream*);
+    Tokenizer(std::istream*);
 
     TokenType nextToken();
     TokenType getTokenType();
     void pushBack();
     double getNumberValue();
-    string getNameValue();
-    string getStringValue();
+    std::string getNameValue();
+    std::string getStringValue();
 
     int getLineNumber() const;
 
@@ -67,7 +64,7 @@ private:
         UnicodeEscapeState  = 11,
     };
 
-    istream* in;
+    std::istream* in;
 
     int nextChar { 0 };
     TokenType tokenType{ TokenBegin };
@@ -85,7 +82,7 @@ private:
 
     double numberValue{ 0.0 };
 
-    string textToken;
+    std::string textToken;
 
     int lineNum{ 1 };
 };

--- a/src/celengine/universe.h
+++ b/src/celengine/universe.h
@@ -62,10 +62,10 @@ class Universe
                        int nContexts = 0,
                        bool i18n = false) const;
     Selection findChildObject(const Selection& sel,
-                              const string& name,
+                              const std::string& name,
                               bool i18n = false) const;
     Selection findObjectInContext(const Selection& sel,
-                                  const string& name,
+                                  const std::string& name,
                                   bool i18n = false) const;
 
     std::vector<std::string> getCompletion(const std::string& s,

--- a/src/celengine/visibleregion.cpp
+++ b/src/celengine/visibleregion.cpp
@@ -20,6 +20,7 @@
 #include "vertexobject.h"
 #include "visibleregion.h"
 
+using namespace std;
 using namespace Eigen;
 using namespace celmath;
 

--- a/src/celestia/CMakeLists.txt
+++ b/src/celestia/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(CELESTIA_SOURCES
   celestiacore.cpp
   celestiacore.h
+  celestiastate.cpp
+  celestiastate.h
   configfile.cpp
   configfile.h
   destination.cpp

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -217,7 +217,7 @@ void CelestiaCore::activateFavorite(FavoritesEntry& fav)
     sim->setFrame(fav.coordSys, sim->getSelection());
 }
 
-void CelestiaCore::addFavorite(string name, string parentFolder, FavoritesList::iterator* iter)
+void CelestiaCore::addFavorite(const string &name, const string &parentFolder, FavoritesList::iterator* iter)
 {
     FavoritesList::iterator pos;
     if(!iter)
@@ -243,7 +243,7 @@ void CelestiaCore::addFavorite(string name, string parentFolder, FavoritesList::
     favorites->insert(pos, fav);
 }
 
-void CelestiaCore::addFavoriteFolder(string name, FavoritesList::iterator* iter)
+void CelestiaCore::addFavoriteFolder(const string &name, FavoritesList::iterator* iter)
 {
     FavoritesList::iterator pos;
     if(!iter)
@@ -1839,12 +1839,12 @@ void CelestiaCore::start()
 
 void CelestiaCore::start(double t)
 {
-    if (config->initScriptFile != "")
+    if (!config->initScriptFile.empty())
     {
         // using the KdeAlerter in runScript would create an infinite loop,
         // break it here by resetting config->initScriptFile:
         fs::path filename(config->initScriptFile);
-        config->initScriptFile = "";
+        config->initScriptFile = {};
         runScript(filename);
     }
 
@@ -1854,16 +1854,16 @@ void CelestiaCore::start(double t)
 
     sysTime = timer->getTime();
 
-    if (startURL != "")
+    if (!startURL.empty())
         goToUrl(startURL);
 }
 
-void CelestiaCore::setStartURL(string url)
+void CelestiaCore::setStartURL(const string &url)
 {
-    if (!url.substr(0,4).compare("cel:"))
+    if (!url.substr(0, 4).compare("cel:"))
     {
         startURL = url;
-        config->initScriptFile = "";
+        config->initScriptFile = {};
     }
     else
     {
@@ -2418,7 +2418,7 @@ Simulation* CelestiaCore::getSimulation() const
     return sim;
 }
 
-void CelestiaCore::showText(string s,
+void CelestiaCore::showText(const std::string &s,
                             int horig, int vorig,
                             int hoff, int voff,
                             double duration)
@@ -2439,7 +2439,7 @@ void CelestiaCore::showText(string s,
     messageDuration = duration;
 }
 
-int CelestiaCore::getTextWidth(string s) const
+int CelestiaCore::getTextWidth(const std::string &s) const
 {
     return titleFont->getWidth(s);
 }
@@ -2918,7 +2918,7 @@ static void displayPlanetInfo(Overlay& overlay,
 
         float density = body.getDensity();
         if (density > 0)
-            fmt::fprintf(overlay, _("Density: %.2f x 1000 kg/m^3\n"), density / 1000.0);
+            fmt::fprintf(overlay, _("Density: %.2f x 1000 kg/m^3\n"), density / 1000.0f);
 
         float planetTemp = body.getTemperature(t);
         if (planetTemp > 0)
@@ -2956,7 +2956,7 @@ static string getSelectionName(const Selection& sel, const Universe& univ)
     case Selection::Type_Location:
         return sel.location()->getName(false);
     default:
-        return "";
+        return {};
     }
 }
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -4441,17 +4441,13 @@ bool CelestiaCore::goToUrl(const string& urlStr)
 
 void CelestiaCore::addToHistory()
 {
-    Url* url = new Url(this);
     if (!history.empty() && historyCurrent < history.size() - 1)
     {
         // truncating history to current position
         while (historyCurrent != history.size() - 1)
-        {
-            delete history.back();
             history.pop_back();
-        }
     }
-    history.push_back(url);
+    history.emplace_back(this);
     historyCurrent = history.size() - 1;
     notifyWatchers(HistoryChanged);
 }
@@ -4468,7 +4464,7 @@ void CelestiaCore::back()
         historyCurrent = history.size()-1;
     }
     historyCurrent--;
-    history[historyCurrent]->goTo();
+    history[historyCurrent].goTo();
     notifyWatchers(HistoryChanged|RenderFlagsChanged|LabelFlagsChanged);
 }
 
@@ -4478,29 +4474,29 @@ void CelestiaCore::forward()
     if (history.size() == 0) return;
     if (historyCurrent == history.size()-1) return;
     historyCurrent++;
-    history[historyCurrent]->goTo();
+    history[historyCurrent].goTo();
     notifyWatchers(HistoryChanged|RenderFlagsChanged|LabelFlagsChanged);
 }
 
 
-const vector<Url*>& CelestiaCore::getHistory() const
+const vector<Url>& CelestiaCore::getHistory() const
 {
     return history;
 }
 
-vector<Url*>::size_type CelestiaCore::getHistoryCurrent() const
+vector<Url>::size_type CelestiaCore::getHistoryCurrent() const
 {
     return historyCurrent;
 }
 
-void CelestiaCore::setHistoryCurrent(vector<Url*>::size_type curr)
+void CelestiaCore::setHistoryCurrent(vector<Url>::size_type curr)
 {
     if (curr >= history.size()) return;
     if (historyCurrent == history.size()) {
         addToHistory();
     }
     historyCurrent = curr;
-    history[curr]->goTo();
+    history[curr].goTo();
     notifyWatchers(HistoryChanged|RenderFlagsChanged|LabelFlagsChanged);
 }
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -66,6 +66,7 @@
 
 using namespace Eigen;
 using namespace std;
+using namespace astro::literals;
 using namespace celmath;
 using namespace celestia::scripts;
 
@@ -762,16 +763,16 @@ void CelestiaCore::keyDown(int key, int modifiers)
         sim->setTargetSpeed(1000.0f);
         break;
     case Key_F4:
-        sim->setTargetSpeed((float) astro::speedOfLight);
+        sim->setTargetSpeed(1.0_c);
         break;
     case Key_F5:
-        sim->setTargetSpeed((float) astro::speedOfLight * 10.0f);
+        sim->setTargetSpeed(10.0_c);
         break;
     case Key_F6:
-        sim->setTargetSpeed(astro::AUtoKilometers(1.0f));
+        sim->setTargetSpeed(1.0_au);
         break;
     case Key_F7:
-        sim->setTargetSpeed(astro::lightYearsToKilometers(1.0f));
+        sim->setTargetSpeed(1.0_ly);
         break;
     case Key_F11:
         if (movieCapture != nullptr)
@@ -1324,7 +1325,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
             int hours, mins;
             float secs;
             string buf;
-            if (v.norm() >= 86400.0 * astro::speedOfLight)
+            if (v.norm() >= 86400.0_c)
             {
                 // Light travel time in years, if >= 1day
                 buf = fmt::sprintf(_("Light travel time:  %.4f yr"),
@@ -1353,7 +1354,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
         addToHistory();
 
         if (sim->getSelection().body() &&
-            (sim->getTargetSpeed() < 0.99 * astro::speedOfLight))
+            (sim->getTargetSpeed() < 0.99_c))
         {
             Vector3d v = sim->getSelection().getPosition(sim->getTime()).offsetFromKm(sim->getObserver().getPosition());
             lightTravelFlag = !lightTravelFlag;
@@ -1804,7 +1805,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
 void CelestiaCore::getLightTravelDelay(double distanceKm, int& hours, int& mins, float& secs)
 {
     // light travel time in hours
-    double lt = distanceKm / (3600.0 * astro::speedOfLight);
+    double lt = distanceKm / (3600.0_c);
     hours = (int) lt;
     double mm = (lt - hours) * 60;
     mins = (int) mm;
@@ -1815,7 +1816,7 @@ void CelestiaCore::getLightTravelDelay(double distanceKm, int& hours, int& mins,
 void CelestiaCore::setLightTravelDelay(double distanceKm)
 {
     // light travel time in days
-    double lt = distanceKm / (86400.0 * astro::speedOfLight);
+    double lt = distanceKm / (86400.0_c);
     sim->setTime(sim->getTime() - lt);
 }
 
@@ -2551,12 +2552,12 @@ static void displaySpeed(Overlay& overlay, float speed)
         n = SigDigitNum(speed, 3);
         u = _("km/s");
     }
-    else if (speed < (float) astro::speedOfLight * 100.0f)
+    else if (speed < (float) 100.0_c)
     {
         n = SigDigitNum(speed / astro::speedOfLight, 3);
         u = "c";
     }
-    else if (speed < astro::AUtoKilometers(1000.0f))
+    else if (speed < (float) 1000.0_au)
     {
         n = SigDigitNum(astro::kilometersToAU(speed), 3);
         u = _("AU/s");
@@ -3046,13 +3047,13 @@ void CelestiaCore::renderOverlay()
         double lt = 0.0;
 
         if (sim->getSelection().getType() == Selection::Type_Body &&
-            (sim->getTargetSpeed() < 0.99 * astro::speedOfLight))
+            (sim->getTargetSpeed() < 0.99_c))
         {
             if (lightTravelFlag)
             {
                 Vector3d v = sim->getSelection().getPosition(sim->getTime()).offsetFromKm(sim->getObserver().getPosition());
                 // light travel time in days
-                lt = v.norm() / (86400.0 * astro::speedOfLight);
+                lt = v.norm() / (86400.0_c);
             }
         }
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -4427,13 +4427,15 @@ void CelestiaCore::notifyWatchers(int property)
 
 bool CelestiaCore::goToUrl(const string& urlStr)
 {
-    Url url(urlStr, this);
-    bool ret = url.goTo();
-    if (ret)
-        notifyWatchers(RenderFlagsChanged | LabelFlagsChanged);
-    else
+    Url url(this);
+    if (!url.parse(urlStr))
+    {
         fatalError(_("Invalid URL"));
-    return ret;
+        return false;
+    }
+    url.goTo();
+    notifyWatchers(RenderFlagsChanged | LabelFlagsChanged);
+    return true;
 }
 
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -38,6 +38,7 @@
 #include <celutil/debug.h>
 #include <celutil/gettext.h>
 #include <celutil/utf8.h>
+#include <celutil/util.h>
 #include <celcompat/filesystem.h>
 #include <Eigen/Geometry>
 #include <iostream>

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2602,10 +2602,8 @@ static void displayDeclination(Overlay& overlay, double angle)
     double seconds;
     astro::decimalToDegMinSec(angle, degrees, minutes, seconds);
 
-    const char sign = angle < 0.0 ? '-' : '+';
-
-    fmt::fprintf(overlay, "Dec: %c%d%s %02d' %.1f\"\n",
-                          sign, abs(degrees), UTF8_DEGREE_SIGN,
+    fmt::fprintf(overlay, _("Dec: %+d%s %02d' %.1f\"\n"),
+                          abs(degrees), UTF8_DEGREE_SIGN,
                           abs(minutes), abs(seconds));
 }
 
@@ -2616,7 +2614,7 @@ static void displayRightAscension(Overlay& overlay, double angle)
     double seconds;
     astro::decimalToHourMinSec(angle, hours, minutes, seconds);
 
-    fmt::fprintf(overlay, "RA: %dh %02dm %.1fs\n",
+    fmt::fprintf(overlay, _("RA: %dh %02dm %.1fs\n"),
                           hours, abs(minutes), abs(seconds));
 }
 

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -195,9 +195,9 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     void addToHistory();
     void back();
     void forward();
-    const std::vector<Url*>& getHistory() const;
-    std::vector<Url*>::size_type getHistoryCurrent() const;
-    void setHistoryCurrent(std::vector<Url*>::size_type curr);
+    const std::vector<Url>& getHistory() const;
+    std::vector<Url>::size_type getHistoryCurrent() const;
+    void setHistoryCurrent(std::vector<Url>::size_type curr);
 
     // event processing methods
     void charEntered(const char*, int modifiers = 0);
@@ -479,8 +479,8 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     ContextMenuHandler* contextMenuHandler{ nullptr };
     TextDisplayHandler* textDisplayHandler{ nullptr };
 
-    std::vector<Url*> history;
-    std::vector<Url*>::size_type historyCurrent{ 0 };
+    std::vector<Url> history;
+    std::vector<Url>::size_type historyCurrent{ 0 };
     std::string startURL;
 
     std::list<View*> views;

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -11,6 +11,7 @@
 #define _CELESTIACORE_H_
 
 #include <fstream>
+#include <string>
 #include <celutil/filetype.h>
 #include <celutil/timer.h>
 #include <celutil/watcher.h>
@@ -189,7 +190,7 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     void setLightTravelDelay(double distanceKm);
 
     // URLs and history navigation
-    void setStartURL(std::string url);
+    void setStartURL(const std::string& url);
     bool goToUrl(const std::string& urlStr);
     void addToHistory();
     void back();
@@ -218,17 +219,17 @@ class CelestiaCore // : public Watchable<CelestiaCore>
 
     Simulation* getSimulation() const;
     Renderer* getRenderer() const;
-    void showText(std::string s,
+    void showText(const std::string &s,
                   int horig = 0, int vorig = 0,
                   int hoff = 0, int voff = 0,
                   double duration = 1.0e9);
-    int getTextWidth(string s) const;
+    int getTextWidth(const std::string &s) const;
 
     void readFavoritesFile();
     void writeFavoritesFile();
     void activateFavorite(FavoritesEntry&);
-    void addFavorite(std::string, std::string, FavoritesList::iterator* iter=nullptr);
-    void addFavoriteFolder(std::string, FavoritesList::iterator* iter=nullptr);
+    void addFavorite(const std::string&, const std::string&, FavoritesList::iterator* iter=nullptr);
+    void addFavoriteFolder(const std::string&, FavoritesList::iterator* iter=nullptr);
     FavoritesList* getFavorites();
 
     bool viewUpdateRequired() const;
@@ -493,7 +494,7 @@ class CelestiaCore // : public Watchable<CelestiaCore>
 
     float pickTolerance { 4.0f };
 
-    unique_ptr<ViewportEffect> viewportEffect { nullptr };
+    std::unique_ptr<ViewportEffect> viewportEffect { nullptr };
     bool isViewportEffectUsed { false };
 
     struct EdgeInsets
@@ -507,7 +508,7 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     EdgeInsets safeAreaInsets { 0, 0, 0, 0 };
 
     Selection lastSelection;
-    string selectionNames;
+    std::string selectionNames;
 
     std::unique_ptr<Console> console;
     std::ofstream m_logfile;

--- a/src/celestia/celestiastate.cpp
+++ b/src/celestia/celestiastate.cpp
@@ -1,0 +1,59 @@
+// celestiastate.cpp
+//
+// Copyright (C) 2002-present, the Celestia Development Team
+// Original version written by Chris Teyssier (chris@tux.teyssier.org)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "celestiacore.h"
+#include "celestiastate.h"
+#include "url.h"
+
+using namespace celmath;
+
+
+CelestiaState::CelestiaState(CelestiaCore* appCore) :
+    m_appCore(appCore)
+{
+}
+
+void CelestiaState::captureState()
+{
+    auto *sim = m_appCore->getSimulation();
+    auto *renderer = m_appCore->getRenderer();
+
+    auto frame = sim->getFrame();
+
+    m_coordSys = frame->getCoordinateSystem();
+    if (m_coordSys != ObserverFrame::Universal)
+    {
+        m_refBodyName = Url::getEncodedObjectName(frame->getRefObject(), m_appCore);
+        if (m_coordSys == ObserverFrame::PhaseLock)
+            m_targetBodyName = Url::getEncodedObjectName(frame->getTargetObject(), m_appCore);
+    }
+
+    m_tdb = sim->getTime();
+
+    // Store the position and orientation of the observer in the current
+    // frame.
+    m_observerPosition = sim->getObserver().getPosition();
+    m_observerPosition = frame->convertFromUniversal(m_observerPosition, m_tdb);
+
+    Eigen::Quaterniond q = sim->getObserver().getOrientation();
+    q = frame->convertFromUniversal(q, m_tdb);
+    m_observerOrientation = q.cast<float>();
+
+    auto tracked = sim->getTrackedObject();
+    m_trackedBodyName = Url::getEncodedObjectName(tracked, m_appCore);
+    auto selected = sim->getSelection();
+    m_selectedBodyName = Url::getEncodedObjectName(selected, m_appCore);
+    m_fieldOfView = radToDeg(sim->getActiveObserver()->getFOV());
+    m_timeScale = static_cast<float>(sim->getTimeScale());
+    m_pauseState = sim->getPauseState();
+    m_lightTimeDelay = m_appCore->getLightDelayActive();
+    m_renderFlags = renderer->getRenderFlags();
+    m_labelMode = renderer->getLabelMode();
+}

--- a/src/celestia/celestiastate.h
+++ b/src/celestia/celestiastate.h
@@ -1,0 +1,67 @@
+// celestiastate.h
+//
+// Copyright (C) 2002-present, the Celestia Development Team
+// Original version written by Chris Teyssier (chris@tux.teyssier.org)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <Eigen/Geometry>
+#include <celengine/observer.h>
+
+class CelestiaCore;
+
+/*! The CelestiaState class holds the current observer position, orientation,
+ *  frame, time, and render settings. It is designed to be serialized as a cel
+ *  URL, thus strings are stored for bodies instead of Selections.
+ *
+ *  Some information is *not* stored in cel URLs, including the current
+ *  lists of reference marks and markers. Such lists can be arbitrarily long,
+ *  and thus not practical to store in a URL.
+ */
+class CelestiaState
+{
+ public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    CelestiaState() = default;
+    CelestiaState(CelestiaCore* appCore);
+    ~CelestiaState() = default;
+    // FIXME
+
+    bool loadState(std::map<std::string, std::string> &params);
+    void saveState(std::map<std::string, std::string> &params);
+    void captureState();
+
+ private:
+    // Observer frame, position, and orientation. For multiview, there needs
+    // be one instance of these parameters per view saved.
+    ObserverFrame::CoordinateSystem m_coordSys              { ObserverFrame::Universal };
+    UniversalCoord                  m_observerPosition      { 0.0, 0.0, 0.0 };
+    Eigen::Quaternionf              m_observerOrientation   { Eigen::Quaternionf::Identity() };
+    float                           m_fieldOfView           { 45.0f };
+
+    // Time parameters
+    double                          m_tdb                   { 0.0 };
+    float                           m_timeScale             { 1.0f };
+    bool                            m_pauseState            { false };
+    bool                            m_lightTimeDelay        { false };
+
+    std::string                     m_refBodyName;
+    std::string                     m_targetBodyName;
+    std::string                     m_trackedBodyName;
+    std::string                     m_selectedBodyName;
+
+    int                             m_labelMode             { 0 };
+    uint64_t                        m_renderFlags           { 0 };
+
+    CelestiaCore                   *m_appCore               { nullptr };
+
+    friend class Url;
+};

--- a/src/celestia/destination.cpp
+++ b/src/celestia/destination.cpp
@@ -10,6 +10,7 @@
 #include <config.h>
 #include <algorithm>
 #include <celutil/debug.h>
+#include <celutil/stringutils.h>
 #include <celutil/util.h>
 #include <celengine/astro.h>
 #include <celengine/parser.h>

--- a/src/celestia/eclipsefinder.h
+++ b/src/celestia/eclipsefinder.h
@@ -52,7 +52,7 @@ class EclipseFinder
     void findEclipses(double startDate,
                       double endDate,
                       int eclipseTypeMask,
-                      vector<Eclipse>& eclipses);
+                      std::vector<Eclipse>& eclipses);
  private:
     Body* body;
     EclipseFinderWatcher* watcher;

--- a/src/celestia/glut/glutmain.cpp
+++ b/src/celestia/glut/glutmain.cpp
@@ -30,6 +30,7 @@
 #include <fmt/printf.h>
 #include <celutil/gettext.h>
 #include <celutil/debug.h>
+#include <celutil/util.h>
 #include <celmath/mathlib.h>
 #include <celengine/astro.h>
 #include <celestia/celestiacore.h>

--- a/src/celestia/helper.cpp
+++ b/src/celestia/helper.cpp
@@ -5,6 +5,7 @@
 #include <celutil/gettext.h>
 #include "helper.h"
 
+using namespace std;
 
 constexpr const int SpacecraftPrimaryBody = Body::Planet | Body::DwarfPlanet | Body::Moon |
                                             Body::MinorMoon | Body::Asteroid | Body::Comet;

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -58,8 +58,9 @@
 #include "qtsettimedialog.h"
 #include "qtgotoobjectdialog.h"
 //#include "qtvideocapturedialog.h"
-#include "celestia/scriptmenu.h"
-#include "celestia/url.h"
+#include <celestia/celestiastate.h>
+#include <celestia/scriptmenu.h>
+#include <celestia/url.h>
 #include "qtbookmark.h"
 
 #if defined(_WIN32)
@@ -743,10 +744,10 @@ void CelestiaAppWindow::slotCopyImage()
 
 void CelestiaAppWindow::slotCopyURL()
 {
-    CelestiaState appState;
-    appState.captureState(m_appCore);
+    CelestiaState appState(m_appCore);
+    appState.captureState();
 
-    Url url(appState, Url::CurrentVersion);
+    Url url(appState);
     QApplication::clipboard()->setText(url.getAsString().c_str());
     m_appCore->flash(_("Copied URL"));
 }
@@ -956,8 +957,8 @@ void CelestiaAppWindow::slotAddBookmark()
     if (defaultTitle.isEmpty())
         defaultTitle = _("New bookmark");
 
-    CelestiaState appState;
-    appState.captureState(m_appCore);
+    CelestiaState appState(m_appCore);
+    appState.captureState();
 
     // Capture the current frame buffer to use as a bookmark icon.
     QImage grabbedImage = glWidget->grabFrameBuffer();

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -43,6 +43,7 @@
 #include <string>
 #include <cassert>
 #include <celutil/gettext.h>
+#include <celutil/util.h>
 #include "qtappwin.h"
 #include "qtglwidget.h"
 #include "qtpreferencesdialog.h"

--- a/src/celestia/qt/qtinfopanel.cpp
+++ b/src/celestia/qt/qtinfopanel.cpp
@@ -20,6 +20,7 @@
 #include <QItemSelection>
 #include "qtinfopanel.h"
 
+using namespace std;
 using namespace Eigen;
 using namespace celmath;
 

--- a/src/celestia/sdl/sdlmain.cpp
+++ b/src/celestia/sdl/sdlmain.cpp
@@ -6,6 +6,7 @@
 #include <fmt/printf.h>
 #include <celengine/glsupport.h>
 #include <celutil/gettext.h>
+#include <celutil/util.h>
 #include <SDL.h>
 #ifdef GL_ES
 #include <SDL_opengles2.h>

--- a/src/celestia/url.cpp
+++ b/src/celestia/url.cpp
@@ -1,703 +1,68 @@
-/***************************************************************************
-                          url.cpp  -  description
-                             -------------------
-    begin                : Wed Aug 7 2002
-    copyright            : (C) 2002 by chris
-    email                : chris@tux.teyssier.org
- ***************************************************************************/
+// url.cpp
+//
+// Copyright (C) 2002-present, the Celestia Development Team
+// Original version written by Chris Teyssier (chris@tux.teyssier.org)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
 
-/***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
-
-#include <string>
-#include <cassert>
-#include <sstream>
-#include <iomanip>
-#include <utility>
-#include <celengine/astro.h>
-#include <celutil/debug.h>
+#include <iostream>
+#include <fmt/printf.h>
+#include <celcompat/charconv.h>
+#include <celutil/bigfix.h>
 #include <celutil/gettext.h>
+#include <celutil/stringutils.h>
 #include "celestiacore.h"
 #include "url.h"
 
-using namespace Eigen;
-using namespace std;
-using namespace celmath;
-
-constexpr const uint64_t NewRenderFlags = Renderer::ShowDwarfPlanets |
-                                          Renderer::ShowMoons        |
-                                          Renderer::ShowMinorMoons   |
-                                          Renderer::ShowAsteroids    |
-                                          Renderer::ShowComets       |
-                                          Renderer::ShowSpacecrafts;
-
-
-const string getEncodedObjectName(const Selection& sel, const CelestiaCore* appCore);
-
-void
-CelestiaState::captureState(CelestiaCore* appCore)
+namespace
 {
-    Simulation *sim = appCore->getSimulation();
-    Renderer *renderer = appCore->getRenderer();
 
-    auto frame = sim->getFrame();
-
-    coordSys = frame->getCoordinateSystem();
-    if (coordSys != ObserverFrame::Universal)
-    {
-        refBodyName = getEncodedObjectName(frame->getRefObject(), appCore);
-        if (coordSys == ObserverFrame::PhaseLock)
-        {
-            targetBodyName = getEncodedObjectName(frame->getTargetObject(), appCore);
-        }
-    }
-
-    tdb = sim->getTime();
-
-    // Store the position and orientation of the observer in the current
-    // frame.
-    observerPosition = sim->getObserver().getPosition();
-    observerPosition = frame->convertFromUniversal(observerPosition, tdb);
-
-    Quaterniond q = sim->getObserver().getOrientation();
-    q = frame->convertFromUniversal(q, tdb);
-    observerOrientation = q.cast<float>();
-
-    Selection tracked = sim->getTrackedObject();
-    trackedBodyName = getEncodedObjectName(tracked, appCore);
-    Selection selected = sim->getSelection();
-    selectedBodyName = getEncodedObjectName(selected, appCore);
-    fieldOfView = radToDeg(sim->getActiveObserver()->getFOV());
-    timeScale = (float) sim->getTimeScale();
-    pauseState = sim->getPauseState();
-    lightTimeDelay = appCore->getLightDelayActive();
-    renderFlags = renderer->getRenderFlags();
-    labelMode = renderer->getLabelMode();
-}
-
-
-#if 0
-bool CelestiaState::loadState(std::map<std::string, std::string> params)
+std::string getBodyName(Universe* universe, Body* body)
 {
-    sscanf(timeString.c_str(), "%d-%d-%dT%d:%d:%lf",
-           &date.year, &date.month, &date.day,
-           &date.hour, &date.minute, &date.seconds);
+    std::string name = body->getName();
+    PlanetarySystem* parentSystem = body->getSystem();
+    const Body* parentBody = nullptr;
 
-    observerPosition = UniversalCoord(BigFix(params["x"]),
-                                      BigFix(params["y"]),
-                                      BigFix(params["z"]));
-
-    float ow = 0.0f;
-    float ox = 0.0f;
-    float oy = 0.0f;
-    float oz = 0.0f;
-    if (sscanf(params["ow"].c_str(), "%f", &ow) != 1 ||
-        sscanf(params["ox"].c_str(), "%f", &ox) != 1 ||
-        sscanf(params["oy"].c_str(), "%f", &oy) != 1 ||
-        sscanf(params["oz"].c_str(), "%f", &oz) != 1)
-    {
-        return false;
-    }
-
-    orientation = Quatf(ow, ox, oy, oz);
-
-    if (params.count("select") != 0)
-        selectedBodyName = params["select"];
-    if (params.count("track") != 0)
-        trackedBodyName = params["track"];
-    if (params.count("ltd") != 0)
-        lightTimeDelay = (strcmp(params["ltd"].c_str(), "1") == 0);
+    if (parentSystem != nullptr)
+        parentBody = parentSystem->getPrimaryBody();
     else
-        lightTimeDelay = false;
+        assert(0);
+        // TODO: Figure out why the line below was added.
+        //parentBody = body->getOrbitBarycenter();
 
-    if (params.count("fov") != 0)
+    while (parentBody != nullptr)
     {
-        if (sscanf(params["fov"].c_str(), "%f", &fieldOfView) != 1.0f)
-            return false;
-    }
-
-    if (params.count("ts") != 0)
-    {
-        if (sscanf(params["ts"].c_str(), "%f", &timeScale) != 1.0f)
-            return false;
-    }
-
-    int paused = 0;
-    if (params.count("p") != 0)
-    {
-        if (sscanf(params["p"].c_str(), "%d", &paused) != 1)
-            return false;
-        if (paused != 0 && paused != 1)
-            return false;
-        pauseState = paused == 1;
-    }
-
-    // Render settings
-    if (params.count("rf") != 0)
-    {
-        if (sscanf(params["rf"].c_str(), "%d", &renderFlags) != 1)
-            return false;
-    }
-    if (params.count("lm") != 0)
-    {
-        if (sscanf(params["lm"].c_str(), "%d", &labelMode) != 1)
-            return false;
-    }
-}
-#endif
-
-
-Url::Url(std::string str, CelestiaCore *core):
-    urlStr(std::move(str)),
-    appCore(core)
-{
-    if (urlStr.compare(0, 6, "cel://") != 0)
-    {
-        urlStr.clear();
-        return;
-    }
-
-    std::map<std::string, std::string> params = parseUrlParams(urlStr);
-    if (params.empty())
-    {
-        urlStr.clear();
-        return;
-    }
-
-    // Version labelling of cel URLs was only added in Celestia 1.5, cel URL
-    // version 2. Assume any URL without a version is version 1.
-    version = params.count("ver") == 0 ? 1 : (unsigned) stoi(params["ver"]);
-
-    auto pos = urlStr.find('/', 6);
-    if (pos == std::string::npos)
-        pos = urlStr.find('?', 6);
-
-    if (pos == std::string::npos)
-        modeStr = urlStr.substr(6);
-    else
-        modeStr = decodeString(urlStr.substr(6, pos - 6));
-
-    if (!compareIgnoringCase(modeStr, "Freeflight"))
-    {
-        mode = ObserverFrame::Universal;
-        nbBodies = 0;
-    }
-    else if (!compareIgnoringCase(modeStr, "Follow"))
-    {
-        mode = ObserverFrame::Ecliptical;
-        nbBodies = 1;
-    }
-    else if (!compareIgnoringCase(modeStr, "SyncOrbit"))
-    {
-        mode = ObserverFrame::BodyFixed;
-        nbBodies = 1;
-    }
-    else if (!compareIgnoringCase(modeStr, "Chase"))
-    {
-        mode = ObserverFrame::Chase;
-        nbBodies = 1;
-    }
-    else if (!compareIgnoringCase(modeStr, "PhaseLock"))
-    {
-        mode = ObserverFrame::PhaseLock;
-        nbBodies = 2;
-    }
-    else if (!compareIgnoringCase(modeStr, "Settings"))
-    {
-        type = Settings;
-        nbBodies = 0;
-    }
-
-    if (nbBodies == -1)
-    {
-        urlStr.clear();
-        return; // Mode not recognized
-    }
-
-    auto endPrevious = pos;
-    int nb = nbBodies, i = 1;
-    std::vector<Selection> bodies;
-    auto *sim = appCore->getSimulation();
-
-    while (nb != 0 && endPrevious != std::string::npos)
-    {
-        std::string bodyName;
-        pos = urlStr.find('/', endPrevious + 1);
-        if (pos == std::string::npos)
-            pos = urlStr.find('?', endPrevious + 1);
-        if (pos == std::string::npos)
-            bodyName = urlStr.substr(endPrevious + 1);
-        else
-            bodyName = urlStr.substr(endPrevious + 1, pos - endPrevious - 1);
-        endPrevious = pos;
-
-        bodyName = decodeString(bodyName);
-        pos = 0;
-        if (i==1) body1 = bodyName;
-        if (i==2) body2 = bodyName;
-        while (pos != std::string::npos)
-        {
-            pos = bodyName.find(":", pos + 1);
-            if (pos != std::string::npos)
-                bodyName[pos] = '/';
-        }
-
-        bodies.push_back(sim->findObjectFromPath(bodyName));
-
-        nb--;
-        i++;
-    }
-
-    if (nb != 0)
-    {
-        urlStr.clear();
-        return; // Number of bodies in Url doesn't match Mode
-    }
-
-    switch (nbBodies)
-    {
-    case 0:
-        ref = ObserverFrame();
-        break;
-    case 1:
-        ref = ObserverFrame(mode, bodies[0]);
-        break;
-    case 2:
-        ref = ObserverFrame(mode, bodies[0], bodies[1]);
-        break;
-    default:
-        break;
-    }
-    fromString = true;
-
-    std::string time;
-    pos = urlStr.find('?', endPrevious + 1);
-    if (pos == std::string::npos)
-        time = urlStr.substr(endPrevious + 1);
-    else
-        time = urlStr.substr(endPrevious + 1, pos - endPrevious -1);
-    time = decodeString(time);
-
-    try
-    {
-        switch (version)
-        {
-        case 1:
-        case 2:
-            initVersion2(params, time);
+        name = parentBody->getName() + ":" + name;
+        parentSystem = parentBody->getSystem();
+        if (parentSystem == nullptr)
             break;
-        case 3:
-        case 4:
-            // Version 4 has only render flags defined as uint64_t
-            initVersion3(params, time);
-            break;
-        default:
-            urlStr.clear();
-            return;
-        }
-    }
-    catch (...)
-    {
-        urlStr.clear();
-        return;
+        parentBody = parentSystem->getPrimaryBody();
     }
 
-    evalName();
-}
+    auto *star = body->getSystem()->getStar();
+    if (star != nullptr)
+        name = universe->getStarCatalog()->getStarName(*star) + ":" + name;
 
-
-Url::Url(CelestiaCore* core, UrlType type)
-{
-    appCore = core;
-    timeSource = UseUrlTime;
-
-    Simulation *sim = appCore->getSimulation();
-    Renderer *renderer = appCore->getRenderer();
-
-    this->type = type;
-
-    modeStr = getCoordSysName(sim->getFrame()->getCoordinateSystem());
-    if (type == Settings) modeStr = "Settings";
-    ref = *sim->getFrame();
-    urlStr += "cel://" + modeStr;
-    if (type != Settings && sim->getFrame()->getCoordinateSystem() != ObserverFrame::Universal) {
-        body1 = getEncodedObjectName(sim->getFrame()->getRefObject());
-        urlStr += "/" + body1;
-        if (sim->getFrame()->getCoordinateSystem() == ObserverFrame::PhaseLock) {
-            body2 = getEncodedObjectName(sim->getFrame()->getTargetObject());
-            urlStr += "/" + body2;
-        }
-    }
-
-    double simTime = sim->getTime();
-
-    string date_str;
-    date = astro::Date(simTime);
-
-    switch (type) {
-    case Absolute:
-        date_str = fmt::sprintf("%04d-%02d-%02dT%02d:%02d:%08.5f",
-            date.year, date.month, date.day, date.hour, date.minute, date.seconds);
-
-        coord = sim->getObserver().getPosition();
-        urlStr += std::string("/") + date_str + "?x=" + coord.x.toString();
-        urlStr += "&y=" +  coord.y.toString();
-        urlStr += "&z=" +  coord.z.toString();
-
-        orientation = sim->getObserver().getOrientationf();
-        urlStr += fmt::sprintf("&ow=%f&ox=%f&oy=%f&oz=%f", orientation.w(), orientation.x(), orientation.y(), orientation.z());
-        break;
-    case Relative:
-        sim->getSelectionLongLat(distance, longitude, latitude);
-        urlStr += fmt::sprintf("/?dist=%f&long=%f&lat=%f", distance, longitude, latitude);
-        break;
-    case Settings:
-        urlStr += std::string("/?");
-        break;
-    }
-
-    switch (type) {
-    case Absolute: // Intentional Fall-Through
-    case Relative:
-        tracked = sim->getTrackedObject();
-        trackedStr = getEncodedObjectName(tracked);
-        if (trackedStr != "") urlStr += "&track=" + trackedStr;
-
-        selected = sim->getSelection();
-        selectedStr = getEncodedObjectName(selected);
-        if (selectedStr != "") urlStr += "&select=" + selectedStr;
-
-        fieldOfView = radToDeg(sim->getActiveObserver()->getFOV());
-        timeScale = (float) sim->getTimeScale();
-        pauseState = sim->getPauseState();
-        lightTimeDelay = appCore->getLightDelayActive();
-        urlStr += fmt::sprintf("&fov=%f&ts=%f&ltd=%c&p=%c&", fieldOfView,
-                               timeScale, lightTimeDelay ? '1' : '0',
-                               pauseState ? '1' : '0');
-    case Settings: // Intentional Fall-Through
-        renderFlags = renderer->getRenderFlags();
-        labelMode = renderer->getLabelMode();
-        if (version >= 4)
-            urlStr += fmt::sprintf("rf=%lu&lm=%d", renderFlags, labelMode);
-        else
-            urlStr += fmt::sprintf("rf=%d&lm=%d", (int) (renderFlags & 0xffffffff), labelMode);
-        break;
-    }
-
-    // Append the Celestia URL version
-    urlStr += fmt::sprintf("&ver=%u", version);
-
-    evalName();
-}
-
-
-/*! Construct a new cel URL from a saved CelestiaState object. This method may
- *  may only be called to create a version 3 or later url.
- */
-Url::Url(const CelestiaState& appState, unsigned int _version, TimeSource _timeSource)
-{
-    ostringstream u;
-
-    appCore = nullptr;
-
-    assert(_version >= 3);
-    version = _version;
-    timeSource = _timeSource;
-    type = Absolute;
-
-    modeStr      = getCoordSysName(appState.coordSys);
-    body1        = appState.refBodyName;
-    body2        = appState.targetBodyName;
-    selectedStr  = appState.selectedBodyName;
-    trackedStr   = appState.trackedBodyName;
-
-    coord        = appState.observerPosition;
-    orientation  = appState.observerOrientation;
-
-    //ref =
-    //selected =
-    //tracked =
-    nbBodies = 1;
-    if (appState.coordSys == ObserverFrame::Universal)
-        nbBodies = 0;
-    else if (appState.coordSys ==  ObserverFrame::PhaseLock)
-        nbBodies = 2;
-
-    fieldOfView      = appState.fieldOfView;
-    renderFlags      = appState.renderFlags;
-    labelMode        = appState.labelMode;
-
-    date             = astro::Date(appState.tdb);
-    timeScale        = appState.timeScale;
-    pauseState       = appState.pauseState;
-    lightTimeDelay   = appState.lightTimeDelay;
-
-    u << "cel://" << modeStr;
-
-    if (appState.coordSys != ObserverFrame::Universal)
-    {
-        u << "/" << appState.refBodyName;
-        if (appState.coordSys == ObserverFrame::PhaseLock)
-        {
-            u << "/" << appState.targetBodyName;
-        }
-    }
-
-    string date_str;
-    date_str = fmt::sprintf("%04d-%02d-%02dT%02d:%02d:%08.5f",
-                            date.year, date.month, date.day, date.hour, date.minute, date.seconds);
-    u << "/" << date_str;
-
-    // observer position
-    u << "?x=" << coord.x.toString() << "&y=" << coord.y.toString() << "&z=" << coord.z.toString();
-
-    // observer orientation
-    u << "&ow=" << orientation.w()
-      << "&ox=" << orientation.x()
-      << "&oy=" << orientation.y()
-      << "&oz=" << orientation.z();
-
-    if (trackedStr != "")
-        u << "&track=" << trackedStr;
-    if (selectedStr != "")
-        u << "&select=" << selectedStr;
-
-    u << "&fov=" << fieldOfView;
-    u << "&ts=" << timeScale;
-    u << "&ltd=" << (lightTimeDelay ? 1 : 0);
-    u << "&p=" << (pauseState ? 1 : 0);
-
-    if (_version >= 4)
-        u << "&rf=" << renderFlags;
-    else
-        u << "&rf=" << (int) (renderFlags & 0xffffffff);
-    u << "&lm=" << labelMode;
-
-    // Append the url settings: time source and version
-    u << "&tsrc=" << (int) timeSource;
-    u << "&ver=" << version;
-
-    urlStr = u.str();
-
-    evalName();
-}
-
-
-void Url::initVersion2(std::map<std::string, std::string>& params,
-                       const std::string& timeString)
-{
-    if (type != Settings)
-    {
-        if (params.count("dist") != 0)
-            type = Relative;
-        else
-            type = Absolute;
-    }
-
-    switch (type) {
-        case Absolute:
-            date = astro::Date(0.0);
-            sscanf(timeString.c_str(), "%d-%d-%dT%d:%d:%lf",
-                   &date.year, &date.month, &date.day,
-                   &date.hour, &date.minute, &date.seconds);
-
-            coord = UniversalCoord(BigFix(params["x"]),
-                                   BigFix(params["y"]),
-                                   BigFix(params["z"]));
-
-            float ow, ox, oy, oz;
-            ow = stof(params["ow"]);
-            ox = stof(params["ox"]);
-            oy = stof(params["oy"]);
-            oz = stof(params["oz"]);
-
-            orientation = Quaternionf(ow, ox, oy, oz);
-
-            // Intentional Fall-Through
-        case Relative:
-            if (params.count("dist") != 0)
-                distance = stof(params["dist"]);
-            if (params.count("long") != 0)
-                longitude = stof(params["long"]);
-            if (params.count("lat") != 0)
-                latitude = stof(params["lat"]);
-            if (params.count("select") != 0)
-                selectedStr = params["select"];
-            if (params.count("track") != 0)
-                trackedStr = params["track"];
-            if (params.count("fov") != 0)
-                fieldOfView = stof(params["fov"]);
-            if (params.count("ts") != 0)
-                timeScale = stof(params["ts"]);
-
-            lightTimeDelay = params.count("ltd") != 0 && params["ltd"] == "1";
-            pauseState = params.count("p") != 0 && stoi(params["p"]) == 1;
-            break;
-        case Settings:
-            break;
-    }
-
-    if (params.count("rf") != 0)
-    {
-        renderFlags = static_cast<uint64_t>(stoi(params["rf"]));
-        // older celestia versions didn't know about new renderer flags
-        if ((renderFlags & Renderer::ShowPlanets) != 0)
-            renderFlags |= NewRenderFlags;
-    }
-    if (params.count("lm") != 0)
-        labelMode = stoi(params["lm"]);
-}
-
-
-void Url::initVersion3(std::map<std::string, std::string>& params,
-                       const std::string& timeString)
-{
-    // Type field not used for version 3 urls; position is always relative
-    // to the frame center. Time setting is controlled by the time source.
-    type = Absolute;
-
-    date = astro::Date(0.0);
-    sscanf(timeString.c_str(), "%d-%d-%dT%d:%d:%lf",
-           &date.year, &date.month, &date.day,
-           &date.hour, &date.minute, &date.seconds);
-
-    coord = UniversalCoord(BigFix(params["x"]),
-                           BigFix(params["y"]),
-                           BigFix(params["z"]));
-
-    float ow, ox, oy, oz;
-    ow = stof(params["ow"]);
-    ox = stof(params["ox"]);
-    oy = stof(params["oy"]);
-    oz = stof(params["oz"]);
-
-    orientation = Quaternionf(ow, ox, oy, oz);
-
-    if (params.count("select") != 0)
-        selectedStr = params["select"];
-    if (params.count("track") != 0)
-        trackedStr = params["track"];
-    if (params.count("ltd") != 0)
-        lightTimeDelay = params["ltd"] == "1";
-    else
-        lightTimeDelay = false;
-
-    if (params.count("fov") != 0)
-        fieldOfView = stof(params["fov"]);
-    if (params.count("ts") != 0)
-        timeScale = stof(params["ts"]);
-
-    pauseState = params.count("p") != 0 && stoi(params["p"]) == 1;
-
-    // Render settings
-    if (params.count("rf") != 0)
-    {
-        if (version == 4)
-        {
-            renderFlags = static_cast<uint64_t>(stoull(params["rf"]));
-        }
-        else
-        {
-            // old renderer flags are int
-            renderFlags = static_cast<uint64_t>(stoi(params["rf"]));
-            // older celestia versions didn't know about new renderer flags
-            if ((renderFlags & Renderer::ShowPlanets) != 0)
-                renderFlags |= NewRenderFlags;
-        }
-    }
-    if (params.count("lm") != 0)
-        labelMode = stoi(params["lm"]);
-
-    int timeSourceInt = 0;
-    if (params.count("tsrc") != 0)
-        timeSourceInt = stoi(params["tsrc"]);
-    if (timeSourceInt >= 0 && timeSourceInt < TimeSourceCount)
-        timeSource = (TimeSource) timeSourceInt;
-    else
-        timeSource = UseUrlTime;
-}
-
-
-std::string Url::getAsString() const
-{
-    return urlStr;
-}
-
-
-std::string Url::getName() const
-{
     return name;
 }
 
-
-void Url::evalName()
+// We use std::string here because we pass result to C API (gettext())
+std::string getBodyShortName(const std::string &body)
 {
-    double lo = longitude, la = latitude;
-    char los = 'E';
-    char las = 'N';
-    switch(type) {
-    case Absolute:
-        name = _(modeStr.c_str());
-        if (body1 != "") name += " " + std::string(_(getBodyShortName(body1).c_str()));
-        if (body2 != "") name += " " + std::string(_(getBodyShortName(body2).c_str()));
-        if (trackedStr != "") name += " -> " + std::string(_(getBodyShortName(trackedStr).c_str()));
-        if (selectedStr != "") name += " [" + std::string(_(getBodyShortName(selectedStr).c_str())) + "]";
-        break;
-    case Relative:
-        if (selectedStr != "") name = std::string(_(getBodyShortName(selectedStr).c_str())) + " ";
-        if (lo < 0) { lo = -lo; los = 'W'; }
-        if (la < 0) { la = -la; las = 'S'; }
-        name += fmt::sprintf("(%.1lf%c, %.1lf%c)", lo, los, la, las);
-        break;
-    case Settings:
-        name = _("Settings");
-        break;
+    if (!body.empty())
+    {
+        auto pos = body.rfind(":");
+        if (pos != std::string_view::npos)
+            return body.substr(pos + 1);
     }
+    return body;
 }
 
-
-std::string Url::getBodyShortName(const std::string& body) const
-{
-    std::string::size_type pos;
-    if (body != "") {
-        pos = body.rfind(":");
-        if (pos != std::string::npos) return body.substr(pos+1);
-        else return body;
-    }
-    return "";
-}
-
-
-std::map<std::string, std::string> Url::parseUrlParams(const std::string& url) const
-{
-    std::string::size_type pos, startName, startValue;
-    std::map<std::string, std::string> params;
-
-    pos = url.find("?");
-    while (pos != std::string::npos) {
-        startName = pos + 1;
-        startValue = url.find('=', startName);
-        pos = url.find('&', pos + 1);
-        if (startValue != std::string::npos) {
-             startValue++;
-             if (pos != std::string::npos)
-                 params[url.substr(startName, startValue - startName -1)] = decodeString(url.substr(startValue, pos - startValue));
-             else
-                 params[url.substr(startName, startValue - startName -1)] = decodeString(url.substr(startValue));
-        }
-    }
-
-    return params;
-}
-
-
-std::string Url::getCoordSysName(ObserverFrame::CoordinateSystem mode) const
+std::string_view
+getCoordSysName(ObserverFrame::CoordinateSystem mode)
 {
     switch (mode)
     {
@@ -720,174 +85,252 @@ std::string Url::getCoordSysName(ObserverFrame::CoordinateSystem mode) const
     }
 }
 
+} // anon namespace
 
-static std::string getBodyName(Universe* universe, Body* body)
+Url::Url(CelestiaCore *core) :
+    m_appCore(core)
 {
-    std::string name = body->getName();
-    PlanetarySystem* parentSystem = body->getSystem();
-    const Body* parentBody = nullptr;
-
-    if (parentSystem != nullptr)
-        parentBody = parentSystem->getPrimaryBody();
-    else
-        assert(0);
-        // TODO: Figure out why the line below was added.
-        //parentBody = body->getOrbitBarycenter();
-
-    while (parentBody != nullptr)
-    {
-        name = parentBody->getName() + ":" + name;
-        parentSystem = parentBody->getSystem();
-        if (parentSystem == nullptr)
-            parentBody = nullptr;
-        else
-            parentBody = parentSystem->getPrimaryBody();
-    }
-
-    if (body->getSystem()->getStar() != nullptr)
-    {
-        name = universe->getStarCatalog()->getStarName(*(body->getSystem()->getStar())) + ":" + name;
-    }
-
-    return name;
 }
 
-
-bool Url::goTo()
+Url::Url(const CelestiaState &appState, int version, Url::TimeSource timeSource) :
+    m_appCore(appState.m_appCore),
+    m_state(appState),
+    m_version(version),
+    m_timeSource(timeSource)
 {
-    if (urlStr.empty())
+    assert(version == 3);
+    std::ostringstream u;
+
+    switch (m_state.m_coordSys)
+    {
+    case ObserverFrame::Universal:
+        m_nBodies = 0;
+        break;
+    case ObserverFrame::PhaseLock:
+        m_nBodies = 2;
+        break;
+    default:
+        m_nBodies = 1;
+    }
+
+    u << Url::proto() << getCoordSysName(m_state.m_coordSys);
+
+    if (appState.m_coordSys != ObserverFrame::Universal)
+    {
+        u << '/' << m_state.m_refBodyName;
+        if (appState.m_coordSys == ObserverFrame::PhaseLock)
+            u << '/' << m_state.m_targetBodyName;
+    }
+
+    m_date = astro::Date(m_state.m_tdb);
+    u << '/' << m_date.toCStr(astro::Date::ISO8601);
+
+    // observer position
+    u << fmt::format("?x={}&y={}&z={}",
+                     m_state.m_observerPosition.x.toString(),
+                     m_state.m_observerPosition.y.toString(),
+                     m_state.m_observerPosition.z.toString());
+
+    // observer orientation
+    u << fmt::format("&ow={}&ox={}&oy={}&oz={}",
+                     m_state.m_observerOrientation.w(),
+                     m_state.m_observerOrientation.x(),
+                     m_state.m_observerOrientation.y(),
+                     m_state.m_observerOrientation.z());
+
+    if (!m_state.m_trackedBodyName.empty())
+        u << "&track=" << m_state.m_trackedBodyName;
+    if (!m_state.m_selectedBodyName.empty())
+        u << "&select=" << m_state.m_selectedBodyName;
+
+    u << fmt::format("&fov={}&ts={}&ltd={}&p={}",
+                     m_state.m_fieldOfView,
+                     m_state.m_timeScale,
+                     m_state.m_lightTimeDelay ? 1 : 0,
+                     m_state.m_pauseState ? 1 : 0);
+
+
+    // ShowTintedIllumination == 0x04000000, the last 1.6 parameter
+    // we keep only old parameters and clear new ones
+    int rf = static_cast<int>(m_state.m_renderFlags & 0x04ffffffull);
+    // 1.6 uses ShowPlanets to control display of all types of solar
+    // system objects. So set it if any one is displayed.
+    if ((m_state.m_renderFlags & Renderer::ShowSolarSystemObjects) != 0)
+        rf |= static_cast<int>(Renderer::ShowPlanets);
+    // But we need to store actual value of the bit which controls
+    // planets display. 27th bit is unused in 1.6.
+    if ((m_state.m_renderFlags & Renderer::ShowPlanets) != 0)
+        rf |= (1<<27);
+    int nrf = static_cast<int>(m_state.m_renderFlags >> 27);
+
+    u << fmt::format("&rf={}&nrf={}&lm={}",
+                     rf, nrf, m_state.m_labelMode);
+
+    // Append the url settings: time source and version
+    u << "&tsrc=" << (int) m_timeSource;
+    u << "&ver=" << m_version;
+
+    m_url = u.str();
+    m_valid = true;
+    evalName();
+}
+
+bool
+Url::goTo()
+{
+    if (!m_valid)
         return false;
 
-    Simulation *sim = appCore->getSimulation();
-    Renderer *renderer = appCore->getRenderer();
-    std::string::size_type pos;
+    assert(m_appCore != nullptr);
+    auto *sim = m_appCore->getSimulation();
+    auto *renderer = m_appCore->getRenderer();
 
     sim->update(0.0);
-
-    switch(type)
+    sim->setFrame(m_ref.getCoordinateSystem(), m_ref.getRefObject(), m_ref.getTargetObject());
+    sim->getActiveObserver()->setFOV(celmath::degToRad(m_state.m_fieldOfView));
+    m_appCore->setZoomFromFOV();
+    sim->setTimeScale(m_state.m_timeScale);
+    sim->setPauseState(m_state.m_pauseState);
+    m_appCore->setLightDelayActive(m_state.m_lightTimeDelay);
+    if (!m_state.m_selectedBodyName.empty())
     {
-    case Absolute:// Intentional Fall-Through
-    case Relative:
-        sim->setFrame(ref.getCoordinateSystem(), ref.getRefObject(), ref.getTargetObject());
-        sim->getActiveObserver()->setFOV(degToRad(fieldOfView));
-        appCore->setZoomFromFOV();
-        sim->setTimeScale(timeScale);
-        sim->setPauseState(pauseState);
-        appCore->setLightDelayActive(lightTimeDelay);
+        auto body = m_state.m_selectedBodyName;
+        std::replace(body.begin(), body.end(), ':', '/');
+        auto sel = sim->findObjectFromPath(body);
+        sim->setSelection(sel);
+    }
+    else
+    {
+        sim->setSelection(Selection());
+    }
 
-        if (!selectedStr.empty())
-        {
-            pos = 0;
-            while (pos != std::string::npos)
-            {
-                pos = selectedStr.find(":", pos + 1);
-                if (pos != std::string::npos) selectedStr[pos] = '/';
-            }
-            auto sel = sim->findObjectFromPath(selectedStr);
-            sim->setSelection(sel);
-        }
-        else
-        {
-            sim->setSelection(Selection());
-        }
+    if (!m_state.m_trackedBodyName.empty())
+    {
+        auto body = m_state.m_trackedBodyName;
+        std::replace(body.begin(), body.end(), ':', '/');
+        auto sel = sim->findObjectFromPath(body);
+        sim->setTrackedObject(sel);
+    }
+    else
+    {
+        if (!sim->getTrackedObject().empty())
+            sim->setTrackedObject(Selection());
+    }
 
-        if (!trackedStr.empty())
-        {
-            pos = 0;
-            while (pos != std::string::npos)
-            {
-                pos = trackedStr.find(":", pos + 1);
-                if (pos != std::string::npos) trackedStr[pos] = '/';
-            }
-            auto sel = sim->findObjectFromPath(trackedStr);
-            sim->setTrackedObject(sel);
-        }
-        else
-        {
-            if (!sim->getTrackedObject().empty())
-                sim->setTrackedObject(Selection());
-        }
-        // Intentional Fall-Through
-    case Settings:
-        renderer->setRenderFlags(renderFlags);
-        renderer->setLabelMode(labelMode);
+    renderer->setRenderFlags(m_state.m_renderFlags);
+    renderer->setLabelMode(m_state.m_labelMode);
+
+    switch (m_timeSource)
+    {
+    case UseUrlTime:
+        sim->setTime(m_state.m_tdb);
+        break;
+    case UseSimulationTime:
+        // Leave the current simulation time unmodified
+        break;
+    case UseSystemTime:
+        sim->setTime(astro::UTCtoTDB(astro::Date::systemDate()));
+        break;
+    default:
         break;
     }
 
-    if (version >= 3)
-    {
-        switch (timeSource)
-        {
-            case UseUrlTime:
-                sim->setTime((double) date);
-                break;
-            case UseSimulationTime:
-                // Leave the current simulation time unmodified
-                break;
-            case UseSystemTime:
-                sim->setTime(astro::UTCtoTDB(astro::Date::systemDate()));
-                break;
-            default:
-                break;
-        }
+    // Position and orientation stored in frame coordinates; convert them
+    // to universal and set the observer position.
+    double tdb = sim->getTime();
+    auto coord = sim->getObserver().getFrame()->convertToUniversal(m_state.m_observerPosition, m_state.m_tdb);
+    Eigen::Quaterniond q = m_state.m_observerOrientation.cast<double>();
+    q = sim->getObserver().getFrame()->convertToUniversal(q, m_state.m_tdb);
+    sim->setObserverPosition(coord);
+    sim->setObserverOrientation(q.cast<float>());
 
-        // Position and orientation stored in frame coordinates; convert them
-        // to universal and set the observer position.
-        double tdb = sim->getTime();
-        coord = sim->getObserver().getFrame()->convertToUniversal(coord, tdb);
-        Quaterniond q = sim->getObserver().getFrame()->convertToUniversal(orientation.cast<double>(), tdb);
-        sim->setObserverPosition(coord);
-        sim->setObserverOrientation(q.cast<float>());
-    }
-    else
-    {
-        switch(type)
-        {
-        case Absolute:
-            sim->setTime((double) date);
-            sim->setObserverPosition(coord);
-            sim->setObserverOrientation(orientation);
-            break;
-        case Relative:
-            sim->gotoSelectionLongLat(0, distance, (float) (longitude * PI / 180), (float) (latitude * PI / 180), Vector3f::UnitY());
-            break;
-        case Settings:
-            break;
-        }
-    }
     return true;
 }
 
-
-std::string Url::decodeString(const std::string& str)
+std::string
+Url::getAsString() const
 {
-    std::string::size_type a=0, b;
-    std::string out = "";
+    return m_url;
+}
 
-    b = str.find("%");
-    while (b != std::string::npos)
+std::string
+Url::getEncodedObjectName(const Selection& selection, const CelestiaCore* appCore)
+{
+    auto *universe = appCore->getSimulation()->getUniverse();
+    std::string name;
+    Body* parentBody = nullptr;
+
+    switch (selection.getType())
     {
-        unsigned int c;
-        out += str.substr(a, b-a);
-        std::string c_code = str.substr(b+1, 2);
-        sscanf(c_code.c_str(), "%02x", &c);
-        out += (char) c;
-        a = b + 3;
+    case Selection::Type_Body:
+        name = getBodyName(universe, selection.body());
+        break;
+
+    case Selection::Type_Star:
+        name = universe->getStarCatalog()->getStarName(*selection.star());
+        break;
+
+    case Selection::Type_DeepSky:
+        name = universe->getDSOCatalog()->getDSOName(selection.deepsky());
+        break;
+
+    case Selection::Type_Location:
+        name = selection.location()->getName();
+        parentBody = selection.location()->getParentBody();
+        if (parentBody != nullptr)
+            name = getBodyName(universe, parentBody) + ":" + name;
+        break;
+
+    default:
+        return {};
+    }
+
+    return Url::encodeString(name);
+}
+
+std::string
+Url::decodeString(std::string_view str)
+{
+    std::string_view::size_type a = 0, b = 0;
+    std::string out;
+
+    b = str.find('%');
+    while (b != std::string_view::npos && a < str.length())
+    {
+        auto s = str.substr(a, b - a);
+        out.append(s.data(), s.length());
+        auto c_code = str.substr(b + 1, 2);
+        int8_t c;
+        if (to_number(c_code, c, 16))
+        {
+            out += static_cast<std::string::value_type>(c);
+        }
+        else
+        {
+            fmt::fprintf(std::cerr, _("Incorrect hex value \"%s\"\n"), c_code);
+            out += '%';
+            out.append(c_code.data(), c_code.length());
+        }
+        a = b + 1 + c_code.length();
         b = str.find('%', a);
     }
-    out += str.substr(a);
+    if (a < str.length())
+    {
+        auto s = str.substr(a);
+        out.append(s.data(), s.length());
+    }
 
     return out;
 }
 
-
-string Url::encodeString(const string& str)
+std::string
+Url::encodeString(std::string_view str)
 {
-    ostringstream enc;
+    std::ostringstream enc;
 
     for (const auto _ch : str)
     {
-        int ch = (unsigned char) _ch;
+        auto ch = static_cast<unsigned char>(_ch);
         bool encode = false;
         if (ch <= 32 || ch >= 128)
         {
@@ -913,59 +356,285 @@ string Url::encodeString(const string& str)
         }
 
         if (encode)
-        {
-            enc << '%' << setw(2) << hex << ch;
-        }
+            enc << fmt::sprintf("%%%02x", ch);
         else
-        {
             enc << _ch;
-        }
     }
 
     return enc.str();
 }
 
-
-// Utility function that returns the complete path for a selection.
-string
-Url::getEncodedObjectName(const Selection& selection)
+struct Mode
 {
-    return ::getEncodedObjectName(selection, appCore);
-}
+    std::string_view                modeStr;
+    ObserverFrame::CoordinateSystem mode;
+    int                             nBodies;
+};
 
-
-const string
-getEncodedObjectName(const Selection& selection, const CelestiaCore* appCore)
+static Mode modes[] =
 {
-    Universe *universe = appCore->getSimulation()->getUniverse();
-    string name;
+    { "Freeflight", ObserverFrame::Universal,   0 },
+    { "Follow",     ObserverFrame::Ecliptical,  1 },
+    { "SyncOrbit",  ObserverFrame::BodyFixed,   1 },
+    { "Chase",      ObserverFrame::Chase,       1 },
+    { "PhaseLock",  ObserverFrame::PhaseLock,   2 },
+};
 
-    switch (selection.getType())
+auto ParseURLParams(std::string_view paramsStr)
+    -> std::map<std::string_view, std::string>;
+
+bool Url::parse(std::string_view urlStr)
+{
+    constexpr auto npos = std::string_view::npos;
+
+    // proper URL string must start with protocol (cel://)
+    if (urlStr.compare(0, Url::proto().length(), Url::proto()) != 0)
     {
-        case Selection::Type_Body:
-            name = getBodyName(universe, selection.body());
-            break;
-
-        case Selection::Type_Star:
-            name = universe->getStarCatalog()->getStarName(*selection.star());
-            break;
-
-        case Selection::Type_DeepSky:
-            name = universe->getDSOCatalog()->getDSOName(selection.deepsky());
-            break;
-
-        case Selection::Type_Location:
-            name = selection.location()->getName();
-            {
-                Body* parentBody = selection.location()->getParentBody();
-                if (parentBody != nullptr)
-                    name = getBodyName(universe, parentBody) + ":" + name;
-            }
-            break;
-
-        default:
-            return "";
+        fmt::fprintf(std::cerr, _("URL must start with \"%s\"!\n"), Url::proto());
+        return false;
     }
 
-    return Url::encodeString(name);
+    // extract @path and @params from the URL
+    auto pos = urlStr.find('?');
+    auto pathStr = urlStr.substr(Url::proto().length(), pos - Url::proto().length());
+    while (pathStr.back() == '/')
+        pathStr.remove_suffix(1);
+    std::string_view paramsStr;
+    if (pos != npos)
+        paramsStr = urlStr.substr(pos + 1);
+
+    pos = pathStr.find('/');
+    if (pos == npos)
+    {
+        std::cerr << _("URL must have at least mode and time!\n");
+        return false;
+    }
+    auto modeStr = pathStr.substr(0, pos);
+
+    int nBodies = -1;
+    CelestiaState state;
+    auto lambda = [modeStr](Mode &m) { return compareIgnoringCase(modeStr, m.modeStr) == 0; };
+    auto it = std::find_if(std::begin(modes), std::end(modes), lambda);
+    if (it == std::end(modes))
+    {
+        fmt::fprintf(std::cerr, _("Unsupported URL mode \"%s\"!\n"), modeStr);
+        return false;
+    }
+    state.m_coordSys = it->mode;
+    nBodies = it->nBodies;
+
+    auto timepos = nBodies == 0 ? pos : pathStr.rfind('/');
+    auto timeStr = pathStr.substr(timepos + 1);
+
+    Selection bodies[2];
+    if (nBodies > 0)
+    {
+        auto bodiesStr = pathStr.substr(pos + 1, timepos - pos - 1);
+        pos = bodiesStr.find('/');
+        if (nBodies == 1)
+        {
+            if (pos != npos)
+            {
+                std::cerr << _("URL must contain only one body\n");
+                return false;
+            }
+            auto body = Url::decodeString(bodiesStr);
+            std::replace(body.begin(), body.end(), ':', '/');
+            bodies[0] = m_appCore->getSimulation()->findObjectFromPath(body);
+            state.m_refBodyName = std::move(body);
+        }
+        else if (nBodies == 2)
+        {
+            if (pos == npos || bodiesStr.find('/', pos + 1) != npos)
+            {
+                std::cerr << _("URL must contain 2 bodies\n");
+                return false;
+            }
+            auto body = Url::decodeString(bodiesStr.substr(0, pos));
+            std::replace(body.begin(), body.end(), ':', '/');
+            bodies[0] = m_appCore->getSimulation()->findObjectFromPath(body);
+            state.m_refBodyName = std::move(body);
+
+            body = Url::decodeString(bodiesStr.substr(pos + 1));
+            std::replace(body.begin(), body.end(), ':', '/');
+            bodies[1] = m_appCore->getSimulation()->findObjectFromPath(body);
+            state.m_targetBodyName = std::move(body);
+        }
+    }
+
+    ObserverFrame ref;
+    switch (nBodies)
+    {
+    case 0:
+        ref = ObserverFrame();
+        break;
+    case 1:
+        ref = ObserverFrame(state.m_coordSys, bodies[0]);
+        break;
+    case 2:
+        ref = ObserverFrame(state.m_coordSys, bodies[0], bodies[1]);
+        break;
+    default:
+        break;
+    }
+
+    auto params = ParseURLParams(paramsStr);
+
+    // Version labelling of cel URLs was only added in Celestia 1.5, cel URL
+    // version 2. Assume any URL without a version is version 1.
+    int version = 1;
+    if (params.count("ver") != 0)
+    {
+        auto &p = params["ver"];
+        if (!to_number(p, version))
+        {
+            fmt::fprintf(std::cerr, _("Invalid URL version \"%s\"!\n"), p);
+            return false;
+        }
+    }
+
+    if (version != 3)
+    {
+        fmt::fprintf(std::cerr, _("Unsupported URL version: %i\n"), version);
+        return false;
+    }
+
+    m_ref = ref;
+    m_state = state;
+    m_nBodies = nBodies;
+    if (!initVersion3(params, timeStr))
+        return false;
+    m_valid = true;
+    evalName();
+
+    return true;
+}
+
+auto ParseURLParams(std::string_view paramsStr)
+   -> std::map<std::string_view, std::string>
+{
+    std::map<std::string_view, std::string> params;
+    if (paramsStr.empty())
+        return params;
+
+    constexpr auto npos = std::string_view::npos;
+    for (auto iter = paramsStr;;)
+    {
+        auto pos = iter.find('&');
+        auto kv = iter.substr(0, pos);
+        auto vpos = kv.find('=');
+        if (vpos == npos)
+        {
+            std::cerr << _("URL parameter must look like key=value\n");
+            break;
+        }
+        params[kv.substr(0, vpos)] = Url::decodeString(kv.substr(vpos + 1));
+        if (pos == npos)
+            break;
+        iter.remove_prefix(pos + 1);
+    }
+
+    return params;
+}
+
+bool Url::initVersion3(std::map<std::string_view, std::string> &params, std::string_view timeStr)
+{
+    m_version = 3;
+
+    if (!astro::parseDate(std::string(timeStr), m_date))
+        return false;
+    m_state.m_tdb = (double) m_date;
+
+    if (params.count("x") == 0 || params.count("y") == 0 || params.count("z") == 0)
+        return false;
+    m_state.m_observerPosition = UniversalCoord(BigFix(params["x"]),
+                                                BigFix(params["y"]),
+                                                BigFix(params["z"]));
+
+    float ow, ox, oy, oz;
+    if (to_number(params["ow"], ow) &&
+        to_number(params["ox"], ox) &&
+        to_number(params["oy"], oy) &&
+        to_number(params["oz"], oz))
+        m_state.m_observerOrientation = Eigen::Quaternionf(ow, ox, oy, oz);
+    else
+        return false;
+
+    if (params.count("select") != 0)
+        m_state.m_selectedBodyName = params["select"];
+    if (params.count("track") != 0)
+        m_state.m_trackedBodyName = params["track"];
+    if (params.count("ltd") != 0)
+        m_state.m_lightTimeDelay = params["ltd"] != "0";
+
+    if (params.count("fov") != 0 && !to_number(params["fov"], m_state.m_fieldOfView))
+        return false;
+    if (params.count("ts") != 0 && !to_number(params["ts"], m_state.m_timeScale))
+        return false;
+
+    if (params.count("p") != 0)
+        m_state.m_pauseState = params["p"] != "0";
+
+    // Render settings
+    bool hasNewRenderFlags = false;
+    uint64_t newFlags = 0ull, oldFlags = 0ull;
+    if (params.count("nrf") != 0)
+    {
+        hasNewRenderFlags = true;
+        int nrf;
+        if (!to_number(params["nrf"], nrf))
+            return false;
+        newFlags = static_cast<uint64_t>(nrf) << 27;
+    }
+    if (params.count("rf") != 0)
+    {
+        // old renderer flags are int
+        int rf;
+        if (!to_number(params["rf"], rf))
+            return false;
+        // older celestia versions don't know about the new renderer flags
+        if (hasNewRenderFlags)
+        {
+
+            oldFlags = static_cast<uint64_t>(rf & 0x04ffffff);
+            // get actual Renderer::ShowPlanets value in 27th bit
+            // clear ShowPlanets if 27th bit is unset
+            if ((rf & (1<<27)) == 0)
+                oldFlags &= ~Renderer::ShowPlanets;
+        }
+        else
+        {
+            oldFlags = static_cast<uint64_t>(rf);
+            // new options enabled by default in 1.7
+            oldFlags |= Renderer::ShowPlanetRings | Renderer::ShowFadingOrbits;
+            // old ShowPlanets == new ShowSolarSystemObjects
+            if ((oldFlags & Renderer::ShowPlanets) != 0)
+                oldFlags |= Renderer::ShowSolarSystemObjects;
+        }
+        m_state.m_renderFlags = newFlags | oldFlags;
+    }
+    if (params.count("lm") != 0 && !to_number(params["lm"], m_state.m_labelMode))
+        return false;
+
+    int tsrc = 0;
+    if (params.count("tsrc") != 0 && !to_number(params["tsrc"], tsrc))
+        return false;
+    if (tsrc >= 0 && tsrc < TimeSourceCount)
+        m_timeSource = static_cast<TimeSource>(tsrc);
+
+    return true;
+}
+
+void Url::evalName()
+{
+    std::string name;
+    if (!m_state.m_refBodyName.empty())
+        name += fmt::sprintf(" %s", _(getBodyShortName(m_state.m_refBodyName).c_str()));
+    if (!m_state.m_targetBodyName.empty())
+        name += fmt::sprintf(" %s", _(getBodyShortName(m_state.m_targetBodyName).c_str()));
+    if (!m_state.m_trackedBodyName.empty())
+        name += fmt::sprintf(" -> %s", _(getBodyShortName(m_state.m_trackedBodyName).c_str()));
+    if (!m_state.m_selectedBodyName.empty())
+        name += fmt::sprintf(" [%s]", _(getBodyShortName(m_state.m_selectedBodyName).c_str()));
+    m_name = std::move(name);
 }

--- a/src/celestia/url.h
+++ b/src/celestia/url.h
@@ -151,9 +151,9 @@ public:
     // Observer frame, position, and orientation. For multiview, there needs
     // be one instance of these parameters per view saved.
     ObserverFrame::CoordinateSystem coordSys{ ObserverFrame::Universal };
-    string refBodyName;
-    string targetBodyName;
-    string trackedBodyName;
+    std::string refBodyName;
+    std::string targetBodyName;
+    std::string trackedBodyName;
     UniversalCoord observerPosition{ 0.0, 0.0, 0.0 };
     Eigen::Quaternionf observerOrientation{ Eigen::Quaternionf::Identity() };
     float fieldOfView{ 45.0f };
@@ -164,7 +164,7 @@ public:
     bool pauseState{ false };
     bool lightTimeDelay{ false };
 
-    string selectedBodyName;
+    std::string selectedBodyName;
 
     int labelMode{ 0 };
     uint64_t renderFlags{ 0 };

--- a/src/celestia/view.cpp
+++ b/src/celestia/view.cpp
@@ -13,7 +13,7 @@
 #include <celutil/color.h>
 #include "view.h"
 
-#include<iostream>
+using namespace std;
 
 View::View(View::Type _type,
            Renderer *_renderer,

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -447,10 +447,10 @@ static bool CopyStateURLToClipboard()
     if (!b)
         return false;
 
-    CelestiaState appState;
-    appState.captureState(appCore);
+    CelestiaState appState(appCore);
+    appState.captureState();
 
-    Url url(appState, Url::CurrentVersion);
+    Url url(appState);
     string urlString = url.getAsString();
 
     char* s = const_cast<char*>(urlString.c_str());

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -35,6 +35,7 @@
 #include <celutil/debug.h>
 #include <celutil/gettext.h>
 #include <celutil/winutil.h>
+#include <celutil/util.h>
 #include <celutil/filetype.h>
 #include <celengine/astro.h>
 #include <celscript/legacy/cmdparser.h>

--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -9,20 +9,19 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <config.h>
 #include <algorithm>
+#include <iostream>
 #include <sstream>
 #include <Eigen/Geometry>
 #include <celutil/util.h>
 #include <celutil/debug.h>
 #include <celmath/mathlib.h>
 #include <celengine/astro.h>
-#include <celengine/render.h>
+#include <celengine/parser.h>
 #include <celengine/tokenizer.h>
 #ifdef USE_GLCONTEXT
 #include <celengine/glcontext.h>
 #endif
-#include <celscript/common/scriptmaps.h>
 #include "cmdparser.h"
 
 using namespace std;
@@ -99,15 +98,16 @@ CommandSequence* CommandParser::parse()
 }
 
 
-const vector<string>* CommandParser::getErrors() const
+auto CommandParser::getErrors() const
+    -> celestia::util::array_view<std::string>
 {
-    return &errorList;
+    return errorList;
 }
 
 
-void CommandParser::error(const string errMsg)
+void CommandParser::error(string errMsg)
 {
-    errorList.push_back(errMsg);
+    errorList.emplace_back(std::move(errMsg));
 }
 
 
@@ -399,7 +399,7 @@ Command* CommandParser::parseCommand()
     }
     else if (commandName == "time")
     {
-        double jd = 2451545;
+        double jd = 2451545.0;
         if (!paramList->getNumber("jd", jd))
         {
             std::string utc;

--- a/src/celscript/legacy/cmdparser.h
+++ b/src/celscript/legacy/cmdparser.h
@@ -12,11 +12,15 @@
 #ifndef _CMDPARSER_H_
 #define _CMDPARSER_H_
 
-#include "command.h"
-#include <iostream>
-#include <celengine/parser.h>
-#include <celengine/render.h>
+#include <iosfwd>
+#include <celcompat/string_view.h>
 #include <celscript/common/scriptmaps.h>
+#include <celutil/array_view.h>
+#include "command.h" // CommandSequence
+
+class Command;
+class Parser;
+class Tokenizer;
 
 
 class CommandParser
@@ -27,11 +31,11 @@ class CommandParser
     ~CommandParser();
 
     CommandSequence* parse();
-    const std::vector<std::string>* getErrors() const;
+    celestia::util::array_view<std::string> getErrors() const;
 
  private:
     Command* parseCommand();
-    void error(const string);
+    void error(std::string);
 
     Parser* parser;
     Tokenizer* tokenizer;

--- a/src/celscript/legacy/command.h
+++ b/src/celscript/legacy/command.h
@@ -13,8 +13,8 @@
 #define MAX_CONSTELLATIONS 100
 
 #include <array>
-#include <iostream>
-#include <celengine/astro.h>
+#include <iosfwd>
+#include <celcompat/string_view.h>
 #include <celutil/color.h>
 #include "execenv.h"
 
@@ -22,8 +22,9 @@
 class Command
 {
  public:
-    Command() {};
-    virtual ~Command() {};
+    Command() = default;
+    virtual ~Command() = default;
+
     virtual void process(ExecutionEnvironment&, double t, double dt) = 0;
     virtual double getDuration() const = 0;
 };
@@ -34,23 +35,17 @@ typedef std::vector<Command*> CommandSequence;
 class InstantaneousCommand : public Command
 {
  public:
-    InstantaneousCommand() {};
-    virtual ~InstantaneousCommand() {};
-    virtual double getDuration() const { return 0.0; };
+    double getDuration() const override;
+    void process(ExecutionEnvironment& env, double /*t*/, double /*dt*/) override;
     virtual void process(ExecutionEnvironment&) = 0;
-    void process(ExecutionEnvironment& env, double /*t*/, double /*dt*/)
-    {
-        process(env);
-    };
 };
-
 
 class TimedCommand : public Command
 {
  public:
-    TimedCommand(double _duration) : duration(_duration) {};
-    virtual ~TimedCommand() {};
-    double getDuration() const { return duration; };
+    TimedCommand(double _duration);
+
+    double getDuration() const override;
 
  private:
     double duration;
@@ -61,8 +56,8 @@ class CommandWait : public TimedCommand
 {
  public:
     CommandWait(double _duration);
-    ~CommandWait() = default;
-    void process(ExecutionEnvironment&, double t, double dt);
+
+    void process(ExecutionEnvironment&, double t, double dt) override;
 };
 
 
@@ -70,8 +65,8 @@ class CommandSelect : public InstantaneousCommand
 {
  public:
     CommandSelect(std::string _target);
-    ~CommandSelect() = default;
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string target;
@@ -81,11 +76,12 @@ class CommandSelect : public InstantaneousCommand
 class CommandGoto : public InstantaneousCommand
 {
  public:
-    CommandGoto(double t, double dist,
-                Eigen::Vector3f _up,
+    CommandGoto(double t,
+                double dist,
+                const Eigen::Vector3f &_up,
                 ObserverFrame::CoordinateSystem _upFrame);
-    ~CommandGoto() = default;
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     double gotoTime;
@@ -100,10 +96,11 @@ class CommandGotoLongLat : public InstantaneousCommand
  public:
     CommandGotoLongLat(double t,
                        double dist,
-                       float _longitude, float _latitude,
-                       Eigen::Vector3f _up);
-    ~CommandGotoLongLat() = default;
-    void process(ExecutionEnvironment&);
+                       float _longitude,
+                       float _latitude,
+                       const Eigen::Vector3f &_up);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     double gotoTime;
@@ -123,8 +120,7 @@ class CommandGotoLocation : public InstantaneousCommand
                         const Eigen::Vector3d& translation,
                         const Eigen::Quaterniond& rotation);
 
-    ~CommandGotoLocation() = default;
-    void process(ExecutionEnvironment&);
+    void process(ExecutionEnvironment&) override;
 
  private:
     double gotoTime;
@@ -135,8 +131,9 @@ class CommandGotoLocation : public InstantaneousCommand
 class CommandSetUrl : public InstantaneousCommand
 {
  public:
-    CommandSetUrl(std::string  _url);
-    void process(ExecutionEnvironment&);
+    CommandSetUrl(std::string);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string url;
@@ -147,8 +144,7 @@ class CommandCenter : public InstantaneousCommand
 {
  public:
     CommandCenter(double t);
-    ~CommandCenter() = default;
-    void process(ExecutionEnvironment&);
+    void process(ExecutionEnvironment&) override;
 
  private:
     double centerTime;
@@ -158,55 +154,35 @@ class CommandCenter : public InstantaneousCommand
 class CommandFollow : public InstantaneousCommand
 {
  public:
-    CommandFollow() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;   // Keep the class from having zero size
+    void process(ExecutionEnvironment&) override;
 };
 
 
 class CommandSynchronous : public InstantaneousCommand
 {
  public:
-    CommandSynchronous() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;   // Keep the class from having zero size
+    void process(ExecutionEnvironment&) override;
 };
 
 
 class CommandLock : public InstantaneousCommand
 {
  public:
-    CommandLock() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;
+    void process(ExecutionEnvironment&) override;
 };
 
 
 class CommandChase : public InstantaneousCommand
 {
  public:
-    CommandChase() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;
+    void process(ExecutionEnvironment&) override;
 };
 
 
 class CommandTrack : public InstantaneousCommand
 {
  public:
-    CommandTrack() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;
+    void process(ExecutionEnvironment&) override;
 };
 
 
@@ -215,7 +191,8 @@ class CommandSetFrame : public InstantaneousCommand
  public:
     CommandSetFrame(ObserverFrame::CoordinateSystem,
                     std::string, std::string);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     ObserverFrame::CoordinateSystem coordSys;
@@ -228,7 +205,8 @@ class CommandSetSurface : public InstantaneousCommand
 {
  public:
     CommandSetSurface(std::string);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string surfaceName;
@@ -238,22 +216,14 @@ class CommandSetSurface : public InstantaneousCommand
 class CommandCancel : public InstantaneousCommand
 {
  public:
-    CommandCancel() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;   // Keep the class from having zero size
+    void process(ExecutionEnvironment&) override;
 };
 
 
 class CommandExit : public InstantaneousCommand
 {
  public:
-    CommandExit() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;   // Keep the class from having zero size
+    void process(ExecutionEnvironment&) override;
 };
 
 
@@ -261,8 +231,9 @@ class CommandPrint : public InstantaneousCommand
 {
  public:
     CommandPrint(std::string, int horig, int vorig, int hoff, int voff,
-                 double _duration);
-    void process(ExecutionEnvironment&);
+                 float _duration);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string text;
@@ -277,11 +248,7 @@ class CommandPrint : public InstantaneousCommand
 class CommandClearScreen : public InstantaneousCommand
 {
  public:
-    CommandClearScreen() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;   // Keep the class from having zero size
+    void process(ExecutionEnvironment&) override;
 };
 
 
@@ -289,7 +256,8 @@ class CommandSetTime : public InstantaneousCommand
 {
  public:
     CommandSetTime(double _jd);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     double jd;
@@ -300,7 +268,8 @@ class CommandSetTimeRate : public InstantaneousCommand
 {
  public:
     CommandSetTimeRate(double);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     double rate;
@@ -311,7 +280,8 @@ class CommandChangeDistance : public TimedCommand
 {
  public:
     CommandChangeDistance(double _duration, double _rate);
-    void process(ExecutionEnvironment&, double t, double dt);
+
+    void process(ExecutionEnvironment&, double t, double dt) override;
 
  private:
     double rate;
@@ -322,7 +292,8 @@ class CommandOrbit : public TimedCommand
 {
  public:
     CommandOrbit(double _duration, const Eigen::Vector3f& axis, float rate);
-    void process(ExecutionEnvironment&, double t, double dt);
+
+    void process(ExecutionEnvironment&, double t, double dt) override;
 
  private:
     Eigen::Vector3f spin;
@@ -333,7 +304,8 @@ class CommandRotate : public TimedCommand
 {
  public:
     CommandRotate(double _duration, const Eigen::Vector3f& axis, float rate);
-    void process(ExecutionEnvironment&, double t, double dt);
+
+    void process(ExecutionEnvironment&, double t, double dt) override;
 
  private:
     Eigen::Vector3f spin;
@@ -344,7 +316,8 @@ class CommandMove : public TimedCommand
 {
  public:
     CommandMove(double _duration, const Eigen::Vector3d& _velocity);
-    void process(ExecutionEnvironment&, double t, double dt);
+
+    void process(ExecutionEnvironment&, double t, double dt) override;
 
  private:
     Eigen::Vector3d velocity;
@@ -355,7 +328,8 @@ class CommandSetPosition : public InstantaneousCommand
 {
  public:
     CommandSetPosition(const UniversalCoord&);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     UniversalCoord pos;
@@ -365,10 +339,11 @@ class CommandSetPosition : public InstantaneousCommand
 class CommandSetOrientation : public InstantaneousCommand
 {
  public:
-     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     CommandSetOrientation(const Eigen::Quaternionf&);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     Eigen::Quaternionf orientation;
@@ -377,11 +352,7 @@ class CommandSetOrientation : public InstantaneousCommand
 class CommandLookBack : public InstantaneousCommand
 {
  public:
-    CommandLookBack() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;   // Keep the class from having zero size
+    void process(ExecutionEnvironment&) override;
 };
 
 
@@ -389,7 +360,8 @@ class CommandRenderFlags : public InstantaneousCommand
 {
  public:
     CommandRenderFlags(uint64_t _setFlags, uint64_t _clearFlags);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     uint64_t setFlags;
@@ -406,17 +378,21 @@ class CommandConstellations : public InstantaneousCommand
     };
 
  public:
-    CommandConstellations() = default;
-    void process(ExecutionEnvironment&);
-    void setValues(string cons, int act);
+    void process(ExecutionEnvironment&) override;
+
+    void setValues(std::string_view cons, bool act);
 
     Flags flags { false, false };
 
  private:
     struct Cons
     {
-       std::string name;
-       int active;
+        Cons(std::string name, bool active) :
+            name(std::move(name)),
+            active(active)
+        {}
+        std::string name;
+        bool active;
     };
     std::vector<Cons> constellations;
 };
@@ -432,9 +408,8 @@ class CommandConstellationColor : public InstantaneousCommand
     };
 
  public:
-    CommandConstellationColor() = default;
-    void process(ExecutionEnvironment&);
-    void setConstellations(string cons);
+    void process(ExecutionEnvironment&) override;
+    void setConstellations(std::string_view cons);
     void setColor(float r, float g, float b);
     void unsetColor();
 
@@ -450,7 +425,8 @@ class CommandLabels : public InstantaneousCommand
 {
  public:
     CommandLabels(int _setFlags, int _clearFlags);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     int setFlags;
@@ -462,7 +438,8 @@ class CommandOrbitFlags : public InstantaneousCommand
 {
  public:
     CommandOrbitFlags(int _setFlags, int _clearFlags);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     int setFlags;
@@ -474,7 +451,8 @@ class CommandSetVisibilityLimit : public InstantaneousCommand
 {
  public:
     CommandSetVisibilityLimit(double);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     double magnitude;
@@ -484,7 +462,8 @@ class CommandSetFaintestAutoMag45deg : public InstantaneousCommand
 {
  public:
     CommandSetFaintestAutoMag45deg(double);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     double magnitude;
@@ -494,7 +473,8 @@ class CommandSetAmbientLight : public InstantaneousCommand
 {
  public:
     CommandSetAmbientLight(float);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     float lightLevel;
@@ -505,7 +485,8 @@ class CommandSetGalaxyLightGain : public InstantaneousCommand
 {
  public:
     CommandSetGalaxyLightGain(float);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     float lightGain;
@@ -516,7 +497,8 @@ class CommandSet : public InstantaneousCommand
 {
  public:
     CommandSet(std::string, double);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string name;
@@ -528,7 +510,8 @@ class CommandPreloadTextures : public InstantaneousCommand
 {
  public:
     CommandPreloadTextures(std::string);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string name;
@@ -539,7 +522,8 @@ class CommandMark : public InstantaneousCommand
 {
  public:
     CommandMark(std::string, MarkerRepresentation, bool);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string target;
@@ -552,7 +536,8 @@ class CommandUnmark : public InstantaneousCommand
 {
  public:
     CommandUnmark(std::string);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string target;
@@ -562,11 +547,7 @@ class CommandUnmark : public InstantaneousCommand
 class CommandUnmarkAll : public InstantaneousCommand
 {
  public:
-    CommandUnmarkAll() = default;
-    void process(ExecutionEnvironment&);
-
- private:
-    int dummy;   // Keep the class from having zero size
+    void process(ExecutionEnvironment&) override;
 };
 
 
@@ -574,7 +555,7 @@ class CommandCapture : public InstantaneousCommand
 {
  public:
     CommandCapture(std::string, std::string);
-    void process(ExecutionEnvironment&);
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string type;
@@ -586,7 +567,8 @@ class CommandSetTextureResolution : public InstantaneousCommand
 {
  public:
     CommandSetTextureResolution(unsigned int);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     unsigned int res;
@@ -598,7 +580,7 @@ class CommandRenderPath : public InstantaneousCommand
 {
  public:
     CommandRenderPath(GLContext::GLRenderPath);
-    void process(ExecutionEnvironment&);
+    void process(ExecutionEnvironment&) override;
 
  private:
     GLContext::GLRenderPath path;
@@ -610,7 +592,8 @@ class CommandSplitView : public InstantaneousCommand
 {
  public:
     CommandSplitView(unsigned int, std::string, double);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     unsigned int view;
@@ -623,7 +606,8 @@ class CommandDeleteView : public InstantaneousCommand
 {
  public:
     CommandDeleteView(unsigned int);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     unsigned int view;
@@ -633,8 +617,7 @@ class CommandDeleteView : public InstantaneousCommand
 class CommandSingleView : public InstantaneousCommand
 {
  public:
-    CommandSingleView() = default;
-    void process(ExecutionEnvironment&);
+    void process(ExecutionEnvironment&) override;
 };
 
 
@@ -642,7 +625,7 @@ class CommandSetActiveView : public InstantaneousCommand
 {
  public:
     CommandSetActiveView(unsigned int);
-    void process(ExecutionEnvironment&);
+    void process(ExecutionEnvironment&) override;
 
  private:
     unsigned int view;
@@ -653,7 +636,8 @@ class CommandSetRadius : public InstantaneousCommand
 {
  public:
     CommandSetRadius(std::string, double);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string object;
@@ -664,8 +648,9 @@ class CommandSetRadius : public InstantaneousCommand
 class CommandSetLineColor : public InstantaneousCommand
 {
  public:
-    CommandSetLineColor(std::string, Color);
-    void process(ExecutionEnvironment&);
+    CommandSetLineColor(std::string, const Color&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string item;
@@ -676,8 +661,9 @@ class CommandSetLineColor : public InstantaneousCommand
 class CommandSetLabelColor : public InstantaneousCommand
 {
  public:
-    CommandSetLabelColor(std::string, Color);
-    void process(ExecutionEnvironment&);
+    CommandSetLabelColor(std::string, const Color&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string item;
@@ -688,8 +674,9 @@ class CommandSetLabelColor : public InstantaneousCommand
 class CommandSetTextColor : public InstantaneousCommand
 {
  public:
-    CommandSetTextColor(Color);
-    void process(ExecutionEnvironment&);
+    CommandSetTextColor(const Color&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     Color color;
@@ -702,9 +689,10 @@ class RepeatCommand : public Command
 {
  public:
     RepeatCommand(CommandSequence* _body, int _repeatCount);
-    ~RepeatCommand();
-    void process(ExecutionEnvironment&, double t, double dt) = 0;
-    double getDuration() const;
+    ~RepeatCommand() override;
+
+    double getDuration() const override;
+    void process(ExecutionEnvironment& env, double t, double dt) override;
 
  private:
     CommandSequence* body;
@@ -717,11 +705,12 @@ class RepeatCommand : public Command
 class CommandScriptImage : public InstantaneousCommand
 {
  public:
-    CommandScriptImage(float, float, float, float, fs::path, bool, std::array<Color, 4>&);
-    void process(ExecutionEnvironment&);
+    CommandScriptImage(float, float, float, float, const fs::path&, bool, std::array<Color, 4>&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
-    float duration;
+    double duration;
     float fadeafter;
     float xoffset;
     float yoffset;
@@ -734,7 +723,8 @@ class CommandVerbosity : public InstantaneousCommand
 {
  public:
     CommandVerbosity(int _level);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     int level;
@@ -745,7 +735,8 @@ class CommandSetWindowBordersVisible : public InstantaneousCommand
 {
  public:
     CommandSetWindowBordersVisible(bool _visible) : visible(_visible) {};
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     bool visible;
@@ -756,7 +747,8 @@ class CommandSetRingsTexture : public InstantaneousCommand
 {
  public:
     CommandSetRingsTexture(std::string, std::string, std::string);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string object, textureName, path;
@@ -767,7 +759,8 @@ class CommandLoadFragment : public InstantaneousCommand
 {
  public:
     CommandLoadFragment(std::string, std::string, std::string);
-    void process(ExecutionEnvironment&);
+
+    void process(ExecutionEnvironment&) override;
 
  private:
     std::string type, fragment, dir;

--- a/src/celscript/legacy/legacyscript.cpp
+++ b/src/celscript/legacy/legacyscript.cpp
@@ -69,9 +69,9 @@ bool LegacyScript::load(ifstream &scriptfile, const fs::path &/*path*/, string &
     CommandSequence* script = parser.parse();
     if (script == nullptr)
     {
-        const vector<string>* errors = parser.getErrors();
-        if (errors->size() > 0)
-            errorMsg = (*errors)[0];
+        auto errors = parser.getErrors();
+        if (!errors.empty())
+            errorMsg = errors[0];
         return false;
     }
     m_runningScript = unique_ptr<Execution>(new Execution(*script, *m_execEnv));

--- a/src/celscript/lua/celx.h
+++ b/src/celscript/lua/celx.h
@@ -64,7 +64,7 @@ public:
     bool handleTickEvent(double dt);
 
     // Lua hook handling
-    void setLuaPath(const string& s);
+    void setLuaPath(const std::string& s);
     void allowSystemAccess();
     void allowLuaPackageAccess();
     void setLuaHookEventHandlerEnabled(bool);

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -32,6 +32,7 @@
 #include <celestia/view.h>
 #include <celscript/common/scriptmaps.h>
 
+using namespace std;
 using namespace Eigen;
 using namespace celestia::scripts;
 

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -2037,10 +2037,10 @@ static int celestia_geturl(lua_State* l)
     View* view = getViewByObserver(appCore, obs);
     appCore->setActiveView(view);
 
-    CelestiaState appState;
-    appState.captureState(appCore);
+    CelestiaState appState(appCore);
+    appState.captureState();
 
-    Url url(appState, 3);
+    Url url(appState);
     lua_pushstring(l, url.getAsString().c_str());
 
     return 1;

--- a/src/celscript/lua/celx_frame.cpp
+++ b/src/celscript/lua/celx_frame.cpp
@@ -16,6 +16,7 @@
 #include <celengine/observer.h>
 #include <Eigen/Geometry>
 
+using namespace std;
 using namespace Eigen;
 
 

--- a/src/celscript/lua/celx_misc.cpp
+++ b/src/celscript/lua/celx_misc.cpp
@@ -15,6 +15,7 @@
 #include <celestia/celestiacore.h>
 #include <celttf/truetypefont.h>
 
+using namespace std;
 using namespace celestia::scripts;
 
 LuaState *getLuaStateObject(lua_State*);

--- a/src/celscript/lua/celx_misc.cpp
+++ b/src/celscript/lua/celx_misc.cpp
@@ -35,9 +35,9 @@ class CelScriptWrapper : public ExecutionEnvironment
         }
         else
         {
-            const vector<string>* errors = parser.getErrors();
-            if (errors->size() > 0)
-                errorMessage = "Error while parsing CEL-script: " + (*errors)[0];
+            auto errors = parser.getErrors();
+            if (!errors.empty())
+                errorMessage = "Error while parsing CEL-script: " + errors[0];
             else
                 errorMessage = "Error while parsing CEL-script.";
         }

--- a/src/celscript/lua/celx_position.cpp
+++ b/src/celscript/lua/celx_position.cpp
@@ -15,6 +15,7 @@
 #include <Eigen/Geometry>
 
 
+using namespace std;
 using namespace Eigen;
 
 // ==================== Position ====================

--- a/src/celscript/lua/celx_rotation.cpp
+++ b/src/celscript/lua/celx_rotation.cpp
@@ -14,6 +14,7 @@
 #include "celx_vector.h"
 #include <celutil/align.h>
 
+using namespace std;
 using namespace Eigen;
 
 int rotation_new(lua_State* l, const Quaterniond& qd)

--- a/src/celscript/lua/celx_vector.cpp
+++ b/src/celscript/lua/celx_vector.cpp
@@ -15,6 +15,7 @@
 #include <celutil/align.h>
 #include <Eigen/Geometry>
 
+using namespace std;
 using namespace Eigen;
 
 int vector_new(lua_State* l, const Vector3d& v)

--- a/src/celutil/CMakeLists.txt
+++ b/src/celutil/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CELUTIL_SOURCES
   #memorypool.h
   reshandle.h
   resmanager.h
+  stringutils.cpp
+  stringutils.h
   strnatcmp.cpp
   strnatcmp.h
   timer.cpp

--- a/src/celutil/filetype.cpp
+++ b/src/celutil/filetype.cpp
@@ -7,9 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <cctype>
-#include <cstdlib>
-#include "util.h"
+#include "stringutils.h"
 #include "filetype.h"
 
 using namespace std;

--- a/src/celutil/stringutils.cpp
+++ b/src/celutil/stringutils.cpp
@@ -1,0 +1,54 @@
+// stringutils.cpp
+//
+// Copyright (C) 2001-present, the Celestia Development Team
+// Original version by Chris Laurel <claurel@shatters.net>
+//
+// Miscellaneous useful functions.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "stringutils.h"
+
+using namespace std;
+
+int compareIgnoringCase(string_view s1, string_view s2)
+{
+    auto i1 = s1.begin();
+    auto i2 = s2.begin();
+
+    while (i1 != s1.end() && i2 != s2.end())
+    {
+        if (toupper(*i1) != toupper(*i2))
+            return (toupper(*i1) < toupper(*i2)) ? -1 : 1;
+        ++i1;
+        ++i2;
+    }
+
+    return s2.size() - s1.size();
+}
+
+int compareIgnoringCase(string_view s1, string_view s2, int n)
+{
+    auto i1 = s1.begin();
+    auto i2 = s2.begin();
+
+    while (i1 != s1.end() && i2 != s2.end() && n > 0)
+    {
+        if (toupper(*i1) != toupper(*i2))
+            return (toupper(*i1) < toupper(*i2)) ? -1 : 1;
+        ++i1;
+        ++i2;
+        n--;
+    }
+
+    return n > 0 ? s2.size() - s1.size() : 0;
+}
+
+bool CompareIgnoringCasePredicate::operator()(string_view s1,
+                                              string_view s2) const
+{
+    return compareIgnoringCase(s1, s2) < 0;
+}

--- a/src/celutil/stringutils.h
+++ b/src/celutil/stringutils.h
@@ -1,0 +1,38 @@
+// stringutils.h
+//
+// Copyright (C) 2001-present, the Celestia Development Team
+// Original version by Chris Laurel <claurel@shatters.net>
+//
+// Miscellaneous useful functions.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <celcompat/charconv.h>
+#include <celcompat/string_view.h>
+
+int compareIgnoringCase(std::string_view s1, std::string_view s2);
+int compareIgnoringCase(std::string_view s1, std::string_view s2, int n);
+
+struct CompareIgnoringCasePredicate
+{
+    bool operator()(std::string_view, std::string_view) const;
+};
+
+template <typename T>
+[[nodiscard]] bool to_number(std::string_view p, T &result)
+{
+    auto r = std::from_chars(p.begin(), p.end(), result);
+    return r.ec == std::errc();
+}
+
+template <typename T>
+[[nodiscard]] bool to_number(std::string_view p, T &result, int base)
+{
+    auto r = std::from_chars(p.begin(), p.end(), result, base);
+    return r.ec == std::errc();
+}

--- a/src/celutil/utf8.cpp
+++ b/src/celutil/utf8.cpp
@@ -7,13 +7,13 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include "utf8.h"
 #include <cctype>
 #include <cstring>
-#include "util.h"
 #include <wchar.h>
 #include <climits>
 #include <fmt/printf.h>
+#include "stringutils.h"
+#include "utf8.h"
 
 uint16_t WGL4_Normalization_00[256] = {
     0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007,

--- a/src/celutil/util.cpp
+++ b/src/celutil/util.cpp
@@ -10,7 +10,7 @@
 // of the License, or (at your option) any later version.
 
 #include <config.h>
-#include <celutil/debug.h>
+#include <fmt/printf.h>
 #include "util.h"
 #include "gettext.h"
 #ifdef _WIN32
@@ -25,48 +25,6 @@
 #endif // !_WIN32
 
 using namespace std;
-
-
-int compareIgnoringCase(const string& s1, const string& s2)
-{
-    string::const_iterator i1 = s1.begin();
-    string::const_iterator i2 = s2.begin();
-
-    while (i1 != s1.end() && i2 != s2.end())
-    {
-        if (toupper(*i1) != toupper(*i2))
-            return (toupper(*i1) < toupper(*i2)) ? -1 : 1;
-        ++i1;
-        ++i2;
-    }
-
-    return s2.size() - s1.size();
-}
-
-
-int compareIgnoringCase(const string& s1, const string& s2, int n)
-{
-    string::const_iterator i1 = s1.begin();
-    string::const_iterator i2 = s2.begin();
-
-    while (i1 != s1.end() && i2 != s2.end() && n > 0)
-    {
-        if (toupper(*i1) != toupper(*i2))
-            return (toupper(*i1) < toupper(*i2)) ? -1 : 1;
-        ++i1;
-        ++i2;
-        n--;
-    }
-
-    return n > 0 ? s2.size() - s1.size() : 0;
-}
-
-
-bool CompareIgnoringCasePredicate::operator()(const string& s1,
-                                              const string& s2) const
-{
-    return compareIgnoringCase(s1, s2) < 0;
-}
 
 
 fs::path LocaleFilename(const fs::path &p)
@@ -172,7 +130,7 @@ fs::path homeDir()
     return fs::path();
 }
 
-bool GetTZInfo(std::string &tzName, int &dstBias)
+bool GetTZInfo(std::string_view tzName, int &dstBias)
 {
 #ifdef _WIN32
     TIME_ZONE_INFORMATION tzi;

--- a/src/celutil/util.h
+++ b/src/celutil/util.h
@@ -16,15 +16,9 @@
 #include <iostream>
 #include <functional>
 #include <celcompat/filesystem.h>
+#include <celcompat/string_view.h>
 
-extern int compareIgnoringCase(const std::string& s1, const std::string& s2);
-extern int compareIgnoringCase(const std::string& s1, const std::string& s2, int n);
-extern fs::path LocaleFilename(const fs::path& filename);
-
-struct CompareIgnoringCasePredicate
-{
-    bool operator()(const std::string&, const std::string&) const;
-};
+fs::path LocaleFilename(const fs::path& filename);
 
 template <class T> struct printlineFunc
 {
@@ -47,6 +41,6 @@ template<typename T> constexpr typename T::size_type memsize(const T &c)
 fs::path PathExp(const fs::path& filename);
 fs::path homeDir();
 
-bool GetTZInfo(std::string&, int&);
+bool GetTZInfo(std::string_view, int&);
 
 #endif // _CELUTIL_UTIL_H_

--- a/src/celutil/winutil.cpp
+++ b/src/celutil/winutil.cpp
@@ -10,6 +10,8 @@
 
 #include "winutil.h"
 
+using namespace std;
+
 void SetMouseCursor(LPCTSTR lpCursor)
 {
     HCURSOR hNewCrsr;

--- a/src/celutil/winutil.h
+++ b/src/celutil/winutil.h
@@ -23,11 +23,11 @@ void CenterWindow(HWND hParent, HWND hWnd);
 void RemoveButtonDefaultStyle(HWND hWnd);
 void AddButtonDefaultStyle(HWND hWnd);
 const char* CurrentCP();
-string UTF8ToCurrentCP(const string& str);
-string CurrentCPToUTF8(const string& str);
-string WideToCurrentCP(const wstring& ws);
-wstring CurrentCPToWide(const string& str);
-string WideToUTF8(const wstring& ws);
-wstring UTF8ToWide(const string& str);
+std::string UTF8ToCurrentCP(const std::string& str);
+std::string CurrentCPToUTF8(const std::string& str);
+std::string WideToCurrentCP(const std::wstring& ws);
+std::wstring CurrentCPToWide(const std::string& str);
+std::string WideToUTF8(const std::wstring& ws);
+std::wstring UTF8ToWide(const std::string& str);
 
 #endif

--- a/src/tools/cmod/cmodview/CMakeLists.txt
+++ b/src/tools/cmod/cmodview/CMakeLists.txt
@@ -20,3 +20,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 build_cmod_tool(cmodview WIN32 cmodview.cpp glframebuffer.cpp  glshader.cpp  mainwindow.cpp  materialwidget.cpp  modelviewwidget.cpp glsupport.cpp)
 qt5_use_modules(cmodview ${QT_LIBS})
+
+if(NOT MSVC)
+  target_compile_options(cmodview PRIVATE "-frtti")
+endif()


### PR DESCRIPTION
Based on the previous PR, so:
 * Enable `array_view` and `string_view` in some obvious places.
 * Remove `using namespace std` from header files. Considered a no go in C++ style guides. With appropriate changes in cpp files.
 * A few literals for distance and speed.
 * Additional format for astro::Date represented as string. Moved from Url.
 * Split string-processing functions from celutil/util.* to own files.
 * Refactor Url. The most important change.
   - No more legacy version 1 & 2 support.
   - Drop version 4, refactor version 3 to be compatible between 1.6 and 1.7.
   - Use string_view and non-throwing function to convert strings to numbers.
 * Build without exceptions and RTTI.

With the last change size of binaries is reduced noticebly:
With exceptions & RTTI:
3,1M src/celestia/libcelestia.so.1.7.0
715K src/celestia/qt/celestia-qt

With `-fno-exceptions` only:
2,9M src/celestia/libcelestia.so.1.7.0
663K src/celestia/qt/celestia-qt

With `-fno-exceptions` and `-fno-rtti`:
2,9M src/celestia/libcelestia.so.1.7.0
655K src/celestia/qt/celestia-qt

Only if built using GCC or Clang.