### PR TITLE
[celx] Use default GLSL program in gl.Begin

### DIFF
--- a/src/celscript/lua/celx_gl.cpp
+++ b/src/celscript/lua/celx_gl.cpp
@@ -157,6 +157,7 @@ static int gl_Begin(lua_State* l)
     CelxLua celx(l);
     celx.checkArgs(1, 1, "One argument expected for gl.Begin()");
     int i = (int)celx.safeGetNumber(1, WrongType, "argument 1 to gl.Begin must be a number", 0.0);
+    glUseProgram(0);
     glBegin(i);
     return 0;
 }


### PR DESCRIPTION
This is a hack because we should `glUseProgram(0);` in `Renderer.draw()` and in overlay functions but there are too many places to find all of them so now let's got with this to allow LUT usage with 1.7 (so far with desktop GL only).

Fixes #1091 (i hope :))

![screenshot](https://user-images.githubusercontent.com/1612688/127042730-28bb92c5-f2ea-4bdb-b215-6eda203cfebe.png)
