### PR TITLE
Refactoring galaxy and globular code

### DIFF
--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -112,20 +112,20 @@ constexpr const GalaxyTypeName GalaxyTypeNames[] =
     { "E7",  GalaxyType::E7 },
 };
 
-void galaxyTextureEval(float u, float v, float /*w*/, unsigned char *pixel)
+void galaxyTextureEval(float u, float v, float /*w*/, std::uint8_t *pixel)
 {
     float r = 0.9f - std::sqrt(u * u + v * v );
     if (r < 0)
         r = 0;
 
-    auto pixVal = static_cast<unsigned char>(r * 255.99f);
+    auto pixVal = static_cast<std::uint8_t>(r * 255.99f);
     pixel[0] = 255;//65;
     pixel[1] = 255;//64;
     pixel[2] = 255;//65;
     pixel[3] = pixVal;
 }
 
-void colorTextureEval(float u, float /*v*/, float /*w*/, unsigned char *pixel)
+void colorTextureEval(float u, float /*v*/, float /*w*/, std::uint8_t *pixel)
 {
     unsigned int i = static_cast<unsigned int>((static_cast<float>(u)*0.5f + 0.5f)*255.99f); // [-1, 1] -> [0, 255]
 
@@ -136,9 +136,9 @@ void colorTextureEval(float u, float /*v*/, float /*w*/, unsigned char *pixel)
     //convert Hue to RGB
     float r, g, b;
     DeepSkyObject::hsv2rgb(&r, &g, &b, hue, 0.20f, 1.0f);
-    pixel[0] = static_cast<unsigned char>(r * 255.99f);
-    pixel[1] = static_cast<unsigned char>(g * 255.99f);
-    pixel[2] = static_cast<unsigned char>(b * 255.99f);
+    pixel[0] = static_cast<std::uint8_t>(r * 255.99f);
+    pixel[1] = static_cast<std::uint8_t>(g * 255.99f);
+    pixel[2] = static_cast<std::uint8_t>(b * 255.99f);
 }
 
 struct GalaxyVertex

--- a/src/celengine/galaxy.h
+++ b/src/celengine/galaxy.h
@@ -25,13 +25,6 @@ struct Matrices;
 class Renderer;
 
 
-struct Blob
-{
-    Eigen::Vector4f position;
-    unsigned int    colorIndex;
-    float           brightness;
-};
-
 class GalacticForm;
 
 class Galaxy : public DeepSkyObject
@@ -96,12 +89,6 @@ class Galaxy : public DeepSkyObject
                                   float pixelSize,
                                   const Matrices& mvp,
                                   Renderer* r);
-#if 0
-    void renderGalaxyEllipsoid(const Eigen::Vector3f& offset,
-                               const Eigen::Quaternionf& viewerOrientation,
-                               float brightness,
-                               float pixelSize);
-#endif
 
     float         detail{ 1.0f };
     std::string*  customTmpName{ nullptr };

--- a/src/celengine/galaxy.h
+++ b/src/celengine/galaxy.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 #include <string>
 
 #include <Eigen/Core>
@@ -25,7 +26,25 @@ struct Matrices;
 class Renderer;
 
 
-class GalacticForm;
+enum class GalaxyType {
+    Irr  =  0,
+    S0   =  1,
+    Sa   =  2,
+    Sb   =  3,
+    Sc   =  4,
+    SBa  =  5,
+    SBb  =  6,
+    SBc  =  7,
+    E0   =  8,
+    E1   =  9,
+    E2   = 10,
+    E3   = 11,
+    E4   = 12,
+    E5   = 13,
+    E6   = 14,
+    E7   = 15,
+};
+
 
 class Galaxy : public DeepSkyObject
 {
@@ -33,8 +52,6 @@ class Galaxy : public DeepSkyObject
     const char* getType() const override;
     void setType(const std::string&) override;
     std::string getDescription() const override;
-    std::string getCustomTmpName() const;
-    void setCustomTmpName(const std::string&);
 
     float getDetail() const;
     void setDetail(float);
@@ -50,8 +67,6 @@ class Galaxy : public DeepSkyObject
                 const Matrices& m,
                 Renderer* r) override;
 
