### PR TITLE
Fix galaxy hue calculation

### DIFF
--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -115,12 +115,13 @@ void galaxyTextureEval(float u, float v, float /*w*/, std::uint8_t *pixel)
 
 void colorTextureEval(float u, float /*v*/, float /*w*/, std::uint8_t *pixel)
 {
-    unsigned int i = static_cast<unsigned int>((static_cast<float>(u)*0.5f + 0.5f)*255.99f); // [-1, 1] -> [0, 255]
+    int i = static_cast<int>((u * 0.5f + 0.5f) * 255.99f); // [-1, 1] -> [0, 255]
 
     // generic Hue profile as deduced from true-color imaging for spirals
     // Hue in degrees
-    float hue = 25.0f * std::tanh(0.0615f * (27.0f - static_cast<float>(i)));
-    if (i >= 28) hue += 220.0f;
+    float hue = (i < 28)
+        ? 25.0f * std::tanh(0.0615f * static_cast<float>(27 - i))
+        : 245.0f;
     //convert Hue to RGB
     float r, g, b;
     DeepSkyObject::hsv2rgb(&r, &g, &b, hue, 0.20f, 1.0f);


### PR DESCRIPTION
Restores behaviour of original code https://github.com/CelestiaProject/Celestia/blob/73176faeb47b92dc3a9d03ed99c079cac6d527c2/src/celengine/galaxy.cpp#L105-L110

This relies on `27 - i` being promoted to `unsigned int - unsigned int` and values of `i`≥28 wrapping to a large positive value, which gives a value of 1 from the `tanh` function. It's simpler to avoid the `tanh` call entirely in this case.

Resolves #1293 