### PR TITLE
Allow to build gtk frontend with Gtk3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ set(DISPLAY_NAME "Celestia")
 option(ENABLE_CELX    "Enable celx scripting, requires Lua library? (Default: on)" ON)
 option(ENABLE_SPICE   "Use spice library? (Default: off)" OFF)
 option(ENABLE_NLS     "Enable interface translation? (Default: on)" ON)
-option(ENABLE_GLUT    "Build simple Glut frontend? (Default: on)" OFF)
+option(ENABLE_GLUT    "Build simple Glut frontend? (Default: off)" OFF)
 option(ENABLE_GTK     "Build GTK2 frontend (Unix only)? (Default: off)" OFF)
 option(ENABLE_QT      "Build Qt frontend? (Default: on)" ON)
 option(ENABLE_SDL     "Build SDL frontend? (Default: off)" OFF)
@@ -57,9 +57,12 @@ option(FAST_MATH      "Build with unsafe fast-math compiller option (Default: of
 option(ENABLE_TESTS   "Enable unit tests? (Default: off)" OFF)
 option(ENABLE_DATA    "Install data from content submodule? (Default: on)" ON)
 option(ENABLE_GLES    "Build for OpenGL ES 2.0 instead of OpenGL 2.1 (Default: off)" OFF)
+option(USE_GTKGLEXT   "Use libgtkglext1 for GTK2 frontend (Default: on)" ON)
 
 if(ENABLE_GLES)
   add_definitions(-DGL_ES)
+  # Disable USE_GTKGLEXT if using OpenGL ES
+  set(USE_GTKGLEXT OFF)
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,16 @@ option(ENABLE_TESTS   "Enable unit tests? (Default: off)" OFF)
 option(ENABLE_DATA    "Install data from content submodule? (Default: on)" ON)
 option(ENABLE_GLES    "Build for OpenGL ES 2.0 instead of OpenGL 2.1 (Default: off)" OFF)
 option(USE_GTKGLEXT   "Use libgtkglext1 for GTK2 frontend (Default: on)" ON)
+option(USE_GTK3       "Use Gtk3 in GTK2 frontend (Default: off)" OFF)
 
 if(ENABLE_GLES)
   add_definitions(-DGL_ES)
   # Disable USE_GTKGLEXT if using OpenGL ES
+  set(USE_GTKGLEXT OFF)
+endif()
+
+if(USE_GTK3)
+  # Disable USE_GTKGLEXT if using Gtk+3
   set(USE_GTKGLEXT OFF)
 endif()
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -345,6 +345,8 @@ List of supported parameters (passed as `-DPARAMETER=VALUE`):
 | ENABLE_DATA          | bool | OFF     | Use CelestiaContent submodule for data
 | ENABLE_GLES          | bool | OFF     | Use OpenGL ES 2.0 in rendering code
 | NATIVE_OSX_APP       | bool | OFF     | Support native OSX data paths
+| USE_GTKGLEXT         | bool | ON      | Use libgtkglext1 in GTK2 frontend
+| USE_GTK3             | bool | OFF     | Use Gtk3 instead of Gtk2 in GTK2 frontend
 
 Notes:
  \* /usr/local on Unix-like systems, c:\Program Files or c:\Program Files (x86)
@@ -362,6 +364,11 @@ On Windows systems two additonal options are supported:
   64-bit Celestia. To build 32-bit Celestia it should be omitted.
 - `CMAKE_TOOLCHAIN_FILE` - location of vcpkg.cmake if vcpkg is used.
 
+Please note that not all options are compatible:
+- `USE_GTKGLEXT` is not compatible with `ENABLE_GLES` and `USE_GTK3` and will
+  be disabled if any of this is set.
+- `ENABLE_GLES` is not compatible with `ENABLE_GLUT` and with `ENABLE_QT` if
+  your `glut` or Qt5 installation don't support OpenGL ES.
 
 Executable files
 ----------------

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -816,6 +816,7 @@ INPUT_ENCODING         = UTF-8
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
 FILE_PATTERNS          = *.cpp \
+                         *.c \
                          *.h
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -35,6 +35,7 @@ namespace gl
 {
 
 constexpr const int GL_2_1 = 21;
+constexpr const int GLES_2 = 20;
 
 extern bool ARB_shader_texture_lod;
 extern bool EXT_texture_compression_s3tc;

--- a/src/celestia/gtk/CMakeLists.txt
+++ b/src/celestia/gtk/CMakeLists.txt
@@ -37,20 +37,51 @@ set(GTK_HEADERS
   ui.h
 )
 
+if (NOT USE_GTKGLEXT)
+  set(GTK_SOURCES ${GTK_SOURCES} gtkegl.c)
+  set(GTK_HEADERS ${GTK_HEADERS} gtkegl.h)
+endif()
+
 pkg_check_modules(GTK2 gtk+-2.0 REQUIRED)
-pkg_check_modules(GTK2GLEXT gtkglext-1.0 REQUIRED)
 pkg_check_modules(CAIRO cairo)
+
+if (ENABLE_GLES)
+  pkg_check_modules(GLESv2 glesv2 REQUIRED)
+endif()
+
+if (USE_GTKGLEXT)
+  pkg_check_modules(GTK2GLEXT gtkglext-1.0 REQUIRED)
+else()
+  pkg_check_modules(EGL egl REQUIRED)
+endif()
 
 add_executable(celestia-gtk ${GTK_SOURCES})
 add_dependencies(celestia-gtk celestia)
 cotire(celestia-gtk)
+
+target_include_directories(celestia-gtk PRIVATE ${GTK2_INCLUDE_DIRS})
+target_link_libraries(celestia-gtk celestia ${GTK2_LIBRARIES})
+
 if (CAIRO_FOUND)
   target_include_directories(celestia-gtk PRIVATE ${CAIRO_INCLUDE_DIRS})
   target_link_libraries(celestia-gtk ${CAIRO_LIBRARIES})
   target_compile_definitions(celestia-gtk PRIVATE CAIRO)
 endif()
-target_include_directories(celestia-gtk PRIVATE ${GTK2_INCLUDE_DIRS} ${GTK2GLEXT_INCLUDE_DIRS})
-target_link_libraries(celestia-gtk celestia ${GTK2_LIBRARIES} ${GTK2GLEXT_LIBRARIES})
+
+if (USE_GTKGLEXT)
+  target_include_directories(celestia-gtk PRIVATE ${GTK2GLEXT_INCLUDE_DIRS})
+  target_link_libraries(celestia-gtk celestia ${GTK2GLEXT_LIBRARIES})
+  target_compile_definitions(celestia-gtk PRIVATE GTKGLEXT)
+else()
+  target_include_directories(celestia-gtk PRIVATE ${EGL_INCLUDE_DIRS})
+  target_link_libraries(celestia-gtk celestia ${EGL_LIBRARIES})
+endif()
+
+if (ENABLE_GLES)
+  target_include_directories(celestia-gtk PRIVATE ${GLESv2_INCLUDE_DIRS})
+  target_link_libraries(celestia-gtk celestia ${GLESv2_LIBRARIES})
+endif()
+
 install(TARGETS celestia-gtk RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_subdirectory(data)

--- a/src/celestia/gtk/CMakeLists.txt
+++ b/src/celestia/gtk/CMakeLists.txt
@@ -42,7 +42,11 @@ if (NOT USE_GTKGLEXT)
   set(GTK_HEADERS ${GTK_HEADERS} gtkegl.h)
 endif()
 
-pkg_check_modules(GTK2 gtk+-2.0 REQUIRED)
+if (USE_GTK3)
+  pkg_check_modules(GTK gtk+-3.0 REQUIRED)
+else()
+  pkg_check_modules(GTK gtk+-2.0 REQUIRED)
+endif()
 pkg_check_modules(CAIRO cairo)
 
 if (ENABLE_GLES)
@@ -59,8 +63,8 @@ add_executable(celestia-gtk ${GTK_SOURCES})
 add_dependencies(celestia-gtk celestia)
 cotire(celestia-gtk)
 
-target_include_directories(celestia-gtk PRIVATE ${GTK2_INCLUDE_DIRS})
-target_link_libraries(celestia-gtk celestia ${GTK2_LIBRARIES})
+target_include_directories(celestia-gtk PRIVATE ${GTK_INCLUDE_DIRS})
+target_link_libraries(celestia-gtk celestia ${GTK_LIBRARIES})
 
 if (CAIRO_FOUND)
   target_include_directories(celestia-gtk PRIVATE ${CAIRO_INCLUDE_DIRS})

--- a/src/celestia/gtk/actions.cpp
+++ b/src/celestia/gtk/actions.cpp
@@ -14,7 +14,7 @@
 #include <cstring>
 #include <fstream>
 #include <gtk/gtk.h>
-#include <fmt/printf.h>
+#include <fmt/format.h>
 
 #ifdef GNOME
 #include <gconf/gconf-client.h>
@@ -666,12 +666,16 @@ void actionHelpAbout(GtkAction*, AppData* app)
 
     GdkPixbuf *logo = gdk_pixbuf_new_from_file ("celestia-logo.png", NULL);
 
+    string comments = fmt::format("GTK+ Front-End, built using gtk+ version {}.{}",
+                                  GTK_MAJOR_VERSION,
+                                  GTK_MINOR_VERSION);
+
     gtk_show_about_dialog(GTK_WINDOW(app->mainWindow),
                          "name", "Celestia",
                          "version", VERSION,
-                         "copyright", "Copyright \xc2\xa9 2001-2011 Celestia Development Team",
-                         "comments", FRONTEND " Front-End",
-                         "website", "http://celestia.sf.net",
+                         "copyright", "Copyright \xc2\xa9 2001-2021 Celestia Development Team",
+                         "comments", comments.c_str(),
+                         "website", "https://celestia.space",
                          "authors", authors,
                          "license", readFromFile("COPYING"),
                          "logo", logo,

--- a/src/celestia/gtk/dialog-tour.cpp
+++ b/src/celestia/gtk/dialog-tour.cpp
@@ -61,6 +61,7 @@ void dialogTourGuide(AppData* app)
     td->descLabel = gtk_label_new("");
     gtk_label_set_line_wrap(GTK_LABEL(td->descLabel), TRUE);
     gtk_label_set_justify(GTK_LABEL(td->descLabel), GTK_JUSTIFY_FILL);
+    gtk_label_set_max_width_chars(GTK_LABEL(td->descLabel), 40);
     gtk_box_pack_start(GTK_BOX(content_area), td->descLabel, FALSE, FALSE, 0);
 
     const DestinationList* destinations = app->core->getDestinations();

--- a/src/celestia/gtk/glwidget.cpp
+++ b/src/celestia/gtk/glwidget.cpp
@@ -28,7 +28,11 @@
 /* Declarations: Callbacks */
 static gint glarea_idle(AppData* app);
 static gint glarea_configure(GtkWidget* widget, GdkEventConfigure*, AppData* app);
+#if GTK_MAJOR_VERSION == 2
 static gint glarea_expose(GtkWidget* widget, GdkEventExpose* event, AppData* app);
+#else
+static gint glarea_draw(GtkWidget*, cairo_t*, AppData* app);
+#endif
 static gint glarea_motion_notify(GtkWidget*, GdkEventMotion* event, AppData* app);
 static gint glarea_mouse_scroll(GtkWidget*, GdkEventScroll* event, AppData* app);
 static gint glarea_button_press(GtkWidget*, GdkEventButton* event, AppData* app);
@@ -44,8 +48,13 @@ static bool handleSpecialKey(int key, int state, bool down, AppData* app);
 /* ENTRY: Initialize/Bind all glArea Callbacks */
 void initGLCallbacks(AppData* app)
 {
+#if GTK_MAJOR_VERSION == 2
     g_signal_connect(G_OBJECT(app->glArea), "expose_event",
                      G_CALLBACK(glarea_expose), app);
+#else
+    g_signal_connect(G_OBJECT(app->glArea), "draw",
+                     G_CALLBACK(glarea_draw), app);
+#endif
     g_signal_connect(G_OBJECT(app->glArea), "configure_event",
                      G_CALLBACK(glarea_configure), app);
     g_signal_connect(G_OBJECT(app->glArea), "button_press_event",
@@ -102,6 +111,7 @@ static gint glarea_configure(GtkWidget* widget, GdkEventConfigure*, AppData* app
 }
 
 
+#if GTK_MAJOR_VERSION == 2
 /* CALLBACK: GL Function for event "expose_event" */
 static gint glarea_expose(GtkWidget*, GdkEventExpose* event, AppData* app)
 {
@@ -112,6 +122,13 @@ static gint glarea_expose(GtkWidget*, GdkEventExpose* event, AppData* app)
     /* Redraw -- draw checks are made in function */
     return glDrawFrame(app);
 }
+#else
+/* CALLBACK: GL Function for event "draw" */
+static gint glarea_draw(GtkWidget*, cairo_t*, AppData* app)
+{
+    return glDrawFrame(app);
+}
+#endif
 
 
 /* CALLBACK: GL Function for event "motion_notify_event" */

--- a/src/celestia/gtk/gtkegl.c
+++ b/src/celestia/gtk/gtkegl.c
@@ -1,0 +1,467 @@
+/* gtkegl.h
+ *
+ * Copyright (C) 2021, Celestia Development Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include <gtk/gtk.h>
+#include <gdk/gdkx.h>
+#if GTK_MAJOR_VERSION >= 3
+#include <gdk/gdkwayland.h>
+#endif /* GTK_MAJOR_VERSION >= 3 */
+#include <EGL/egl.h>
+#include "gtkegl.h"
+
+/* In Gtk2 mode we support X11 only */
+#if GTK_MAJOR_VERSION == 2
+# define GDK_WINDOWING_X11
+# define GDK_IS_X11_DISPLAY(gdk_display)        TRUE
+#endif /* GTK_MAJOR_VERSION == 2 */
+
+struct _GtkEGLPrivate
+{
+    EGLDisplay *egl_display;
+    EGLSurface *egl_surface;
+    EGLContext *egl_context;
+    gint8       require_version_major;
+    gint8       require_version_minor;
+    gint8       require_depth_size;
+    gint8       require_stencil_size;
+    gint8       require_red_size;
+    gint8       require_green_size;
+    gint8       require_blue_size;
+    gint8       require_alpha_size;
+    gint8       require_msaa_samples;
+    gboolean    require_es    : 1;
+    gboolean    realized      : 1;
+};
+
+typedef struct _GtkEGLPrivate GtkEGLPrivate;
+
+static void
+gtk_egl_private_init(GtkEGLPrivate *private)
+{
+    private->realized               = FALSE;
+    private->require_es             = FALSE;
+    private->require_version_major  = 0;
+    private->require_version_minor  = 0;
+    private->require_depth_size     = 0;
+    private->require_stencil_size   = 0;
+    private->require_msaa_samples   = 0;
+    private->require_red_size       = 0;
+    private->require_green_size     = 0;
+    private->require_blue_size      = 0;
+    private->require_alpha_size     = 0;
+}
+
+static void
+gtk_egl_widget_realize(GtkWidget        *widget,
+                       GtkEGLPrivate    *private);
+
+static gboolean
+gtk_egl_widget_configure_event(GtkWidget     *widget,
+                               GdkEvent      *ev,
+                               GtkEGLPrivate *private);
+
+static void
+gtk_egl_widget_size_allocate(GtkWidget      *widget,
+                             GtkAllocation  *allocation,
+                             GtkEGLPrivate  *private);
+
+static void
+gtk_egl_widget_unrealize(GtkWidget      *widget,
+                         GtkEGLPrivate  *private);
+
+static GQuark egl_property_quark = 0;
+
+#define GTK_EGL_GET_PRIVATE(widget) \
+        ((GtkEGLPrivate*) g_object_get_qdata(G_OBJECT(widget), egl_property_quark))
+
+/**
+ * Make EGL context attached to a widget current EGL context.
+ *
+ * See eglMakeCurrent for more information.
+ *
+ * @param widget EGL capable GtkWidget.
+ */
+gboolean
+gtk_egl_drawable_make_current(GtkWidget *widget)
+{
+    GtkEGLPrivate *private = GTK_EGL_GET_PRIVATE(widget);
+    if (private == NULL)
+        return FALSE;
+
+    eglMakeCurrent(private->egl_display,
+                   private->egl_surface,
+                   private->egl_surface,
+                   private->egl_context);
+    return TRUE;
+}
+
+/**
+ * Swap back-buffers attached to a widget.
+ *
+ * See eglSwapBuffers for more information.
+ *
+ * @param widget EGL capable GtkWidget.
+ */
+void
+gtk_egl_drawable_swap_buffers(GtkWidget *widget)
+{
+    GtkEGLPrivate *private = GTK_EGL_GET_PRIVATE(widget);
+    if (private != NULL)
+        eglSwapBuffers(private->egl_display, private->egl_surface);
+}
+
+/**
+ * Check if a widget is EGL capable.
+ *
+ * @param widget a GtkWidget.
+ */
+gboolean
+gtk_widget_is_egl_capable(GtkWidget *widget)
+{
+    return egl_property_quark != 0 &&
+           g_object_get_qdata(G_OBJECT(widget), egl_property_quark) != NULL;
+}
+
+/**
+ * Make a widget EGL capable.
+ *
+ * Initialize EGL subsystem and create EGL context for drawing operations.
+ *
+ * @param widget a GtkWidget.
+ */
+gboolean
+gtk_widget_set_egl_capability(GtkWidget *widget)
+{
+    GtkEGLPrivate *private = NULL;
+
+    if (gtk_widget_is_egl_capable(widget))
+        return TRUE;
+
+#if !GTK_CHECK_VERSION(3, 10, 0)
+    // No double buffering as we might have triple buffering
+    gtk_widget_set_double_buffered(widget, FALSE);
+#endif
+
+    private = g_new(GtkEGLPrivate, 1);
+    g_assert(private != NULL);
+    gtk_egl_private_init(private);
+
+    if (egl_property_quark == 0)
+        egl_property_quark = g_quark_from_static_string("egl-drawable-private");
+    g_object_set_qdata(G_OBJECT(widget), egl_property_quark, private);
+
+    // Connect signal handlers to realize OpenGL-capable widget.
+    g_signal_connect(G_OBJECT(widget), "realize",
+                     G_CALLBACK(gtk_egl_widget_realize),
+                     private);
+
+    // gtk_widget sends configure_event when it is realized.
+    g_signal_connect(G_OBJECT(widget), "configure_event",
+                     G_CALLBACK(gtk_egl_widget_configure_event),
+                     private);
+
+    // Connect "size_allocate" signal handler to synchronize OpenGL
+    // and window resizing request streams.
+    g_signal_connect(G_OBJECT(widget), "size_allocate",
+                     G_CALLBACK(gtk_egl_widget_size_allocate),
+                     private);
+
+    g_signal_connect(G_OBJECT(widget), "unrealize",
+                     G_CALLBACK(gtk_egl_widget_unrealize),
+                     private);
+
+    return TRUE;
+}
+
+/**
+ * Request OpenGL ES or desktop OpenGL usage a in EGL capable widget.
+ *
+ * @param widget a EGL capable GtkWidget.
+ * @param require_es if TRUE then use OpenGL ES, else use OpenGL.
+ */
+void
+gtk_egl_drawable_set_require_es(GtkWidget *widget,
+                                gboolean   require_es)
+{
+    GtkEGLPrivate *private = GTK_EGL_GET_PRIVATE(widget);
+    g_assert(private != NULL);
+
+    private->require_es = require_es;
+}
+
+/**
+ * Request OpenGL ES version to use in a EGL capable widget.
+ *
+ * Currently can be called to request OpenGL ES 2.0 context
+ * instead of 1.1 created by default.
+ *
+ * @param widget a EGL capable GtkWidget.
+ * @param major major OpenGL ES version.
+ * @param minor minor OpenGL ES version.
+ */
+void
+gtk_egl_drawable_set_require_version(GtkWidget *widget,
+                                     gint major,
+                                     gint minor)
+{
+    GtkEGLPrivate *private = GTK_EGL_GET_PRIVATE(widget);
+    g_assert(private != NULL);
+
+    private->require_version_major = major;
+    private->require_version_minor = minor;
+}
+
+/**
+ * Request minimal depth buffer size.
+ *
+ * @param widget a EGL capable GtkWidget.
+ * @param depth_size required depth buffer size in bits.
+ */
+void
+gtk_egl_drawable_set_require_depth_size(GtkWidget *widget,
+                                        gint       depth_size)
+{
+    GtkEGLPrivate *private = GTK_EGL_GET_PRIVATE(widget);
+    g_assert(private != NULL);
+
+    private->require_depth_size = depth_size;
+}
+
+/**
+ * Request minimal stencil buffer size.
+ *
+ * @param widget a EGL capable GtkWidget.
+ * @param depth_size required stencil buffer size in bits.
+ */
+void
+gtk_egl_drawable_set_require_stencil_size(GtkWidget *widget,
+                                          gint       stencil_size)
+{
+    GtkEGLPrivate *private = GTK_EGL_GET_PRIVATE(widget);
+    g_assert(private != NULL);
+
+    private->require_stencil_size = stencil_size;
+}
+
+/**
+ * Request minimal color buffer sizes for R,G,B and alpha channels.
+ *
+ * @param widget a EGL capable GtkWidget.
+ * @param red_size required red channel size in bits.
+ * @param green_size required green channel size in bits.
+ * @param blue_size required blue channel size in bits.
+ * @param alpha_size required alpha channel size in bits.
+ */
+void
+gtk_egl_drawable_set_require_rgba_sizes   (GtkWidget *widget,
+                                           gint       red_size,
+                                           gint       green_size,
+                                           gint       blue_size,
+                                           gint       alpha_size)
+{
+    GtkEGLPrivate *private = GTK_EGL_GET_PRIVATE(widget);
+    g_assert(private != NULL);
+
+    private->require_red_size   = red_size;
+    private->require_green_size = green_size;
+    private->require_blue_size  = blue_size;
+    private->require_alpha_size = alpha_size;
+}
+
+/**
+ * Request a MSAA capable color buffer creation.
+ *
+ * @param widget a EGL capable GtkWidget.
+ * @param msaa_samples number of samples used by MSAA.
+ */
+void
+gtk_egl_drawable_set_require_msaa_samples(GtkWidget *widget,
+                                          gint       msaa_samples)
+{
+    GtkEGLPrivate *private = GTK_EGL_GET_PRIVATE(widget);
+    g_assert(private != NULL);
+
+    private->require_msaa_samples = msaa_samples;
+}
+
+#define MIN_ATTR_LIST_SIZE 20
+static void
+gtk_egl_build_screen_attributes_list(GtkEGLPrivate *private,
+                                     EGLint        *attributes,
+                                     int            count)
+{
+    g_assert(count >= MIN_ATTR_LIST_SIZE);
+
+    int i = 0;
+    attributes[i++] = EGL_RENDERABLE_TYPE;
+    if (private->require_es)
+    {
+        if (private->require_version_major == 2)
+            attributes[i] = EGL_OPENGL_ES2_BIT;
+        else
+            attributes[i] = EGL_OPENGL_ES_BIT;
+    }
+    else
+    {
+        attributes[i] = EGL_OPENGL_BIT;
+    }
+    i++;
+
+    if (private->require_depth_size > 0)
+    {
+        attributes[i++] = EGL_DEPTH_SIZE;
+        attributes[i++] = private->require_depth_size;
+    }
+
+    if (private->require_stencil_size > 0)
+    {
+        attributes[i++] = EGL_STENCIL_SIZE;
+        attributes[i++] = private->require_stencil_size;
+    }
+
+    if (private->require_msaa_samples > 0)
+    {
+        attributes[i++] = EGL_SAMPLE_BUFFERS;
+        attributes[i++] = 1;
+        attributes[i++] = EGL_SAMPLES;
+        attributes[i++] = private->require_msaa_samples;
+    }
+
+    {
+        attributes[i++] = EGL_ALPHA_SIZE;
+        attributes[i++] = 8;
+        attributes[i++] = EGL_RED_SIZE;
+        attributes[i++] = 8;
+        attributes[i++] = EGL_GREEN_SIZE;
+        attributes[i++] = 8;
+        attributes[i++] = EGL_BLUE_SIZE;
+        attributes[i++] = 8;
+    }
+
+    attributes[i] = EGL_NONE;
+    g_assert(i < MIN_ATTR_LIST_SIZE);
+}
+
+static void
+gtk_egl_build_context_attributes_list(GtkEGLPrivate *private,
+                                      EGLint        *attributes,
+                                      int            count)
+{
+    g_assert(count >= 3);
+    int i = 0;
+    if (private->require_es && private->require_version_major == 2)
+    {
+        attributes[0] = EGL_CONTEXT_CLIENT_VERSION;
+        attributes[1] = 2;
+        i = 2;
+    }
+    attributes[i] = EGL_NONE;
+}
+
+/* drawing area signal handlers */
+static void
+gtk_egl_widget_realize(GtkWidget        *widget,
+                       GtkEGLPrivate    *private)
+{
+    EGLConfig egl_config;
+    EGLint n_config;
+    EGLint attributes[MIN_ATTR_LIST_SIZE] = {EGL_NONE};
+
+    if (private->realized)
+        return;
+
+    gtk_egl_build_screen_attributes_list(private, attributes, sizeof(attributes));
+
+    GdkWindow  *gdk_window  = gtk_widget_get_window(widget);
+    g_assert(gdk_window != NULL);
+    GdkDisplay *gdk_display = gtk_widget_get_display(widget);
+    g_assert(gdk_display != NULL);
+
+    EGLDisplay *egl_display = NULL;
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_DISPLAY(gdk_display))
+        egl_display = eglGetDisplay((EGLNativeDisplayType) GDK_DISPLAY_XDISPLAY(gdk_display));
+#endif /* GDK_WINDOWING_X11 */
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_DISPLAY(gdk_display))
+        egl_display = eglGetDisplay((EGLNativeDisplayType) gdk_wayland_display_get_wl_display(gdk_display));
+#endif /* GDK_WINDOWING_WAYLAND */
+
+    if (egl_display == NULL)
+    {
+        g_print("eglGetDisplay() returned NULL or was not called!\n");
+        return;
+    }
+
+    if (!eglInitialize(egl_display, NULL, NULL))
+    {
+        g_print("eglInitialize() failed!\n");
+        return;
+    }
+
+    if (!eglChooseConfig(egl_display, attributes, &egl_config, 1, &n_config))
+    {
+        g_print("eglChooseConfig() failed!\n");
+        return;
+    }
+
+    EGLenum api = private->require_es ? EGL_OPENGL_ES_API : EGL_OPENGL_API;
+    if (!eglBindAPI(api))
+    {
+        g_print("eglBindAPI(0x%X) failed!\n", api);
+        return;
+    }
+
+    EGLSurface *egl_surface = eglCreateWindowSurface(egl_display, egl_config, GDK_WINDOW_XID(gdk_window), NULL);
+
+    gtk_egl_build_context_attributes_list(private, attributes, sizeof(attributes));
+    EGLContext *egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT, attributes);
+
+    private->egl_display = egl_display;
+    private->egl_surface = egl_surface;
+    private->egl_context = egl_context;
+    private->realized    = TRUE;
+}
+
+static gboolean
+gtk_egl_widget_configure_event(GtkWidget     *widget,
+                               GdkEvent      *ev,
+                               GtkEGLPrivate *private)
+{
+    // Realize if OpenGL-capable window is not realized yet
+    if (!private->realized)
+        gtk_egl_widget_realize(widget, private);
+
+    return FALSE;
+}
+
+static void
+gtk_egl_widget_size_allocate(GtkWidget     *widget,
+                             GtkAllocation *allocation,
+                             GtkEGLPrivate *private)
+{
+    // Synchronize OpenGL and window resizing request streams.
+    if (gtk_widget_get_realized(widget) && private->realized)
+        eglWaitNative(EGL_CORE_NATIVE_ENGINE);
+}
+
+static void
+gtk_egl_widget_unrealize(GtkWidget     *widget,
+                         GtkEGLPrivate *private)
+{
+    eglMakeCurrent(private->egl_display,
+                   private->egl_surface,
+                   private->egl_surface,
+                   private->egl_context);
+
+    eglTerminate(private->egl_display);
+    g_object_set_qdata(G_OBJECT(widget), egl_property_quark, NULL);
+    g_free(private);
+}

--- a/src/celestia/gtk/gtkegl.h
+++ b/src/celestia/gtk/gtkegl.h
@@ -1,0 +1,61 @@
+/* gtkegl.h
+ *
+ * Copyright (C) 2021, Celestia Development Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+gboolean
+gtk_egl_drawable_make_current             (GtkWidget *drawing_area);
+
+void
+gtk_egl_drawable_swap_buffers             (GtkWidget *drawing_area);
+
+gboolean
+gtk_widget_is_egl_capable                 (GtkWidget *drawing_area);
+
+gboolean
+gtk_widget_set_egl_capability             (GtkWidget *drawing_area);
+
+void
+gtk_egl_drawable_set_require_es           (GtkWidget *drawing_area,
+                                           gboolean   require_es);
+
+void
+gtk_egl_drawable_set_require_version      (GtkWidget *drawing_area,
+                                           gint major,
+                                           gint minor);
+
+void
+gtk_egl_drawable_set_require_depth_size   (GtkWidget *drawing_area,
+                                           gint       depth_size);
+
+void
+gtk_egl_drawable_set_require_stencil_size (GtkWidget *drawing_area,
+                                           gint       stencil_size);
+
+void
+gtk_egl_drawable_set_require_rgba_sizes   (GtkWidget *drawing_area,
+                                           gint       red_size,
+                                           gint       green_size,
+                                           gint       blue_size,
+                                           gint       alpha_size);
+
+void
+gtk_egl_drawable_set_require_msaa_samples (GtkWidget *drawing_area,
+                                           gint       msaa_samples);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/celestia/gtk/main.cpp
+++ b/src/celestia/gtk/main.cpp
@@ -498,6 +498,7 @@ int main(int argc, char* argv[])
                           GDK_KEY_RELEASE_MASK |
                           GDK_BUTTON_PRESS_MASK |
                           GDK_BUTTON_RELEASE_MASK |
+                          GDK_SCROLL_MASK |
                           GDK_POINTER_MOTION_MASK);
 
     /* Load settings the can be applied before the simulation is initialized */

--- a/src/celestia/gtk/splash.cpp
+++ b/src/celestia/gtk/splash.cpp
@@ -23,7 +23,9 @@
 using namespace std;
 
 /* Declarations */
+#if GTK_MAJOR_VERSION == 2
 static gboolean splashExpose(GtkWidget* win, GdkEventExpose *event, SplashData* ss);
+#endif
 
 
 /* OBJECT: Overrides ProgressNotifier to receive feedback from core */
@@ -58,7 +60,7 @@ SplashData* splashStart(AppData* app, gboolean showSplash)
     gtk_window_set_position(GTK_WINDOW(ss->splash), GTK_WIN_POS_CENTER);
     gtk_widget_set_app_paintable(ss->splash, TRUE);
 
-    #ifdef CAIRO
+    #if defined(CAIRO) && GTK_MAJOR_VERSION == 2
     /* Colormap Magic */
     GdkScreen* screen = gtk_widget_get_screen(ss->splash);
     GdkColormap* colormap = gdk_screen_get_rgba_colormap(screen);
@@ -93,9 +95,11 @@ SplashData* splashStart(AppData* app, gboolean showSplash)
     gtk_fixed_put(GTK_FIXED(gf), ss->label, 40, allocation.height / 2 - 40);
     gtk_widget_show(ss->label);
 
+#if GTK_MAJOR_VERSION == 2
     g_signal_connect (ss->splash, "expose_event",
                       G_CALLBACK (splashExpose),
                       ss);
+#endif
 
     while (gtk_events_pending()) gtk_main_iteration();
 
@@ -133,7 +137,7 @@ void splashSetText(SplashData* ss, const char* text)
     while (gtk_events_pending()) gtk_main_iteration();
 }
 
-
+#if GTK_MAJOR_VERSION == 2
 /* CALLBACK: Called when the splash screen is exposed */
 static gboolean splashExpose(GtkWidget* win, GdkEventExpose *event, SplashData* ss)
 {
@@ -190,3 +194,4 @@ static gboolean splashExpose(GtkWidget* win, GdkEventExpose *event, SplashData* 
 
     return FALSE;
 }
+#endif


### PR DESCRIPTION
Gtk 2 is reached EOL. It will be supported by GNU/Linux and *BSD distributions for several years, but probably it will dropped earlier than we release 1.7. So when I test these changes for Gtk frontend I'll port them to 1.6 branch.

This PR:
* Introduces own library to create GL capable windows. Unlike gtkglext it uses EGL instead of GLX and WGL. So as a tiny-tiny downside it works on Windows only with AMD video HW, but I dropped Windows support long time ago (who really needs Gtk on Windows?). But as a huge advantages it supports OpenGL ES and Wayland, but it was not tested on Wayland actually.
* Adds some fixes to Gtk code to make it work with Gtk3.
* Adds display of Gtk version used in Help->About dialog.

Gtk3 introduced GtkGLArea widget in version 3.16 but it works with core GL contexts only while Celestia requires compatibility context. We can try to workaround this compiling in GLES mode, but this change will be useless for 1.6. So that's because I added own library.

There are some bugs in Gtk3 mode with Options dialog synchronization with menus (menus doesn't reflect changes made in Options), but currently I have no idea how to fix this, something was changed in action handling. Anyway Gtk2 is a default mode. So lets merge this as is.