### PR TITLE
Fix buffer overflow error in cel3ds, improve error handling

### DIFF
--- a/src/cel3ds/3dschunk.h
+++ b/src/cel3ds/3dschunk.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _3DSCHUNK_H_
-#define _3DSCHUNK_H_
+#pragma once
 
 enum M3DChunkType
 {
@@ -56,5 +55,3 @@ enum M3DChunkType
 
     M3DCHUNK_KFDATA              = 0xb000,
 };
-
-#endif // _3DSCHUNK_H_

--- a/src/cel3ds/3dsmodel.cpp
+++ b/src/cel3ds/3dsmodel.cpp
@@ -9,12 +9,6 @@
 
 #include "3dsmodel.h"
 
-#include <utility>
-
-using namespace Eigen;
-using namespace std;
-
-
 M3DColor::M3DColor() :
     red(0), green(0), blue(0)
 {
@@ -25,12 +19,12 @@ M3DColor::M3DColor(float _red, float _green, float _blue) :
 {
 }
 
-string M3DMaterial::getName() const
+std::string M3DMaterial::getName() const
 {
     return name;
 }
 
-void M3DMaterial::setName(string _name)
+void M3DMaterial::setName(std::string _name)
 {
     name = std::move(_name);
 }
@@ -85,12 +79,12 @@ void M3DMaterial::setOpacity(float _opacity)
     opacity = _opacity;
 }
 
-string M3DMaterial::getTextureMap() const
+std::string M3DMaterial::getTextureMap() const
 {
     return texmap;
 }
 
-void M3DMaterial::setTextureMap(const string& _texmap)
+void M3DMaterial::setTextureMap(const std::string& _texmap)
 {
     texmap = _texmap;
 }
@@ -98,50 +92,50 @@ void M3DMaterial::setTextureMap(const string& _texmap)
 
 M3DTriangleMesh::M3DTriangleMesh()
 {
-    matrix = Matrix4f::Identity();
+    matrix = Eigen::Matrix4f::Identity();
 }
 
-Matrix4f M3DTriangleMesh::getMatrix() const
+Eigen::Matrix4f M3DTriangleMesh::getMatrix() const
 {
     return matrix;
 }
 
-void M3DTriangleMesh::setMatrix(const Matrix4f& m)
+void M3DTriangleMesh::setMatrix(const Eigen::Matrix4f& m)
 {
     matrix = m;
 }
 
-Vector3f M3DTriangleMesh::getVertex(uint16_t n) const
+Eigen::Vector3f M3DTriangleMesh::getVertex(std::uint16_t n) const
 {
     return points[n];
 }
 
-uint16_t M3DTriangleMesh::getVertexCount() const
+std::uint16_t M3DTriangleMesh::getVertexCount() const
 {
-    return (uint16_t) (points.size());
+    return (std::uint16_t) (points.size());
 }
 
-void M3DTriangleMesh::addVertex(const Vector3f& p)
+void M3DTriangleMesh::addVertex(const Eigen::Vector3f& p)
 {
     points.push_back(p);
 }
 
-Vector2f M3DTriangleMesh::getTexCoord(uint16_t n) const
+Eigen::Vector2f M3DTriangleMesh::getTexCoord(std::uint16_t n) const
 {
     return texCoords[n];
 }
 
-uint16_t M3DTriangleMesh::getTexCoordCount() const
+std::uint16_t M3DTriangleMesh::getTexCoordCount() const
 {
     return (uint16_t) (texCoords.size());
 }
 
-void M3DTriangleMesh::addTexCoord(const Vector2f& p)
+void M3DTriangleMesh::addTexCoord(const Eigen::Vector2f& p)
 {
     texCoords.push_back(p);
 }
 
-void M3DTriangleMesh::getFace(uint16_t n, uint16_t& v0, uint16_t& v1, uint16_t& v2) const
+void M3DTriangleMesh::getFace(std::uint16_t n, std::uint16_t& v0, std::uint16_t& v1, std::uint16_t& v2) const
 {
     int m = (int) n * 3;
     v0 = faces[m];
@@ -149,31 +143,31 @@ void M3DTriangleMesh::getFace(uint16_t n, uint16_t& v0, uint16_t& v1, uint16_t& 
     v2 = faces[m + 2];
 }
 
-uint16_t M3DTriangleMesh::getFaceCount() const
+std::uint16_t M3DTriangleMesh::getFaceCount() const
 {
-    return (uint16_t) (faces.size() / 3);
+    return (std::uint16_t) (faces.size() / 3);
 }
 
-void M3DTriangleMesh::addFace(uint16_t v0, uint16_t v1, uint16_t v2)
+void M3DTriangleMesh::addFace(std::uint16_t v0, std::uint16_t v1, std::uint16_t v2)
 {
     faces.push_back(v0);
     faces.push_back(v1);
     faces.push_back(v2);
 }
 
-uint32_t M3DTriangleMesh::getSmoothingGroups(uint16_t face) const
+std::uint32_t M3DTriangleMesh::getSmoothingGroups(uint16_t face) const
 {
     return face < smoothingGroups.size() ? smoothingGroups[face] : 0;
 }
 
-void M3DTriangleMesh::addSmoothingGroups(uint32_t smGroups)
+void M3DTriangleMesh::addSmoothingGroups(std::uint32_t smGroups)
 {
     smoothingGroups.push_back(smGroups);
 }
 
-uint16_t M3DTriangleMesh::getSmoothingGroupCount() const
+std::uint16_t M3DTriangleMesh::getSmoothingGroupCount() const
 {
-    return (uint16_t) (smoothingGroups.size());
+    return (std::uint16_t) (smoothingGroups.size());
 }
 
 void M3DTriangleMesh::addMeshMaterialGroup(M3DMeshMaterialGroup* matGroup)
@@ -181,12 +175,12 @@ void M3DTriangleMesh::addMeshMaterialGroup(M3DMeshMaterialGroup* matGroup)
     meshMaterialGroups.push_back(matGroup);
 }
 
-M3DMeshMaterialGroup* M3DTriangleMesh::getMeshMaterialGroup(uint32_t index) const
+M3DMeshMaterialGroup* M3DTriangleMesh::getMeshMaterialGroup(std::uint32_t index) const
 {
     return meshMaterialGroups[index];
 }
 
-uint32_t M3DTriangleMesh::getMeshMaterialGroupCount() const
+std::uint32_t M3DTriangleMesh::getMeshMaterialGroupCount() const
 {
     return meshMaterialGroups.size();
 }
@@ -198,12 +192,12 @@ M3DModel::~M3DModel()
         delete triMesh;
 }
 
