### PR TITLE
Fixes for the Windows build

### DIFF
--- a/src/celcompat/cc.cpp
+++ b/src/celcompat/cc.cpp
@@ -11,12 +11,14 @@
 
 #include "cc.h"
 
-namespace std
+namespace celestia
+{
+namespace compat
 {
 
 auto from_chars(const char* first, const char* last, float &value,
-                std::chars_format fmt)
-    -> std::from_chars_result
+                celestia::compat::chars_format fmt)
+    -> celestia::compat::from_chars_result
 {
     char *end;
     errno = 0;
@@ -33,8 +35,8 @@ auto from_chars(const char* first, const char* last, float &value,
 }
 
 auto from_chars(const char* first, const char* last, double &value,
-                std::chars_format fmt)
-    -> std::from_chars_result
+                celestia::compat::chars_format fmt)
+    -> celestia::compat::from_chars_result
 {
     char *end;
     errno = 0;
@@ -51,8 +53,8 @@ auto from_chars(const char* first, const char* last, double &value,
 }
 
 auto from_chars(const char* first, const char* last, long double &value,
-                std::chars_format fmt)
-    -> std::from_chars_result
+                celestia::compat::chars_format fmt)
+    -> celestia::compat::from_chars_result
 {
     char *end;
     errno = 0;
@@ -68,4 +70,5 @@ auto from_chars(const char* first, const char* last, long double &value,
     return { end, std::errc() };
 }
 
+}
 }

--- a/src/celcompat/cc.h
+++ b/src/celcompat/cc.h
@@ -15,7 +15,9 @@
 #include <system_error>
 #include <type_traits>
 
-namespace std
+namespace celestia
+{
+namespace compat
 {
 struct from_chars_result
 {
@@ -33,25 +35,25 @@ enum class chars_format
 
 template <typename T, typename std::enable_if<std::numeric_limits<T>::is_integer, T>::type = 0>
 auto from_chars(const char* first, const char* last, T& value, int base = 10)
-    -> std::from_chars_result;
+    -> celestia::compat::from_chars_result;
 
 auto from_chars(const char* first, const char* last, float &value,
-                std::chars_format fmt = std::chars_format::general)
-    -> std::from_chars_result;
+                celestia::compat::chars_format fmt = celestia::compat::chars_format::general)
+    -> celestia::compat::from_chars_result;
 
 auto from_chars(const char* first, const char* last, double &value,
-                std::chars_format fmt = std::chars_format::general)
-    -> std::from_chars_result;
+                celestia::compat::chars_format fmt = celestia::compat::chars_format::general)
+    -> celestia::compat::from_chars_result;
 
 auto from_chars(const char* first, const char* last, long double &value,
-                std::chars_format fmt = std::chars_format::general)
-    -> std::from_chars_result;
+                celestia::compat::chars_format fmt = celestia::compat::chars_format::general)
+    -> celestia::compat::from_chars_result;
 
 namespace
 {
 template <typename T>
 auto int_from_chars(const char* first, const char* last, T& value, int base) noexcept
-    -> std::from_chars_result
+    -> celestia::compat::from_chars_result
 {
     auto p = first;
     bool has_minus = false;
@@ -61,7 +63,7 @@ auto int_from_chars(const char* first, const char* last, T& value, int base) noe
         p++;
     }
 
-    using U = typename make_unsigned<T>::type;
+    using U = typename std::make_unsigned<T>::type;
 
     U risky_value;
     U max_digit;
@@ -125,8 +127,9 @@ auto int_from_chars(const char* first, const char* last, T& value, int base) noe
 
 template <typename T, typename std::enable_if<std::numeric_limits<T>::is_integer, T>::type>
 auto from_chars(const char* first, const char* last, T& value, int base)
-    -> std::from_chars_result
+    -> celestia::compat::from_chars_result
 {
     return int_from_chars(first, last, value, base);
+}
 }
 }

