### PR TITLE
Remove using namespace from headers

### DIFF
--- a/src/celengine/spheremesh.cpp
+++ b/src/celengine/spheremesh.cpp
@@ -342,17 +342,17 @@ void SphereMesh::displace(DisplacementMapFunc func, void* info)
 }
 
 
-Mesh* SphereMesh::convertToMesh() const
+cmod::Mesh* SphereMesh::convertToMesh() const
 {
     uint32_t stride = 32;
-    Mesh::VertexAttribute attributes[3];
-    attributes[0] = Mesh::VertexAttribute(Mesh::Position, Mesh::Float3, 0);
-    attributes[1] = Mesh::VertexAttribute(Mesh::Normal, Mesh::Float3, 12);
-    attributes[2] = Mesh::VertexAttribute(Mesh::Texture0, Mesh::Float2, 24);
+    cmod::Mesh::VertexAttribute attributes[3];
+    attributes[0] = cmod::Mesh::VertexAttribute(cmod::Mesh::Position, cmod::Mesh::Float3, 0);
+    attributes[1] = cmod::Mesh::VertexAttribute(cmod::Mesh::Normal, cmod::Mesh::Float3, 12);
+    attributes[2] = cmod::Mesh::VertexAttribute(cmod::Mesh::Texture0, cmod::Mesh::Float2, 24);
 
-    Mesh* mesh = new Mesh();
+    cmod::Mesh* mesh = new cmod::Mesh();
 
-    mesh->setVertexDescription(Mesh::VertexDescription(stride, 3, attributes));
+    mesh->setVertexDescription(cmod::Mesh::VertexDescription(stride, 3, attributes));
 
     // Copy the vertex data from the separate position, normal, and texture coordinate
     // arrays into a single array.
@@ -382,7 +382,7 @@ Mesh* SphereMesh::convertToMesh() const
             indexData[j * 2 + 1] = (i + 1) * (nSlices + 1) + j;
         }
 
-        mesh->addGroup(Mesh::TriStrip, ~0u, (nSlices + 1) * 2, indexData);
+        mesh->addGroup(cmod::Mesh::TriStrip, ~0u, (nSlices + 1) * 2, indexData);
     }
 
     return mesh;

--- a/src/celengine/spheremesh.h
+++ b/src/celengine/spheremesh.h
@@ -18,8 +18,6 @@
 #include <celengine/dispmap.h>
 #include <celmodel/mesh.h>
 
-using namespace cmod;
-
 
 /*! The SphereMesh class is used to generate displacement mapped
  *  spheres when loading the now-deprecated .cms geometry files.
@@ -41,7 +39,7 @@ public:
     ~SphereMesh();
 
     //! Convert this object into a standard Celestia mesh.
-    Mesh* convertToMesh() const;
+    cmod::Mesh* convertToMesh() const;
 
  private:
     void createSphere(float radius, int _nRings, int _nSlices);

--- a/src/celestia/win32/odmenu.h
+++ b/src/celestia/win32/odmenu.h
@@ -5,24 +5,22 @@
 #include <map>
 #include <string>
 
-using namespace std;
-
 enum bitmapType {eNormal, eDisabled, eShadow, eFaded};
 
 typedef struct tagODMENUITEM
 {
     UINT dwType;
     UINT wID;
-    string rawText;
-    string displayText;
-    string rawDisplayText;
-    string shortcutText;
+    std::string rawText;
+    std::string displayText;
+    std::string rawDisplayText;
+    std::string shortcutText;
     HBITMAP hBitmap;
     bool topMost;
 
 } ODMENUITEM;
 
-typedef map<UINT, ODMENUITEM> ODMENUITEMS;
+typedef std::map<UINT, ODMENUITEM> ODMENUITEMS;
 
 class ODMenu
 {


### PR DESCRIPTION
Remove a couple of `using namespace` declarations lurking in header files. I *think* this is the last of them.