### PR TITLE
Support HiDPI on Win32 frontend

### DIFF
--- a/src/celestia/win32/odmenu.h
+++ b/src/celestia/win32/odmenu.h
@@ -68,11 +68,11 @@ class ODMenu
     void SetMenuItemOwnerDrawn(HMENU hMenu, UINT item, UINT type);
     void GenerateDisplayText(ODMENUITEM& item);
     void DrawItemText(DRAWITEMSTRUCT* lpdis, ODMENUITEM& item);
-    void DrawIconBar(DRAWITEMSTRUCT* lpdis, ODMENUITEM& item);
+    void DrawIconBar(HWND hWnd, DRAWITEMSTRUCT* lpdis, ODMENUITEM& item);
     void ComputeMenuTextPos(DRAWITEMSTRUCT* lpdis, ODMENUITEM& item, int& x, int& y, SIZE& size);
-    void DrawTransparentBitmap(HDC hDC, HBITMAP hBitmap, short xStart, short yStart,
+    void DrawTransparentBitmap(HWND hWnd, HDC hDC, HBITMAP hBitmap, short centerX, short centerY,
             COLORREF cTransparentColor, bitmapType eType=eNormal);
-    void DrawCheckMark(HDC hDC, short x, short y, bool bNarrow=true);
+    void DrawCheckMark(HWND hWnd, HDC hDC, short centerX, short centerY, bool bNarrow=true);
     COLORREF LightenColor(COLORREF col, double factor);
     COLORREF DarkenColor(COLORREF col, double factor);
     COLORREF AverageColor(COLORREF col1, COLORREF col2, double weight1=0.5);

--- a/src/celestia/win32/res/celestia.exe.manifest
+++ b/src/celestia/win32/res/celestia.exe.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -19,4 +19,10 @@
         />
     </dependentAssembly>
 </dependency>
+<asmv3:application>
+  <asmv3:windowsSettings>
+    <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+  </asmv3:windowsSettings>
+</asmv3:application>
 </assembly>

--- a/src/celestia/win32/wineclipses.cpp
+++ b/src/celestia/win32/wineclipses.cpp
@@ -29,10 +29,9 @@
 using namespace Eigen;
 using namespace std;
 using namespace celmath;
+using namespace celestia::win32;
 
 static vector<Eclipse> eclipseList;
-
-extern void SetMouseCursor(LPCTSTR lpCursor);
 
 const char* MonthNames[12] =
 {
@@ -63,15 +62,15 @@ bool InitEclipseFinderColumns(HWND listView)
     string header4 = UTF8ToCurrentCP(_("Duration"));
 
     columns[0].pszText = const_cast<char*>(header0.c_str());
-    columns[0].cx = 65;
+    columns[0].cx = DpToPixels(65, listView);
     columns[1].pszText = const_cast<char*>(header1.c_str());
-    columns[1].cx = 65;
+    columns[1].cx = DpToPixels(65, listView);
     columns[2].pszText = const_cast<char*>(header2.c_str());
-    columns[2].cx = 80;
+    columns[2].cx = DpToPixels(80, listView);
     columns[3].pszText = const_cast<char*>(header3.c_str());
-    columns[3].cx = 55;
+    columns[3].cx = DpToPixels(55, listView);
     columns[4].pszText = const_cast<char*>(header4.c_str());
-    columns[4].cx = 135;
+    columns[4].cx = DpToPixels(135, listView);
 
     for (i = 0; i < nColumns; i++)
     {

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -68,6 +68,7 @@
 using namespace celestia;
 using namespace celestia::util;
 using namespace std;
+using namespace celestia::win32;
 
 typedef pair<int,string> IntStrPair;
 typedef vector<IntStrPair> IntStrPairVec;
@@ -988,7 +989,7 @@ BOOL APIENTRY AddBookmarkProc(HWND hDlg,
                                 if (strstr(text, ">>"))
                                 {
                                     //Increase size of dialog
-                                    int height = treeRect.bottom - dlgRect.top + 12;
+                                    int height = treeRect.bottom - dlgRect.top + DpToPixels(12, hDlg);
                                     SetWindowPos(hDlg, HWND_TOP, 0, 0, width, height,
                                                  SWP_NOMOVE | SWP_NOZORDER);
                                     //Change text in button
@@ -3186,8 +3187,8 @@ int APIENTRY WinMain(HINSTANCE hInstance,
     LoadPreferencesFromRegistry(CelestiaRegKey, prefs);
 
     // Adjust window dimensions for screen dimensions
-    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
-    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
+    int screenWidth = GetSystemMetricsForWindow(SM_CXSCREEN, nullptr);
+    int screenHeight = GetSystemMetricsForWindow(SM_CYSCREEN, nullptr);
     if (prefs.winWidth > screenWidth)
         prefs.winWidth = screenWidth;
     if (prefs.winHeight > screenHeight)
@@ -3385,6 +3386,8 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 
     extern void RegisterDatePicker();
     RegisterDatePicker();
+
+    appCore->setScreenDpi(GetDPIForWindow(hWnd));
 
     if (!appCore->initRenderer())
     {

--- a/src/celestia/win32/winsplash.h
+++ b/src/celestia/win32/winsplash.h
@@ -43,4 +43,6 @@ private:
     std::string message;
     unsigned int winWidth;
     unsigned int winHeight;
+    unsigned int imageWidth;
+    unsigned int imageHeight;
 };

--- a/src/celestia/win32/winstarbrowser.cpp
+++ b/src/celestia/win32/winstarbrowser.cpp
@@ -21,11 +21,11 @@
 #include <celmath/mathlib.h>
 #include "winstarbrowser.h"
 #include "res/resource.h"
-
-extern void SetMouseCursor(LPCTSTR lpCursor);
+#include "winuiutils.h"
 
 using namespace Eigen;
 using namespace std;
+using namespace celestia::win32;
 
 static const int MinListStars = 10;
 static const int MaxListStars = 500;
@@ -49,7 +49,7 @@ bool InitStarBrowserColumns(HWND listView)
 
     lvc.mask = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;
     lvc.fmt = LVCFMT_LEFT;
-    lvc.cx = 60;
+    lvc.cx = DpToPixels(60, listView);
     lvc.pszText = const_cast<char*>("");
 
     int nColumns = sizeof(columns) / sizeof(columns[0]);
@@ -65,16 +65,16 @@ bool InitStarBrowserColumns(HWND listView)
     string header4 = UTF8ToCurrentCP(_("Type"));
 
     columns[0].pszText = const_cast<char*>(header0.c_str());
-    columns[0].cx = 100;
+    columns[0].cx = DpToPixels(100, listView);
     columns[1].pszText = const_cast<char*>(header1.c_str());
     columns[1].fmt = LVCFMT_RIGHT;
-    columns[1].cx = 115;
+    columns[1].cx = DpToPixels(115, listView);
     columns[2].pszText = const_cast<char*>(header2.c_str());
     columns[2].fmt = LVCFMT_RIGHT;
-    columns[2].cx = 65;
+    columns[2].cx = DpToPixels(65, listView);
     columns[3].pszText = const_cast<char*>(header3.c_str());
     columns[3].fmt = LVCFMT_RIGHT;
-    columns[3].cx = 65;
+    columns[3].cx = DpToPixels(65, listView);
     columns[4].pszText = const_cast<char*>(header4.c_str());
 
     for (i = 0; i < nColumns; i++)

--- a/src/celestia/win32/winuiutils.h
+++ b/src/celestia/win32/winuiutils.h
@@ -15,7 +15,15 @@
 #include <windows.h>
 #include <commctrl.h>
 
+namespace celestia::win32
+{
+
 void SetMouseCursor(LPCTSTR lpCursor);
 void CenterWindow(HWND hParent, HWND hWnd);
 void RemoveButtonDefaultStyle(HWND hWnd);
 void AddButtonDefaultStyle(HWND hWnd);
+int DpToPixels(int dp, HWND hWnd);
+UINT GetDPIForWindow(HWND hWnd);
+int GetSystemMetricsForWindow(int index, HWND hWnd);
+
+}


### PR DESCRIPTION
1. Define support for HiDPI in manifest
2. Adds methods for handling DPI issues
3. Scale icons and splash image using StretchBlt
4. Rework the checkmark drawing method