### PR TITLE
Update cmod I/O

### DIFF
--- a/src/celengine/CMakeLists.txt
+++ b/src/celengine/CMakeLists.txt
@@ -151,8 +151,6 @@ set(CELENGINE_SOURCES
   timeline.h
   timelinephase.cpp
   timelinephase.h
-  tokenizer.cpp
-  tokenizer.h
   trajmanager.cpp
   trajmanager.h
   univcoord.cpp

--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -9,11 +9,12 @@
 
 #include <celutil/gettext.h>
 #include <celutil/debug.h>
+#include <celutil/tokenizer.h>
 #include <celutil/util.h>
 #include "stardb.h"
 #include "asterism.h"
 #include "parser.h"
-#include "tokenizer.h"
+
 
 using namespace std;
 

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -29,7 +29,7 @@
 #include "parseobject.h"
 #include "multitexture.h"
 #include "meshmanager.h"
-#include "tokenizer.h"
+#include <celutil/tokenizer.h>
 #include <celutil/debug.h>
 
 #include <celengine/galaxy.h>

--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -21,7 +21,7 @@
 #include "texmanager.h"
 #include "meshmanager.h"
 #include "modelgeometry.h"
-#include "tokenizer.h"
+#include <celutil/tokenizer.h>
 
 #include <cel3ds/3dsmodel.h>
 #include <cel3ds/3dsread.h>

--- a/src/celengine/parser.cpp
+++ b/src/celengine/parser.cpp
@@ -8,9 +8,9 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <celutil/tokenizer.h>
 #include "astro.h"
 #include "parser.h"
-#include "tokenizer.h"
 #include "value.h"
 
 using namespace std;

--- a/src/celengine/particlesystemfile.h
+++ b/src/celengine/particlesystemfile.h
@@ -14,7 +14,7 @@
 
 #include <iostream>
 #include <string>
-#include "tokenizer.h"
+#include <celutil/tokenizer.h>
 #include "parser.h"
 
 class ParticleSystem;

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -21,7 +21,7 @@
 #include <celutil/gettext.h>
 #include "astro.h"
 #include "parser.h"
-#include "tokenizer.h"
+#include <celutil/tokenizer.h>
 #include "texmanager.h"
 #include "meshmanager.h"
 #include "universe.h"

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -18,13 +18,14 @@
 #include <celutil/binaryread.h>
 #include <celutil/debug.h>
 #include <celutil/gettext.h>
+#include <celutil/tokenizer.h>
 #include "stardb.h"
 #include "astro.h"
 #include "parser.h"
 #include "parseobject.h"
 #include "multitexture.h"
 #include "meshmanager.h"
-#include "tokenizer.h"
+
 #include <fmt/printf.h>
 
 using namespace Eigen;

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -21,7 +21,7 @@
 #include <celcompat/filesystem.h>
 #include <celutil/filetype.h>
 #include "parser.h"
-#include "tokenizer.h"
+#include <celutil/tokenizer.h>
 #include "virtualtex.h"
 
 

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -15,7 +15,7 @@
 #include <celutil/fsutils.h>
 #include <celutil/util.h>
 #include <celengine/texmanager.h>
-#include <celengine/tokenizer.h>
+#include <celutil/tokenizer.h>
 #include "configfile.h"
 
 using namespace std;

--- a/src/celestia/destination.cpp
+++ b/src/celestia/destination.cpp
@@ -14,7 +14,7 @@
 #include <celutil/util.h>
 #include <celengine/astro.h>
 #include <celengine/parser.h>
-#include <celengine/tokenizer.h>
+#include <celutil/tokenizer.h>
 #include "destination.h"
 
 using namespace std;

--- a/src/celestia/favorites.cpp
+++ b/src/celestia/favorites.cpp
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <iomanip>
 #include <celengine/parser.h>
-#include <celengine/tokenizer.h>
+#include <celutil/tokenizer.h>
 #include <celutil/debug.h>
 #include <celutil/util.h>
 #include "favorites.h"

--- a/src/celmodel/material.h
+++ b/src/celmodel/material.h
@@ -30,14 +30,14 @@ public:
     class Color
     {
     public:
-        Color() :
+        constexpr Color() :
             m_red(0.0f),
             m_green(0.0f),
             m_blue(0.0f)
         {
         }
 
-        Color(float r, float g, float b) :
+        constexpr Color(float r, float g, float b) :
             m_red(r),
             m_green(g),
             m_blue(b)
@@ -51,17 +51,17 @@ public:
         {
         }
 
-        float red() const
+        constexpr float red() const
         {
             return m_red;
         }
 
-        float green() const
+        constexpr float green() const
         {
             return m_green;
         }
 
-        float blue() const
+        constexpr float blue() const
         {
             return m_blue;
         }
@@ -71,12 +71,12 @@ public:
             return Eigen::Vector3f(m_red, m_green, m_blue);
         }
 
-        bool operator==(const Color& other) const
+        constexpr bool operator==(const Color& other) const
         {
             return m_red == other.m_red && m_green == other.m_green && m_blue == other.m_blue;
         }
 
-        bool operator!=(const Color& other) const
+        constexpr bool operator!=(const Color& other) const
         {
             return !(*this == other);
         }

--- a/src/celmodel/modelfile.h
+++ b/src/celmodel/modelfile.h
@@ -8,20 +8,16 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELMODEL_MODELFILE_H_
-#define _CELMODEL_MODELFILE_H_
+#pragma once
 
-#include "model.h"
-#include <iostream>
+#include <iosfwd>
 #include <string>
 
-#define CEL_MODEL_HEADER_LENGTH 16
-#define CEL_MODEL_HEADER_ASCII "#celmodel__ascii"
-#define CEL_MODEL_HEADER_BINARY "#celmodel_binary"
-
+#include "material.h"
 
 namespace cmod
 {
+class Model;
 
 /** Texture loading interface. Applications which want custom behavor for
   * texture loading should pass an instance of a TextureLoader subclass to
@@ -35,75 +31,9 @@ public:
 };
 
 
-class ModelLoader
-{
- public:
-    ModelLoader() = default;
-    virtual ~ModelLoader() = default;
-
-    virtual Model* load() = 0;
-
-    const std::string& getErrorMessage() const;
-    TextureLoader* getTextureLoader() const;
-    void setTextureLoader(TextureLoader* _textureLoader);
-
-    static ModelLoader* OpenModel(std::istream& in);
-
- protected:
-    virtual void reportError(const std::string&);
-
- private:
-    std::string errorMessage;
-    TextureLoader* textureLoader{ nullptr };
-};
-
-
-class ModelWriter
-{
- public:
-    virtual ~ModelWriter() {};
-
-    virtual bool write(const Model&) = 0;
-};
-
-
-
 Model* LoadModel(std::istream& in, TextureLoader* textureLoader = nullptr);
 
 bool SaveModelAscii(const Model* model, std::ostream& out);
 bool SaveModelBinary(const Model* model, std::ostream& out);
 
-
-// Binary file tokens
-enum ModelFileToken
-{
-    CMOD_Material       = 1001,
-    CMOD_EndMaterial    = 1002,
-    CMOD_Diffuse        = 1003,
-    CMOD_Specular       = 1004,
-    CMOD_SpecularPower  = 1005,
-    CMOD_Opacity        = 1006,
-    CMOD_Texture        = 1007,
-    CMOD_Mesh           = 1009,
-    CMOD_EndMesh        = 1010,
-    CMOD_VertexDesc     = 1011,
-    CMOD_EndVertexDesc  = 1012,
-    CMOD_Vertices       = 1013,
-    CMOD_Emissive       = 1014,
-    CMOD_Blend          = 1015,
-};
-
-enum ModelFileType
-{
-    CMOD_Float1         = 1,
-    CMOD_Float2         = 2,
-    CMOD_Float3         = 3,
-    CMOD_Float4         = 4,
-    CMOD_String         = 5,
-    CMOD_Uint32         = 6,
-    CMOD_Color          = 7,
-};
-
 }
-
-#endif // !_CELMODEL_MODELFILE_H_

--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -18,7 +18,7 @@
 #include <celmath/mathlib.h>
 #include <celengine/astro.h>
 #include <celengine/parser.h>
-#include <celengine/tokenizer.h>
+#include <celutil/tokenizer.h>
 #ifdef USE_GLCONTEXT
 #include <celengine/glcontext.h>
 #endif

--- a/src/celutil/CMakeLists.txt
+++ b/src/celutil/CMakeLists.txt
@@ -25,6 +25,8 @@ set(CELUTIL_SOURCES
   strnatcmp.h
   timer.cpp
   timer.h
+  tokenizer.cpp
+  tokenizer.h
   utf8.cpp
   utf8.h
   util.cpp

--- a/src/celutil/tokenizer.cpp
+++ b/src/celutil/tokenizer.cpp
@@ -10,12 +10,10 @@
 
 #include <cctype>
 #include <cerrno>
-#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 
-#include "celutil/utf8.h"
-
+#include "utf8.h"
 #include "tokenizer.h"
 
 namespace
@@ -419,6 +417,20 @@ void Tokenizer::pushBack()
 double Tokenizer::getNumberValue() const
 {
     return tokenValue;
+}
+
+
+bool Tokenizer::isInteger() const
+{
+    return tokenType == TokenNumber
+        && textToken.find_first_of(".eE") == std::string::npos
+        && tokenValue >= INT32_MIN && tokenValue <= INT32_MAX;
+}
+
+
+std::int32_t Tokenizer::getIntegerValue() const
+{
+    return static_cast<std::int32_t>(tokenValue);
 }
 
 

--- a/src/celutil/tokenizer.h
+++ b/src/celutil/tokenizer.h
@@ -8,10 +8,10 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _TOKENIZER_H_
-#define _TOKENIZER_H_
+#pragma once
 
 #include <cmath>
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 
@@ -43,6 +43,8 @@ public:
     TokenType getTokenType() const;
     void pushBack();
     double getNumberValue() const;
+    bool isInteger() const;
+    std::int32_t getIntegerValue() const;
     std::string getNameValue() const;
     std::string getStringValue() const;
 
@@ -61,5 +63,3 @@ private:
 
     bool skipUtf8Bom();
 };
-
-#endif // _TOKENIZER_H_

--- a/src/celutil/utf8.h
+++ b/src/celutil/utf8.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELUTIL_UTF8_
-#define _CELUTIL_UTF8_
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -26,6 +25,7 @@
 #define UTF8_SUPERSCRIPT_7       "\342\201\267"
 #define UTF8_SUPERSCRIPT_8       "\342\201\270"
 #define UTF8_SUPERSCRIPT_9       "\342\201\271"
+#define UTF8_REPLACEMENT_CHAR    "\357\277\275"
 
 
 bool UTF8Decode(const std::string& str, int pos, wchar_t& ch);
@@ -136,4 +136,27 @@ class Greek
 
 std::vector<std::string> getGreekCompletion(const std::string &);
 
-#endif // _CELUTIL_UTF8_
+class UTF8Validator
+{
+public:
+    UTF8Validator() = default;
+    ~UTF8Validator() = default;
+
+    bool check(char c);
+    bool check(unsigned char c);
+
+private:
+    enum class State
+    {
+        Initial,
+        Continuation1,
+        Continuation2,
+        Continuation3,
+        E0Continuation,
+        EDContinuation,
+        F0Continuation,
+        F4Continuation,
+    };
+
+    State state{ State::Initial };
+};

--- a/src/tools/cmod/3dstocmod/3dstocmod.cpp
+++ b/src/tools/cmod/3dstocmod/3dstocmod.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdio>
+#include <iostream>
 #include <memory>
 
 using namespace cmod;

--- a/src/tools/cmod/cmodfix/cmodfix.cpp
+++ b/src/tools/cmod/cmodfix/cmodfix.cpp
@@ -9,6 +9,8 @@
 //
 // Perform various adjustments to a cmod file
 
+#include <celmodel/mesh.h>
+#include <celmodel/model.h>
 #include <celmodel/modelfile.h>
 #include <celmath/mathlib.h>
 #include <Eigen/Core>
@@ -18,6 +20,7 @@
 #include <cmath>
 #include <cstdio>
 #include <algorithm>
+#include <iostream>
 #include <vector>
 #ifdef TRISTRIP
 #include <NvTriStrip.h>

--- a/src/tools/cmod/common/cmodops.cpp
+++ b/src/tools/cmod/common/cmodops.cpp
@@ -14,6 +14,7 @@
 #include <celmath/mathlib.h>
 #include <Eigen/Core>
 #include <algorithm>
+#include <iostream>
 #include <vector>
 #ifdef TRISTRIP
 #include <NvTriStrip.h>


### PR DESCRIPTION
* Replace the tokenizer implementation in the celmodel code with the one used for other file types, move the tokenizer to celutil
* Use the binaryread.hpp/binarywrite.hpp routines for parsing binary CMOD files
* Enforce maximum token length limit of 1024 characters - resolves #1151 
* Disallow creation of surrogate pair characters (U+D800 to U+DFFF) via Unicode escape sequences
* Detect and reject invalid UTF-8 sequences in the tokenizer