### PR TITLE
Allow to use a custom date formatter for display

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3133,8 +3133,16 @@ void CelestiaCore::renderOverlay()
         }
 
         double tdb = sim->getTime() + lt;
-        astro::Date d = timeZoneBias != 0 ? astro::TDBtoLocal(tdb) : astro::TDBtoUTC(tdb);
-        const char* dateStr = d.toCStr(dateFormat);
+        string dateStr;
+        if (customDateFormatter)
+        {
+            dateStr = customDateFormatter(tdb);
+        }
+        else
+        {
+            astro::Date d = timeZoneBias != 0 ? astro::TDBtoLocal(tdb) : astro::TDBtoUTC(tdb);
+            dateStr = d.toCStr(dateFormat);
+        }
         int dateWidth = (font->getWidth(dateStr)/(emWidth * 3) + 2) * emWidth * 3;
         if (dateWidth > dateStrWidth) dateStrWidth = dateWidth;
 
@@ -3144,7 +3152,7 @@ void CelestiaCore::renderOverlay()
         overlay->moveBy(width - safeAreaInsets.right - dateStrWidth, height - safeAreaInsets.top - fontHeight);
         overlay->beginText();
 
-        overlay->printf(dateStr);
+        overlay->printf(dateStr.c_str());
 
         if (lightTravelFlag && lt > 0.0)
         {

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -12,6 +12,7 @@
 
 #include <fstream>
 #include <string>
+#include <functional>
 #include <celutil/filetype.h>
 #include <celutil/timer.h>
 #include <celutil/watcher.h>
@@ -342,6 +343,8 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     void setContextMenuHandler(ContextMenuHandler*);
     ContextMenuHandler* getContextMenuHandler() const;
 
+    void setCustomDateFormatter(std::function<std::string(double)> df) { customDateFormatter = df; };
+
     class TextDisplayHandler
     {
     public:
@@ -490,6 +493,7 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     CursorShape defaultCursorShape{ CelestiaCore::CrossCursor };
     ContextMenuHandler* contextMenuHandler{ nullptr };
     TextDisplayHandler* textDisplayHandler{ nullptr };
+    std::function<std::string(double)> customDateFormatter{ nullptr };
 
     std::vector<Url> history;
     std::vector<Url>::size_type historyCurrent{ 0 };


### PR DESCRIPTION
Locale is not fully available in C on Android/iOS so time is not localized in strftime. While it should possible to get localized date on iOS CoreFoundation in C, on Android it seems we have to call into Java methods, so it is not feasible to implement in celestiacore so probably we could just do with a custom formatter.