### PR TITLE
Match line length in row inversion in captured image with Image constructor

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -5535,6 +5535,7 @@ bool Renderer::captureFrame(int x, int y, int w, int h, PixelFormat format, unsi
     if (!gl::MESA_pack_invert)
     {
         int realWidth = w * formatWidth(format);
+        realWidth = (realWidth + 3) & ~0x3;
 #if defined(__GNUC__) && !defined(__STRICT_ANSI__)
         uint8_t tempLine[realWidth]; // G++ supports VLA as an extension
 #else


### PR DESCRIPTION
Fixes an issue in image capturing when `MESA_pack_invert` is not supported. The row length calculated in the routine to invert the row order needs to match the pitch calculated in the `Image` constructor, otherwise the saved/copied image ends up being diagonal unless the viewport width is a multiple of 12.