### PR TITLE
Don't use suggestions if object searched is not found

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -1045,10 +1045,12 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
             if (typedText != "")
             {
                 Selection sel = sim->findObjectFromPath(typedText, true);
+#ifdef AUTO_COMPLETION
                 if (sel.empty() && typedTextCompletion.size() > 0)
                 {
                     sel = sim->findObjectFromPath(typedTextCompletion[0], true);
                 }
+#endif
                 if (!sel.empty())
                 {
                     addToHistory();


### PR DESCRIPTION
Closes: #604

It seems not all users are happy with this feature so let's hide it behind `#ifdef`.