### PR TITLE
Set up common binary IO functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,9 @@ endif()
 try_compile(HAVE_STRING_VIEW ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/checks/cxxsv.cpp")
 try_compile(HAVE_EXPERIMENTAL_STRING_VIEW ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/checks/cxxsvexp.cpp")
 
+include(TestBigEndian)
+test_big_endian(WORDS_BIGENDIAN)
+
 configure_file("config.h.in" "config.h")
 
 set(BASE_DATA_SOURCES

--- a/config.h.in
+++ b/config.h.in
@@ -4,3 +4,4 @@
 #cmakedefine HAVE_STRING_VIEW
 #cmakedefine HAVE_EXPERIMENTAL_STRING_VIEW
 #cmakedefine HAVE_WORDEXP
+#cmakedefine WORDS_BIGENDIAN

--- a/src/celutil/CMakeLists.txt
+++ b/src/celutil/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(CELUTIL_SOURCES
   bigfix.cpp
   bigfix.h
+  binaryread.h
+  binarywrite.h
   blockarray.h
   bytes.h
   color.cpp

--- a/src/celutil/binaryread.h
+++ b/src/celutil/binaryread.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <cstring>
+#include <istream>
+#include <type_traits>
+#include <utility>
+
+#include <config.h>
+
+
+namespace celestia
+{
+namespace util
+{
+/*! Read a value stored in machine-native byte order from an input stream.
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool readNative(std::istream& in, T& value)
+{
+    char data[sizeof(T)];
+    if (!in.read(data, sizeof(T)).good()) { return false; }
+    std::memcpy(&value, data, sizeof(T));
+    return true;
+}
+
+template<>
+inline bool readNative<char>(std::istream& in, char& value)
+{
+    return in.get(value).good();
+}
+
+template<>
+inline bool readNative<signed char>(std::istream& in, signed char& value)
+{
+    char c;
+    if (!in.get(c).good()) { return false; }
+    value = static_cast<signed char>(c);
+    return true;
+}
+
+template<>
+inline bool readNative<unsigned char>(std::istream& in, unsigned char& value)
+{
+    char c;
+    if (!in.get(c).good()) { return false; }
+    value = static_cast<unsigned char>(c);
+    return true;
+}
+
+
+/*! Read a value stored opposite to machine-native byte order from an input stream
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool readReversed(std::istream& in, T& value)
+{
+    char data[sizeof(T)];
+    if (!in.read(data, sizeof(T)).good()) { return false; }
+    for (std::size_t i = 0; i < sizeof(T) / 2; ++i)
+    {
+        std::swap(data[i], data[sizeof(T) - i - 1]);
+    }
+
+    std::memcpy(&value, data, sizeof(T));
+    return true;
+}
+
+template<>
+inline bool readReversed<char>(std::istream& in, char& value)
+{
+    return readNative(in, value);
+}
+
+template<>
+inline bool readReversed<signed char>(std::istream& in, signed char& value)
+{
+    return readNative(in, value);
+}
+
+template<>
+inline bool readReversed<unsigned char>(std::istream& in, unsigned char& value)
+{
+    return readNative(in, value);
+}
+
+#ifdef WORDS_BIGENDIAN
+
+/*! Read a value stored in little-endian byte order from an input stream.
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool readLE(std::istream& in, T& value)
+{
+    return readReversed(in, value);
+}
+
+/*! Read a value stored in big-endian byte order from an input stream.
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool readBE(std::istream& in, T& value)
+{
+    return readNative(in, value);
+}
+
+#else
+
+/*! Read a value stored in little-endian byte order from an input stream.
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool readLE(std::istream& in, T& value)
+{
+    return readNative(in, value);
+}
+
+/*! Read a value stored in big-endian byte order from an input stream.
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool readBE(std::istream& in, T& value)
+{
+    return readReversed(in, value);
+}
+
+#endif
+
+}
+}

--- a/src/celutil/binarywrite.h
+++ b/src/celutil/binarywrite.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <cstring>
+#include <ostream>
+#include <type_traits>
+#include <utility>
+
+#include <config.h>
+
+
+namespace celestia
+{
+namespace util
+{
+/*! Write a value to an output stream in machine-native byte order.
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool writeNative(std::ostream& out, T value)
+{
+    char data[sizeof(T)];
+    std::memcpy(data, &value, sizeof(T));
+    return out.write(data, sizeof(T)).good();
+}
+
+template<>
+inline bool writeNative<char>(std::ostream& out, char value)
+{
+    return out.put(value).good();
+}
+
+template<>
+inline bool writeNative<signed char>(std::ostream& out, signed char value)
+{
+    return out.put(static_cast<char>(value)).good();
+}
+
+template<>
+inline bool writeNative<unsigned char>(std::ostream& out, unsigned char value)
+{
+    return out.put(static_cast<unsigned char>(value)).good();
+}
+
+
+/*! Write a value to an output stream with the opposite of machine-native byte order.
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool writeReversed(std::ostream& out, T value)
+{
+    char data[sizeof(T)];
+    std::memcpy(data, &value, sizeof(T));
+    for (std::size_t i = 0; i < sizeof(T) / 2; ++i)
+    {
+        std::swap(data[i], data[sizeof(T) - i - 1]);
+    }
+    return out.write(data, sizeof(T)).good();
+}
+
+template<>
+inline bool writeReversed<char>(std::ostream& out, char value)
+{
+    return writeNative(out, value);
+}
+
+template<>
+inline bool writeReversed<signed char>(std::ostream& out, signed char value)
+{
+    return writeNative(out, value);
+}
+
+template<>
+inline bool writeReversed<unsigned char>(std::ostream& out, unsigned char value)
+{
+    return writeNative(out, value);
+}
+
+#ifdef WORDS_BIGENDIAN
+
+/*! Write a value to an output stream in little-endian byte order
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool writeLE(std::ostream& out, T value)
+{
+    return writeReversed(out, value);
+}
+
+/*! Write a value to an output stream in big-endian byte order
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool writeBE(std::ostream& out, T value)
+{
+    return writeNative(out, value);
+}
+
+#else
+
+/*! Write a value to an output stream in little-endian byte order
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool writeLE(std::ostream& out, T value)
+{
+    return writeNative(out, value);
+}
+
+/*! Write a value to an output stream in big-endian byte order
+ */
+template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
+inline bool writeBE(std::ostream& out, T value)
+{
+    return writeReversed(out, value);
+}
+
+#endif
+
+}
+}


### PR DESCRIPTION
Extracts little/big-endian utiilty functions that were present across several cpp files and moves them into common header files. I've also added some more error handling where I updated the files.

The file binarywrite.h is currently not used, this will be used in a follow-up cleanup of modelfile.cpp, which I will raise as a separate pull request as the fixes required there are quite extensive.