### PR TITLE
Experimental Qt6 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(FAST_MATH      "Build with unsafe fast-math compiller option (Default: of
 option(ENABLE_TESTS   "Enable unit tests? (Default: off)" OFF)
 option(ENABLE_GLES    "Build for OpenGL ES 2.0 instead of OpenGL 2.1 (Default: off)" OFF)
 option(USE_GTKGLEXT   "Use libgtkglext1 for GTK2 frontend (Default: on)" ON)
+option(USE_QT6        "Use Qt6 in Qt frontend (Default: off)" OFF)
 option(USE_GTK3       "Use Gtk3 in GTK2 frontend (Default: off)" OFF)
 
 if(ENABLE_GLES)

--- a/src/celestia/qt/CMakeLists.txt
+++ b/src/celestia/qt/CMakeLists.txt
@@ -10,7 +10,11 @@ if(APPLE AND EXISTS /usr/local/opt/qt5)
   list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
 endif()
 
-find_package(Qt5 COMPONENTS Widgets OpenGL CONFIG REQUIRED)
+if(USE_QT6)
+  find_package(Qt6 COMPONENTS Widgets OpenGLWidgets Core5Compat CONFIG REQUIRED)
+else()
+  find_package(Qt5 COMPONENTS Widgets CONFIG REQUIRED)
+endif()
 
 set(QT_SOURCES
   qtappwin.cpp
@@ -58,7 +62,11 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-qt5_add_resources(RC_SRC "icons.qrc")
+if(USE_QT6)
+  qt6_add_resources(RC_SRC "icons.qrc")
+else()
+  qt5_add_resources(RC_SRC "icons.qrc")
+endif()
 
 if(WIN32)
   set (RES celestia.rc)
@@ -66,7 +74,11 @@ endif()
 
 add_executable(celestia-qt WIN32 ${QT_SOURCES} ${RC_SRC} ${RES})
 add_dependencies(celestia-qt celestia)
-target_link_libraries(celestia-qt Qt5::Widgets Qt5::OpenGL celestia)
+if(USE_QT6)
+  target_link_libraries(celestia-qt Qt6::Widgets Qt6::OpenGLWidgets Qt6::Core5Compat celestia)
+else()
+  target_link_libraries(celestia-qt Qt5::Widgets celestia)
+endif()
 if(APPLE)
   set_property(TARGET celestia-qt APPEND_STRING PROPERTY LINK_FLAGS " -framework CoreFoundation")
   set_property(TARGET celestia-qt APPEND_STRING PROPERTY LINK_FLAGS " -framework CoreServices")

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -1630,7 +1630,7 @@ void CelestiaAppWindow::setCustomFPS()
 
 void CelestiaAppWindow::requestContextMenu(float x, float y, Selection sel)
 {
-    float scale = devicePixelRatioF();
+    qreal scale = devicePixelRatioF();
     SelectionPopup* menu = new SelectionPopup(sel, m_appCore, this);
     connect(menu, SIGNAL(selectionInfoRequested(Selection&)),
             this, SLOT(slotShowObjectInfo(Selection&)));

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -60,7 +60,7 @@ const unsigned int DEFAULT_TEXTURE_RESOLUTION = medres;
 
 
 CelestiaGlWidget::CelestiaGlWidget(QWidget* parent, const char* /* name */, CelestiaCore* core) :
-    QGLWidget(parent)
+    QOpenGLWidget(parent)
 {
     setFocusPolicy(Qt::ClickFocus);
 
@@ -96,7 +96,7 @@ void CelestiaGlWidget::initializeGL()
     using namespace celestia;
     if (!gl::init(appCore->getConfig()->ignoreGLExtensions) || !gl::checkVersion(gl::GL_2_1))
     {
-        QMessageBox::critical(0, "Celestia", _("Celestia was unable to initialize OpenGL 2.1."));
+        QMessageBox::critical(0, "Celestia", _("Celestia was unable to initialize OpenGL 2.1."));
         exit(1);
     }
 
@@ -133,7 +133,10 @@ void CelestiaGlWidget::initializeGL()
 
 void CelestiaGlWidget::resizeGL(int w, int h)
 {
-    appCore->resize(w, h);
+    float scale = devicePixelRatioF();
+    int width = static_cast<int>(static_cast<float>(w) * scale);
+    int height = static_cast<int>(static_cast<float>(h) * scale);
+    appCore->resize(width, height);
 }
 
 

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -133,18 +133,18 @@ void CelestiaGlWidget::initializeGL()
 
 void CelestiaGlWidget::resizeGL(int w, int h)
 {
-    float scale = devicePixelRatioF();
-    int width = static_cast<int>(static_cast<float>(w) * scale);
-    int height = static_cast<int>(static_cast<float>(h) * scale);
+    qreal scale = devicePixelRatioF();
+    auto width = static_cast<int>(w * scale);
+    auto height = static_cast<int>(h * scale);
     appCore->resize(width, height);
 }
 
 
 void CelestiaGlWidget::mouseMoveEvent(QMouseEvent* m)
 {
-    float scale = devicePixelRatioF();
-    int x = (int)(m->x() * scale);
-    int y = (int)(m->y() * scale);
+    qreal scale = devicePixelRatioF();
+    auto x = static_cast<int>(m->x() * scale);
+    auto y = static_cast<int>(m->y() * scale);
 
     int buttons = 0;
     if (m->buttons() & LeftButton)
@@ -201,9 +201,9 @@ void CelestiaGlWidget::mouseMoveEvent(QMouseEvent* m)
 
 void CelestiaGlWidget::mousePressEvent( QMouseEvent* m )
 {
-    float scale = devicePixelRatioF();
-    int x = (int)(m->x() * scale);
-    int y = (int)(m->y() * scale);
+    qreal scale = devicePixelRatioF();
+    auto x = static_cast<int>(m->x() * scale);
+    auto y = static_cast<int>(m->y() * scale);
 
     if (m->button() == LeftButton)
         appCore->mouseButtonDown(x, y, CelestiaCore::LeftButton);
@@ -216,9 +216,9 @@ void CelestiaGlWidget::mousePressEvent( QMouseEvent* m )
 
 void CelestiaGlWidget::mouseReleaseEvent( QMouseEvent* m )
 {
-    float scale = devicePixelRatioF();
-    int x = (int)(m->x() * scale);
-    int y = (int)(m->y() * scale);
+    qreal scale = devicePixelRatioF();
+    auto x = static_cast<int>(m->x() * scale);
+    auto y = static_cast<int>(m->y() * scale);
 
     if (m->button() == LeftButton)
     {

--- a/src/celestia/qt/qtglwidget.h
+++ b/src/celestia/qt/qtglwidget.h
@@ -14,7 +14,7 @@
 #ifndef QTGLWIDGET_H
 #define QTGLWIDGET_H
 
-#include <QGLWidget>
+#include <QOpenGLWidget>
 
 #include "celestia/celestiacore.h"
 #include "celengine/simulation.h"
@@ -26,7 +26,7 @@
   *@author Christophe Teyssier
   */
 
-class CelestiaGlWidget : public QGLWidget, public CelestiaCore::CursorHandler
+class CelestiaGlWidget : public QOpenGLWidget, public CelestiaCore::CursorHandler
 {
     Q_OBJECT
 

--- a/src/celestia/qt/qtmain.cpp
+++ b/src/celestia/qt/qtmain.cpp
@@ -28,7 +28,6 @@
 #include <QLibraryInfo>
 #include <vector>
 #include "qtappwin.h"
-#include <qtextcodec.h>
 #include <fmt/printf.h>
 
 using namespace std;

--- a/src/tools/cmod/cmodview/CMakeLists.txt
+++ b/src/tools/cmod/cmodview/CMakeLists.txt
@@ -1,5 +1,10 @@
 if(NOT ENABLE_QT)
-  message("Qt frontend is disabled, not building cmodview.")
+  message("Qt5 frontend is disabled, not building cmodview.")
+  return()
+endif()
+
+if(USE_QT6)
+  message("Qt tools not supported on Qt6, not building cmodview.")
   return()
 endif()
 

--- a/src/tools/qttxf/CMakeLists.txt
+++ b/src/tools/qttxf/CMakeLists.txt
@@ -3,6 +3,11 @@ if(NOT ENABLE_QT)
   return()
 endif()
 
+if(USE_QT6)
+  message("Qt tools not supported on Qt6, not building cmodview.")
+  return()
+endif()
+
 if(APPLE AND EXISTS /usr/local/opt/qt5)
   # Homebrew installs Qt5 (up to at least 5.9.1) in
   # /usr/local/qt5, ensure it can be found by CMake since


### PR DESCRIPTION
- Switch from legacy QGLWidget to QOpenGLWidget
- [win32] Use a frameless window 1 pixel larger than the monitor instead of a fullscreen window, in order to avoid issues showing context menus

Using a frameless window with a size just larger than the actual screen solves the invisible menu issue on Windows with QOpenGLWidget, although 1 pixel of window will appear on an adjacent monitor. Making the window exactly the same size as the screen causes the menus to stop working again. For me, this does not seem to be a Linux issue (at least on Kubuntu 21.10), so I only do this workaround on Windows.

The Qt5 compatibility module is required to provide `QRegExp`: the `QRegularExpression::wildcardToRegularExpression` helper method that we'd need to use if we replace this with `QRegularExpression` is not available in Qt5.

I don't have a Mac to test with, so no idea what happens there.