### PR TITLE
Ensure reproducibility of "random" template generation

### DIFF
--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -602,7 +602,7 @@ GalacticForm* buildGalacticForms(const fs::path& filename)
     height = img->getHeight();
     rgb    = img->getComponents();
 
-    auto& rng = getRNG();
+    celmath::Jsf32 rng(UINT32_C(0xa0030c29));
     for (int i = 0; i < width * height; i++)
     {
         value = img->getPixels()[rgb * i];
@@ -667,7 +667,7 @@ GalacticForm* buildGalacticForms(const fs::path& filename)
     // reshuffle the galaxy points randomly...except the first kmin+1 in the center!
     // the higher that number the stronger the central "glow"
 
-    shuffle(galacticPoints->begin() + kmin, galacticPoints->end(), getRNG());
+    shuffle(galacticPoints->begin() + kmin, galacticPoints->end(), celmath::Jsf32(UINT32_C(0x29bf0617)));
 
     auto* galacticForm  = new GalacticForm();
     galacticForm->blobs = galacticPoints;
@@ -726,7 +726,7 @@ void InitializeForms()
     BlobVector* irregularPoints = new BlobVector;
     irregularPoints->reserve(galaxySize);
 
-    auto& rng = getRNG();
+    celmath::Jsf32 rng(UINT32_C(0xa24af6d3));
     while (ip < galaxySize)
     {
         p = Vector3f(RealDists<float>::SignedUnit(rng),

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -563,7 +563,7 @@ GlobularForm* buildGlobularForms(float c)
      *  coreRadius r_c, tidalRadius r_t, King concentration c = log10(r_t/r_c).
      */
 
-    auto& rng = getRNG();
+    celmath::Jsf32 rng(UINT32_C(0xd3f1c5e9));
     while (i < GLOBULAR_POINTS)
     {
         /*!

--- a/src/celmath/randutils.h
+++ b/src/celmath/randutils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstdint>
 #include <random>
 
 #include <Eigen/Core>
@@ -9,6 +10,27 @@
 
 namespace celmath
 {
+
+// Small noncryptographic pseudorandom number generator by Bob Jenkins
+// http://burtleburtle.net/bob/rand/talksmall.html
+class Jsf32
+{
+public:
+    using result_type = std::uint32_t;
+    Jsf32(std::uint32_t seed);
+
+    static constexpr result_type min() { return 0; }
+    static constexpr result_type max() { return UINT32_MAX; }
+
+    result_type operator()();
+
+private:
+    std::uint32_t a;
+    std::uint32_t b;
+    std::uint32_t c;
+    std::uint32_t d;
+};
+
 extern float turbulence(const Eigen::Vector2f& p, float freq);
 extern float turbulence(const Eigen::Vector3f& p, float freq);
 extern float fractalsum(const Eigen::Vector2f& p, float freq);
@@ -38,7 +60,7 @@ template<typename T>
 std::uniform_real_distribution<T>
 RealDists<T>::SignedFullAngle{static_cast<T>(-PI), static_cast<T>(PI)};
 
-template<typename T, typename RNG = std::mt19937>
+template<typename T, typename RNG = Jsf32>
 Eigen::Matrix<T, 2, 1> randomOnCircle(RNG&& rng)
 {
     using std::cos;
@@ -47,7 +69,7 @@ Eigen::Matrix<T, 2, 1> randomOnCircle(RNG&& rng)
     return Eigen::Matrix<T, 2, 1>{cos(phi), sin(phi)};
 }
 
-template<typename T, typename RNG = std::mt19937>
+template<typename T, typename RNG = Jsf32>
 Eigen::Matrix<T, 3, 1> randomOnSphere(RNG&& rng)
 {
     using std::cos;
@@ -60,6 +82,4 @@ Eigen::Matrix<T, 3, 1> randomOnSphere(RNG&& rng)
                                   xyScale * sin(phi),
                                   cosTheta};
 }
-
-std::mt19937& getRNG();
 }


### PR DESCRIPTION
- Add an implementation of [Bob Jenkins' small fast noncryptographic random number generator](http://burtleburtle.net/bob/rand/talksmall.html), adapted to meet the [UniformRandomBitGenerator](https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator) named requirement to allow it to be used with the distributions in the `<random>` header.
- Use separate generators in galaxy, globular and Perlin noise generation to ensure these generations are independent.

The seed values are taken from the output of a random device. According to [this article by the creator of the PCG pseudorandom number generator](https://www.pcg-random.org/posts/bob-jenkins-small-prng-passes-practrand.html), this generator passes PractRand, and it's a lot smaller than the Mersenne Twister (which does not).

This ensures that the galaxy and globular cluster sprite distributions, and the shape of cms meshes is consistent between runs and across distributions.