-    GalacticForm* getForm() const;
-
     static void  increaseLightGain();
     static void  decreaseLightGain();
     static float getLightGain();
@@ -62,38 +77,12 @@ class Galaxy : public DeepSkyObject
 
     const char* getObjTypeName() const override;
 
- public:
-    enum GalaxyType {
-        S0   =  0,
-        Sa   =  1,
-        Sb   =  2,
-        Sc   =  3,
-        SBa  =  4,
-        SBb  =  5,
-        SBc  =  6,
-        E0   =  7,
-        E1   =  8,
-        E2   =  9,
-        E3   = 10,
-        E4   = 11,
-        E5   = 12,
-        E6   = 13,
-        E7   = 14,
-        Irr  = 15
-    };
-
  private:
-    void renderGalaxyPointSprites(const Eigen::Vector3f& offset,
-                                  const Eigen::Quaternionf& viewerOrientation,
-                                  float brightness,
-                                  float pixelSize,
-                                  const Matrices& mvp,
-                                  Renderer* r);
+    void setForm(const std::string&);
 
-    float         detail{ 1.0f };
-    std::string*  customTmpName{ nullptr };
-    GalaxyType    type{ S0 };
-    GalacticForm* form{ nullptr };
+    float       detail{ 1.0f };
+    GalaxyType  type{ GalaxyType::Irr };
+    std::size_t form{ 0 };
 
-    static float  lightGain;
+    static float lightGain;
 };

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -80,7 +80,7 @@ constexpr const float RADIUS_CORRECTION = 0.025f;
 
 float CBin, RRatio, XI, Rr = 1.0f, Gg = 1.0f, Bb = 1.0f;
 
-void globularTextureEval(float u, float v, float /*w*/, unsigned char *pixel)
+void globularTextureEval(float u, float v, float /*w*/, std::uint8_t *pixel)
 {
     // use an exponential luminosity shape for the individual stars
     // giving sort of a halo for the brighter (i.e.bigger) stars.
@@ -91,7 +91,7 @@ void globularTextureEval(float u, float v, float /*w*/, unsigned char *pixel)
     if (lumi <= 0.0f)
         lumi = 0.0f;
 
-    auto pixVal = static_cast<unsigned char>(lumi * 255.99f);
+    auto pixVal = static_cast<std::uint8_t>(lumi * 255.99f);
     pixel[0] = 255;
     pixel[1] = 255;
     pixel[2] = 255;
@@ -123,7 +123,7 @@ float relStarDensity(float eta)
     return ((std::log(rho2) + 4.0f * (1.0f - std::sqrt(rho2)) * Xi) / (rho2 - 1.0f) + XI2) / (1.0f - 2.0f * Xi + XI2);
 }
 
-void centerCloudTexEval(float u, float v, float /*w*/, unsigned char *pixel)
+void centerCloudTexEval(float u, float v, float /*w*/, std::uint8_t *pixel)
 {
     /*! For reasons of speed, calculate central "cloud" texture only for
      *  8 bins of King_1962 concentration, c = CBin, XI(CBin), RRatio(CBin).
@@ -154,7 +154,7 @@ void centerCloudTexEval(float u, float v, float /*w*/, unsigned char *pixel)
     pixel[0] = 255;
     pixel[1] = 255;
     pixel[2] = 255;
