### PR TITLE
Fix fault due to result expanded to int

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -886,7 +886,7 @@ static string getKeyName(const char* c, int modifiers)
     // Translate control characters
     if (length == 1 && c[0] >= '\001' && c[0] <= '\032')
     {
-        return fmt::format("C-{:c}", '\140' + c[0]);
+        return fmt::format("C-{:c}", static_cast<char>('\140' + c[0]));
     }
 
     if (modifiers & CelestiaCore::ControlKey)


### PR DESCRIPTION
I have a crash when I press "Enter" key:
```
terminate called after throwing an instance of 'fmt::FormatError'
  what():  unknown format code 'c' for integer
```