### PR TITLE
Drop content submodule from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "thirdparty/Spice"]
 	path = thirdparty/Spice
 	url = https://github.com/OpenSpace/Spice.git
-[submodule "content"]
-	path = content
-	url = https://github.com/CelestiaProject/CelestiaContent.git
 [submodule "thirdparty/fmt"]
 	path = thirdparty/fmt
 	url = https://github.com/fmtlib/fmt.git


### PR DESCRIPTION
It's seems a bit confusing to have it in .gitmodules and .gitignore at
the same time.
Furthermore it makes distro packaging fail for my distro.