-M3DTriangleMesh* M3DModel::getTriMesh(uint32_t n)
+M3DTriangleMesh* M3DModel::getTriMesh(std::uint32_t n)
 {
     return n < triMeshes.size() ? triMeshes[n] : nullptr;
 }
 
-uint32_t M3DModel::getTriMeshCount()
+std::uint32_t M3DModel::getTriMeshCount()
 {
     return triMeshes.size();
 }
@@ -213,12 +207,12 @@ void M3DModel::addTriMesh(M3DTriangleMesh* triMesh)
     triMeshes.push_back(triMesh);
 }
 
-void M3DModel::setName(const string& _name)
+void M3DModel::setName(const std::string& _name)
 {
     name = _name;
 }
 
-const string M3DModel::getName() const
+const std::string M3DModel::getName() const
 {
     return name;
 }
@@ -232,12 +226,12 @@ M3DScene::~M3DScene()
         delete material;
 }
 
-M3DModel* M3DScene::getModel(uint32_t n) const
+M3DModel* M3DScene::getModel(std::uint32_t n) const
 {
     return n < models.size() ? models[n] : nullptr;
 }
 
-uint32_t M3DScene::getModelCount() const
+std::uint32_t M3DScene::getModelCount() const
 {
     return models.size();
 }
@@ -247,12 +241,12 @@ void M3DScene::addModel(M3DModel* model)
     models.push_back(model);
 }
 
-M3DMaterial* M3DScene::getMaterial(uint32_t n) const
+M3DMaterial* M3DScene::getMaterial(std::uint32_t n) const
 {
     return n < materials.size() ? materials[n] : nullptr;
 }
 
-uint32_t M3DScene::getMaterialCount() const
+std::uint32_t M3DScene::getMaterialCount() const
 {
     return materials.size();
 }

--- a/src/cel3ds/3dsmodel.h
+++ b/src/cel3ds/3dsmodel.h
@@ -130,12 +130,12 @@ class M3DScene
     M3DScene() = default;
     ~M3DScene();
 
-    M3DModel* getModel(uint32_t) const;
-    uint32_t getModelCount() const;
+    M3DModel* getModel(std::uint32_t) const;
+    std::uint32_t getModelCount() const;
     void addModel(M3DModel*);
 
-    M3DMaterial* getMaterial(uint32_t) const;
-    uint32_t getMaterialCount() const;
+    M3DMaterial* getMaterial(std::uint32_t) const;
+    std::uint32_t getMaterialCount() const;
     void addMaterial(M3DMaterial*);
 
     M3DColor getBackgroundColor() const;

--- a/src/cel3ds/3dsmodel.h
+++ b/src/cel3ds/3dsmodel.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -29,8 +30,6 @@ class M3DColor
 class M3DMaterial
 {
  public:
-    M3DMaterial() = default;
-
     std::string getName() const;
     void setName(std::string);
     M3DColor getAmbientColor() const;
@@ -47,8 +46,8 @@ class M3DMaterial
     void setTextureMap(const std::string&);
 
  private:
-    std::string name;
-    std::string texmap;
+    std::string name{};
+    std::string texmap{};
     M3DColor ambient{ 0, 0, 0 };
     M3DColor diffuse{ 0, 0, 0 };
     M3DColor specular{ 0, 0, 0 };
@@ -70,9 +69,6 @@ class M3DTriangleMesh
  public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    M3DTriangleMesh();
-    ~M3DTriangleMesh() = default;
-
     Eigen::Matrix4f getMatrix() const;
     void setMatrix(const Eigen::Matrix4f&);
 
@@ -92,57 +88,51 @@ class M3DTriangleMesh
     std::uint32_t getSmoothingGroups(std::uint16_t) const;
     std::uint16_t getSmoothingGroupCount() const;
 
-    void addMeshMaterialGroup(M3DMeshMaterialGroup* matGroup);
+    void addMeshMaterialGroup(std::unique_ptr<M3DMeshMaterialGroup> matGroup);
     M3DMeshMaterialGroup* getMeshMaterialGroup(std::uint32_t) const;
     std::uint32_t getMeshMaterialGroupCount() const;
 
  private:
-    std::vector<Eigen::Vector3f> points;
-    std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f>> texCoords;
-    std::vector<std::uint16_t> faces;
-    std::vector<std::uint32_t> smoothingGroups;
-    std::vector<M3DMeshMaterialGroup*> meshMaterialGroups;
-    Eigen::Matrix4f matrix;
+    std::vector<Eigen::Vector3f> points{};
+    std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f>> texCoords{};
+    std::vector<std::uint16_t> faces{};
+    std::vector<std::uint32_t> smoothingGroups{};
+    std::vector<std::unique_ptr<M3DMeshMaterialGroup>> meshMaterialGroups{};
+    Eigen::Matrix4f matrix{ Eigen::Matrix4f::Identity() };
 };
 
 
 class M3DModel
 {
  public:
-    M3DModel() = default;
-    ~M3DModel();
-
-    M3DTriangleMesh* getTriMesh(uint32_t);
-    uint32_t getTriMeshCount();
-    void addTriMesh(M3DTriangleMesh*);
+    M3DTriangleMesh* getTriMesh(std::uint32_t);
+    std::uint32_t getTriMeshCount();
+    void addTriMesh(std::unique_ptr<M3DTriangleMesh>);
     void setName(const std::string&);
     const std::string getName() const;
 
  private:
-    std::string name;
-    std::vector<M3DTriangleMesh*> triMeshes;
+    std::string name{};
+    std::vector<std::unique_ptr<M3DTriangleMesh>> triMeshes{};
 };
 
 
 class M3DScene
 {
  public:
-    M3DScene() = default;
-    ~M3DScene();
-
     M3DModel* getModel(std::uint32_t) const;
     std::uint32_t getModelCount() const;
-    void addModel(M3DModel*);
+    void addModel(std::unique_ptr<M3DModel>);
 
     M3DMaterial* getMaterial(std::uint32_t) const;
     std::uint32_t getMaterialCount() const;
-    void addMaterial(M3DMaterial*);
+    void addMaterial(std::unique_ptr<M3DMaterial>);
 
     M3DColor getBackgroundColor() const;
     void setBackgroundColor(M3DColor);
 
  private:
-    std::vector<M3DModel*> models;
-    std::vector<M3DMaterial*> materials;
-    M3DColor backgroundColor;
+    std::vector<std::unique_ptr<M3DModel>> models{};
+    std::vector<std::unique_ptr<M3DMaterial>> materials{};
+    M3DColor backgroundColor{};
 };

