### PR TITLE
Only pass -fno-rtti and -fno-exceptions for C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,10 @@ if("${build_type_lc}" STREQUAL "debug")
 else()
   add_definitions(-DNO_DEBUG -DEIGEN_NO_DEBUG)
   if(NOT MSVC)
-    add_compile_options(-fno-rtti -fno-exceptions)
+    add_compile_options(
+      $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+      $<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
+    )
   endif()
 endif()
 


### PR DESCRIPTION
Fixes some warnings that `-fno-rtti` and `fno-exceptions` are not valid for C code.