### PR TITLE
Return const reference from tokenizer getStringValue

### DIFF
--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -18,8 +18,8 @@
 using namespace std;
 using celestia::util::GetLogger;
 
-Asterism::Asterism(string _name) :
-    name(std::move(_name))
+Asterism::Asterism(string_view _name) :
+    name(_name)
 {
 #ifdef ENABLE_NLS
     i18nName = D_(name.c_str());
@@ -121,13 +121,12 @@ AsterismList* ReadAsterismList(istream& in, const StarDatabase& stardb)
             return nullptr;
         }
 
-        string name = tokenizer.getStringValue();
-        Asterism* ast = new Asterism(name);
+        Asterism* ast = new Asterism(tokenizer.getStringValue());
 
         Value* chainsValue = parser.readValue();
         if (chainsValue == nullptr || chainsValue->getType() != Value::ArrayType)
         {
-            GetLogger()->error("Error parsing asterism {}\n", name);
+            GetLogger()->error("Error parsing asterism {}\n", ast->getName());
             for_each(asterisms->begin(), asterisms->end(), [](Asterism* ast) { delete ast; });
             delete ast;
             delete asterisms;
@@ -157,7 +156,9 @@ AsterismList* ReadAsterismList(istream& in, const StarDatabase& stardb)
                         if (star != nullptr)
                             new_chain->push_back(star->getPosition());
                         else
-                            GetLogger()->error("Error loading star \"{}\" for asterism \"{}\".\n", name, i->getString());
+                            GetLogger()->error("Error loading star \"{}\" for asterism \"{}\".\n",
+                                               ast->getName(),
+                                               i->getString());
                     }
                 }
 

--- a/src/celengine/asterism.h
+++ b/src/celengine/asterism.h
@@ -12,6 +12,7 @@
 #define _CELENGINE_ASTERISM_H_
 
 #include <string>
+#include <string_view>
 #include <vector>
 #include <iostream>
 #include <celutil/color.h>
@@ -21,7 +22,7 @@ class StarDatabase;
 class Asterism
 {
  public:
-    Asterism(std::string);
+    Asterism(std::string_view);
     ~Asterism() = default;
     Asterism() = delete;
     Asterism(const Asterism&) = delete;

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -242,7 +242,7 @@ bool DSODatabase::load(istream& in, const fs::path& resourcePath)
             GetLogger()->error("Error parsing deep sky catalog file.\n");
             return false;
         }
-        objType = tokenizer.getNameValue();
+        objType = tokenizer.getStringValue();
 
         bool autoGenCatalogNumber = true;
         AstroCatalog::IndexNumber objCatalogNumber = AstroCatalog::InvalidIndex;

--- a/src/celengine/parser.cpp
+++ b/src/celengine/parser.cpp
@@ -76,7 +76,7 @@ Hash* Parser::readHash()
             delete hash;
             return nullptr;
         }
-        string name = tokenizer->getNameValue();
+        string name = tokenizer->getStringValue();
 
 #ifndef USE_POSTFIX_UNITS
         readUnits(name, hash);
@@ -126,7 +126,7 @@ bool Parser::readUnits(const string& propertyName, Hash* hash)
             return false;
         }
 
-        string unit = tokenizer->getNameValue();
+        string unit = tokenizer->getStringValue();
         Value* value = new Value(unit);
 
         if (astro::isLengthUnit(unit))
@@ -174,9 +174,9 @@ Value* Parser::readValue()
         return new Value(tokenizer->getStringValue());
 
     case Tokenizer::TokenName:
-        if (tokenizer->getNameValue() == "false")
+        if (tokenizer->getStringValue() == "false")
             return new Value(false);
-        else if (tokenizer->getNameValue() == "true")
+        else if (tokenizer->getStringValue() == "true")
             return new Value(true);
         else
         {

--- a/src/celengine/parser.cpp
+++ b/src/celengine/parser.cpp
@@ -8,6 +8,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <string_view>
+
 #include <celutil/tokenizer.h>
 #include "astro.h"
 #include "parser.h"
@@ -76,7 +78,7 @@ Hash* Parser::readHash()
             delete hash;
             return nullptr;
         }
-        string name = tokenizer->getStringValue();
+        string name(tokenizer->getStringValue());
 
 #ifndef USE_POSTFIX_UNITS
         readUnits(name, hash);
@@ -126,7 +128,7 @@ bool Parser::readUnits(const string& propertyName, Hash* hash)
             return false;
         }
 