--- a/src/celcompat/charconv.h
+++ b/src/celcompat/charconv.h
@@ -4,6 +4,15 @@
 
 #ifdef HAVE_CHARCONV
 #include <charconv>
+namespace celestia
+{
+namespace compat
+{
+    using std::from_chars_result;
+    using std::chars_format;
+    using std::from_chars;
+}
+}
 #else
 #include "cc.h"
 #endif

--- a/src/celcompat/string_view.h
+++ b/src/celcompat/string_view.h
@@ -4,12 +4,36 @@
 
 #ifdef HAVE_STRING_VIEW
 #include <string_view>
+namespace celestia
+{
+namespace compat
+{
+    using std::basic_string_view;
+    using std::string_view;
+}
+}
 #elif defined(HAVE_EXPERIMENTAL_STRING_VIEW)
 #include <experimental/string_view>
-namespace std
+namespace celestia
 {
-    using string_view = std::experimental::string_view;
+namespace compat
+{
+    using std::experimental::basic_string_view;
+    using std::experimental::string_view;
+}
 }
 #else
+#include <fmt/format.h>
 #include "sv.h"
+
+template<>
+struct fmt::formatter<celestia::compat::string_view> : formatter<fmt::string_view>
+{
+    template<typename FormatContext>
+    auto format(celestia::compat::string_view v, FormatContext& ctx)
+    {
+        fmt::string_view f{v.data(), v.size()};
+        return formatter<fmt::string_view>::format(f, ctx);
+    }
+};
 #endif

--- a/src/celcompat/sv.h
+++ b/src/celcompat/sv.h
@@ -26,7 +26,9 @@
 #include <cstdlib>
 #endif
 
