### PR TITLE
Implement skip_permission_denied and align behavior with std::filesystem

### DIFF
--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -268,7 +268,7 @@ void VirtualTexture::populateTileTree()
             int uLimit = 2 << maxLevel;
             int vLimit = 1 << maxLevel;
 
-            for (auto& d : fs::directory_iterator(path))
+            for (auto& d : fs::directory_iterator(path, ec))
             {
                 int u = -1, v = -1;
                 if (sscanf(d.path().filename().string().c_str(), pattern.c_str(), &u, &v) == 2)

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3790,11 +3790,14 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
                 continue;
 
             entries.clear();
-            for (const auto& fn : fs::recursive_directory_iterator(dir))
+            std::error_code ec;
+            auto iter = fs::recursive_directory_iterator(dir, ec);
+            for (; iter != end(iter); iter.increment(ec))
             {
-                std::error_code ec;
-                if (!fs::is_directory(fn.path(), ec))
-                    entries.push_back(fn.path());
+                if (ec)
+                    continue;
+                if (!fs::is_directory(iter->path(), ec))
+                    entries.push_back(iter->path());
             }
             std::sort(begin(entries), end(entries));
             for (const auto& fn : entries)
@@ -3838,11 +3841,14 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
                 continue;
 
             entries.clear();
-            for (const auto& fn : fs::recursive_directory_iterator(dir))
+            std::error_code ec;
+            auto iter = fs::recursive_directory_iterator(dir, ec);
+            for (; iter != end(iter); iter.increment(ec))
             {
-                std::error_code ec;
-                if (!fs::is_directory(fn.path(), ec))
-                    entries.push_back(fn.path());
+                if (ec)
+                    continue;
+                if (!fs::is_directory(iter->path(), ec))
+                    entries.push_back(iter->path());
             }
             sort(begin(entries), end(entries));
             for(const auto& fn : entries)
@@ -4147,11 +4153,14 @@ bool CelestiaCore::readStars(const CelestiaConfig& cfg,
                 continue;
 
             entries.clear();
-            for (const auto& fn : fs::recursive_directory_iterator(dir))
+            std::error_code ec;
+            auto iter = fs::recursive_directory_iterator(dir, ec);
+            for (; iter != end(iter); iter.increment(ec))
             {
-                std::error_code ec;
-                if (!fs::is_directory(fn.path(), ec))
-                    entries.push_back(fn.path());
+                if (ec)
+                    continue;
+                if (!fs::is_directory(iter->path(), ec))
+                    entries.push_back(iter->path());
             }
             std::sort(begin(entries), end(entries));
             for (const auto& fn : entries)

--- a/src/celscript/lua/luascript.cpp
+++ b/src/celscript/lua/luascript.cpp
@@ -172,8 +172,13 @@ static string lua_path(const CelestiaConfig *config)
         }
 
         LuaPathFinder loader;
-        for (const auto& fn : fs::recursive_directory_iterator(dir))
-            loader.process(fn);
+        auto iter = fs::recursive_directory_iterator(dir, ec);
+        for (; iter != end(iter); iter.increment(ec))
+        {
+            if (ec)
+                continue;
+            loader.process(*iter);
+        }
         LuaPath += loader.getLuaPath();
     }
     return LuaPath;


### PR DESCRIPTION
Use recursive_directory_iterator's `increment` with ec in place of operator++ since it might throw.