### PR TITLE
Potential out-of-bounds read in 3DS loader: quick fix for 1.6

### DIFF
--- a/src/cel3ds/3dsread.cpp
+++ b/src/cel3ds/3dsread.cpp
@@ -97,6 +97,8 @@ static string readString(ifstream& in)
             break;
     }
 
+    s[maxLength - 1] = '\0'; // prevent out-of-bounds read
+
     return string(s);
 }
 


### PR DESCRIPTION
Extremely simple fix for the out-of-bounds issue in the 3DS loader for v1.6, without rewriting massive chunks of the parser.