-    pixel[3] = static_cast<unsigned char>(relStarDensity(eta) * profile_2d * 255.99f);
+    pixel[3] = static_cast<std::uint8_t>(relStarDensity(eta) * profile_2d * 255.99f);
 }
 
 void initGlobularData(celgl::VertexObject& vo,

--- a/src/celengine/globular.h
+++ b/src/celengine/globular.h
@@ -21,25 +21,14 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <celcompat/filesystem.h>
 #include "deepskyobj.h"
 #include "vertexobject.h"
 
+struct GlobularForm;
 struct Matrices;
 class Renderer;
 
-
-struct GBlob
-{
-    Eigen::Vector3f position;
-    unsigned int   colorIndex;
-    float          radius_2d;
-};
-
-struct GlobularForm
-{
-    std::vector<GBlob>* gblobs;
-    Eigen::Vector3f scale;
-};
 
 class Globular : public DeepSkyObject
 {
@@ -71,22 +60,13 @@ class Globular : public DeepSkyObject
                 const Matrices& m,
                 Renderer* r) override;
 
-    GlobularForm* getForm() const;
-
     std::uint64_t getRenderMask() const override;
     unsigned int getLabelMask() const override;
     const char* getObjTypeName() const override;
 
  private:
-    void renderGlobularPointSprites(const Eigen::Vector3f& offset,
-                                    const Eigen::Quaternionf& viewerOrientation,
-                                    float brightness,
-                                    float pixelSize,
-                                    const Matrices& m,
-                                    Renderer* r);
-
-   // Reference values ( = data base averages) of core radius, King concentration
-   // and mu25 isophote radius:
+    // Reference values ( = data base averages) of core radius, King concentration
+    // and mu25 isophote radius:
     static constexpr float R_c_ref = 0.83f, C_ref = 2.1f, R_mu25 = 40.32f;
 
     void recomputeTidalRadius();

--- a/src/celengine/globular.h
+++ b/src/celengine/globular.h
@@ -39,10 +39,10 @@ class Globular : public DeepSkyObject
     void setType(const std::string&) override;
     std::string getDescription() const override;
     float getDetail() const;
-    void  setDetail(float);
+    void setDetail(float);
     float getCoreRadius() const;
-    void  setCoreRadius(const float);
-    void  setConcentration(const float);
+    void setCoreRadius(float);
+    void setConcentration(float);
     float getConcentration() const;
     float getHalfMassRadius() const override;
     unsigned int cSlot(float) const;
@@ -71,11 +71,11 @@ class Globular : public DeepSkyObject
 
     void recomputeTidalRadius();
 
-    float         detail{ 1.0f };
-    GlobularForm* form{ nullptr };
-    float         r_c{ R_c_ref };
-    float         c{ C_ref };
-    float         tidalRadius{ 0.0f };
+    float detail{ 1.0f };
+    const GlobularForm* form{ nullptr };
+    float r_c{ R_c_ref };
+    float c{ C_ref };
+    float tidalRadius{ 0.0f };
 
     celgl::VertexObject vo{ GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW };
 };

--- a/src/celengine/texture.h
+++ b/src/celengine/texture.h
@@ -10,13 +10,14 @@
 #ifndef _CELENGINE_TEXTURE_H_
 #define _CELENGINE_TEXTURE_H_
 
+#include <cstdint>
 #include <string>
 #include <celutil/color.h>
 #include <celcompat/filesystem.h>
 #include <celengine/image.h>
 
 
-typedef void (*ProceduralTexEval)(float, float, float, unsigned char*);
+typedef void (*ProceduralTexEval)(float, float, float, std::uint8_t*);
 
 
 struct TextureTile
@@ -40,7 +41,7 @@ class TexelFunctionObject
     TexelFunctionObject() {};
     virtual ~TexelFunctionObject() {};
     virtual void operator()(float u, float v, float w,
-                            unsigned char* pixel) = 0;
+                            std::uint8_t* pixel) = 0;
 };
 
 


### PR DESCRIPTION
A bit of refactoring of the galaxy/globular code, mainly focusing on

- Avoid `using namespace std` and friends
- Use C++-style casts
- Put local types into unnamed namespaces
- Avoid excess indirection