### PR TITLE
Replace invalid use of memcpy in curveplot

### DIFF
--- a/src/celengine/curveplot.h
+++ b/src/celengine/curveplot.h
@@ -30,10 +30,10 @@
 #pragma once
 
 #include <deque>
+
+#include <Eigen/Core>
 #include <Eigen/Geometry>
 
-
-class HighPrec_Frustum;
 
 class CurvePlotSample
 {
@@ -110,7 +110,7 @@ class CurvePlot
 
  private:
     std::deque<CurvePlotSample> m_samples;
- 
+
     double m_duration{ 0.0 };
 
     unsigned int m_lastUsed{ 0 };


### PR DESCRIPTION
- Vertex is not trivially copyable, therefore memcpy is not allowed.
- Put local classes and functions into unnamed namespace.
- Remove `using namespace std`, `using namespace Eigen`.
- Prefer C++-style casts.
- Use C++17 std::clamp where appropriate.
- Use logger for debugging