### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,10 @@ include(FastMath)
 # Compile options
 #
 if(MSVC)
+  # CMake 3.14 and below set warning flags by default, remove them to prevent conflicts
+  string(REGEX REPLACE "/W[3|4]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  string(REGEX REPLACE "/W[3|4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
   # Disabled warnings
   # C4244, C4267, C4503: implicit type conversion to a smaller type
   # C4786: long names in templates

--- a/src/celestia/win32/res/CMakeLists.txt
+++ b/src/celestia/win32/res/CMakeLists.txt
@@ -2,7 +2,7 @@ if(NOT ENABLE_NLS)
   return()
 endif()
 
-find_package(PERL)
+find_package(Perl)
 
 if(PERL_FOUND)
   include(windres)

--- a/src/tools/cmod/cmodview/CMakeLists.txt
+++ b/src/tools/cmod/cmodview/CMakeLists.txt
@@ -10,8 +10,7 @@ if(APPLE AND EXISTS /usr/local/opt/qt5)
   list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
 endif()
 
-set(QT_LIBS Widgets OpenGL)
-find_package(Qt5 COMPONENTS ${QT_LIBS} CONFIG REQUIRED)
+find_package(Qt5 COMPONENTS Widgets OpenGL CONFIG REQUIRED)
 
 # Instruct CMake to run moc automatically when needed
 set(CMAKE_AUTOMOC ON)
@@ -19,7 +18,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 build_cmod_tool(cmodview WIN32 cmodview.cpp glframebuffer.cpp  glshader.cpp  mainwindow.cpp  materialwidget.cpp  modelviewwidget.cpp glsupport.cpp)
-qt5_use_modules(cmodview ${QT_LIBS})
+target_link_libraries(cmodview Qt5::Widgets Qt5::OpenGL)
 
 if(NOT MSVC)
   target_compile_options(cmodview PRIVATE "-frtti")


### PR DESCRIPTION
- [msvc] Remove defaulted /W option to prevent override warnings from Spice
- Fix capitalization of Perl in find_package
- Replace deprecated qt5_use_modules in cmodview