### PR TITLE
Fix for fmt 4.0 (as used by Ubuntu 18.04 LTS)

### DIFF
--- a/src/celmodel/modelfile.cpp
+++ b/src/celmodel/modelfile.cpp
@@ -12,7 +12,7 @@
 #include <cstring>
 #include <iostream>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 
 #include <celutil/binaryread.h>


### PR DESCRIPTION
Ubuntu 18.04 LTS supplies fmt 4.0, which doesn't have the core.h header.