### PR TITLE
Tokenizer improvements, recover from invalid UTF-8 sequences

### DIFF
--- a/src/celutil/tokenizer.h
+++ b/src/celutil/tokenizer.h
@@ -60,6 +60,7 @@ private:
     int lineNumber{ 1 };
     char nextChar{ '\0' };
     bool reprocess{ false };
+    bool hasUtf8Errors{ false };
 
     bool skipUtf8Bom();
 };

--- a/src/celutil/utf8.cpp
+++ b/src/celutil/utf8.cpp
@@ -1008,50 +1008,50 @@ std::vector<std::string> getGreekCompletion(const std::string &s)
     return ret;
 }
 
-bool
+UTF8Status
 UTF8Validator::check(char c)
 {
     return check(static_cast<unsigned char>(c));
 }
 
-bool
+UTF8Status
 UTF8Validator::check(unsigned char c)
 {
     switch (state)
     {
     case State::Initial:
-        if (c < 0x80) { return true; }
-        if (c < 0xc2) { return false; }
-        if (c < 0xe0) { state = State::Continuation1; return true; }
-        if (c == 0xe0) { state = State::E0Continuation; return true; }
-        if (c < 0xed) { state = State::Continuation2; return true; }
-        if (c== 0xed) { state = State::EDContinuation; return true; }
-        if (c < 0xf0) { state = State::Continuation2; return true; }
-        if (c == 0xf0) { state = State::F0Continuation; return true; }
-        if (c < 0xf4) { state = State::Continuation3; return true; }
-        if (c == 0xf4) { state = State::F4Continuation; return true; }
-        return false;
+        if (c < 0x80) { return UTF8Status::Ok; }
+        if (c < 0xc2) { return UTF8Status::InvalidFirstByte; }
+        if (c < 0xe0) { state = State::Continuation1; return UTF8Status::Ok; }
+        if (c == 0xe0) { state = State::E0Continuation; return UTF8Status::Ok; }
+        if (c < 0xed) { state = State::Continuation2; return UTF8Status::Ok; }
+        if (c== 0xed) { state = State::EDContinuation; return UTF8Status::Ok; }
+        if (c < 0xf0) { state = State::Continuation2; return UTF8Status::Ok; }
+        if (c == 0xf0) { state = State::F0Continuation; return UTF8Status::Ok; }
+        if (c < 0xf4) { state = State::Continuation3; return UTF8Status::Ok; }
+        if (c == 0xf4) { state = State::F4Continuation; return UTF8Status::Ok; }
+        return UTF8Status::InvalidFirstByte;
     case State::Continuation1:
-        if (c >= 0x80 && c < 0xc0) { state = State::Initial; return true; }
+        if (c >= 0x80 && c < 0xc0) { state = State::Initial; return UTF8Status::Ok; }
         break;
     case State::Continuation2:
-        if (c >= 0x80 && c < 0xc0) { state = State::Continuation1; return true; }
+        if (c >= 0x80 && c < 0xc0) { state = State::Continuation1; return UTF8Status::Ok; }
         break;
     case State::Continuation3:
-        if (c >= 0x80 && c < 0xc0) { state = State::Continuation2; return true; }
+        if (c >= 0x80 && c < 0xc0) { state = State::Continuation2; return UTF8Status::Ok; }
         break;
     case State::E0Continuation: // disallow overlong sequences
-        if (c >= 0xa0 && c < 0xc0) { state = State::Continuation1; return true; }
+        if (c >= 0xa0 && c < 0xc0) { state = State::Continuation1; return UTF8Status::Ok; }
         break;
     case State::EDContinuation: // disallow surrogate pairs
-        if (c >= 0x80 && c < 0xa0) { state = State::Continuation1; return true; }
+        if (c >= 0x80 && c < 0xa0) { state = State::Continuation1; return UTF8Status::Ok; }
         break;
     case State::F0Continuation: // disallow overlong sequences
-        if (c >= 0x90 && c < 0xc0) { state = State::Continuation2; return true; }
+        if (c >= 0x90 && c < 0xc0) { state = State::Continuation2; return UTF8Status::Ok; }
         break;
     case State::F4Continuation: // disallow out-of-range
-        if (c >= 0x80 && c < 0x90) { state = State::Continuation2; return true; }
+        if (c >= 0x80 && c < 0x90) { state = State::Continuation2; return UTF8Status::Ok; }
     }
     state = State::Initial;
-    return false;
+    return UTF8Status::InvalidTrailingByte;
 }


### PR DESCRIPTION
* Disallow numbers ending with a sign (+, -, 3.2e+, 4.7e-)
* Disallow exponents immediately after the sign character (+e12, -e6)
* Disallow invalid string escapes (\q)
* More forgiving UTF-8 parsing: write an error to the log (once per stream). In string literals, remove any partially-written sequences and append U+FFFD REPLACEMENT CHARACTER. Then continue processing the next byte of the input string.