### PR TITLE
Fix for debug builds

### DIFF
--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -14,6 +14,9 @@
 #include <cstdlib>
 #include <cassert>
 #include <algorithm>
+
+#include <fmt/printf.h>
+
 #include <celutil/debug.h>
 #include <celmath/mathlib.h>
 #include <celutil/gettext.h>

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <random>
 #include <cassert>
+#include <fmt/printf.h>
 
 using namespace Eigen;
 using namespace std;

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -24,6 +24,7 @@
 #include "render.h"
 #include "texture.h"
 #include "vecgl.h"
+#include <fmt/printf.h>
 
 using namespace Eigen;
 using namespace std;

--- a/src/celengine/image.cpp
+++ b/src/celengine/image.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <iostream>
 #include <fmt/ostream.h>
+#include <fmt/printf.h>
 #include <celengine/glsupport.h>
 #include <celutil/debug.h>
 #include <celutil/filetype.h>

--- a/src/celengine/mapmanager.cpp
+++ b/src/celengine/mapmanager.cpp
@@ -8,10 +8,12 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <fstream>
 #include <celutil/debug.h>
 #include <celutil/fsutils.h>
-#include <array>
-#include <fstream>
 #include "mapmanager.h"
 
 using namespace std;

--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -39,6 +39,7 @@
 #include <utility>
 #include <memory>
 #include <fmt/ostream.h>
+#include <fmt/printf.h>
 
 
 using namespace cmod;

--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -18,6 +18,7 @@
 #include "planetgrid.h"
 #include "render.h"
 #include "vecgl.h"
+#include <fmt/printf.h>
 
 using namespace std;
 using namespace Eigen;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -33,6 +33,8 @@ std::ofstream hdrlog;
 #define EXPOSURE_HALFLIFE   0.4f
 #endif
 
+#include <fmt/printf.h>
+
 #include "render.h"
 #include "boundaries.h"
 #include "dsorenderer.h"

--- a/src/celengine/selection.cpp
+++ b/src/celengine/selection.cpp
@@ -17,6 +17,7 @@
 #include <celengine/body.h>
 #include <celengine/location.h>
 #include <celengine/deepskyobj.h>
+#include <fmt/printf.h>
 
 using namespace Eigen;
 using namespace std;

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -16,6 +16,7 @@
 #include <iomanip>
 #include <tuple>
 #include <fmt/ostream.h>
+#include <fmt/printf.h>
 #include <Eigen/Geometry>
 #include <celcompat/filesystem.h>
 #include <celmath/geomutil.h>

--- a/src/celengine/star.cpp
+++ b/src/celengine/star.cpp
@@ -17,6 +17,7 @@
 #include "star.h"
 #include "texmanager.h"
 #include "celephem/orbit.h"
+#include <fmt/printf.h>
 
 using namespace Eigen;
 using namespace std;

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -25,6 +25,7 @@
 #include "multitexture.h"
 #include "meshmanager.h"
 #include "tokenizer.h"
+#include <fmt/printf.h>
 
 using namespace Eigen;
 using namespace std;
@@ -1491,4 +1492,3 @@ Star* StarDatabase::findWhileLoading(AstroCatalog::IndexNumber catalogNumber) co
     // Star not found
     return nullptr;
 }
-

--- a/src/celengine/stellarclass.cpp
+++ b/src/celengine/stellarclass.cpp
@@ -8,6 +8,7 @@
 // of the License, or (at your option) any later version.
 
 #include <cstring>
+#include <fmt/printf.h>
 #include <celutil/debug.h>
 #include <cassert>
 #include <config.h>

--- a/src/celengine/texture.cpp
+++ b/src/celengine/texture.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <iostream>
 
+#include <fmt/printf.h>
 #include <Eigen/Core>
 #include "glsupport.h"
 

--- a/src/celengine/trajmanager.cpp
+++ b/src/celengine/trajmanager.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <cassert>
 #include <celutil/debug.h>
+#include <fmt/printf.h>
 
 using namespace std;
 

