### PR TITLE
[qt] Do not capture menu bar/toolbars when taking screenshots

### DIFF
--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -622,8 +622,8 @@ void CelestiaAppWindow::slotGrabImage()
 
     if (!saveAsName.isEmpty())
     {
-        m_appCore->saveScreenShot(saveAsName.toStdString());
-        settings.setValue("GrabImageDir", QFileInfo(saveAsName).absolutePath());
+        QImage grabbedImage = glWidget->grabFramebuffer();
+        grabbedImage.save(saveAsName);
     }
     settings.endGroup();
 }
@@ -751,17 +751,9 @@ static QImage::Format toQFormat(PixelFormat format)
 
 void CelestiaAppWindow::slotCopyImage()
 {
-    //glWidget->repaint();
-    std::array<int, 4> viewport;
-    celestia::PixelFormat format;
-    m_appCore->getCaptureInfo(viewport, format);
-    QImage grabbedImage = QImage(viewport[2], viewport[3],
-                                 toQFormat(format));
-    if (m_appCore->captureImage(grabbedImage.bits(), viewport, format))
-    {
-        QApplication::clipboard()->setImage(grabbedImage);
-        m_appCore->flash(_("Captured screen shot to clipboard"));
-    }
+    QImage grabbedImage = glWidget->grabFramebuffer();
+    QApplication::clipboard()->setImage(grabbedImage);
+    m_appCore->flash(_("Captured screen shot to clipboard"));
 }
 
 


### PR DESCRIPTION
Restores the old behaviour that the menu bar/toolbars are not captured when using "grab screenshot" or "copy image".

There may be a similar issue with video capture but this always crashes for me (including with QGLWidget), will look into doing this in another PR.