### PR TITLE
Set correct audio session category on iOS

### DIFF
--- a/src/celestia/miniaudiosession.h
+++ b/src/celestia/miniaudiosession.h
@@ -32,6 +32,8 @@ class MiniAudioSession: public AudioSession
 
  private:
     std::unique_ptr<MiniAudioSessionPrivate> p  { nullptr };
+
+    bool startEngine();
 };
 
 }


### PR DESCRIPTION
the default value will output only to speaker, should use ma_ios_session_category_playback (in apple world, AVAudioSessionCategoryPlayback) instead.