### PR TITLE
[qt] Fix storing window state on transition to fullscreen

### DIFF
--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -952,7 +952,11 @@ void CelestiaAppWindow::slotToggleFullScreen()
     {
         // save window state only when switching to fullscreen
         QSettings settings;
+        settings.beginGroup("MainWindow");
         settings.setValue("State", saveState(CELESTIA_MAIN_WINDOW_VERSION));
+        settings.setValue("Size", size());
+        settings.setValue("Pos", pos());
+        settings.endGroup();
         switchToFullscreen();
     }
 }


### PR DESCRIPTION
The code that restores the state expects to find the values in the MainWindow settings group. Also save the window position and size so that these can be restored.