### PR TITLE
Further tokenizer improvements

### DIFF
--- a/src/celutil/tokenizer.h
+++ b/src/celutil/tokenizer.h
@@ -60,6 +60,7 @@ private:
     int lineNumber{ 1 };
     char nextChar{ '\0' };
     bool reprocess{ false };
+    bool hasUtf8Errors{ false };
 
     bool skipUtf8Bom();
 };


### PR DESCRIPTION
* More forgiving handling of invalid UTF-8 sequences: instead of erroring out, report the error in the log (once per stream). In case the current token is a quote-delimited string, the invalid character will be replaced by U+FFFD REPLACEMENT CHARACTER, and processing continues at the next byte.
* Reject invalid string escape sequences
* Do not allow numbers to terminate at a sign character (-, +, 3.2e-, 4.5e+)
* Do not allow exponents immediately after the sign (+e32, -e14)