-namespace std
+namespace celestia
+{
+namespace compat
 {
 template<
     typename CharT,
@@ -70,7 +72,7 @@ template<
 
     constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
 
-    explicit operator basic_string<CharT, Traits>() const
+    explicit operator std::basic_string<CharT, Traits>() const
     {
         return { m_data, m_size };
     }
@@ -352,12 +354,12 @@ constexpr bool operator==(basic_string_view <CharT, Traits> lhs,
  */
 template<class CharT, class Traits>
 constexpr bool operator==(basic_string_view <CharT, Traits> lhs,
-                          basic_string <CharT, Traits> rhs) noexcept
+                          std::basic_string <CharT, Traits> rhs) noexcept
 {
     return lhs == basic_string_view<CharT, Traits>(rhs);
 }
 template<class CharT, class Traits>
-constexpr bool operator==(basic_string <CharT, Traits> lhs,
+constexpr bool operator==(std::basic_string <CharT, Traits> lhs,
                           basic_string_view <CharT, Traits> rhs) noexcept
 {
     return rhs == lhs;
@@ -399,12 +401,12 @@ constexpr bool operator!=(basic_string_view <CharT, Traits> lhs,
  */
 template<class CharT, class Traits>
 constexpr bool operator!=(basic_string_view <CharT, Traits> lhs,
-                          basic_string <CharT, Traits> rhs) noexcept
+                          std::basic_string <CharT, Traits> rhs) noexcept
 {
     return !(lhs == rhs);
 }
 template<class CharT, class Traits>
-constexpr bool operator!=(basic_string <CharT, Traits> lhs,
+constexpr bool operator!=(std::basic_string <CharT, Traits> lhs,
                           basic_string_view <CharT, Traits> rhs) noexcept
 {
     return !(lhs == rhs);
@@ -449,7 +451,7 @@ constexpr bool operator>=(basic_string_view <CharT, Traits> lhs,
 
 template <class CharT, class Traits>
 std::basic_ostream <CharT, Traits>& operator<<(std::basic_ostream <CharT, Traits>& os,
-                                              std::basic_string_view <CharT, Traits> v)
+                                              celestia::compat::basic_string_view <CharT, Traits> v)
 {
     os.write(v.data(), v.size());
     return os;
@@ -508,6 +510,7 @@ struct hash<string_view>
     }
 };
 }
+}
 
 #if defined(__clang__)
 #pragma clang diagnostic ignored "-Wreserved-user-defined-literal"
@@ -517,25 +520,26 @@ struct hash<string_view>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wliteral-suffix"
 #endif
-constexpr std::string_view operator "" sv(const char *str, size_t len)
+constexpr celestia::compat::string_view operator "" sv(const char *str, std::size_t len)
 {
     return { str, len };
 }
 
-constexpr std::wstring_view operator "" sv(const wchar_t *str, size_t len)
+constexpr celestia::compat::wstring_view operator "" sv(const wchar_t *str, std::size_t len)
 {
     return { str, len };
 }
 
-constexpr std::string_view operator "" _sv(const char *str, size_t len)
+constexpr celestia::compat::string_view operator "" _sv(const char *str, std::size_t len)
 {
     return { str, len };
 }
 
-constexpr std::wstring_view operator "" _sv(const wchar_t *str, size_t len)
+constexpr celestia::compat::wstring_view operator "" _sv(const wchar_t *str, std::size_t len)
 {
     return { str, len };
 }
+
 #if defined(__clang__)
 //#pragma clang diagnostic pop
 #elif defined(__GNUC__)

--- a/src/celengine/astro.cpp
+++ b/src/celengine/astro.cpp
@@ -103,7 +103,7 @@ static const char* MonthAbbrList[12] =
 
 struct UnitDefinition
 {
-    string_view name;
+    celestia::compat::string_view name;
     double conversion;
 };
 
@@ -763,7 +763,7 @@ astro::TAItoJDUTC(double tai)
 
 
 // Get scale of given length unit in kilometers
-bool astro::getLengthScale(string_view unitName, double& scale)
+bool astro::getLengthScale(celestia::compat::string_view unitName, double& scale)
 {
     unsigned int nUnits = sizeof(lengthUnits) / sizeof(lengthUnits[0]);
     bool foundMatch = false;
@@ -782,7 +782,7 @@ bool astro::getLengthScale(string_view unitName, double& scale)
 
 
 // Get scale of given time unit in days
-bool astro::getTimeScale(string_view unitName, double& scale)
+bool astro::getTimeScale(celestia::compat::string_view unitName, double& scale)
 {
     for (const auto& timeUnit : timeUnits)
     {
@@ -798,7 +798,7 @@ bool astro::getTimeScale(string_view unitName, double& scale)
 
 
 // Get scale of given angle unit in degrees
-bool astro::getAngleScale(string_view unitName, double& scale)
+bool astro::getAngleScale(celestia::compat::string_view unitName, double& scale)
 {
     for (const auto& angleUnit : angleUnits)
     {
@@ -813,7 +813,7 @@ bool astro::getAngleScale(string_view unitName, double& scale)
 }
 
 
-bool astro::getMassScale(string_view unitName, double& scale)
+bool astro::getMassScale(celestia::compat::string_view unitName, double& scale)
 {
     for (const auto& massUnit : massUnits)
     {
@@ -829,7 +829,7 @@ bool astro::getMassScale(string_view unitName, double& scale)
 
 
 // Check if unit is a length unit
-bool astro::isLengthUnit(string_view unitName)
+bool astro::isLengthUnit(celestia::compat::string_view unitName)
 {
     double dummy;
     return getLengthScale(unitName, dummy);
@@ -837,7 +837,7 @@ bool astro::isLengthUnit(string_view unitName)
 
 
 // Check if unit is a time unit
-bool astro::isTimeUnit(string_view unitName)
+bool astro::isTimeUnit(celestia::compat::string_view unitName)
 {
     double dummy;
     return getTimeScale(unitName, dummy);
@@ -845,14 +845,14 @@ bool astro::isTimeUnit(string_view unitName)
 
 
 // Check if unit is an angle unit
-bool astro::isAngleUnit(string_view unitName)
+bool astro::isAngleUnit(celestia::compat::string_view unitName)
 {
     double dummy;
     return getAngleScale(unitName, dummy);
 }
 
 
-bool astro::isMassUnit(string_view unitName)
+bool astro::isMassUnit(celestia::compat::string_view unitName)
 {
     double dummy;
     return getMassScale(unitName, dummy);

--- a/src/celengine/astro.h
+++ b/src/celengine/astro.h
@@ -195,14 +195,14 @@ namespace astro
         return jd * SECONDS_PER_DAY;
     }
 
-    bool isLengthUnit(std::string_view unitName);
-    bool isTimeUnit(std::string_view unitName);
-    bool isAngleUnit(std::string_view unitName);
-    bool isMassUnit(std::string_view unitName);
-    bool getLengthScale(std::string_view unitName, double& scale);
-    bool getTimeScale(std::string_view unitName, double& scale);
-    bool getAngleScale(std::string_view unitName, double& scale);
-    bool getMassScale(std::string_view unitName, double& scale);
+    bool isLengthUnit(celestia::compat::string_view unitName);
+    bool isTimeUnit(celestia::compat::string_view unitName);
+    bool isAngleUnit(celestia::compat::string_view unitName);
+    bool isMassUnit(celestia::compat::string_view unitName);
+    bool getLengthScale(celestia::compat::string_view unitName, double& scale);
+    bool getTimeScale(celestia::compat::string_view unitName, double& scale);
+    bool getAngleScale(celestia::compat::string_view unitName, double& scale);
+    bool getMassScale(celestia::compat::string_view unitName, double& scale);
 
     void decimalToDegMinSec(double angle, int& degrees, int& minutes, double& seconds);
     double degMinSecToDecimal(int degrees, int minutes, double seconds);
@@ -262,4 +262,3 @@ namespace astro
 std::ostream& operator<<(std::ostream& s, const astro::Date&);
 
 #endif // _CELENGINE_ASTRO_H_
-

--- a/src/celestia/gtk/actions.cpp
+++ b/src/celestia/gtk/actions.cpp
@@ -322,7 +322,7 @@ void actionCaptureMovie(GtkAction*, AppData* app)
         AVCodecID codec = MovieCodecs[vcidx].codecId;
         float bitrate = 400000;
         const gchar *last = &brtext[gtk_entry_get_text_length(GTK_ENTRY(brentry))];
-        std::from_chars(brtext, last, bitrate);
+        celestia::compat::from_chars(brtext, last, bitrate);
 
         gtk_widget_destroy(fs);
         for (int i=0; i < 10 && gtk_events_pending ();i++)

--- a/src/celestia/url.cpp
+++ b/src/celestia/url.cpp
@@ -9,6 +9,7 @@
 // of the License, or (at your option) any later version.
 
 #include <iostream>
+#include <fmt/ostream.h>
 #include <fmt/printf.h>
 #include <celcompat/charconv.h>
 #include <celutil/bigfix.h>
@@ -16,6 +17,7 @@
 #include <celutil/stringutils.h>
 #include "celestiacore.h"
 #include "url.h"
+
 
 namespace
 {
@@ -55,13 +57,13 @@ std::string getBodyShortName(const std::string &body)
     if (!body.empty())
     {
         auto pos = body.rfind(":");
-        if (pos != std::string_view::npos)
+        if (pos != celestia::compat::string_view::npos)
             return body.substr(pos + 1);
     }
     return body;
 }
 
-std::string_view
+celestia::compat::string_view
 getCoordSysName(ObserverFrame::CoordinateSystem mode)
 {
     switch (mode)
@@ -289,17 +291,17 @@ Url::getEncodedObjectName(const Selection& selection, const CelestiaCore* appCor
 }
 
 std::string
-Url::decodeString(std::string_view str)
+Url::decodeString(celestia::compat::string_view str)
 {
-    std::string_view::size_type a = 0, b = 0;
+    celestia::compat::string_view::size_type a = 0, b = 0;
     std::string out;
 
     b = str.find('%');
-    while (b != std::string_view::npos && a < str.length())
+    while (b != celestia::compat::string_view::npos && a < str.length())
     {
         auto s = str.substr(a, b - a);
         out.append(s.data(), s.length());
-        auto c_code = str.substr(b + 1, 2);
+        celestia::compat::string_view c_code = str.substr(b + 1, 2);
         uint8_t c;
         if (to_number(c_code, c, 16))
         {
@@ -307,7 +309,7 @@ Url::decodeString(std::string_view str)
         }
         else
         {
-            fmt::fprintf(std::cerr, _("Incorrect hex value \"%s\"\n"), c_code);
+            fmt::print(std::cerr, _("Incorrect hex value \"{}\"\n"), c_code);
             out += '%';
             out.append(c_code.data(), c_code.length());
         }
@@ -324,7 +326,7 @@ Url::decodeString(std::string_view str)
 }
 
 std::string
-Url::encodeString(std::string_view str)
+Url::encodeString(celestia::compat::string_view str)
 {
     std::ostringstream enc;
 
@@ -366,7 +368,7 @@ Url::encodeString(std::string_view str)
 
 struct Mode
 {
-    std::string_view                modeStr;
+    celestia::compat::string_view                 modeStr;
     ObserverFrame::CoordinateSystem mode;
     int                             nBodies;
 };
@@ -380,12 +382,12 @@ static Mode modes[] =
     { "PhaseLock",  ObserverFrame::PhaseLock,   2 },
 };
 
-auto ParseURLParams(std::string_view paramsStr)
-    -> std::map<std::string_view, std::string>;
+auto ParseURLParams(celestia::compat::string_view paramsStr)
+    -> std::map<celestia::compat::string_view, std::string>;
 
-bool Url::parse(std::string_view urlStr)
+bool Url::parse(celestia::compat::string_view urlStr)
 {
-    constexpr auto npos = std::string_view::npos;
+    constexpr auto npos = celestia::compat::string_view::npos;
 
     // proper URL string must start with protocol (cel://)
     if (urlStr.compare(0, Url::proto().length(), Url::proto()) != 0)
@@ -399,7 +401,7 @@ bool Url::parse(std::string_view urlStr)
     auto pathStr = urlStr.substr(Url::proto().length(), pos - Url::proto().length());
     while (pathStr.back() == '/')
         pathStr.remove_suffix(1);
-    std::string_view paramsStr;
+    celestia::compat::string_view paramsStr;
     if (pos != npos)
         paramsStr = urlStr.substr(pos + 1);
 
@@ -512,14 +514,14 @@ bool Url::parse(std::string_view urlStr)
     return true;
 }
 
-auto ParseURLParams(std::string_view paramsStr)
-   -> std::map<std::string_view, std::string>
+auto ParseURLParams(celestia::compat::string_view paramsStr)
+   -> std::map<celestia::compat::string_view, std::string>
 {
-    std::map<std::string_view, std::string> params;
+    std::map<celestia::compat::string_view, std::string> params;
     if (paramsStr.empty())
         return params;
 
-    constexpr auto npos = std::string_view::npos;
+    constexpr auto npos = celestia::compat::string_view::npos;
     for (auto iter = paramsStr;;)
     {
         auto pos = iter.find('&');
@@ -539,7 +541,7 @@ auto ParseURLParams(std::string_view paramsStr)
     return params;
 }
 
-bool Url::initVersion3(std::map<std::string_view, std::string> &params, std::string_view timeStr)
+bool Url::initVersion3(std::map<celestia::compat::string_view, std::string> &params, celestia::compat::string_view timeStr)
 {
     m_version = 3;
 
@@ -627,7 +629,7 @@ bool Url::initVersion3(std::map<std::string_view, std::string> &params, std::str
     return true;
 }
 
-bool Url::initVersion4(std::map<std::string_view, std::string> &params, std::string_view timeStr)
+bool Url::initVersion4(std::map<celestia::compat::string_view, std::string> &params, celestia::compat::string_view timeStr)
 {
     if (params.count("rf") != 0)
     {

--- a/src/celestia/url.h
+++ b/src/celestia/url.h
@@ -55,17 +55,17 @@ class Url
     ~Url() = default;
 
     static std::string getEncodedObjectName(const Selection& sel, const CelestiaCore* appCore);
-    static constexpr std::string_view proto();
-    static std::string decodeString(std::string_view);
-    static std::string encodeString(std::string_view);
+    static constexpr celestia::compat::string_view proto();
+    static std::string decodeString(celestia::compat::string_view);
+    static std::string encodeString(celestia::compat::string_view);
 
-    bool parse(std::string_view);
+    bool parse(celestia::compat::string_view);
     bool goTo();
     std::string getAsString() const;
 
  private:
-    bool initVersion3(std::map<std::string_view, std::string> &params, std::string_view timeStr);
-    bool initVersion4(std::map<std::string_view, std::string> &params, std::string_view timeStr);
+    bool initVersion3(std::map<celestia::compat::string_view, std::string> &params, celestia::compat::string_view timeStr);
+    bool initVersion4(std::map<celestia::compat::string_view, std::string> &params, celestia::compat::string_view timeStr);
     void evalName();
 
     CelestiaState   m_state;
@@ -86,7 +86,7 @@ class Url
     bool            m_valid         { false };
 };
 
-constexpr std::string_view Url::proto()
+constexpr celestia::compat::string_view Url::proto()
 {
     return "cel://";
 }

--- a/src/celestia/win32/res/CMakeLists.txt
+++ b/src/celestia/win32/res/CMakeLists.txt
@@ -2,7 +2,13 @@ if(NOT ENABLE_NLS)
   return()
 endif()
 
-include(windres)
+find_package(PERL)
 
-file(GLOB PO_FILES2 "${CMAKE_SOURCE_DIR}/po/*.po")
-WINDRES_CREATE_TRANSLATIONS(celestia.rc ALL ${PO_FILES2})
+if(PERL_FOUND)
+  include(windres)
+
+  file(GLOB PO_FILES2 "${CMAKE_SOURCE_DIR}/po/*.po")
+  WINDRES_CREATE_TRANSLATIONS(celestia.rc ALL ${PO_FILES2})
+else()
+  message("Perl not found, skipping generation of translations")
+endif()

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -1014,7 +1014,7 @@ void CommandConstellations::process(ExecutionEnvironment& env)
     }
 }
 
-void CommandConstellations::setValues(string_view _cons, bool act)
+void CommandConstellations::setValues(celestia::compat::string_view _cons, bool act)
 {
     // ignore all above 99 constellations
     if (constellations.size() == MAX_CONSTELLATIONS)
@@ -1080,7 +1080,7 @@ void CommandConstellationColor::unsetColor()
     flags.unset = true;
 }
 
-void CommandConstellationColor::setConstellations(string_view _cons)
+void CommandConstellationColor::setConstellations(celestia::compat::string_view _cons)
 {
     // ignore all above 99 constellations
     if (constellations.size() == MAX_CONSTELLATIONS)

--- a/src/celscript/legacy/command.h
+++ b/src/celscript/legacy/command.h
@@ -380,7 +380,7 @@ class CommandConstellations : public InstantaneousCommand
  public:
     void process(ExecutionEnvironment&) override;
 
-    void setValues(std::string_view cons, bool act);
+    void setValues(celestia::compat::string_view cons, bool act);
 
     Flags flags { false, false };
 
@@ -409,7 +409,7 @@ class CommandConstellationColor : public InstantaneousCommand
 
  public:
     void process(ExecutionEnvironment&) override;
-    void setConstellations(std::string_view cons);
+    void setConstellations(celestia::compat::string_view cons);
     void setColor(float r, float g, float b);
     void unsetColor();
 

--- a/src/celutil/stringutils.cpp
+++ b/src/celutil/stringutils.cpp
@@ -15,7 +15,7 @@
 
 using namespace std;
 
-int compareIgnoringCase(string_view s1, string_view s2)
+int compareIgnoringCase(celestia::compat::string_view s1, celestia::compat::string_view s2)
 {
     auto i1 = s1.begin();
     auto i2 = s2.begin();
@@ -31,7 +31,7 @@ int compareIgnoringCase(string_view s1, string_view s2)
     return s2.size() - s1.size();
 }
 
-int compareIgnoringCase(string_view s1, string_view s2, int n)
+int compareIgnoringCase(celestia::compat::string_view s1, celestia::compat::string_view s2, int n)
 {
     auto i1 = s1.begin();
     auto i2 = s2.begin();
@@ -48,8 +48,8 @@ int compareIgnoringCase(string_view s1, string_view s2, int n)
     return n > 0 ? s2.size() - s1.size() : 0;
 }
 
-bool CompareIgnoringCasePredicate::operator()(string_view s1,
-                                              string_view s2) const
+bool CompareIgnoringCasePredicate::operator()(celestia::compat::string_view s1,
+                                              celestia::compat::string_view s2) const
 {
     return compareIgnoringCase(s1, s2) < 0;
 }

--- a/src/celutil/stringutils.h
+++ b/src/celutil/stringutils.h
@@ -15,24 +15,24 @@
 #include <celcompat/charconv.h>
 #include <celcompat/string_view.h>
 
-int compareIgnoringCase(std::string_view s1, std::string_view s2);
-int compareIgnoringCase(std::string_view s1, std::string_view s2, int n);
+int compareIgnoringCase(celestia::compat::string_view s1, celestia::compat::string_view s2);
+int compareIgnoringCase(celestia::compat::string_view s1, celestia::compat::string_view s2, int n);
 
 struct CompareIgnoringCasePredicate
 {
-    bool operator()(std::string_view, std::string_view) const;
+    bool operator()(celestia::compat::string_view, celestia::compat::string_view) const;
 };
 
 template <typename T>
-[[nodiscard]] bool to_number(std::string_view p, T &result)
+[[nodiscard]] bool to_number(celestia::compat::string_view p, T &result)
 {
-    auto r = std::from_chars(p.data(), p.data() + p.size(), result);
+    auto r = celestia::compat::from_chars(p.data(), p.data() + p.size(), result);
     return r.ec == std::errc();
 }
 
 template <typename T>
-[[nodiscard]] bool to_number(std::string_view p, T &result, int base)
+[[nodiscard]] bool to_number(celestia::compat::string_view p, T &result, int base)
 {
-    auto r = std::from_chars(p.data(), p.data() + p.size(), result, base);
+    auto r = celestia::compat::from_chars(p.data(), p.data() + p.size(), result, base);
     return r.ec == std::errc();
 }

--- a/src/celutil/util.cpp
+++ b/src/celutil/util.cpp
@@ -19,7 +19,7 @@
 
 using namespace std;
 
-bool GetTZInfo(std::string_view tzName, int &dstBias)
+bool GetTZInfo(celestia::compat::string_view tzName, int &dstBias)
 {
 #ifdef _WIN32
     TIME_ZONE_INFORMATION tzi;

--- a/src/celutil/util.h
+++ b/src/celutil/util.h
@@ -34,6 +34,6 @@ template<typename T> constexpr typename T::size_type memsize(const T &c)
     return c.size() * sizeof(typename T::value_type);
 }
 
-bool GetTZInfo(std::string_view, int&);
+bool GetTZInfo(celestia::compat::string_view, int&);
 
 #endif // _CELUTIL_UTIL_H_


### PR DESCRIPTION
- Move the compatibility classes into the cel17 namespace
- Skip generating resource translations if Perl not present
- Use fmt/ostream.h instead of fmt/printf.h for string_view