### PR TITLE
Add support for imperial units

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3969,6 +3969,16 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
             DPRINTF(LOG_LEVEL_WARNING, "Unknown viewport effect %s\n", config->viewportEffect);
     }
 
+    if (!config->measurementSystem.empty())
+    {
+        if (compareIgnoringCase(config->measurementSystem, "imperial") == 0)
+            measurement = Imperial;
+        else if (compareIgnoringCase(config->measurementSystem, "metric") == 0)
+            measurement = Metric;
+        else
+            DPRINTF(LOG_LEVEL_WARNING, "Unknown measurement system %s\n", config->measurementSystem);
+    }
+
     sim = new Simulation(universe);
     if ((renderer->getRenderFlags() & Renderer::ShowAutoMag) == 0)
     {

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -149,15 +149,16 @@ class CelestiaCore // : public Watchable<CelestiaCore>
 
     enum
     {
-        LabelFlagsChanged       = 1,
-        RenderFlagsChanged      = 2,
-        VerbosityLevelChanged   = 4,
-        TimeZoneChanged         = 8,
-        AmbientLightChanged     = 16,
-        FaintestChanged         = 32,
-        HistoryChanged          = 64,
-        TextEnterModeChanged    = 128,
-        GalaxyLightGainChanged  = 256,
+        LabelFlagsChanged           = 0x0001,
+        RenderFlagsChanged          = 0x0002,
+        VerbosityLevelChanged       = 0x0004,
+        TimeZoneChanged             = 0x0008,
+        AmbientLightChanged         = 0x0010,
+        FaintestChanged             = 0x0020,
+        HistoryChanged              = 0x0040,
+        TextEnterModeChanged        = 0x0080,
+        GalaxyLightGainChanged      = 0x0100,
+        MeasurementSystemChanged    = 0x0200,
     };
 
     enum
@@ -174,6 +175,12 @@ class CelestiaCore // : public Watchable<CelestiaCore>
         ShowVelocity  = 0x004,
         ShowSelection = 0x008,
         ShowFrame     = 0x010,
+    };
+
+    enum MeasurementSystem
+    {
+        Metric      = 0,
+        Imperial    = 1,
     };
 
  public:
@@ -369,6 +376,9 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     Image captureImage() const;
     bool saveScreenShot(const fs::path&, ContentType = Content_Unknown) const;
 
+    void setMeasurementSystem(MeasurementSystem);
+    MeasurementSystem getMeasurementSystem() const;
+
  protected:
     bool readStars(const CelestiaConfig&, ProgressNotifier*);
     void renderOverlay();
@@ -508,6 +518,8 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     };
 
     EdgeInsets safeAreaInsets { 0, 0, 0, 0 };
+
+    MeasurementSystem measurement { Metric };
 
     Selection lastSelection;
     std::string selectionNames;

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -99,6 +99,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
     configParams->getString("WarpMeshFile", config->warpMeshFile);
     configParams->getString("X264EncoderOptions", config->x264EncoderOptions);
     configParams->getString("FFVHEncoderOptions", config->ffvhEncoderOptions);
+    configParams->getString("MeasurementSystem", config->measurementSystem);
 
     float maxDist = 1.0;
     configParams->getNumber("SolarSystemMaxDistance", maxDist);

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -82,6 +82,7 @@ public:
     std::string projectionMode;
     std::string viewportEffect;
     std::string warpMeshFile;
+    std::string measurementSystem;
 
     std::string x264EncoderOptions;
     std::string ffvhEncoderOptions;


### PR DESCRIPTION
Had quite a few reviews from Play asking for supporting imperial units. These units are added but I'm not sure if they are the common ones.

mi, ft for length (km, m)
mi/s, ft/s for speed (km/s, m/s)
slug/ft^3 for density (1000 kg/m^3)
lb for mass (kg)

@SevenSpheres 