--- a/src/celephem/samporbit.cpp
+++ b/src/celephem/samporbit.cpp
@@ -14,6 +14,7 @@
 #include "samporbit.h"
 #include "xyzvbinary.h"
 #include <fmt/ostream.h>
+#include <fmt/printf.h>
 #include <celengine/astro.h>
 #include <celmath/mathlib.h>
 #include <celutil/bytes.h>

--- a/src/celephem/scriptobject.cpp
+++ b/src/celephem/scriptobject.cpp
@@ -10,6 +10,7 @@
 // of the License, or (at your option) any later version.
 
 #include <celutil/debug.h>
+#include <fmt/printf.h>
 
 #include "scriptobject.h"
 

--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -8,6 +8,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <algorithm>

--- a/src/celimage/png.cpp
+++ b/src/celimage/png.cpp
@@ -12,6 +12,7 @@
 #include <png.h>
 #include <zlib.h>
 #include <fmt/ostream.h>
+#include <fmt/printf.h>
 #include <celengine/image.h>
 #include <celutil/debug.h>
 #include <celutil/gettext.h>
@@ -266,4 +267,3 @@ bool SavePNGImage(const fs::path& filename, Image& image)
                         image.getPixels(),
                         image.hasAlpha());
 }
-

--- a/src/celmodel/modelfile.cpp
+++ b/src/celmodel/modelfile.cpp
@@ -8,6 +8,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <fmt/printf.h>
+
 #include "modelfile.h"
 #include <celutil/bytes.h>
 #include <cassert>

--- a/src/celscript/lua/celx_category.cpp
+++ b/src/celscript/lua/celx_category.cpp
@@ -1,8 +1,11 @@
+#include <string>
+
+#include <fmt/printf.h>
 
 #include <celutil/debug.h>
 #include "celx.h"
 #include "celx_internal.h"
-#include "celx_category.h" 
+#include "celx_category.h"
 #include "celx_object.h"
 #include <celengine/category.h>
 #include <celengine/selection.h>

--- a/src/celutil/debug.h
+++ b/src/celutil/debug.h
@@ -7,29 +7,21 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _DEBUG_H_
-#define _DEBUG_H_
+#pragma once
+
+#ifdef DPRINTF
+#undef DPRINTF // OSX has DPRINTF
+#endif // DPRINTF
+
+#if defined(_DEBUG) || defined(DEBUG)
 
 #ifdef _MSC_VER
 #include <windows.h>
 #endif
 #include <iostream>
 #include <fmt/printf.h>
+#include <fmt/ostream.h>
 
-#ifdef DPRINTF
-#undef DPRINTF // OSX has DPRINTF
-#endif // DPRINTF
-
-// verbosity choices
-#define LOG_LEVEL_ERROR           0
-#define LOG_LEVEL_WARNING         1
-#define LOG_LEVEL_INFO            2
-#define LOG_LEVEL_VERBOSE         3
-#define LOG_LEVEL_DEBUG           4
-
-#if !defined(_DEBUG) && !defined(DEBUG)
-#define DPRINTF(level, ...) static_cast<void>(level);
-#else
 extern int debugVerbosity;
 template <typename... T>
 void DPRINTF(int level, const char *format, const T & ... args)
@@ -50,9 +42,16 @@ void DPRINTF(int level, const char *format, const T & ... args)
 #endif
     }
 }
+#else
+#define DPRINTF(level, ...) static_cast<void>(level);
 #endif /* DEBUG */
+
+// verbosity choices
+#define LOG_LEVEL_ERROR           0
+#define LOG_LEVEL_WARNING         1
+#define LOG_LEVEL_INFO            2
+#define LOG_LEVEL_VERBOSE         3
+#define LOG_LEVEL_DEBUG           4
 
 extern void SetDebugVerbosity(int);
 extern int GetDebugVerbosity();
-
-#endif // _DEBUG_H_


### PR DESCRIPTION
- Include fmt/ostream.h in debug.h to allow formatting filesystem paths
- Avoid including headers via debug.h on non-debug builds