--- a/src/cel3ds/3dsmodel.h
+++ b/src/cel3ds/3dsmodel.h
@@ -7,11 +7,12 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _3DSMODEL_H_
-#define _3DSMODEL_H_
+#pragma once
 
-#include <vector>
+#include <cstdint>
 #include <string>
+#include <vector>
+
 #include <Eigen/Core>
 
 class M3DColor
@@ -60,7 +61,7 @@ class M3DMeshMaterialGroup
 {
 public:
     std::string materialName;
-    std::vector<uint16_t> faces;
+    std::vector<std::uint16_t> faces;
 };
 
 
@@ -75,31 +76,31 @@ class M3DTriangleMesh
     Eigen::Matrix4f getMatrix() const;
     void setMatrix(const Eigen::Matrix4f&);
 
-    Eigen::Vector3f getVertex(uint16_t) const;
-    uint16_t getVertexCount() const;
+    Eigen::Vector3f getVertex(std::uint16_t) const;
+    std::uint16_t getVertexCount() const;
     void addVertex(const Eigen::Vector3f&);
 
-    Eigen::Vector2f getTexCoord(uint16_t) const;
-    uint16_t getTexCoordCount() const;
+    Eigen::Vector2f getTexCoord(std::uint16_t) const;
+    std::uint16_t getTexCoordCount() const;
     void addTexCoord(const Eigen::Vector2f&);
 
-    void getFace(uint16_t, uint16_t&, uint16_t&, uint16_t&) const;
-    uint16_t getFaceCount() const;
-    void addFace(uint16_t, uint16_t, uint16_t);
+    void getFace(std::uint16_t, std::uint16_t&, std::uint16_t&, std::uint16_t&) const;
+    std::uint16_t getFaceCount() const;
+    void addFace(std::uint16_t, std::uint16_t, std::uint16_t);
 
-    void addSmoothingGroups(uint32_t);
-    uint32_t getSmoothingGroups(uint16_t) const;
-    uint16_t getSmoothingGroupCount() const;
+    void addSmoothingGroups(std::uint32_t);
+    std::uint32_t getSmoothingGroups(std::uint16_t) const;
+    std::uint16_t getSmoothingGroupCount() const;
 
     void addMeshMaterialGroup(M3DMeshMaterialGroup* matGroup);
-    M3DMeshMaterialGroup* getMeshMaterialGroup(uint32_t) const;
-    uint32_t getMeshMaterialGroupCount() const;
+    M3DMeshMaterialGroup* getMeshMaterialGroup(std::uint32_t) const;
+    std::uint32_t getMeshMaterialGroupCount() const;
 
  private:
     std::vector<Eigen::Vector3f> points;
     std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f>> texCoords;
-    std::vector<uint16_t> faces;
-    std::vector<uint32_t> smoothingGroups;
+    std::vector<std::uint16_t> faces;
+    std::vector<std::uint32_t> smoothingGroups;
     std::vector<M3DMeshMaterialGroup*> meshMaterialGroups;
     Eigen::Matrix4f matrix;
 };
@@ -145,5 +146,3 @@ class M3DScene
     std::vector<M3DMaterial*> materials;
     M3DColor backgroundColor;
 };
-
-#endif // _3DSMODEL_H_

--- a/src/cel3ds/3dsread.cpp
+++ b/src/cel3ds/3dsread.cpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -17,7 +18,7 @@
 #include <Eigen/Core>
 #include <fmt/ostream.h>
 
-#include "celutil/bytes.h"
+#include <celutil/bytes.h>
 #include "3dschunk.h"
 #include "3dsmodel.h"
 #include "3dsread.h"
