### PR TITLE
Correctly finish rendering point stars before drawing new ones

### DIFF
--- a/src/celengine/pointstarvertexbuffer.cpp
+++ b/src/celengine/pointstarvertexbuffer.cpp
@@ -76,6 +76,9 @@ void PointStarVertexBuffer::makeCurrent()
     if (current == this || program == nullptr)
         return;
 
+    if (current != nullptr)
+        current->finish();
+
     program->use();
     program->setMVPMatrices(renderer.getProjectionMatrix(), renderer.getModelViewMatrix());
     if (pointSizeFromVertex)
@@ -101,6 +104,7 @@ void PointStarVertexBuffer::finish()
     glDisableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
     if (pointSizeFromVertex)
         glDisableVertexAttribArray(CelestiaGLProgram::PointSizeAttributeIndex);
+    current = nullptr;
 }
 
 void PointStarVertexBuffer::enable()

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1988,7 +1988,7 @@ void Renderer::renderObjectAsPoint(const Vector3f& position,
     {
         float alpha = 1.0f;
         float fade = 1.0f;
-        float size = BaseStarDiscSize * screenDpi / 96;
+        float size = BaseStarDiscSize * screenDpi / 96.0f;
 #ifdef USE_HDR
         float fieldCorr = 2.0f * FOV/(fov + FOV);
         float satPoint = saturationMagNight * (1.0f + fieldCorr * fieldCorr);
@@ -4652,7 +4652,7 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
     float effDistanceToScreen = mmToInches((float) REF_DISTANCE_TO_SCREEN) * pixelSize * getScreenDpi();
     starRenderer.labelThresholdMag = 1.2f * max(1.0f, (faintestMag - 4.0f) * (1.0f - 0.5f * (float) log10(effDistanceToScreen)));
 
-    starRenderer.size = BaseStarDiscSize * screenDpi / 96;
+    starRenderer.size = BaseStarDiscSize * screenDpi / 96.0f;
     if (starStyle == ScaledDiscStars)
     {
         starRenderer.useScaledDiscs = true;


### PR DESCRIPTION
We forgot to call glDisableVertexAttribArray(CelestiaGLProgram::PointSizeAttributeIndex) when switching PointStarVertexBuffers, should always correctly finish the current ones before starting rendering new ones.

<img width="1043" alt="Screen Shot 2021-11-16 at 4 52 48 PM" src="https://user-images.githubusercontent.com/17924287/141953539-f51a38fe-3f20-4704-a478-c5c0b79cd7eb.png">

Closes #1156 