### PR TITLE
Don't read DDS header twice, reallow triggering eof()

### DIFF
--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -144,7 +144,6 @@ Image* LoadDDSImage(const fs::path& filename)
     }
 
     char header[4];
-    in.read(header, sizeof header);
     if (!in.read(header, sizeof(header)).good()
         || header[0] != 'D' || header[1] != 'D'
         || header[2] != 'S' || header[3] != ' ')
@@ -301,7 +300,7 @@ Image* LoadDDSImage(const fs::path& filename)
                            (int) ddsd.height,
                            max(ddsd.mipMapLevels, 1u));
     in.read(reinterpret_cast<char*>(img->getPixels()), img->getSize());
-    if (!in.good())
+    if (!in.eof() && !in.good())
     {
         DPRINTF(LOG_LEVEL_ERROR, "Failed reading data from DDS texture file %s.\n", filename);
         delete img;


### PR DESCRIPTION
Fixes #1167

I'm not particularly happy about allowing the `eof()` condition at the end as this implies we are attempting to read more data than the file contains, but it seems to be necessary at least with the Celestia Origin .dds files. I will take another look at this in future, but in the meantime it addresses the issue for people using master builds.