-        string unit = tokenizer->getStringValue();
+        std::string_view unit = tokenizer->getStringValue();
         Value* value = new Value(unit);
 
         if (astro::isLengthUnit(unit))

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -809,7 +809,7 @@ static Body* CreateBody(const string& name,
     double t;
     if (planetData->getNumber("Albedo", t))
     {
-        // TODO: make this warn 
+        // TODO: make this warn
         GetLogger()->verbose("Deprecated parameter Albedo used in {} definition.\nUse GeomAlbedo & BondAlbedo instead.\n", name);
         body->setGeomAlbedo((float) t);
     }
@@ -1158,14 +1158,14 @@ bool LoadSolarSystemObjects(istream& in,
 
         // The name list is a string with zero more names. Multiple names are
         // delimited by colons.
-        string nameList = tokenizer.getStringValue().c_str();
+        string nameList(tokenizer.getStringValue());
 
         if (tokenizer.nextToken() != Tokenizer::TokenString)
         {
             sscError(tokenizer, "bad parent object name");
             return false;
         }
-        string parentName = tokenizer.getStringValue().c_str();
+        string parentName(tokenizer.getStringValue());
 
         Value* objectDataValue = parser.readValue();
         if (objectDataValue == nullptr)

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -1125,17 +1125,17 @@ bool LoadSolarSystemObjects(istream& in,
         DataDisposition disposition = DataDisposition::Add;
         if (tokenizer.getTokenType() == Tokenizer::TokenName)
         {
-            if (tokenizer.getNameValue() == "Add")
+            if (tokenizer.getStringValue() == "Add")
             {
                 disposition = DataDisposition::Add;
                 tokenizer.nextToken();
             }
-            else if (tokenizer.getNameValue() == "Replace")
+            else if (tokenizer.getStringValue() == "Replace")
             {
                 disposition = DataDisposition::Replace;
                 tokenizer.nextToken();
             }
-            else if (tokenizer.getNameValue() == "Modify")
+            else if (tokenizer.getStringValue() == "Modify")
             {
                 disposition = DataDisposition::Modify;
                 tokenizer.nextToken();
@@ -1146,7 +1146,7 @@ bool LoadSolarSystemObjects(istream& in,
         string itemType("Body");
         if (tokenizer.getTokenType() == Tokenizer::TokenName)
         {
-            itemType = tokenizer.getNameValue();
+            itemType = tokenizer.getStringValue();
             tokenizer.nextToken();
         }
 

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -1204,17 +1204,17 @@ bool StarDatabase::load(istream& in, const fs::path& resourcePath)
         DataDisposition disposition = DataDisposition::Add;
         if (tokenizer.getTokenType() == Tokenizer::TokenName)
         {
-            if (tokenizer.getNameValue() == "Modify")
+            if (tokenizer.getStringValue() == "Modify")
             {
                 disposition = DataDisposition::Modify;
                 tokenizer.nextToken();
             }
-            else if (tokenizer.getNameValue() == "Replace")
+            else if (tokenizer.getStringValue() == "Replace")
             {
                 disposition = DataDisposition::Replace;
                 tokenizer.nextToken();
             }
-            else if (tokenizer.getNameValue() == "Add")
+            else if (tokenizer.getStringValue() == "Add")
             {
                 disposition = DataDisposition::Add;
                 tokenizer.nextToken();
@@ -1225,11 +1225,11 @@ bool StarDatabase::load(istream& in, const fs::path& resourcePath)
         // may be omitted. The default is Star.
         if (tokenizer.getTokenType() == Tokenizer::TokenName)
         {
-            if (tokenizer.getNameValue() == "Star")
+            if (tokenizer.getStringValue() == "Star")
             {
                 isStar = true;
             }
-            else if (tokenizer.getNameValue() == "Barycenter")
+            else if (tokenizer.getStringValue() == "Barycenter")
             {
                 isStar = false;
             }

--- a/src/celengine/value.h
+++ b/src/celengine/value.h
@@ -12,7 +12,9 @@
 
 #include <cassert>
 #include <string>
+#include <string_view>
 #include <vector>
+
 #include "hash.h"
 
 class Value;
@@ -46,6 +48,10 @@ class Value
     Value(const char *s) : type(StringType)
     {
         data.s = new std::string(s);
+    }
+    explicit Value(const std::string_view sv) : type(StringType)
+    {
+        data.s = new std::string(sv);
     }
     explicit Value(const std::string &s) : type(StringType)
     {

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -372,7 +372,7 @@ static VirtualTexture* LoadVirtualTexture(istream& in, const fs::path& path)
     if (tokenizer.nextToken() != Tokenizer::TokenName)
         return nullptr;
 
-    string virtTexString = tokenizer.getNameValue();
+    string virtTexString = tokenizer.getStringValue();
     if (virtTexString != "VirtualTexture")
         return nullptr;
 

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -372,8 +372,7 @@ static VirtualTexture* LoadVirtualTexture(istream& in, const fs::path& path)
     if (tokenizer.nextToken() != Tokenizer::TokenName)
         return nullptr;
 
-    string virtTexString = tokenizer.getStringValue();
-    if (virtTexString != "VirtualTexture")
+    if (tokenizer.getStringValue() != "VirtualTexture")
         return nullptr;
 
     Value* texParamsValue = parser.readValue();

--- a/src/celmodel/modelfile.cpp
+++ b/src/celmodel/modelfile.cpp
@@ -307,7 +307,7 @@ AsciiModelLoader::reportError(const std::string& msg)
 bool
 AsciiModelLoader::loadMaterial(Material& material)
 {
-    if (tok.nextToken() != Tokenizer::TokenName || tok.getNameValue() != MaterialToken)
+    if (tok.nextToken() != Tokenizer::TokenName || tok.getStringValue() != MaterialToken)
     {
         reportError("Material definition expected");
         return false;
@@ -319,7 +319,7 @@ AsciiModelLoader::loadMaterial(Material& material)
     material.specularPower = DefaultSpecularPower;
     material.opacity = DefaultOpacity;
 
-    while (tok.nextToken() == Tokenizer::TokenName && tok.getNameValue() != EndMaterialToken)
+    while (tok.nextToken() == Tokenizer::TokenName && tok.getStringValue() != EndMaterialToken)
     {
         std::string property = tok.getStringValue();
         TextureSemantic texType = parseTextureSemantic(property);
@@ -424,7 +424,7 @@ AsciiModelLoader::loadMaterial(Material& material)
 VertexDescription
 AsciiModelLoader::loadVertexDescription()
 {
-    if (tok.nextToken() != Tokenizer::TokenName || tok.getNameValue() != VertexDescToken)
+    if (tok.nextToken() != Tokenizer::TokenName || tok.getStringValue() != VertexDescToken)
     {
         reportError("Vertex description expected");
         return {};
@@ -436,7 +436,7 @@ AsciiModelLoader::loadVertexDescription()
     std::vector<VertexAttribute> attributes;
     attributes.reserve(maxAttributes);
 
-    while (tok.nextToken() == Tokenizer::TokenName && tok.getNameValue() != EndVertexDescToken)
+    while (tok.nextToken() == Tokenizer::TokenName && tok.getStringValue() != EndVertexDescToken)
     {
         std::string semanticName;
         std::string formatName;
@@ -504,7 +504,7 @@ std::vector<VWord>
 AsciiModelLoader::loadVertices(const VertexDescription& vertexDesc,
                                unsigned int& vertexCount)
 {
-    if (tok.nextToken() != Tokenizer::TokenName && tok.getNameValue() != VerticesToken)
+    if (tok.nextToken() != Tokenizer::TokenName && tok.getStringValue() != VerticesToken)
     {
         reportError("Vertex data expected");
         return {};
@@ -597,7 +597,7 @@ AsciiModelLoader::loadVertices(const VertexDescription& vertexDesc,
 bool
 AsciiModelLoader::loadMesh(Mesh& mesh)
 {
-    if (tok.nextToken() != Tokenizer::TokenName && tok.getNameValue() != MeshToken)
+    if (tok.nextToken() != Tokenizer::TokenName && tok.getStringValue() != MeshToken)
     {
         reportError("Mesh definition expected");
         return false;
@@ -617,7 +617,7 @@ AsciiModelLoader::loadMesh(Mesh& mesh)
     mesh.setVertexDescription(std::move(vertexDesc));
     mesh.setVertices(vertexCount, std::move(vertexData));
 
-    while (tok.nextToken() == Tokenizer::TokenName && tok.getNameValue() != EndMeshToken)
+    while (tok.nextToken() == Tokenizer::TokenName && tok.getStringValue() != EndMeshToken)
     {
         PrimitiveGroupType type = parsePrimitiveGroupType(tok.getStringValue());
         if (type == PrimitiveGroupType::InvalidPrimitiveGroupType)

--- a/src/celscript/common/scriptmaps.cpp
+++ b/src/celscript/common/scriptmaps.cpp
@@ -2,207 +2,209 @@
 #include <celestia/celestiacore.h>
 #include <celengine/render.h>
 
+using namespace std::string_view_literals;
+
 namespace celestia::scripts
 {
 
 void initRenderFlagMap(FlagMap64 &RenderFlagMap)
 {
-    RenderFlagMap["orbits"]              = Renderer::ShowOrbits;
-    RenderFlagMap["fadingorbits"]        = Renderer::ShowFadingOrbits;
-    RenderFlagMap["cloudmaps"]           = Renderer::ShowCloudMaps;
-    RenderFlagMap["constellations"]      = Renderer::ShowDiagrams;
-    RenderFlagMap["galaxies"]            = Renderer::ShowGalaxies;
-    RenderFlagMap["globulars"]           = Renderer::ShowGlobulars;
-    RenderFlagMap["planets"]             = Renderer::ShowPlanets;
-    RenderFlagMap["dwarfplanets"]        = Renderer::ShowDwarfPlanets;
-    RenderFlagMap["moons"]               = Renderer::ShowMoons;
-    RenderFlagMap["minormoons"]          = Renderer::ShowMinorMoons;
-    RenderFlagMap["asteroids"]           = Renderer::ShowAsteroids;
-    RenderFlagMap["comets"]              = Renderer::ShowComets;
-    RenderFlagMap["spasecrafts"]         = Renderer::ShowSpacecrafts;
-    RenderFlagMap["stars"]               = Renderer::ShowStars;
-    RenderFlagMap["nightmaps"]           = Renderer::ShowNightMaps;
-    RenderFlagMap["eclipseshadows"]      = Renderer::ShowEclipseShadows;
-    RenderFlagMap["planetrings"]         = Renderer::ShowPlanetRings;
-    RenderFlagMap["ringshadows"]         = Renderer::ShowRingShadows;
-    RenderFlagMap["comettails"]          = Renderer::ShowCometTails;
-    RenderFlagMap["boundaries"]          = Renderer::ShowBoundaries;
-    RenderFlagMap["markers"]             = Renderer::ShowMarkers;
-    RenderFlagMap["automag"]             = Renderer::ShowAutoMag;
-    RenderFlagMap["atmospheres"]         = Renderer::ShowAtmospheres;
-    RenderFlagMap["grid"]                = Renderer::ShowCelestialSphere;
-    RenderFlagMap["equatorialgrid"]      = Renderer::ShowCelestialSphere;
-    RenderFlagMap["galacticgrid"]        = Renderer::ShowGalacticGrid;
-    RenderFlagMap["eclipticgrid"]        = Renderer::ShowEclipticGrid;
-    RenderFlagMap["horizontalgrid"]      = Renderer::ShowHorizonGrid;
-    RenderFlagMap["smoothlines"]         = Renderer::ShowSmoothLines;
-    RenderFlagMap["partialtrajectories"] = Renderer::ShowPartialTrajectories;
-    RenderFlagMap["nebulae"]             = Renderer::ShowNebulae;
-    RenderFlagMap["openclusters"]        = Renderer::ShowOpenClusters;
-    RenderFlagMap["cloudshadows"]        = Renderer::ShowCloudShadows;
-    RenderFlagMap["ecliptic"]            = Renderer::ShowEcliptic;
+    RenderFlagMap["orbits"sv]              = Renderer::ShowOrbits;
+    RenderFlagMap["fadingorbits"sv]        = Renderer::ShowFadingOrbits;
+    RenderFlagMap["cloudmaps"sv]           = Renderer::ShowCloudMaps;
+    RenderFlagMap["constellations"sv]      = Renderer::ShowDiagrams;
+    RenderFlagMap["galaxies"sv]            = Renderer::ShowGalaxies;
+    RenderFlagMap["globulars"sv]           = Renderer::ShowGlobulars;
+    RenderFlagMap["planets"sv]             = Renderer::ShowPlanets;
+    RenderFlagMap["dwarfplanets"sv]        = Renderer::ShowDwarfPlanets;
+    RenderFlagMap["moons"sv]               = Renderer::ShowMoons;
+    RenderFlagMap["minormoons"sv]          = Renderer::ShowMinorMoons;
+    RenderFlagMap["asteroids"sv]           = Renderer::ShowAsteroids;
+    RenderFlagMap["comets"sv]              = Renderer::ShowComets;
+    RenderFlagMap["spasecrafts"sv]         = Renderer::ShowSpacecrafts;
+    RenderFlagMap["stars"sv]               = Renderer::ShowStars;
+    RenderFlagMap["nightmaps"sv]           = Renderer::ShowNightMaps;
+    RenderFlagMap["eclipseshadows"sv]      = Renderer::ShowEclipseShadows;
+    RenderFlagMap["planetrings"sv]         = Renderer::ShowPlanetRings;
+    RenderFlagMap["ringshadows"sv]         = Renderer::ShowRingShadows;
+    RenderFlagMap["comettails"sv]          = Renderer::ShowCometTails;
+    RenderFlagMap["boundaries"sv]          = Renderer::ShowBoundaries;
+    RenderFlagMap["markers"sv]             = Renderer::ShowMarkers;
+    RenderFlagMap["automag"sv]             = Renderer::ShowAutoMag;
+    RenderFlagMap["atmospheres"sv]         = Renderer::ShowAtmospheres;
+    RenderFlagMap["grid"sv]                = Renderer::ShowCelestialSphere;
+    RenderFlagMap["equatorialgrid"sv]      = Renderer::ShowCelestialSphere;
+    RenderFlagMap["galacticgrid"sv]        = Renderer::ShowGalacticGrid;
+    RenderFlagMap["eclipticgrid"sv]        = Renderer::ShowEclipticGrid;
+    RenderFlagMap["horizontalgrid"sv]      = Renderer::ShowHorizonGrid;
+    RenderFlagMap["smoothlines"sv]         = Renderer::ShowSmoothLines;
+    RenderFlagMap["partialtrajectories"sv] = Renderer::ShowPartialTrajectories;
+    RenderFlagMap["nebulae"sv]             = Renderer::ShowNebulae;
+    RenderFlagMap["openclusters"sv]        = Renderer::ShowOpenClusters;
+    RenderFlagMap["cloudshadows"sv]        = Renderer::ShowCloudShadows;
+    RenderFlagMap["ecliptic"sv]            = Renderer::ShowEcliptic;
 }
 
 void initLabelFlagMap(FlagMap &LabelFlagMap)
 {
-    LabelFlagMap["planets"]              = Renderer::PlanetLabels;
-    LabelFlagMap["dwarfplanets"]         = Renderer::DwarfPlanetLabels;
-    LabelFlagMap["moons"]                = Renderer::MoonLabels;
-    LabelFlagMap["minormoons"]           = Renderer::MinorMoonLabels;
-    LabelFlagMap["spacecraft"]           = Renderer::SpacecraftLabels;
-    LabelFlagMap["asteroids"]            = Renderer::AsteroidLabels;
-    LabelFlagMap["comets"]               = Renderer::CometLabels;
-    LabelFlagMap["constellations"]       = Renderer::ConstellationLabels;
-    LabelFlagMap["stars"]                = Renderer::StarLabels;
-    LabelFlagMap["galaxies"]             = Renderer::GalaxyLabels;
-    LabelFlagMap["globulars"]            = Renderer::GlobularLabels;
-    LabelFlagMap["locations"]            = Renderer::LocationLabels;
-    LabelFlagMap["nebulae"]              = Renderer::NebulaLabels;
-    LabelFlagMap["openclusters"]         = Renderer::OpenClusterLabels;
-    LabelFlagMap["i18nconstellations"]   = Renderer::I18nConstellationLabels;
+    LabelFlagMap["planets"sv]              = Renderer::PlanetLabels;
+    LabelFlagMap["dwarfplanets"sv]         = Renderer::DwarfPlanetLabels;
+    LabelFlagMap["moons"sv]                = Renderer::MoonLabels;
+    LabelFlagMap["minormoons"sv]           = Renderer::MinorMoonLabels;
+    LabelFlagMap["spacecraft"sv]           = Renderer::SpacecraftLabels;
+    LabelFlagMap["asteroids"sv]            = Renderer::AsteroidLabels;
+    LabelFlagMap["comets"sv]               = Renderer::CometLabels;
+    LabelFlagMap["constellations"sv]       = Renderer::ConstellationLabels;
+    LabelFlagMap["stars"sv]                = Renderer::StarLabels;
+    LabelFlagMap["galaxies"sv]             = Renderer::GalaxyLabels;
+    LabelFlagMap["globulars"sv]            = Renderer::GlobularLabels;
+    LabelFlagMap["locations"sv]            = Renderer::LocationLabels;
+    LabelFlagMap["nebulae"sv]              = Renderer::NebulaLabels;
+    LabelFlagMap["openclusters"sv]         = Renderer::OpenClusterLabels;
+    LabelFlagMap["i18nconstellations"sv]   = Renderer::I18nConstellationLabels;
 }
 
 void initBodyTypeMap(FlagMap &BodyTypeMap)
 {
-    BodyTypeMap["Planet"]                = Body::Planet;
-    BodyTypeMap["DwarfPlanet"]           = Body::DwarfPlanet;
-    BodyTypeMap["Moon"]                  = Body::Moon;
-    BodyTypeMap["MinorMoon"]             = Body::MinorMoon;
-    BodyTypeMap["Asteroid"]              = Body::Asteroid;
-    BodyTypeMap["Comet"]                 = Body::Comet;
-    BodyTypeMap["Spacecraft"]            = Body::Spacecraft;
-    BodyTypeMap["Invisible"]             = Body::Invisible;
-    BodyTypeMap["Star"]                  = Body::Stellar;
-    BodyTypeMap["Unknown"]               = Body::Unknown;
+    BodyTypeMap["Planet"sv]                = Body::Planet;
+    BodyTypeMap["DwarfPlanet"sv]           = Body::DwarfPlanet;
+    BodyTypeMap["Moon"sv]                  = Body::Moon;
+    BodyTypeMap["MinorMoon"sv]             = Body::MinorMoon;
+    BodyTypeMap["Asteroid"sv]              = Body::Asteroid;
+    BodyTypeMap["Comet"sv]                 = Body::Comet;
+    BodyTypeMap["Spacecraft"sv]            = Body::Spacecraft;
+    BodyTypeMap["Invisible"sv]             = Body::Invisible;
+    BodyTypeMap["Star"sv]                  = Body::Stellar;
+    BodyTypeMap["Unknown"sv]               = Body::Unknown;
 }
 
 void initLocationFlagMap(FlagMap64 &LocationFlagMap)
 {
-    LocationFlagMap["city"]              = Location::City;
-    LocationFlagMap["observatory"]       = Location::Observatory;
-    LocationFlagMap["landingsite"]       = Location::LandingSite;
-    LocationFlagMap["crater"]            = Location::Crater;
-    LocationFlagMap["vallis"]            = Location::Vallis;
-    LocationFlagMap["mons"]              = Location::Mons;
-    LocationFlagMap["planum"]            = Location::Planum;
-    LocationFlagMap["chasma"]            = Location::Chasma;
-    LocationFlagMap["patera"]            = Location::Patera;
-    LocationFlagMap["mare"]              = Location::Mare;
-    LocationFlagMap["rupes"]             = Location::Rupes;
-    LocationFlagMap["tessera"]           = Location::Tessera;
-    LocationFlagMap["regio"]             = Location::Regio;
-    LocationFlagMap["chaos"]             = Location::Chaos;
-    LocationFlagMap["terra"]             = Location::Terra;
-    LocationFlagMap["volcano"]           = Location::EruptiveCenter;
-    LocationFlagMap["astrum"]            = Location::Astrum;
-    LocationFlagMap["corona"]            = Location::Corona;
-    LocationFlagMap["dorsum"]            = Location::Dorsum;
-    LocationFlagMap["fossa"]             = Location::Fossa;
-    LocationFlagMap["catena"]            = Location::Catena;
-    LocationFlagMap["mensa"]             = Location::Mensa;
-    LocationFlagMap["rima"]              = Location::Rima;
-    LocationFlagMap["undae"]             = Location::Undae;
-    LocationFlagMap["tholus"]            = Location::Tholus;
-    LocationFlagMap["reticulum"]         = Location::Reticulum;
-    LocationFlagMap["planitia"]          = Location::Planitia;
-    LocationFlagMap["linea"]             = Location::Linea;
-    LocationFlagMap["fluctus"]           = Location::Fluctus;
-    LocationFlagMap["farrum"]            = Location::Farrum;
-    LocationFlagMap["insula"]            = Location::Insula;
-    LocationFlagMap["albedo"]            = Location::Albedo;
-    LocationFlagMap["arcus"]             = Location::Arcus;
-    LocationFlagMap["cavus"]             = Location::Cavus;
-    LocationFlagMap["colles"]            = Location::Colles;
-    LocationFlagMap["facula"]            = Location::Facula;
-    LocationFlagMap["flexus"]            = Location::Flexus;
-    LocationFlagMap["flumen"]            = Location::Flumen;
-    LocationFlagMap["fretum"]            = Location::Fretum;
-    LocationFlagMap["labes"]             = Location::Labes;
-    LocationFlagMap["labyrinthus"]       = Location::Labyrinthus;
-    LocationFlagMap["lacuna"]            = Location::Lacuna;
-    LocationFlagMap["lacus"]             = Location::Lacus;
-    LocationFlagMap["largeringed"]       = Location::LargeRinged;
-    LocationFlagMap["lenticula"]         = Location::Lenticula;
-    LocationFlagMap["lingula"]           = Location::Lingula;
-    LocationFlagMap["macula"]            = Location::Macula;
-    LocationFlagMap["oceanus"]           = Location::Oceanus;
-    LocationFlagMap["palus"]             = Location::Palus;
-    LocationFlagMap["plume"]             = Location::Plume;
-    LocationFlagMap["promontorium"]      = Location::Promontorium;
-    LocationFlagMap["satellite"]         = Location::Satellite;
-    LocationFlagMap["scopulus"]          = Location::Scopulus;
-    LocationFlagMap["serpens"]           = Location::Serpens;
-    LocationFlagMap["sinus"]             = Location::Sinus;
-    LocationFlagMap["sulcus"]            = Location::Sulcus;
-    LocationFlagMap["vastitas"]          = Location::Vastitas;
-    LocationFlagMap["virga"]             = Location::Virga;
-    LocationFlagMap["other"]             = Location::Other;
-    LocationFlagMap["saxum"]             = Location::Saxum;
-    LocationFlagMap["capital"]           = Location::Capital;
-    LocationFlagMap["cosmodrome"]        = Location::Cosmodrome;
-    LocationFlagMap["ring"]              = Location::Ring;
-    LocationFlagMap["historical"]        = Location::Historical;
+    LocationFlagMap["city"sv]              = Location::City;
+    LocationFlagMap["observatory"sv]       = Location::Observatory;
+    LocationFlagMap["landingsite"sv]       = Location::LandingSite;
+    LocationFlagMap["crater"sv]            = Location::Crater;
+    LocationFlagMap["vallis"sv]            = Location::Vallis;
+    LocationFlagMap["mons"sv]              = Location::Mons;
+    LocationFlagMap["planum"sv]            = Location::Planum;
+    LocationFlagMap["chasma"sv]            = Location::Chasma;
+    LocationFlagMap["patera"sv]            = Location::Patera;
+    LocationFlagMap["mare"sv]              = Location::Mare;
+    LocationFlagMap["rupes"sv]             = Location::Rupes;
+    LocationFlagMap["tessera"sv]           = Location::Tessera;
+    LocationFlagMap["regio"sv]             = Location::Regio;
+    LocationFlagMap["chaos"sv]             = Location::Chaos;
+    LocationFlagMap["terra"sv]             = Location::Terra;
+    LocationFlagMap["volcano"sv]           = Location::EruptiveCenter;
+    LocationFlagMap["astrum"sv]            = Location::Astrum;
+    LocationFlagMap["corona"sv]            = Location::Corona;
+    LocationFlagMap["dorsum"sv]            = Location::Dorsum;
+    LocationFlagMap["fossa"sv]             = Location::Fossa;
+    LocationFlagMap["catena"sv]            = Location::Catena;
+    LocationFlagMap["mensa"sv]             = Location::Mensa;
+    LocationFlagMap["rima"sv]              = Location::Rima;
+    LocationFlagMap["undae"sv]             = Location::Undae;
+    LocationFlagMap["tholus"sv]            = Location::Tholus;
+    LocationFlagMap["reticulum"sv]         = Location::Reticulum;
+    LocationFlagMap["planitia"sv]          = Location::Planitia;
+    LocationFlagMap["linea"sv]             = Location::Linea;
+    LocationFlagMap["fluctus"sv]           = Location::Fluctus;
+    LocationFlagMap["farrum"sv]            = Location::Farrum;
+    LocationFlagMap["insula"sv]            = Location::Insula;
+    LocationFlagMap["albedo"sv]            = Location::Albedo;
+    LocationFlagMap["arcus"sv]             = Location::Arcus;
+    LocationFlagMap["cavus"sv]             = Location::Cavus;
+    LocationFlagMap["colles"sv]            = Location::Colles;
+    LocationFlagMap["facula"sv]            = Location::Facula;
+    LocationFlagMap["flexus"sv]            = Location::Flexus;
+    LocationFlagMap["flumen"sv]            = Location::Flumen;
+    LocationFlagMap["fretum"sv]            = Location::Fretum;
+    LocationFlagMap["labes"sv]             = Location::Labes;
+    LocationFlagMap["labyrinthus"sv]       = Location::Labyrinthus;
+    LocationFlagMap["lacuna"sv]            = Location::Lacuna;
+    LocationFlagMap["lacus"sv]             = Location::Lacus;
+    LocationFlagMap["largeringed"sv]       = Location::LargeRinged;
+    LocationFlagMap["lenticula"sv]         = Location::Lenticula;
+    LocationFlagMap["lingula"sv]           = Location::Lingula;
+    LocationFlagMap["macula"sv]            = Location::Macula;
+    LocationFlagMap["oceanus"sv]           = Location::Oceanus;
+    LocationFlagMap["palus"sv]             = Location::Palus;
+    LocationFlagMap["plume"sv]             = Location::Plume;
+    LocationFlagMap["promontorium"sv]      = Location::Promontorium;
+    LocationFlagMap["satellite"sv]         = Location::Satellite;
+    LocationFlagMap["scopulus"sv]          = Location::Scopulus;
+    LocationFlagMap["serpens"sv]           = Location::Serpens;
+    LocationFlagMap["sinus"sv]             = Location::Sinus;
+    LocationFlagMap["sulcus"sv]            = Location::Sulcus;
+    LocationFlagMap["vastitas"sv]          = Location::Vastitas;
+    LocationFlagMap["virga"sv]             = Location::Virga;
+    LocationFlagMap["other"sv]             = Location::Other;
+    LocationFlagMap["saxum"sv]             = Location::Saxum;
+    LocationFlagMap["capital"sv]           = Location::Capital;
+    LocationFlagMap["cosmodrome"sv]        = Location::Cosmodrome;
+    LocationFlagMap["ring"sv]              = Location::Ring;
+    LocationFlagMap["historical"sv]        = Location::Historical;
 }
 
 void initOverlayElementMap(FlagMap &OverlayElementMap)
 {
-    OverlayElementMap["Time"]            = CelestiaCore::ShowTime;
-    OverlayElementMap["Velocity"]        = CelestiaCore::ShowVelocity;
-    OverlayElementMap["Selection"]       = CelestiaCore::ShowSelection;
-    OverlayElementMap["Frame"]           = CelestiaCore::ShowFrame;
+    OverlayElementMap["Time"sv]            = CelestiaCore::ShowTime;
+    OverlayElementMap["Velocity"sv]        = CelestiaCore::ShowVelocity;
+    OverlayElementMap["Selection"sv]       = CelestiaCore::ShowSelection;
+    OverlayElementMap["Frame"sv]           = CelestiaCore::ShowFrame;
 }
 
 void initOrbitVisibilityMap(FlagMap &OrbitVisibilityMap)
 {
-    OrbitVisibilityMap["never"]          = Body::NeverVisible;
-    OrbitVisibilityMap["normal"]         = Body::UseClassVisibility;
-    OrbitVisibilityMap["always"]         = Body::AlwaysVisible;
+    OrbitVisibilityMap["never"sv]          = Body::NeverVisible;
+    OrbitVisibilityMap["normal"sv]         = Body::UseClassVisibility;
+    OrbitVisibilityMap["always"sv]         = Body::AlwaysVisible;
 }
 
 void initLabelColorMap(ColorMap &LabelColorMap)
 {
-    LabelColorMap["stars"]               = &Renderer::StarLabelColor;
-    LabelColorMap["planets"]             = &Renderer::PlanetLabelColor;
-    LabelColorMap["dwarfplanets"]        = &Renderer::DwarfPlanetLabelColor;
-    LabelColorMap["moons"]               = &Renderer::MoonLabelColor;
-    LabelColorMap["minormoons"]          = &Renderer::MinorMoonLabelColor;
-    LabelColorMap["asteroids"]           = &Renderer::AsteroidLabelColor;
-    LabelColorMap["comets"]              = &Renderer::CometLabelColor;
-    LabelColorMap["spacecraft"]          = &Renderer::SpacecraftLabelColor;
-    LabelColorMap["locations"]           = &Renderer::LocationLabelColor;
-    LabelColorMap["galaxies"]            = &Renderer::GalaxyLabelColor;
-    LabelColorMap["globulars"]           = &Renderer::GlobularLabelColor;
-    LabelColorMap["nebulae"]             = &Renderer::NebulaLabelColor;
-    LabelColorMap["openclusters"]        = &Renderer::OpenClusterLabelColor;
-    LabelColorMap["constellations"]      = &Renderer::ConstellationLabelColor;
-    LabelColorMap["equatorialgrid"]      = &Renderer::EquatorialGridLabelColor;
-    LabelColorMap["galacticgrid"]        = &Renderer::GalacticGridLabelColor;
-    LabelColorMap["eclipticgrid"]        = &Renderer::EclipticGridLabelColor;
-    LabelColorMap["horizontalgrid"]      = &Renderer::HorizonGridLabelColor;
-    LabelColorMap["planetographicgrid"]  = &Renderer::PlanetographicGridLabelColor;
+    LabelColorMap["stars"sv]               = &Renderer::StarLabelColor;
+    LabelColorMap["planets"sv]             = &Renderer::PlanetLabelColor;
+    LabelColorMap["dwarfplanets"sv]        = &Renderer::DwarfPlanetLabelColor;
+    LabelColorMap["moons"sv]               = &Renderer::MoonLabelColor;
+    LabelColorMap["minormoons"sv]          = &Renderer::MinorMoonLabelColor;
+    LabelColorMap["asteroids"sv]           = &Renderer::AsteroidLabelColor;
+    LabelColorMap["comets"sv]              = &Renderer::CometLabelColor;
+    LabelColorMap["spacecraft"sv]          = &Renderer::SpacecraftLabelColor;
+    LabelColorMap["locations"sv]           = &Renderer::LocationLabelColor;
+    LabelColorMap["galaxies"sv]            = &Renderer::GalaxyLabelColor;
+    LabelColorMap["globulars"sv]           = &Renderer::GlobularLabelColor;
+    LabelColorMap["nebulae"sv]             = &Renderer::NebulaLabelColor;
+    LabelColorMap["openclusters"sv]        = &Renderer::OpenClusterLabelColor;
+    LabelColorMap["constellations"sv]      = &Renderer::ConstellationLabelColor;
+    LabelColorMap["equatorialgrid"sv]      = &Renderer::EquatorialGridLabelColor;
+    LabelColorMap["galacticgrid"sv]        = &Renderer::GalacticGridLabelColor;
+    LabelColorMap["eclipticgrid"sv]        = &Renderer::EclipticGridLabelColor;
+    LabelColorMap["horizontalgrid"sv]      = &Renderer::HorizonGridLabelColor;
+    LabelColorMap["planetographicgrid"sv]  = &Renderer::PlanetographicGridLabelColor;
 
 }
 
 void initLineColorMap(ColorMap &LineColorMap)
 {
-    LineColorMap["starorbits"]           = &Renderer::StarOrbitColor;
-    LineColorMap["planetorbits"]         = &Renderer::PlanetOrbitColor;
-    LineColorMap["dwarfplanetorbits"]    = &Renderer::DwarfPlanetOrbitColor;
-    LineColorMap["moonorbits"]           = &Renderer::MoonOrbitColor;
-    LineColorMap["minormoonorbits"]      = &Renderer::MinorMoonOrbitColor;
-    LineColorMap["asteroidorbits"]       = &Renderer::AsteroidOrbitColor;
-    LineColorMap["cometorbits"]          = &Renderer::CometOrbitColor;
-    LineColorMap["spacecraftorbits"]     = &Renderer::SpacecraftOrbitColor;
-    LineColorMap["constellations"]       = &Renderer::ConstellationColor;
-    LineColorMap["boundaries"]           = &Renderer::BoundaryColor;
-    LineColorMap["equatorialgrid"]       = &Renderer::EquatorialGridColor;
-    LineColorMap["galacticgrid"]         = &Renderer::GalacticGridColor;
-    LineColorMap["eclipticgrid"]         = &Renderer::EclipticGridColor;
-    LineColorMap["horizontalgrid"]       = &Renderer::HorizonGridColor;
-    LineColorMap["planetographicgrid"]   = &Renderer::PlanetographicGridColor;
-    LineColorMap["planetequator"]        = &Renderer::PlanetEquatorColor;
-    LineColorMap["ecliptic"]             = &Renderer::EclipticColor;
-    LineColorMap["selectioncursor"]      = &Renderer::SelectionCursorColor;
+    LineColorMap["starorbits"sv]           = &Renderer::StarOrbitColor;
+    LineColorMap["planetorbits"sv]         = &Renderer::PlanetOrbitColor;
+    LineColorMap["dwarfplanetorbits"sv]    = &Renderer::DwarfPlanetOrbitColor;
+    LineColorMap["moonorbits"sv]           = &Renderer::MoonOrbitColor;
+    LineColorMap["minormoonorbits"sv]      = &Renderer::MinorMoonOrbitColor;
+    LineColorMap["asteroidorbits"sv]       = &Renderer::AsteroidOrbitColor;
+    LineColorMap["cometorbits"sv]          = &Renderer::CometOrbitColor;
+    LineColorMap["spacecraftorbits"sv]     = &Renderer::SpacecraftOrbitColor;
+    LineColorMap["constellations"sv]       = &Renderer::ConstellationColor;
+    LineColorMap["boundaries"sv]           = &Renderer::BoundaryColor;
+    LineColorMap["equatorialgrid"sv]       = &Renderer::EquatorialGridColor;
+    LineColorMap["galacticgrid"sv]         = &Renderer::GalacticGridColor;
+    LineColorMap["eclipticgrid"sv]         = &Renderer::EclipticGridColor;
+    LineColorMap["horizontalgrid"sv]       = &Renderer::HorizonGridColor;
+    LineColorMap["planetographicgrid"sv]   = &Renderer::PlanetographicGridColor;
+    LineColorMap["planetequator"sv]        = &Renderer::PlanetEquatorColor;
+    LineColorMap["ecliptic"sv]             = &Renderer::EclipticColor;
+    LineColorMap["selectioncursor"sv]      = &Renderer::SelectionCursorColor;
 }
 
 ScriptMaps::ScriptMaps()

--- a/src/celscript/common/scriptmaps.h
+++ b/src/celscript/common/scriptmaps.h
@@ -1,16 +1,19 @@
 #pragma once
 
+#include <cstddef>
 #include <map>
-#include <string>
+#include <string_view>
 #include <celutil/color.h>
 
 namespace celestia::scripts
 {
 
+constexpr inline std::size_t FlagMapNameLength = 20;
+
 // String to flag mappings
-typedef std::map<std::string, uint32_t> FlagMap;
-typedef std::map<std::string, uint64_t> FlagMap64;
-typedef std::map<std::string, Color*>   ColorMap;
+typedef std::map<std::string_view, uint32_t> FlagMap;
+typedef std::map<std::string_view, uint64_t> FlagMap64;
+typedef std::map<std::string_view, Color*>   ColorMap;
 
 class ScriptMaps
 {

--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 #include <Eigen/Geometry>
 #include <celutil/logger.h>
 #include <celmath/mathlib.h>
@@ -144,7 +145,7 @@ Command* CommandParser::parseCommand()
         return nullptr;
     }
 
-    string commandName = tokenizer->getStringValue();
+    string commandName(tokenizer->getStringValue());
 
     Value* paramListValue = parser->readValue();
     if (paramListValue == nullptr || paramListValue->getType() != Value::HashType)
@@ -870,7 +871,7 @@ uint64_t parseRenderFlags(const string &s, const FlagMap64& RenderFlagMap)
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getStringValue();
+            std::string_view name = tokenizer.getStringValue();
 
             if (RenderFlagMap.count(name) == 0)
                 GetLogger()->warn("Unknown render flag: {}\n", name);
@@ -899,7 +900,7 @@ int parseLabelFlags(const string &s, const FlagMap &LabelFlagMap)
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getStringValue();
+            std::string_view name = tokenizer.getStringValue();
 
             if (LabelFlagMap.count(name) == 0)
                 GetLogger()->warn("Unknown label flag: {}\n", name);
@@ -928,7 +929,7 @@ int parseOrbitFlags(const string &s, const FlagMap &BodyTypeMap)
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getStringValue();
+            std::string name(tokenizer.getStringValue());
             name[0] = toupper(name[0]);
 
             if (BodyTypeMap.count(name) == 0)
@@ -958,7 +959,7 @@ int parseConstellations(CommandConstellations* cmd, const string &s, int act)
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getStringValue();
+            std::string_view name = tokenizer.getStringValue();
             if (compareIgnoringCase(name, "all") == 0 && act==1)
                 cmd->flags.all = true;
             else if (compareIgnoringCase(name, "all") == 0 && act==0)
@@ -998,7 +999,7 @@ int parseConstellationColor(CommandConstellationColor* cmd, const string &s, Eig
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getStringValue();
+            std::string_view name = tokenizer.getStringValue();
             if (compareIgnoringCase(name, "all") == 0 && act==1)
                 cmd->flags.all = true;
             else if (compareIgnoringCase(name, "all") == 0 && act==0)

--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -870,7 +870,7 @@ uint64_t parseRenderFlags(const string &s, const FlagMap64& RenderFlagMap)
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getNameValue();
+            string name = tokenizer.getStringValue();
 
             if (RenderFlagMap.count(name) == 0)
                 GetLogger()->warn("Unknown render flag: {}\n", name);
@@ -899,7 +899,7 @@ int parseLabelFlags(const string &s, const FlagMap &LabelFlagMap)
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getNameValue();
+            string name = tokenizer.getStringValue();
 
             if (LabelFlagMap.count(name) == 0)
                 GetLogger()->warn("Unknown label flag: {}\n", name);
@@ -928,7 +928,7 @@ int parseOrbitFlags(const string &s, const FlagMap &BodyTypeMap)
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getNameValue();
+            string name = tokenizer.getStringValue();
             name[0] = toupper(name[0]);
 
             if (BodyTypeMap.count(name) == 0)
@@ -958,7 +958,7 @@ int parseConstellations(CommandConstellations* cmd, const string &s, int act)
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getNameValue();
+            string name = tokenizer.getStringValue();
             if (compareIgnoringCase(name, "all") == 0 && act==1)
                 cmd->flags.all = true;
             else if (compareIgnoringCase(name, "all") == 0 && act==0)
@@ -998,7 +998,7 @@ int parseConstellationColor(CommandConstellationColor* cmd, const string &s, Eig
     {
         if (ttype == Tokenizer::TokenName)
         {
-            string name = tokenizer.getNameValue();
+            string name = tokenizer.getStringValue();
             if (compareIgnoringCase(name, "all") == 0 && act==1)
                 cmd->flags.all = true;
             else if (compareIgnoringCase(name, "all") == 0 && act==0)

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -280,10 +280,13 @@ static int celestia_getrenderflags(lua_State* l)
     CelestiaCore* appCore = this_celestia(l);
     lua_newtable(l);
     const uint64_t renderFlags = appCore->getRenderer()->getRenderFlags();
+    std::string rfmString;
+    rfmString.reserve(FlagMapNameLength);
     for (const auto& rfm : appCore->scriptMaps()->RenderFlagMap)
     {
-        string key = rfm.first;
-        lua_pushstring(l, key.c_str());
+        rfmString.clear();
+        rfmString.append(rfm.first);
+        lua_pushstring(l, rfmString.c_str());
         lua_pushboolean(l, (rfm.second & renderFlags) != 0);
         lua_settable(l,-3);
     }
@@ -412,10 +415,13 @@ static int celestia_getlabelflags(lua_State* l)
     CelestiaCore* appCore = this_celestia(l);
     lua_newtable(l);
     const int labelFlags = appCore->getRenderer()->getLabelMode();
+    std::string lfmString;
+    lfmString.reserve(FlagMapNameLength);
     for (const auto& lfm : appCore->scriptMaps()->LabelFlagMap)
     {
-        string key = lfm.first;
-        lua_pushstring(l, key.c_str());
+        lfmString.clear();
+        lfmString.append(lfm.first);
+        lua_pushstring(l, lfmString.c_str());
         lua_pushboolean(l, (lfm.second & labelFlags) != 0);
         lua_settable(l,-3);
     }
@@ -481,10 +487,13 @@ static int celestia_getorbitflags(lua_State* l)
     CelestiaCore* appCore = this_celestia(l);
     lua_newtable(l);
     const int orbitFlags = appCore->getRenderer()->getOrbitMask();
+    std::string btmString;
+    btmString.reserve(FlagMapNameLength);
     for (const auto& btm : appCore->scriptMaps()->BodyTypeMap)
     {
-        string key = btm.first;
-        lua_pushstring(l, key.c_str());
+        btmString.clear();
+        btmString.append(btm.first);
+        lua_pushstring(l, btmString.c_str());
         lua_pushboolean(l, (btm.second & orbitFlags) != 0);
         lua_settable(l,-3);
     }
@@ -687,10 +696,13 @@ static int celestia_getoverlayelements(lua_State* l)
     CelestiaCore* appCore = this_celestia(l);
     lua_newtable(l);
     const int overlayElements = appCore->getOverlayElements();
+    std::string oemString;
+    oemString.reserve(FlagMapNameLength);
     for (const auto& oem : appCore->scriptMaps()->OverlayElementMap)
     {
-        string key = oem.first;
-        lua_pushstring(l, key.c_str());
+        oemString.clear();
+        oemString.append(oem.first);
+        lua_pushstring(l, oemString.c_str());
         lua_pushboolean(l, (oem.second & overlayElements) != 0);
         lua_settable(l,-3);
     }

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -721,7 +721,7 @@ static int object_getinfo(lua_State* l)
                                  LocationFlagMap.end(),
                                  [&featureType](auto& it){ return it.second == featureType; });
         if (iter != LocationFlagMap.end())
-             celx.setTable("featureType", iter->first.c_str());
+             celx.setTable("featureType", std::string(iter->first).c_str());
         else
              celx.setTable("featureType", "Unknown");
 

--- a/src/celscript/lua/celx_observer.cpp
+++ b/src/celscript/lua/celx_observer.cpp
@@ -13,9 +13,8 @@
 #include "celx.h"
 #include "celx_internal.h"
 #include "celx_observer.h"
-//#include <celengine/body.h>
-//#include <celengine/timelinephase.h>
 #include <celestia/celestiacore.h>
+#include <celscript/common/scriptmaps.h>
 #include <celutil/logger.h>
 #include <Eigen/Geometry>
 
@@ -928,9 +927,13 @@ static int observer_getlocationflags(lua_State* l)
     lua_newtable(l);
     const auto locationFlags = obs->getLocationFilter();
     auto &LocationFlagMap = celx.appCore(AllErrors)->scriptMaps()->LocationFlagMap;
+    std::string itString;
+    itString.reserve(celestia::scripts::FlagMapNameLength);
     for (const auto& it : LocationFlagMap)
     {
-        lua_pushstring(l, it.first.c_str());
+        itString.clear();
+        itString.append(it.first);
+        lua_pushstring(l, itString.c_str());
         lua_pushboolean(l, (it.second & locationFlags) != 0);
         lua_settable(l, -3);
     }

--- a/src/celutil/tokenizer.cpp
+++ b/src/celutil/tokenizer.cpp
@@ -565,12 +565,6 @@ std::int32_t Tokenizer::getIntegerValue() const
 }
 
 
-std::string Tokenizer::getNameValue() const
-{
-    return textToken;
-}
-
-
 std::string Tokenizer::getStringValue() const
 {
     return textToken;

--- a/src/celutil/tokenizer.cpp
+++ b/src/celutil/tokenizer.cpp
@@ -565,7 +565,7 @@ std::int32_t Tokenizer::getIntegerValue() const
 }
 
 
-std::string Tokenizer::getStringValue() const
+std::string_view Tokenizer::getStringValue() const
 {
     return textToken;
 }

--- a/src/celutil/tokenizer.h
+++ b/src/celutil/tokenizer.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <string>
+#include <string_view>
 
 class Tokenizer
 {
@@ -45,7 +46,7 @@ public:
     double getNumberValue() const;
     bool isInteger() const;
     std::int32_t getIntegerValue() const;
-    std::string getStringValue() const;
+    std::string_view getStringValue() const;
 
     int getLineNumber() const;
 

--- a/src/celutil/tokenizer.h
+++ b/src/celutil/tokenizer.h
@@ -45,7 +45,6 @@ public:
     double getNumberValue() const;
     bool isInteger() const;
     std::int32_t getIntegerValue() const;
-    std::string getNameValue() const;
     std::string getStringValue() const;
 
     int getLineNumber() const;

--- a/test/unit/tokenizer_test.cpp
+++ b/test/unit/tokenizer_test.cpp
@@ -17,19 +17,19 @@ TEST_CASE("Tokenizer parses names", "[Tokenizer]")
         Tokenizer tok(&input);
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-        REQUIRE(tok.getNameValue() == "Normal");
+        REQUIRE(tok.getStringValue() == "Normal");
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-        REQUIRE(tok.getNameValue() == "Number2");
+        REQUIRE(tok.getStringValue() == "Number2");
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-        REQUIRE(tok.getNameValue() == "Number3Number");
+        REQUIRE(tok.getStringValue() == "Number3Number");
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-        REQUIRE(tok.getNameValue() == "snake_case");
+        REQUIRE(tok.getStringValue() == "snake_case");
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-        REQUIRE(tok.getNameValue() == "_prefixed");
+        REQUIRE(tok.getStringValue() == "_prefixed");
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenEnd);
     }
@@ -40,12 +40,12 @@ TEST_CASE("Tokenizer parses names", "[Tokenizer]")
         Tokenizer tok(&input);
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-        REQUIRE(tok.getNameValue() == "Quantity");
+        REQUIRE(tok.getStringValue() == "Quantity");
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenBeginUnits);
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-        REQUIRE(tok.getNameValue() == "unit");
+        REQUIRE(tok.getStringValue() == "unit");
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenEndUnits);
         REQUIRE(tok.nextToken() == Tokenizer::TokenEnd);
@@ -332,13 +332,13 @@ TEST_CASE("Tokenizer skips comments", "[Tokenizer]")
     Tokenizer tok(&input);
 
     REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-    REQUIRE(tok.getNameValue() == "Token1");
+    REQUIRE(tok.getStringValue() == "Token1");
 
     REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-    REQUIRE(tok.getNameValue() == "Token2");
+    REQUIRE(tok.getStringValue() == "Token2");
 
     REQUIRE(tok.nextToken() == Tokenizer::TokenName);
-    REQUIRE(tok.getNameValue() == "Token3");
+    REQUIRE(tok.getStringValue() == "Token3");
 
     REQUIRE(tok.nextToken() == Tokenizer::TokenEnd);
 }


### PR DESCRIPTION
- Remove `Tokenizer::getNameValue` - it does the same thing as `getStringValue`
- Return `const std::string&` from `getStringValue` instead of `std::string` - avoids unnecessary copies in many cases
- Some relatively small-scale refactoring at the areas where it is used to further reduce string copying during parsing

There are some more heavy-duty changes I want to do in addition to this in order to reduce string copying even further, but this would likely require large-scale changes (e.g. in dsodb.cpp / solarsys.cpp) that would likely conflict with the changes in #1189 - so I'm holding off on those for now.