### PR TITLE
Fix nebula/ssc sprite rendering on hidpi setting

### DIFF
--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -100,7 +100,7 @@ void Nebula::render(const Vector3f& /*offset*/,
                                 getOrientation());
 
     GLSLUnlit_RenderContext rc(renderer, getRadius(), &mv, m.projection);
-    rc.setPointScale(2.0f * getRadius() / pixelSize * renderer->getScreenDpi() / 96.0f);
+    rc.setPointScale(2.0f * getRadius() / pixelSize);
     g->render(rc);
 
     renderer->enableBlending();

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2570,14 +2570,14 @@ void Renderer::renderObject(const Vector3f& pos,
         geometryScale = obj.radius;
         scaleFactors = obj.radius * obj.semiAxes;
         ringsScaleFactor = obj.radius * obj.semiAxes.maxCoeff();
-        ri.pointScale = 2.0f * obj.radius / pixelSize * screenDpi / 96.0f;
+        ri.pointScale = 2.0f * obj.radius / pixelSize;
     }
     else
     {
         geometryScale = obj.geometryScale;
         scaleFactors = Vector3f::Constant(geometryScale);
         ringsScaleFactor = geometryScale;
-        ri.pointScale = 2.0f * geometryScale / pixelSize * screenDpi / 96.0f;
+        ri.pointScale = 2.0f * geometryScale / pixelSize;
     }
     // Apply the modelview transform for the object
     Affine3f transform = Translation3f(pos) * obj.orientation.conjugate();


### PR DESCRIPTION
pixelSize already take DPI into account so no longer to multiply again

Closes #1244 