### PR TITLE
Fix minor warnings in celmodel

### DIFF
--- a/src/celmodel/mesh.cpp
+++ b/src/celmodel/mesh.cpp
@@ -261,8 +261,6 @@ Mesh::createLinePrimitiveGroup(bool lineStrip, const std::vector<Index32>& indic
 
         const VWord* origThisVertLoc = vertices.data() + thisIndex * originalStride;
         const VWord* origNextVertLoc = vertices.data() + nextIndex * originalStride;
-        float *ff = (float *)origThisVertLoc;
-        float *ffn = (float *)origNextVertLoc;
 
         // Fill the info for the 4 vertices
         std::memcpy(ptr, origThisVertLoc, originalStrideBytes);
@@ -289,7 +287,6 @@ Mesh::createLinePrimitiveGroup(bool lineStrip, const std::vector<Index32>& indic
         std::memcpy(ptr + originalStride + positionSize, &scaleFactor, sizeof(float));
         ptr += stride;
 
-        int lineIndex = 6 * i;
         Index32 newIndex = 4 * i;
 
         // Fill info for the 6 indices

--- a/src/celmodel/modelfile.cpp
+++ b/src/celmodel/modelfile.cpp
@@ -1808,6 +1808,7 @@ BinaryModelWriter::writeVertices(const VWord* vertexData,
                 break;
             default:
                 assert(0);
+                result = false;
                 break;
             }
 


### PR DESCRIPTION
- Remove unused variables in createLinePrimitiveGroup
- Ensure result is always set in default case in BinaryModelWrite::writeVertices