@@ -34,8 +35,9 @@ using ProcessChunkFunc = std::int32_t (*)(std::istream &, std::uint16_t, std::in
 
 bool readInt(std::istream& in, std::int32_t& value)
 {
-    in.read(reinterpret_cast<char*>(&value), sizeof(std::int32_t));
-    if (!in.good()) { return false; }
+    char buffer[sizeof(value)];
+    if (!in.read(buffer, sizeof(buffer)).good()) { return false; }
+    std::memcpy(&value, buffer, sizeof(value));
     LE_TO_CPU_INT32(value, value);
     return true;
 }
@@ -43,8 +45,9 @@ bool readInt(std::istream& in, std::int32_t& value)
 
 bool readShort(std::istream& in, std::int16_t& value)
 {
-    in.read(reinterpret_cast<char*>(&value), sizeof(std::int16_t));
-    if (!in.good()) { return false; }
+    char buffer[sizeof(value)];
+    if (!in.read(buffer, sizeof(buffer)).good()) { return false; }
+    std::memcpy(&value, buffer, sizeof(value));
     LE_TO_CPU_INT16(value, value);
     return true;
 }
@@ -52,8 +55,9 @@ bool readShort(std::istream& in, std::int16_t& value)
 
 bool readUshort(std::istream& in, std::uint16_t& value)
 {
-    in.read(reinterpret_cast<char*>(&value), sizeof(std::uint16_t));
-    if (!in.good()) { return false; }
+    char buffer[sizeof(value)];
+    if (!in.read(buffer, sizeof(buffer)).good()) { return false; }
+    std::memcpy(&value, buffer, sizeof(value));
     LE_TO_CPU_INT16(value, value);
     return true;
 }
@@ -61,8 +65,9 @@ bool readUshort(std::istream& in, std::uint16_t& value)
 
 bool readFloat(std::istream& in, float& value)
 {
-    in.read(reinterpret_cast<char*>(&value), sizeof(float));
-    if (!in.good()) { return false; }
+    char buffer[sizeof(value)];
+    if (!in.read(buffer, sizeof(buffer)).good()) { return false; }
+    std::memcpy(&value, buffer, sizeof(value));
     LE_TO_CPU_FLOAT(value, value);
     return true;
 }

--- a/src/cel3ds/3dsread.cpp
+++ b/src/cel3ds/3dsread.cpp
@@ -7,90 +7,94 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include <Eigen/Core>
+#include <fmt/ostream.h>
 
 #include "celutil/bytes.h"
-#include "celutil/debug.h"
 #include "3dschunk.h"
 #include "3dsmodel.h"
 #include "3dsread.h"
 
 namespace
 {
+constexpr std::int32_t READ_FAILURE = -1;
+constexpr std::int32_t UNKNOWN_CHUNK = -2;
+
+
 template<typename T>
-using ProcessChunkFunc = bool (*)(std::istream &, std::uint16_t, std::int32_t, T*);
+using ProcessChunkFunc = std::int32_t (*)(std::istream &, std::uint16_t, std::int32_t, T*);
 
 
-std::int32_t readInt(std::istream& in)
+bool readInt(std::istream& in, std::int32_t& value)
 {
-    std::int32_t ret;
-    in.read((char *) &ret, sizeof(std::int32_t));
-    LE_TO_CPU_INT32(ret, ret);
-    return ret;
+    in.read(reinterpret_cast<char*>(&value), sizeof(std::int32_t));
+    if (!in.good()) { return false; }
+    LE_TO_CPU_INT32(value, value);
+    return true;
 }
 
 
-std::int16_t readShort(std::istream& in)
+bool readShort(std::istream& in, std::int16_t& value)
 {
-    std::int16_t ret;
-    in.read((char *) &ret, sizeof(std::int16_t));
-    LE_TO_CPU_INT16(ret, ret);
-    return ret;
+    in.read(reinterpret_cast<char*>(&value), sizeof(std::int16_t));
+    if (!in.good()) { return false; }
+    LE_TO_CPU_INT16(value, value);
+    return true;
 }
 
 
-std::uint16_t readUshort(std::istream& in)
+bool readUshort(std::istream& in, std::uint16_t& value)
 {
-    std::uint16_t ret;
-    in.read((char *) &ret, sizeof(std::uint16_t));
-    LE_TO_CPU_INT16(ret, ret);
-    return ret;
+    in.read(reinterpret_cast<char*>(&value), sizeof(std::uint16_t));
+    if (!in.good()) { return false; }
+    LE_TO_CPU_INT16(value, value);
+    return true;
 }
 
 
-float readFloat(std::istream& in)
+bool readFloat(std::istream& in, float& value)
 {
-    float f;
-    in.read((char*) &f, sizeof(float));
-    LE_TO_CPU_FLOAT(f, f);
-    return f;
+    in.read(reinterpret_cast<char*>(&value), sizeof(float));
+    if (!in.good()) { return false; }
+    LE_TO_CPU_FLOAT(value, value);
+    return true;
 }
 
 
-char readChar(std::istream& in)
+bool readUchar(std::istream& in, unsigned char& value)
 {
     char c;
-    in.read(&c, 1);
-    return c;
+    in.get(c);
+    if (!in.good()) { return false; }
+    value = static_cast<unsigned char>(c);
+    return true;
 }
 
 
-std::string readString(std::istream& in)
+std::int32_t readString(std::istream& in, std::string& value)
 {
-    char s[1024];
-    int maxLength = sizeof(s);
+    constexpr std::size_t maxLength = 1024;
+    char s[maxLength];
 
-    for (int count = 0; count < maxLength; count++)
+    for (std::size_t count = 0; count < maxLength; count++)
     {
         in.read(s + count, 1);
+        if (!in.good()) { return READ_FAILURE; }
         if (s[count] == '\0')
-            break;
+        {
+            value = s;
+            return count + 1;
+        }
     }
 
-    return std::string(s);
-}
-
-
-void skipBytes(std::istream& in, int count)
-{
-    char c;
-    while (count-- > 0)
-        in.get(c);
+    return READ_FAILURE;
 }
 
 
@@ -99,285 +103,325 @@ std::int32_t read3DSChunk(std::istream& in,
                           ProcessChunkFunc<T> chunkFunc,
                           T* obj)
 {
-    std::uint16_t chunkType = readUshort(in);
-    std::int32_t chunkSize = readInt(in);
+    std::uint16_t chunkType;
+    if (!readUshort(in, chunkType)) { return READ_FAILURE; }
+    std::int32_t chunkSize;
+    if (!readInt(in, chunkSize) || chunkSize < 6) { return READ_FAILURE; }
+
     std::int32_t contentSize = chunkSize - 6;
-
-    bool chunkWasRead = chunkFunc(in, chunkType, contentSize, obj);
-
-    if (!chunkWasRead)
+    std::int32_t processedSize = chunkFunc(in, chunkType, contentSize, obj);
+    switch (processedSize)
     {
-        skipBytes(in, contentSize);
+    case READ_FAILURE:
+        return READ_FAILURE;
+    case UNKNOWN_CHUNK:
+        in.ignore(contentSize);
+        return in.good() ? chunkSize : READ_FAILURE;
+    default:
+        if (processedSize != contentSize)
+        {
+            fmt::print(std::clog, "Chunk type {:04x}, expected {} bytes but read {}\n", chunkType, contentSize, processedSize);
+            return READ_FAILURE;
+        }
+        return chunkSize;
     }
-
-    return chunkSize;
 }
 
 
 template<typename T>
-int read3DSChunks(std::istream& in,
-                  int nBytes,
-                  ProcessChunkFunc<T> chunkFunc,
-                  T* obj)
+std::int32_t read3DSChunks(std::istream& in,
+                           std::int32_t nBytes,
+                           ProcessChunkFunc<T> chunkFunc,
+                           T* obj)
 {
-    int bytesRead = 0;
+    std::int32_t bytesRead = 0;
 
     while (bytesRead < nBytes)
-        bytesRead += read3DSChunk(in, chunkFunc, obj);
+    {
+        std::int32_t chunkSize = read3DSChunk(in, chunkFunc, obj);
+        if (chunkSize < 0) {
+            fmt::print(std::clog, "Failed to read 3DS chunk\n");
+            return READ_FAILURE;
+        }
+        bytesRead += chunkSize;
+    }
 
     if (bytesRead != nBytes)
-        std::cout << "Expected " << nBytes << " bytes but read " << bytesRead << '\n';
+    {
+        fmt::print(std::clog, "Multiple chunks, expected {} bytes but read {}\n", nBytes, bytesRead);
+        return READ_FAILURE;
+    }
+
     return bytesRead;
 }
 
 
-M3DColor readColor(std::istream& in/*, int nBytes*/)
+std::int32_t readColor(std::istream& in, M3DColor& color)
 {
-    auto r = (unsigned char) readChar(in);
-    auto g = (unsigned char) readChar(in);
-    auto b = (unsigned char) readChar(in);
+    unsigned char r, g, b;
+    if (!readUchar(in, r) || !readUchar(in, g) || !readUchar(in, b)) { return READ_FAILURE; }
 
-    return {(float) r / 255.0f,
-            (float) g / 255.0f,
-            (float) b / 255.0f};
+    color = {static_cast<float>(r) / 255.0f,
+             static_cast<float>(g) / 255.0f,
+             static_cast<float>(b) / 255.0f};
+
+    return 3;
 }
 
 
-M3DColor readFloatColor(std::istream& in/*, int nBytes*/)
+std::int32_t readFloatColor(std::istream& in, M3DColor& color)
 {
-    float r = readFloat(in);
-    float g = readFloat(in);
-    float b = readFloat(in);
+    float r, g, b;
+    if (!readFloat(in, r) || !readFloat(in, g) || !readFloat(in, b)) { return READ_FAILURE; }
 
-    return {(float) r / 255.0f,
-            (float) g / 255.0f,
-            (float) b / 255.0f};
+    color = { r, g, b };
+    return static_cast<std::int32_t>(3 * sizeof(float));
 }
 
 
-Eigen::Matrix4f readMeshMatrix(std::istream& in/*, int nBytes*/)
+std::int32_t readMeshMatrix(std::istream& in, Eigen::Matrix4f& m)
 {
-    float m00 = readFloat(in);
-    float m01 = readFloat(in);
-    float m02 = readFloat(in);
-    float m10 = readFloat(in);
-    float m11 = readFloat(in);
-    float m12 = readFloat(in);
-    float m20 = readFloat(in);
-    float m21 = readFloat(in);
-    float m22 = readFloat(in);
-    float m30 = readFloat(in);
-    float m31 = readFloat(in);
-    float m32 = readFloat(in);
-
-#if 0
-    cout << m00 << "   " << m01 << "   " << m02 << '\n';
-    cout << m10 << "   " << m11 << "   " << m12 << '\n';
-    cout << m20 << "   " << m21 << "   " << m22 << '\n';
-    cout << m30 << "   " << m31 << "   " << m32 << '\n';
-#endif
-
-    Eigen::Matrix4f m;
-    m << m00, m01, m02, 0,
-         m10, m11, m12, 0,
-         m20, m21, m22, 0,
-         m30, m31, m32, 1;
-
-    return m;
-}
-
-
-void readPointArray(std::istream& in, M3DTriangleMesh* triMesh)
-{
-    std::uint16_t nPoints = readUshort(in);
-
-    for (int i = 0; i < (int) nPoints; i++)
+    float elements[12];
+    for (std::size_t i = 0; i < 12; ++i)
     {
-        float x = readFloat(in);
-        float y = readFloat(in);
-        float z = readFloat(in);
+        if (!readFloat(in, elements[i])) { return READ_FAILURE; }
+    }
+
+    m << elements[0], elements[1], elements[2], 0,
+         elements[3], elements[4], elements[5], 0,
+         elements[6], elements[7], elements[8], 0,
+         elements[9], elements[10], elements[11], 1;
+
+    return static_cast<std::int32_t>(12 * sizeof(float));
+}
+
+
+std::int32_t readPointArray(std::istream& in, M3DTriangleMesh* triMesh)
+{
+    std::uint16_t nPoints;
+    if (!readUshort(in, nPoints)) { return READ_FAILURE; }
+    std::int32_t bytesRead = static_cast<int>(sizeof(nPoints));
+
+    for (int i = 0; i < static_cast<int>(nPoints); i++)
+    {
+        float x, y, z;
+        if (!readFloat(in, x) || !readFloat(in, y) || !readFloat(in, z)) { return READ_FAILURE; }
+        bytesRead += static_cast<int>(3 * sizeof(float));
         triMesh->addVertex(Eigen::Vector3f(x, y, z));
     }
+
+    return bytesRead;
 }
 
 
-void readTextureCoordArray(std::istream& in, M3DTriangleMesh* triMesh)
+std::int32_t readTextureCoordArray(std::istream& in, M3DTriangleMesh* triMesh)
 {
-    std::uint16_t nPoints = readUshort(in);
+    std::int32_t bytesRead = 0;
 
-    for (int i = 0; i < (int) nPoints; i++)
+    std::uint16_t nPoints;
+    if (!readUshort(in, nPoints)) { return READ_FAILURE; }
+    bytesRead += static_cast<int>(sizeof(nPoints));
+
+    for (int i = 0; i < static_cast<int>(nPoints); i++)
     {
-        float u = readFloat(in);
-        float v = readFloat(in);
+        float u, v;
+        if (!readFloat(in, u) || !readFloat(in, v)) { return READ_FAILURE; }
+        bytesRead += static_cast<int>(2 * sizeof(float));
         triMesh->addTexCoord(Eigen::Vector2f(u, -v));
     }
+
+    return bytesRead;
 }
 
 
-bool processFaceArrayChunk(std::istream& in,
-                           std::uint16_t chunkType,
-                           std::int32_t /*contentSize*/,
-                           M3DTriangleMesh* triMesh)
+std::int32_t processFaceArrayChunk(std::istream& in,
+                                   std::uint16_t chunkType,
+                                   std::int32_t /*contentSize*/,
+                                   M3DTriangleMesh* triMesh)
 {
+    std::int32_t bytesRead = 0;
     std::uint16_t nFaces;
-    M3DMeshMaterialGroup* matGroup;
+    std::unique_ptr<M3DMeshMaterialGroup> matGroup;
 
     switch (chunkType)
     {
     case M3DCHUNK_MESH_MATERIAL_GROUP:
-        matGroup = new M3DMeshMaterialGroup();
+        matGroup = std::make_unique<M3DMeshMaterialGroup>();
 
-        matGroup->materialName = readString(in);
-        nFaces = readUshort(in);
+        bytesRead = readString(in, matGroup->materialName);
+        if (bytesRead == READ_FAILURE || !readUshort(in, nFaces)) { return READ_FAILURE; }
+        bytesRead += static_cast<int>(sizeof(nFaces));
 
         for (std::uint16_t i = 0; i < nFaces; i++)
         {
-            std::uint16_t faceIndex = readUshort(in);
+            std::uint16_t faceIndex;
+            if (!readUshort(in, faceIndex)) { return READ_FAILURE; }
+            bytesRead += static_cast<int>(sizeof(faceIndex));
             matGroup->faces.push_back(faceIndex);
         }
 
-        triMesh->addMeshMaterialGroup(matGroup);
+        triMesh->addMeshMaterialGroup(matGroup.release());
 
-        return true;
+        return bytesRead;
+
     case M3DCHUNK_MESH_SMOOTH_GROUP:
         nFaces = triMesh->getFaceCount();
 
         for (std::uint16_t i = 0; i < nFaces; i++)
         {
-            auto groups = (std::uint32_t) readInt(in);
-            triMesh->addSmoothingGroups(groups);
+            std::int32_t groups;
+            if (!readInt(in, groups) || groups < 0) { return READ_FAILURE; }
+            bytesRead += static_cast<int>(sizeof(groups));
+            triMesh->addSmoothingGroups(static_cast<std::uint32_t>(groups));
         }
-        return true;
+        return bytesRead;
+
+    default:
+        return UNKNOWN_CHUNK;
     }
-    return false;
 }
 
 
-void readFaceArray(std::istream& in, M3DTriangleMesh* triMesh, std::int32_t contentSize)
+std::int32_t readFaceArray(std::istream& in, M3DTriangleMesh* triMesh, std::int32_t contentSize)
 {
-    std::uint16_t nFaces = readUshort(in);
+    std::uint16_t nFaces;
+    if (!readUshort(in, nFaces)) { return READ_FAILURE; }
+    std::int32_t bytesRead = static_cast<int>(sizeof(nFaces));
 
-    for (int i = 0; i < (int) nFaces; i++)
+    for (int i = 0; i < static_cast<int>(nFaces); i++)
     {
-        std::uint16_t v0 = readUshort(in);
-        std::uint16_t v1 = readUshort(in);
-        std::uint16_t v2 = readUshort(in);
-        /*uint16_t flags = */ readUshort(in);
+        std::uint16_t v0, v1, v2, flags;
+        if (!readUshort(in, v0) || !readUshort(in, v1) || !readUshort(in, v2) || !readUshort(in, flags))
+        {
+            return READ_FAILURE;
+        }
+        bytesRead += static_cast<int>(4 * sizeof(std::uint16_t));
         triMesh->addFace(v0, v1, v2);
     }
 
-    std::int32_t bytesLeft = contentSize - (8 * nFaces + 2);
-    if (bytesLeft > 0)
+    if (bytesRead > contentSize) { return READ_FAILURE; }
+
+    if (bytesRead < contentSize)
     {
-        read3DSChunks(in,
-                      bytesLeft,
-                      processFaceArrayChunk,
-                      triMesh);
+        std::int32_t trailingSize = read3DSChunks(in,
+                                                  contentSize - bytesRead,
+                                                  processFaceArrayChunk,
+                                                  triMesh);
+        bytesRead += trailingSize;
     }
+
+    return bytesRead;
 }
 
 
-bool processTriMeshChunk(std::istream& in,
-                         std::uint16_t chunkType,
-                         std::int32_t contentSize,
-                         M3DTriangleMesh* triMesh)
+std::int32_t processTriMeshChunk(std::istream& in,
+                                 std::uint16_t chunkType,
+                                 std::int32_t contentSize,
+                                 M3DTriangleMesh* triMesh)
 {
     switch (chunkType)
     {
     case M3DCHUNK_POINT_ARRAY:
-        readPointArray(in, triMesh);
-        return true;
+        return readPointArray(in, triMesh);
     case M3DCHUNK_MESH_TEXTURE_COORDS:
-        readTextureCoordArray(in, triMesh);
-        return true;
+        return readTextureCoordArray(in, triMesh);
     case M3DCHUNK_FACE_ARRAY:
-        readFaceArray(in, triMesh, contentSize);
-        return true;
+        return readFaceArray(in, triMesh, contentSize);
     case M3DCHUNK_MESH_MATRIX:
-        triMesh->setMatrix(readMeshMatrix(in/*, contentSize*/));
-        return true;
+        {
+            Eigen::Matrix4f matrix;
+            std::int32_t bytesRead = readMeshMatrix(in, matrix);
+            if (bytesRead < 0) { return READ_FAILURE; }
+            triMesh->setMatrix(matrix);
+            return bytesRead;
+        }
+    default:
+        return UNKNOWN_CHUNK;
     }
-
-    return false;
 }
 
 
-bool processModelChunk(std::istream& in,
-                       std::uint16_t chunkType,
-                       std::int32_t contentSize,
-                       M3DModel* model)
+std::int32_t processModelChunk(std::istream& in,
+                               std::uint16_t chunkType,
+                               std::int32_t contentSize,
+                               M3DModel* model)
 {
     if (chunkType == M3DCHUNK_TRIANGLE_MESH)
     {
-        auto* triMesh = new M3DTriangleMesh();
-        read3DSChunks(in, contentSize, processTriMeshChunk, triMesh);
-        model->addTriMesh(triMesh);
-        return true;
+        auto triMesh = std::make_unique<M3DTriangleMesh>();
+        std::int32_t bytesRead = read3DSChunks(in, contentSize, processTriMeshChunk, triMesh.get());
+        if (bytesRead == READ_FAILURE) { return READ_FAILURE; }
+        model->addTriMesh(triMesh.release());
+        return bytesRead;
     }
 
-    return false;
+    return UNKNOWN_CHUNK;
 }
 
 
-bool processColorChunk(std::istream& in,
-                       std::uint16_t chunkType,
-                       std::int32_t /*contentSize*/,
-                       M3DColor* color)
+std::int32_t processColorChunk(std::istream& in,
+                               std::uint16_t chunkType,
+                               std::int32_t /*contentSize*/,
+                               M3DColor* color)
 {
     switch (chunkType)
     {
     case M3DCHUNK_COLOR_24:
-        *color = readColor(in/*, contentSize*/);
-        return true;
+        return readColor(in, *color);
     case M3DCHUNK_COLOR_FLOAT:
-        *color = readFloatColor(in/*, contentSize*/);
-        return true;
+        return readFloatColor(in, *color);
+    default:
+        return UNKNOWN_CHUNK;
     }
-
-    return false;
 }
 
 
-static bool processPercentageChunk(std::istream& in,
-                                   std::uint16_t chunkType,
-                                   std::int32_t /*contentSize*/,
-                                   float* percent)
+std::int32_t processPercentageChunk(std::istream& in,
+                                    std::uint16_t chunkType,
+                                    std::int32_t /*contentSize*/,
+                                    float* percent)
 {
     switch (chunkType)
     {
     case M3DCHUNK_INT_PERCENTAGE:
-        *percent = readShort(in);
-        return true;
+        {
+            std::int16_t value;
+            if (!readShort(in, value)) { return READ_FAILURE; }
+            *percent = static_cast<float>(value);
+            return sizeof(value);
+        }
     case M3DCHUNK_FLOAT_PERCENTAGE:
-        *percent = readFloat(in);
-        return true;
+        return readFloat(in, *percent) ? sizeof(float) : READ_FAILURE;
+    default:
+        return UNKNOWN_CHUNK;
     }
-
-    return false;
 }
 
 
-static bool processTexmapChunk(std::istream& in,
-                               std::uint16_t chunkType,
-                               std::int32_t /*contentSize*/,
-                               M3DMaterial* material)
+std::int32_t processTexmapChunk(std::istream& in,
+                                std::uint16_t chunkType,
+                                std::int32_t /*contentSize*/,
+                                M3DMaterial* material)
 {
     if (chunkType == M3DCHUNK_MATERIAL_MAPNAME)
     {
-        std::string name = readString(in);
+        std::string name;
+        std::int32_t bytesRead = readString(in, name);
+        if (bytesRead < 0) { return READ_FAILURE; }
         material->setTextureMap(name);
-        return true;
+        return bytesRead;
     }
 
-    return false;
+    return UNKNOWN_CHUNK;
 }
 
 
-bool processMaterialChunk(std::istream& in,
-                          std::uint16_t chunkType,
-                          std::int32_t contentSize,
-                          M3DMaterial* material)
+std::int32_t processMaterialChunk(std::istream& in,
+                                  std::uint16_t chunkType,
+                                  std::int32_t contentSize,
+                                  M3DMaterial* material)
 {
+    std::int32_t bytesRead;
     std::string name;
     M3DColor color;
     float t;
@@ -385,92 +429,101 @@ bool processMaterialChunk(std::istream& in,
     switch (chunkType)
     {
     case M3DCHUNK_MATERIAL_NAME:
-        name = readString(in);
+        bytesRead = readString(in, name);
+        if (bytesRead < 0) { return READ_FAILURE; }
         material->setName(name);
-        return true;
+        return bytesRead;
     case M3DCHUNK_MATERIAL_AMBIENT:
-        read3DSChunks(in, contentSize, processColorChunk, &color);
+        bytesRead = read3DSChunks(in, contentSize, processColorChunk, &color);
+        if (bytesRead < 0) { return READ_FAILURE; }
         material->setAmbientColor(color);
-        return true;
+        return bytesRead;
     case M3DCHUNK_MATERIAL_DIFFUSE:
-        read3DSChunks(in, contentSize, processColorChunk, &color);
+        bytesRead = read3DSChunks(in, contentSize, processColorChunk, &color);
+        if (bytesRead < 0) { return READ_FAILURE; }
         material->setDiffuseColor(color);
-        return true;
+        return bytesRead;
     case M3DCHUNK_MATERIAL_SPECULAR:
-        read3DSChunks(in, contentSize, processColorChunk, &color);
+        bytesRead = read3DSChunks(in, contentSize, processColorChunk, &color);
+        if (bytesRead < 0) { return READ_FAILURE; }
         material->setSpecularColor(color);
-        return true;
+        return bytesRead;
     case M3DCHUNK_MATERIAL_SHININESS:
-        read3DSChunks(in, contentSize, processPercentageChunk, &t);
+        bytesRead = read3DSChunks(in, contentSize, processPercentageChunk, &t);
+        if (bytesRead < 0) { return READ_FAILURE; }
         material->setShininess(t);
-        return true;
+        return bytesRead;
     case M3DCHUNK_MATERIAL_TRANSPARENCY:
-        read3DSChunks(in, contentSize, processPercentageChunk, &t);
+        bytesRead = read3DSChunks(in, contentSize, processPercentageChunk, &t);
+        if (bytesRead < 0) { return READ_FAILURE; }
         material->setOpacity(1.0f - t / 100.0f);
-        return true;
+        return bytesRead;
     case M3DCHUNK_MATERIAL_TEXMAP:
-        read3DSChunks(in, contentSize, processTexmapChunk, material);
-        return true;
+        return read3DSChunks(in, contentSize, processTexmapChunk, material);
+    default:
+        return UNKNOWN_CHUNK;
     }
-
-    return false;
 }
 
 
-bool processSceneChunk(std::istream& in,
-                       std::uint16_t chunkType,
-                       std::int32_t contentSize,
-                       M3DScene* scene)
+std::int32_t processSceneChunk(std::istream& in,
+                               std::uint16_t chunkType,
+                               std::int32_t contentSize,
+                               M3DScene* scene)
 {
-    M3DModel* model;
-    M3DMaterial* material;
+    std::int32_t bytesRead, chunksSize;
+    std::unique_ptr<M3DModel> model;
+    std::unique_ptr<M3DMaterial> material;
     M3DColor color;
     std::string name;
 
     switch (chunkType)
     {
     case M3DCHUNK_NAMED_OBJECT:
-        name = readString(in);
-        model = new M3DModel();
+        bytesRead = readString(in, name);
+        if (bytesRead < 0) { return READ_FAILURE; }
+        model = std::make_unique<M3DModel>();
         model->setName(name);
-        read3DSChunks(in,
-                      contentSize - (name.length() + 1),
-                      processModelChunk,
-                      model);
-        scene->addModel(model);
+        chunksSize = read3DSChunks(in,
+                                   contentSize - bytesRead,
+                                   processModelChunk,
+                                   model.get());
+        if (chunksSize < 0) { return READ_FAILURE; }
+        scene->addModel(model.release());
 
-        return true;
+        return bytesRead + chunksSize;
     case M3DCHUNK_MATERIAL_ENTRY:
-        material = new M3DMaterial();
-        read3DSChunks(in,
-                      contentSize,
-                      processMaterialChunk,
-                      material);
-        scene->addMaterial(material);
+        material = std::make_unique<M3DMaterial>();
+        bytesRead = read3DSChunks(in,
+                                  contentSize,
+                                  processMaterialChunk,
+                                  material.get());
+        if (bytesRead < 0) { return READ_FAILURE; }
+        scene->addMaterial(material.release());
 
-        return true;
+        return bytesRead;
     case M3DCHUNK_BACKGROUND_COLOR:
-        read3DSChunks(in, contentSize, processColorChunk, &color);
+        bytesRead = read3DSChunks(in, contentSize, processColorChunk, &color);
+        if (bytesRead < 0) { return READ_FAILURE; }
         scene->setBackgroundColor(color);
-        return true;
+        return bytesRead;
     default:
-        return false;
+        return UNKNOWN_CHUNK;
     }
 }
 
 
-bool processTopLevelChunk(std::istream& in,
-                          std::uint16_t chunkType,
-                          std::int32_t contentSize,
-                          M3DScene* scene)
+std::int32_t processTopLevelChunk(std::istream& in,
+                                  std::uint16_t chunkType,
+                                  std::int32_t contentSize,
+                                  M3DScene* scene)
 {
     if (chunkType == M3DCHUNK_MESHDATA)
     {
-        read3DSChunks(in, contentSize, processSceneChunk, scene);
-        return true;
+        return read3DSChunks(in, contentSize, processSceneChunk, scene);
     }
 
-    return false;
+    return UNKNOWN_CHUNK;
 }
 
 } // end namespace
@@ -478,28 +531,33 @@ bool processTopLevelChunk(std::istream& in,
 
 M3DScene* Read3DSFile(std::istream& in)
 {
-    std::uint16_t chunkType = readUshort(in);
-    if (chunkType != M3DCHUNK_MAGIC)
+    std::uint16_t chunkType;
+    if (!readUshort(in, chunkType) || chunkType != M3DCHUNK_MAGIC)
     {
-        DPRINTF(LOG_LEVEL_ERROR, "Read3DSFile: Wrong magic number in header\n");
+        fmt::print(std::clog, "Read3DSFile: Wrong magic number in header\n");
         return nullptr;
     }
 
-    std::int32_t chunkSize = readInt(in);
-    if (in.bad())
+    std::int32_t chunkSize;
+    if (!readInt(in, chunkSize) || chunkSize < 6)
     {
-        DPRINTF(LOG_LEVEL_ERROR, "Read3DSFile: Error reading 3DS file.\n");
+        fmt::print(std::clog, "Read3DSFile: Error reading 3DS file top level chunk size\n");
         return nullptr;
     }
 
-    DPRINTF(LOG_LEVEL_INFO, "3DS file, %d bytes\n", chunkSize);
+    fmt::print(std::clog, "3DS file, {} bytes\n", chunkSize + 6);
 
-    auto* scene = new M3DScene();
+    auto scene = std::make_unique<M3DScene>();
     std::int32_t contentSize = chunkSize - 6;
 
-    read3DSChunks(in, contentSize, processTopLevelChunk, scene);
+    std::int32_t bytesRead = read3DSChunks(in, contentSize, processTopLevelChunk, scene.get());
+    if (bytesRead < 0) { return nullptr; }
+    if (bytesRead != contentSize)
+    {
+        return nullptr;
+    }
 
-    return scene;
+    return scene.release();
 }
 
 
@@ -508,7 +566,7 @@ M3DScene* Read3DSFile(const fs::path& filename)
     std::ifstream in(filename.string(), std::ios::in | std::ios::binary);
     if (!in.good())
     {
-        DPRINTF(LOG_LEVEL_ERROR, "Read3DSFile: Error opening %s\n", filename);
+        fmt::print(std::clog, "Read3DSFile: Error opening {}\n", filename);
         return nullptr;
     }
 

--- a/src/cel3ds/3dsread.h
+++ b/src/cel3ds/3dsread.h
@@ -7,15 +7,12 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _3DSREAD_H_
-#define _3DSREAD_H_
+#pragma once
 
-#include <iostream>
-#include <fstream>
-#include <cel3ds/3dsmodel.h>
+#include <iosfwd>
 #include <celcompat/filesystem.h>
 
-M3DScene* Read3DSFile(std::ifstream& in);
-M3DScene* Read3DSFile(const fs::path& filename);
+class M3DScene;
 
-#endif // _3DSREAD_H_
+M3DScene* Read3DSFile(std::istream& in);
+M3DScene* Read3DSFile(const fs::path& filename);

--- a/src/cel3ds/3dsread.h
+++ b/src/cel3ds/3dsread.h
@@ -10,9 +10,10 @@
 #pragma once
 
 #include <iosfwd>
+#include <memory>
 #include <celcompat/filesystem.h>
 
 class M3DScene;
 
-M3DScene* Read3DSFile(std::istream& in);
-M3DScene* Read3DSFile(const fs::path& filename);
+std::unique_ptr<M3DScene> Read3DSFile(std::istream& in);
+std::unique_ptr<M3DScene> Read3DSFile(const fs::path& filename);

--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -126,7 +126,7 @@ Geometry* GeometryInfo::load(const fs::path& resolvedFilename)
 
     if (fileType == Content_3DStudio)
     {
-        M3DScene* scene = Read3DSFile(filename);
+        std::unique_ptr<M3DScene> scene = Read3DSFile(filename);
         if (scene != nullptr)
         {
             if (resolvedToPath)
@@ -138,8 +138,6 @@ Geometry* GeometryInfo::load(const fs::path& resolvedFilename)
                 model->normalize(center);
             else
                 model->transform(center, scale);
-
-            delete scene;
         }
     }
     else if (fileType == Content_CelestiaModel)

--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -23,6 +23,7 @@
 #include "modelgeometry.h"
 #include "tokenizer.h"
 
+#include <cel3ds/3dsmodel.h>
 #include <cel3ds/3dsread.h>
 #include <celmodel/modelfile.h>
 

--- a/src/tools/cmod/3dstocmod/3dstocmod.cpp
+++ b/src/tools/cmod/3dstocmod/3dstocmod.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdio>
+#include <memory>
 
 using namespace cmod;
 using namespace std;
@@ -41,7 +42,7 @@ int main(int argc, char* argv[])
     string inputFileName = argv[1];
 
     cerr << "Reading...\n";
-    M3DScene* scene = Read3DSFile(inputFileName);
+    std::unique_ptr<M3DScene> scene = Read3DSFile(inputFileName);
     if (scene == nullptr)
     {
         cerr << "Error reading 3DS file '" << inputFileName << "'\n";

--- a/src/tools/cmod/cmodview/mainwindow.cpp
+++ b/src/tools/cmod/cmodview/mainwindow.cpp
@@ -8,6 +8,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <fstream>
+#include <memory>
 #include "mainwindow.h"
 #include "materialwidget.h"
 #include "convert3ds.h"
@@ -382,7 +384,7 @@ MainWindow::openModel(const QString& fileName)
 
         if (info.suffix().toLower() == "3ds")
         {
-            M3DScene* scene = Read3DSFile(fileNameStd);
+            std::unique_ptr<M3DScene> scene = Read3DSFile(fileNameStd);
             if (scene == nullptr)
             {
                 QMessageBox::warning(this, "Load error", tr("Error reading 3DS file %1").arg(fileName));
@@ -395,8 +397,6 @@ MainWindow::openModel(const QString& fileName)
                 QMessageBox::warning(this, "Load error", tr("Internal error converting 3DS file %1").arg(fileName));
                 return;
             }
-
-            delete scene;
 
             // Generate normals for the model
             double smoothAngle = 45.0; // degrees


### PR DESCRIPTION
I noticed a potential buffer overflow error in the `readString` function in 3dsread.cpp: if the string is 1024 characters or longer, the terminating zero byte is not written and the string constructor from `const char*` will therefore read beyond the end of the buffer.

The rest of the loader functionality was in my opinion far too trusting that the input files are not malformed. I've therefore added various error checking that was missing, including verifying that the stream is in a good state after attempting to read data, and consistency checks that the expected amount of data has been read. I also replaced the void pointer usage with templates to ensure better type safety, and switched to using `std::make_unique` rather than `new` to simplify cleanup on the error path.

So far I've checked that the Apollo 11 and Mir models still load.

