### PR TITLE
Components inherit visibility from first non-component ancestor

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4006,12 +4006,24 @@ static bool isBodyVisible(const Body* body, int bodyVisibilityMask)
     case Body::Diffuse:
         return body->isVisible();
 
-    // SurfaceFeature inherits visibility of its parent body
+    // SurfaceFeature and Component inherit visibility of its parent body
+    case Body::Component:
     case Body::SurfaceFeature:
-        assert(body->getSystem() != nullptr);
-        body = body->getSystem()->getPrimaryBody();
-        assert(body != nullptr);
-        return body->isVisible() && (bodyVisibilityMask & body->getClassification()) != 0;
+        for (;;)
+        {
+            assert(body->getSystem() != nullptr);
+            body = body->getSystem()->getPrimaryBody();
+            if (body == nullptr)
+            {
+                // TODO figure out what to do about components/features of stars/barycenters
+                return false;
+            }
+            if (body->getClassification() != Body::SurfaceFeature
+                && body->getClassification() != Body::Component)
+            {
+                return body->isVisible() && (bodyVisibilityMask & body->getClassification()) != 0;
+            }
+        }
 
     default:
         return body->isVisible() && (bodyVisibilityMask & klass) != 0;


### PR DESCRIPTION
- Share visibility logic between Component and SurfaceFeature
- Avoid null dereference for Component/SurfaceFeature defined on stars

Resolves #1195 - although the specific example given there (redefining Earth as a component) will continue to be invisible because the parent is a star. For testing, I redefined the Moon and Apollo 11 as having class `component`.