### PR TITLE
Remove printf-family usage, part 1 + support for fmt 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,9 +362,13 @@ else()
   add_definitions(-DNO_DEBUG -DEIGEN_NO_DEBUG)
   if(NOT MSVC)
     add_compile_options(
-      $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
       $<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
     )
+    if(FMT_VERSION LESS 90000)
+      add_compile_options(
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+      )
+    endif()
   endif()
 endif()
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:42+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr ""
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr ""
 
@@ -55,35 +55,34 @@ msgstr "خطأ في قراءة ملف التركيبة"
 msgid "Loaded {} deep space objects\n"
 msgstr "الفضاء\tالمتجمد"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "مجرة (نوع Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "تحميل صورة من ملف "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "تحميل نموذج : "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "خطأ في تحميل النموذج '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -101,112 +100,107 @@ msgstr "إظهار أسماء المجموعات المفتوحة"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "خطأ في ملف من نوع .ssc (السطر"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "تحذير، تعريف مكرر من "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "سطح بديل سيء"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "موقع سيء"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "عنوان رئسي سيء للفهرس المتقاطع\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "تشغيل الفهرس المتقاطع فشل في السجل "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "تشغيل الفهرس المتقاطع فشل في السجل "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "نوع طيف سيء في قاعدة بيانات النجمة , النجمة #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr "النجوم في قاعدة البيانات الثنائية\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "إجمالي عدد النجوم: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "خطأ في ملف من نوع .stc (السطر"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "نجمة غير صحيحة : نوع الطيف سيء.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "نجمة غير صحيحة : نوع الطيف مفقود.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " غير موجود.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "نجمة غير صحيحة: المطلع المستقيم مفقود\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "نجمة غير صحيحة: البعد الزاوي مفقود\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "نجمة غير صحيحة: المسافة مفقودة\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "نجمة غير صحيحة: مقدار مفقود\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
-msgstr ""
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
 #: ../src/celengine/texture.cpp:928
@@ -240,728 +234,710 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "خطأ في قراءة المفضلة."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "نوع الملف خاطئ"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "حد المقدار: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "تفعيل المعلّم"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "تبطيل المعلّم"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "ذهاب الى السطح"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 #, fuzzy
 msgid "Alt-azimuth mode enabled"
 msgstr "وضعية منظار Alt-azimuth"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 #, fuzzy
 msgid "Alt-azimuth mode disabled"
 msgstr "وضعية منظار Alt-azimuth"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "طراز النجمة: نقاط غير واضحة"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "طراز النجمة: نقاط"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "طراز النجمة: اسطوانات من القشرة الجافة"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "تفعيل ذيل المذنب"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "تبطيل ذيل المذنب"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "مسار التمثيل: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "تفعيل ذيل المذنب"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "تبطيل ذيل المذنب"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "المقدار الآلي مفعل"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "المقدار الآلي معطل"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "إلغاء الامر"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "تم إيقاف الوقت والمستند مؤقتا"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "تم إيقاف الوقت مؤقتا"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "استئناف"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "إجمالي عدد النجوم: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "إجمالي عدد النجوم: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "وقت انتقال الضوء %.4f سنة "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "وقت انتقال الضوء %d دقيقة %.1f ثانية"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "وقت انتقال الضوء %d ساعة %d دقيقة %.1f ثانية"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "تأخير وقت انتقال الضوء متضمن"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "تأخير وقت انتقال الضوء مغلق"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "وقت انتقال الضوء مهمل"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "استعمال قوام السطح الطبيعي."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "استعمال قوام سطح حد المعرفة."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "يتبع"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "الوقت: تقدم"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "الوقت: تراجع"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "معدل الإطار"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "&ضئيل"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "&متوسط"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "استعمال قوام سطح حد المعرفة."
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 #, fuzzy
 msgid "Sync Orbit"
 msgstr "مدار مصاحب"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "قفل"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "ملاحقة"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "حد المقدار: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "حد المقدار الآلي عند 45 درجة: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, fuzzy, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "&الضوء البيئي"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "إكساب الضوء"
 
-#: ../src/celestia/celestiacore.cpp:1812
-#, fuzzy
-msgid "Bloom enabled"
-msgstr "تفعيل المعلّم"
-
-#: ../src/celestia/celestiacore.cpp:1814
-#, fuzzy
-msgid "Bloom disabled"
-msgstr "تبطيل المعلّم"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "خطأ GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "العرض صغير جداً ليقسم"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "العرض المضاف"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 #, fuzzy
 msgid "ly"
 msgstr "مجرة (نوع Hubble: %s)"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "وحدة قياس فضائية"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr "كيلومتر"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "كيلومتر"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr "كيلومتر"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " الأيام"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " الساعات"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " الدقائق"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr "ضبط الوقت..."
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr "مجرة (نوع Hubble: %s)"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr "وحدة قياس فضائية"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr "كيلومتر"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr "مجرة (نوع Hubble: %s)"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "السرعة: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "القطر الظاهر: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "المقدار الظاهر: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "القيمة المطلقة: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "المسافة: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "نقطة منتصف نظام النجوم\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs (app) mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "اللمعان: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "نجم نيوترون"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "فجوة سوداء"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "الفصل: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "حرارة السطح: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "تواجد كواكب مرافقه\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "المسافة من المركز: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "نصف القطر: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "درجة الحرارة: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "الوقت الحقيقي"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-الوقت الحقيقي"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "تم ايقاف الوقت"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " أسرع"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " أبطأ"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (ايقاف موقت)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "الانتقال "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "الانتقال "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "تتبع "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "يتبع "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "مدار مصاحب"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "ملاحقة "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "اسم الهدف: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr " ايقاف مؤقت"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  تسجيل"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 بدأ/ايقاف مؤقت    F12 ايقاف"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "وضع التنسيق"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "تحميل دليل النظام الشمسي: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "تحميل دليل النظام الشمسي: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "تحميل دليل النظام الشمسي: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "تحميل دليل النظام الشمسي: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "خطأ في قراءة المفضلة."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "خطأ في قراءة ملف التركيبة"
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 #, fuzzy
 msgid "Initialization of SPICE library failed."
 msgstr "خطأ في انشاء مستند برنامج جزئي"
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "لا يمكن قراءة قاعدة بيانات النجمة"
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "خطأ في تحميل دليل النظام الشمسي.\n"
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "لا يمكن قراءة قاعدة بيانات النجمة"
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "خطأ في تحميل دليل النظام الشمسي.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "خطأ في فتح ملف الشكل النجمي."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "خطأ في فتح ملف حدود الابراج."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "فشل في انشاء الممثل"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "خطأ في تحميل الخط; النص سيكون غير مرئي.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "خطأ في قراءة الفهرس المتقاطع "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "الفهرس المتقاطع محمل "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "خطأ في قراءة ملف اسماء النجوم\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "خطأ في الفتح "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "خطأ في قراءة ملف النجوم\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "خطأ في فتح دليل النجوم "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1020,37 +996,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "المتصفح السماوي"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "المتصفح السماوي"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "نظام الخلية الشمسية"
 
@@ -1060,20 +1036,20 @@ msgstr "نظام الخلية الشمسية"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "النجوم"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr "العناصر المعلّمة"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1083,122 +1059,119 @@ msgstr "كاشف الكسوف أو الخسوف"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "وقت"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "مرشد الجولة"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "شاشة كاملة"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "التقاط &فيديو...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "خطأ في فتح ملف الشكل النجمي."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&إضافة مفضلة..."
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "انتزاع صورة"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "ليس ملف من نوع PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 #, fuzzy
 msgid "Capture Video"
 msgstr "التقاط &صورة...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 msgid "Matroska Video (*.mkv)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "الدقة"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "معدل الإطار"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 #, fuzzy
 msgid "Copied URL"
 msgstr "ادخل الموقع"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "ابدأ وانتقل الى الموقع"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&فتح مستند..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "إنشاء مجلد مفضلة جديد في هذه القائمة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1215,346 +1188,346 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "خطأ غير معروف في فتح المستند"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "عن Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>لغة تظليل OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>OpenGL 1.1 غير ممتد</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 غير ممتد</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "<b>مجمعات NVIDIA ، لا يوجد برامج قمة</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "استعمال قوام سطح حد المعرفة."
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "حجم المميزات الأقل"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "حجم المميزات الأقل"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "حجم المميزات الأقل"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "حجم المميزات الأقل"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "فشل في انشاء الممثل"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&ملف"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "انتزاع صورة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "التقاط &صورة...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "التقاط &صورة...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "التقاط &فيديو...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "نسخ"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&فتح مستند..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "خيارات Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "خ&روج"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "رسومات\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&ملاحة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&اختيار"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&الاختيار المركزي\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "الاختيار: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "الذهاب إلى عنصر..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&وقت"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "ضبط الوقت..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "عرض"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "العناصر المعلّمة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "إظهار ظل الكسوف أو الخسوف"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "طر&از النجمة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "الدقة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&التحكم"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&المفضلة"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&عرض"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "عرض متعدد"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "تقسيم العرض عامودياً"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "تقسيم أفقي\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "تقسيم العرض أفقياً"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "تقسيم عامودي\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "عرض كامل"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "عرض وحيد"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&عرض وحيد"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "حذف العرض"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "حذف"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "الإطارات مرئية"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "الإطارات الفعّالة مرئية"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "تزامن الوقت"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&مساعدة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "خيارات Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "معلومات عن OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&إضافة مفضلة"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&تنظيم المفضلة..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "التحميل قائم "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 #, fuzzy
 msgid "Scripts"
@@ -1674,11 +1647,11 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "المعلّم"
 
@@ -1694,7 +1667,7 @@ msgstr "&الاختيار المركزي\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "برج فلكي"
 
@@ -1716,7 +1689,7 @@ msgstr "موافق"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "المسارات"
 
@@ -1730,18 +1703,18 @@ msgstr "المسارات"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "الكواب"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 #, fuzzy
 msgid "Dwarf Planets"
 msgstr "مع الكواكب"
@@ -1755,16 +1728,16 @@ msgstr "مع الكواكب"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "الأقمار"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 #, fuzzy
 msgid "Minor Moons"
 msgstr "الأقمار"
@@ -1778,10 +1751,10 @@ msgstr "الأقمار"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "الكويكبات"
 
@@ -1794,10 +1767,10 @@ msgstr "الكويكبات"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "المذنبات"
 
@@ -1814,11 +1787,11 @@ msgstr "المذنبات"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1836,7 +1809,7 @@ msgstr "&أسرع بـ 10 أضعاف\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "أسماء"
 
@@ -1846,9 +1819,9 @@ msgstr "أسماء"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "المجرّات"
 
@@ -1856,8 +1829,8 @@ msgstr "المجرّات"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 #, fuzzy
 msgid "Globulars"
 msgstr "إظهار النجوم"
@@ -1878,9 +1851,9 @@ msgstr "المجموعات المفتوحة"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "السديم"
 
@@ -1892,48 +1865,48 @@ msgid "Locations"
 msgstr "المواقع"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "المجموعات المفتوحة"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "سحب"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "أنوار الجانب المظلم"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "أذيال المذنبات"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "الغلاف الجوي"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "ظلال الحلقة"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "ظلال الكسوف أو الخسوف"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 #, fuzzy
 msgid "Cloud Shadows"
 msgstr "ظلال الحلقة"
@@ -2009,241 +1982,241 @@ msgstr "حد المقدار الآلي عند 45 درجة: %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "حد المقدار: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "الاسم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 #, fuzzy
 msgid "Distance (ly)"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 #, fuzzy
 msgid "App. mag"
 msgstr "مقدار البرنامج"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 #, fuzzy
 msgid "Abs. mag"
 msgstr "القيمة المطلقة"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "النوع"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "السطوع"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "تصفية النجوم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 #, fuzzy
 msgid "With Planets"
 msgstr "مع الكواكب"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "نقطة المنتصف "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "نوع طيف سيء في قاعدة بيانات النجمة , النجمة #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "تحديث"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&تحديد"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "أقصى عدد عرض للنجوم في القائمة"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&تحديد"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "المعلّم"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "لا شيء"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "جوهرة"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "مثلث"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "مربع"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "زائد"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
-#: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
-msgid "Circle"
-msgstr ""
-
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:590
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:510
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
-msgid "Left Arrow"
+msgid "Circle"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:591
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:511
-#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
-msgid "Right Arrow"
+msgid "Left Arrow"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:592
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:512
-#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
-msgid "Up Arrow"
+msgid "Right Arrow"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:593
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:513
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+msgid "Up Arrow"
+msgstr ""
+
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "اختيار &عنصر"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "اختيار &عنصر"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "مميزات الأسماء"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "عناصر"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&تحديد"
@@ -2358,8 +2331,8 @@ msgstr "ذهاب الى السطح"
 msgid "Behind %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2526,86 +2499,91 @@ msgstr "الحجم:"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "طر&از النجمة"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "إظهار الوقت المحلي"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "منطقة الوقت"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "البدء"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Abs (app) mag: "
 
@@ -2618,21 +2596,21 @@ msgid "&Select"
 msgstr "&اختيار"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&المركز"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&ذهاب الى"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&التابع"
 
@@ -2646,12 +2624,12 @@ msgid "Visible"
 msgstr "الإطارات الفعّالة مرئية"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&إلغاء التحديد"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "نمط عرض الاختيار"
@@ -2666,12 +2644,12 @@ msgid "Disk"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&تحديد"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 #, fuzzy
 msgid "&Reference Marks"
 msgstr "&نقاط غير واضحة"
@@ -2720,13 +2698,13 @@ msgid "Show &Terminator"
 msgstr "إظهار النجوم"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "أسطح بديلة"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "عادي"
 
@@ -2738,7 +2716,7 @@ msgstr "عادي"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "مع الكواكب"
@@ -2750,15 +2728,15 @@ msgstr "مع الكواكب"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "الأقمار"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "عناصر"
@@ -2769,7 +2747,7 @@ msgid "Set Time"
 msgstr "ضبط الوقت..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "منطقة الوقت"
 
@@ -2835,7 +2813,7 @@ msgid "Set Seconds"
 msgstr "ضبط الوقت..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 #, fuzzy
 msgid "Julian Date: "
 msgstr "تاريخ/وقت"
@@ -2850,98 +2828,98 @@ msgstr "ضبط التاريخ و ذهاب إلى كوكب"
 msgid "Set time"
 msgstr "ضبط الوقت..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "نقطة المنتصف "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "نوع طيف سيء في قاعدة بيانات النجمة , النجمة #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "كوكب"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "كوكب"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "قمر"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "الأقمار"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "كويكب"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "مذنب"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "مركبة فضائية"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&نقاط غير واضحة"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "حساب"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "ذهاب الى السطح"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "خطأ غير معروف في فتح المستند"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "الكويكبات"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&نقاط غير واضحة"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "مميزات اخرى"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "الكواب"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "عناصر"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3074,7 +3052,7 @@ msgstr "الدقة"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "تنظيم المفضلة"
 
@@ -3181,7 +3159,7 @@ msgstr "إظهار مدار الدوران"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "مواقع الهبوط"
@@ -3189,7 +3167,7 @@ msgstr "مواقع الهبوط"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "جزء المسار المنحني"
@@ -3197,14 +3175,14 @@ msgstr "جزء المسار المنحني"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 #, fuzzy
 msgid "Equatorial"
 msgstr "إظهار النجوم"
@@ -3212,7 +3190,7 @@ msgstr "إظهار النجوم"
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 #, fuzzy
 msgid "Ecliptic"
 msgstr ", السطر"
@@ -3220,7 +3198,7 @@ msgstr ", السطر"
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 #, fuzzy
 msgid "Galactic"
 msgstr "المجرّات"
@@ -3228,7 +3206,7 @@ msgstr "المجرّات"
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 #, fuzzy
 msgid "Horizontal"
 msgstr "تقسيم العرض أفقياً"
@@ -3236,14 +3214,14 @@ msgstr "تقسيم العرض أفقياً"
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 #, fuzzy
 msgid "Boundaries"
 msgstr "إظهار الحدود الفاصلة"
@@ -3447,41 +3425,41 @@ msgstr "تاريخ"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3732,13 +3710,13 @@ msgstr "&عن Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "موافق"
 
@@ -3823,7 +3801,7 @@ msgid "Create in >>"
 msgstr "انشاء في >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "مجلد جديد..."
 
@@ -3906,7 +3884,7 @@ msgid "Go to Object"
 msgstr "ذهاب إلى عنصر"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "ذهاب إلى"
 
@@ -3923,7 +3901,7 @@ msgid "Lat."
 msgstr "خط العرض"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "المسافة"
 
@@ -3972,155 +3950,159 @@ msgstr "الميزة المعلّمة الأقل حجماً"
 msgid "Size:"
 msgstr "الحجم:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "إعادة تسمية..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "إعادة تسمية مفضلة أو مجلد"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "اسم جديد"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "ضبط وقت المحاكاة"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 #, fuzzy
 msgid "Format: "
 msgstr "إظهار الوقت المحلي"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "ضبط إلى الوقت الحالي"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "باحث نظام الخلية الشمسية"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&ذهاب إلى"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "عناصر نظام الخلية الشمسية"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "باحث النجوم"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "الأقرب"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "السطوع"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "مع الكواكب"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&تحديث"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "معيار بحث النجوم"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "أقصى عدد عرض للنجوم في القائمة"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "مرشد الجولة"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "اختيار وجهتك:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "خيارات العرض"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "إظهار"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "إضافة أوضاع المفضلة للمستند الحالي"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "عرض"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 #, fuzzy
 msgid "Ecliptic Line"
 msgstr ", السطر"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "المدارات / أسماء"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 #, fuzzy
 msgid "Latin Names"
 msgstr ""
 "_:أسماء المترجمين \\n Ali Al-Khudair, Hussain Al-Ghamdi, Abdullah Al-Ghamdi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "نص المعلومات"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "مصقول"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "مضجر"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "401"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 #, fuzzy
 msgid "Jan"
 msgstr "جينوس"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 #, fuzzy
 msgid "Mar"
 msgstr "المريخ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 #, fuzzy
 msgid "May"
 msgstr ""
@@ -4128,29 +4110,29 @@ msgstr ""
 "البدء سوف يكمل, لكن البرنامج سوف يفقد بعض البياناتوبعض الملفات لن تقوم "
 "بالعمل بالشكل المطلوب, تأكد من التحميل"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 #, fuzzy
 msgid "Nov"
 msgstr "الآن"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 #, fuzzy
 msgid "Oct"
 msgstr "عنصر"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 #, fuzzy
 msgid "Sep"
 msgstr "ضبط"
@@ -4167,195 +4149,200 @@ msgstr "تاريخ"
 msgid "Start"
 msgstr "البدء"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 #, fuzzy
 msgid "Windowed Mode"
 msgstr "وضع التشكيل الثلاثي الابعاد"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 #, fuzzy
 msgid "Invisibles"
 msgstr "الإطارات الفعّالة مرئية"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 #, fuzzy
 msgid "S&ync Orbit"
 msgstr "تزام%ن اختيار المسارات\tY"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&معلومات"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 #, fuzzy
 msgid "Show Body Axes"
 msgstr "بدن الأصل '"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 #, fuzzy
 msgid "Show Frame Axes"
 msgstr "الإطارات الفعّالة مرئية"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 #, fuzzy
 msgid "Show Sun Direction"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 #, fuzzy
 msgid "Show Velocity Vector"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 #, fuzzy
 msgid "Show Planetographic Grid"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 #, fuzzy
 msgid "Show Terminator"
 msgstr "إظهار النجوم"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "خطأ في تحميل الخط; النص سيكون غير مرئي.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "خطأ : "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "التقاط &صورة...\tF10"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "تحكم Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 #, fuzzy
 msgid "Loading: "
 msgstr "التحميل قائم "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "التحميل قائم "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "ar"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "خطأ في قراءة ملف التركيبة"
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 #, fuzzy
 msgid "Loading URL"
 msgstr "إذهب إلى &موقع..."
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 #, fuzzy
 msgid "Version: "
 msgstr "اصدار سيء للفهرس المتقاطع\n"
@@ -4394,17 +4381,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "خطأ في قراءة ملف من نوع PNG"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "خطأ في فتح مستند."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "خطأ غير معروف في فتح المستند"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4416,7 +4407,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4427,8 +4418,8 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
 msgstr "خطأ في فتح المستند '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:107
@@ -4437,8 +4428,8 @@ msgid "Script coroutine initialization failed"
 msgstr "خطأ في انشاء مستند برنامج جزئي"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "خطأ في فتح المستند '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4454,6 +4445,21 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "خطأ في الفتح "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "مسار التمثيل: OpenGL 2.0"
+
+#, fuzzy
+#~ msgid "Bloom enabled"
+#~ msgstr "تفعيل المعلّم"
+
+#, fuzzy
+#~ msgid "Bloom disabled"
+#~ msgstr "تبطيل المعلّم"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "خطأ في فتح المستند '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6053,10 +6059,6 @@ msgstr "خطأ في الفتح "
 #~ msgstr "اصدار سيء للفهرس المتقاطع\n"
 
 #, fuzzy
-#~ msgid "Error opening script"
-#~ msgstr "خطأ في فتح المستند '%s'"
-
-#, fuzzy
 #~ msgid "Error loading script"
 #~ msgstr "خطأ في تحميل النموذج '"
 
@@ -6571,9 +6573,6 @@ msgstr "خطأ في الفتح "
 
 #~ msgid "Surface Temp: "
 #~ msgstr "حرارة السطح: "
-
-#~ msgid "Radius: "
-#~ msgstr "نصف القطر: "
 
 #~ msgid "Marked objects"
 #~ msgstr "العناصر المعلّمة"

--- a/po/be.po
+++ b/po/be.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
-"PO-Revision-Date: 2021-12-19 21:42+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
+"PO-Revision-Date: 2022-08-02 19:50+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: Belarusian (https://www.transifex.com/celestia/teams/93131/"
 "be/)\n"
@@ -24,11 +24,11 @@ msgstr ""
 "%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -56,37 +56,34 @@ msgstr "{}: кепскі файл настаўленьняў.\n"
 msgid "Loaded {} deep space objects\n"
 msgstr "Загружага {} аб'ектаў глыбокага космасу\n"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Ґаляктыка (Габлаў тып: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Шаравае скопішча (радыюс ядра: %4.2f', канцэнтрацыя Кінґа: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 msgid "Loading image from file {}\n"
 msgstr "Загрузка відарыса з файла {}\n"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, c-format
-msgid "Loading model: %s\n"
-msgstr "Загрузка мадэлі: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+msgid "Loading model: {}\n"
+msgstr "Загрузка мадэлі: {}\n"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
-"   Статыстыка мадэлі: %u вяршынь, %u прымітываў, %u матар'ялаў (%u "
+"   Статыстыка мадэлі: {} вяршынь, {} прымітываў, {} матар'ялаў ({} "
 "унікальных)\n"
 
-#: ../src/celengine/meshmanager.cpp:553
-#, c-format
-msgid "Error loading model '%s'\n"
-msgstr "Памылка загрузкі мадэлі «%s»\n"
+#: ../src/celengine/meshmanager.cpp:504
+msgid "Error loading model '{}'\n"
+msgstr "Памылка загрузкі мадэлі {}\n"
 
 #: ../src/celengine/nebula.cpp:39
 msgid "Nebula"
@@ -100,108 +97,103 @@ msgstr "Адкрытае скопішча"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Памылка ў фале .ssc (радок {}): {}\n"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr "Няправільнае значэньне GeomAlbedo: {}\n"
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr "Няправільнае значэньне Reflectivity: {}\n"
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr "Няправільнае значэньне BondAlbedo: {}\n"
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "бацькоўскае цела «%s» аб'екта «%s» не адшуканае.\n"
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "заўвага, падвоенае азначэньне %s %s\n"
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "кепская дадатковая паверхня"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "кепскае месца"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Кепскі загаловак для перакрыжаванай спасылкі\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Кепская вэрсія для перакрыжаванай спасылкі\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 msgid "Loading cross index failed\n"
 msgstr "Загрузка перакрыжаваных спасылак пацярпела няўдачу\n"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 msgid "Loading cross index failed at record {}\n"
 msgstr "Загрузка перакрыжаваных спасылак пацярпела няўдачу на запісе {}\n"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Кепскі спэктральны тып у базе зорак, зорка #{}\n"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 msgid "{} stars in binary database\n"
 msgstr "{} зорак у двайковай базе\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 msgid "Total star count: {}\n"
 msgstr "Агульная колькасьць зорак: {}\n"
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Памылка ў фале .stc (радок {}): {}\n"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Недапушчальная зорка: кепскі спэктральны тып.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Недапушчальная зорка: спэктральны тып адсутнічае.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 msgid "Barycenter {} does not exist.\n"
 msgstr "Барыцэнтар {} не існуе.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Недапушчальная зорка: адсутнічае правільнае ўзыходжаньне\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Недапушчальная зорка: адсутнічае схіленьне.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Недапушчальная зорка: адсутнічае адлегласьць.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Недапушчальная зорка: адсутнічае яркасьць.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Недапушчальная зорка: абсалтная (ня бачная) велічыня мусіць быць вызначаная "
 "для зорак, блізкіх да пачатку\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr "Ровень %i, %.5f с.г., %i вузлоў, %i  зорак\n"
 
 #: ../src/celengine/texture.cpp:928
 msgid "Creating tiled texture. Width={}, max={}\n"
@@ -231,505 +223,485 @@ msgstr "Парадак байтаў {} не падтрымліваецца, ча
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Колькасьць лічбаў {} не падтрымліваецца, чакалася {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr "Шлях {} ці то не існуе, ці то не зьяўляецца каталёґам\n"
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 msgid "Error reading favorites file {}.\n"
 msgstr "Памылка падчас чытаньня файла абранага {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr "Не атрымалася праверыць існаваньне каталёґу для файла абранага {}\n"
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr "Не атрымалася стварыць каталёґ для файла абранага {}\n"
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Недапушчальны тып файла"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Граніца яркасьці: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Пазнакі задзейнічаныя"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Пазнакі абязьдзейненыя"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Перайсьці на паверхню"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Рэжым «Вышыня-Азімут» задзейнічаны"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Рэжым «Вышыня-Азімут» абязьдзейнены"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Стыль зорак: размытыя кропкі"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Стыль зорак: кропкі"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Стыль зорак: маштабаваныя дыскі"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Хвасты камэт задзейнічаныя"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Хвасты камэт абязьдзейненыя"
 
-#: ../src/celestia/celestiacore.cpp:1188
-msgid "Render path: OpenGL 2.1"
-msgstr "Спосаб рэндэрынґу: OpenGL 2.1"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 msgid "Anti-aliasing enabled"
 msgstr "Згладжваньне задзейнічана"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 msgid "Anti-aliasing disabled"
 msgstr "Згладжваньне абязьдзейнена"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Аўтаяркасьць задзейнічаная"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Аўтаяркасьць абязьдзейненая"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Адмяніць"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Час і сцэнар прыпыненыя"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Хада часу прыпыненая"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Працяг"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr "Колер зорак: чорнае цела D65"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr "Колер зорак: пашыраны"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Сьвятло даходзіць за:  %.4f с.г."
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Сьвятло даходзіць за:  %d хв  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Сьвятло даходзіць за:  %d гадз  %d хв  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Час руху сьвятла ўключаецца"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Затрымка руху сьвятла ня ўлучаная"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Час руху сьвятла іґнаруецца"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Ужываюцца нармальныя тэкстуры паверхняў."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Ужываюцца тэкстуры паверхняў з абмежаваньнем ведаў."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Ісьці ўсьлед"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Час: наперад"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Час: назад"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, c-format
 msgid "Time rate: %.6g"
 msgstr "Хуткасьць часу: %.6g"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 msgid "Low res textures"
 msgstr "Тэкстуры нізкага разрозьненьня"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 msgid "Medium res textures"
 msgstr "Тэкстуры сярэдняга разрозьненьня"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr "Тэкстуры высокага разрозьненьня"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Сынхранізаваць арбіту"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Захапіць"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Даганяць"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Абмежаваньне велічыні:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Гранічная аўтаяркасьць пры 45°:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Узровень расьсеянага сьвятла:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Узмацненьне сьвятла"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Эфэкт «bloom» задзейнічаны"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Эфэкт «bloom» абязьдзейнены"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Насьвятленьне"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Памылка GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Прагляд замалы, каб яго модна было падзяліць"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Даданы прагляд"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr "Мпк"
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr "кпк"
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "с.г."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "аа"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 msgid "mi"
 msgstr "міль"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr "футаў"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 msgid "days"
 msgstr "дзён"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "hours"
 msgstr "гадзін"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 msgid "minutes"
 msgstr "хвіліны"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 msgid "seconds"
 msgstr "сэкунды"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, c-format
-msgid "Rotation period: %s %s\n"
-msgstr "Пэрыяд авароту: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+msgid "Rotation period: {} {}\n"
+msgstr "Пэрыяд авароту: {} {}\n"
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr "Маса:%.6g фунтаў\n"
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr "Маса:%.6g кг\n"
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr "Маса:%.2f Mj\n"
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr "Маса:%.2f Me\n"
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 msgid "ly/s"
 msgstr "с.г./с"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 msgid "AU/s"
 msgstr "АА/с"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr "міль/с"
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr "футаў/с"
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 msgid "km/s"
 msgstr "км/с"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 msgid "m/s"
 msgstr "м/с"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, c-format
-msgid "Speed: %s %s\n"
-msgstr "Хуткасьць: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+msgid "Speed: {} {}\n"
+msgstr "Хуткасьць: {} {}\n"
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr "Сх: %+d%s %02d' %.1f\"\n"
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr "ПУ: %dг %02dм %.1fс\n"
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Бачны дыямэтар: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Бачная велічыня: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Абсалютная велічыня: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr "%.6f%c %.6f%c %s"
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Адлегласьць: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Барыцэнтар сонечнай сыстэмы\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Абс (бач) вел: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, c-format
-msgid "Luminosity: %sx Sun\n"
-msgstr "Сьвятлівасьць: %s сонечных\n"
+#: ../src/celestia/celestiacore.cpp:2884
+msgid "Luminosity: {}x Sun\n"
+msgstr "Сьвятлівасьць: {} сонечных\n"
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Нэўтронная зорка"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Чорная дзірка"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, c-format
 msgid "Class: %s\n"
 msgstr "Кляса: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, c-format
-msgid "Surface temp: %s K\n"
-msgstr "Тэмпэратура паверхні: %s K\n"
+msgid "Surface temp: %s\n"
+msgstr "Тэмпэратура паверхні: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, c-format
-msgid "Radius: %s Rsun  (%s)\n"
-msgstr "Радыюс: %s сонечных  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+msgid "Radius: {} Rsun  ({})\n"
+msgstr "Радыюс: {} сонечных  ({})\n"
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, c-format
-msgid "Radius: %s\n"
-msgstr "Радыюс %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+msgid "Radius: {}\n"
+msgstr "Радыюс {}\n"
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Наяўныя плянэтныя спадарожнікі\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Адлегласьць ад цэнтру: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, c-format
+msgid "Radius: %s\n"
+msgstr "Радыюс %s\n"
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Фазавы вугал: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr "Шчыльнасьць: %.2f × 1000 фунтаў/фут³\n"
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "Шчыльнасьць: %.2f × 1000 кг/м³\n"
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, c-format
-msgid "Temperature: %.0f K\n"
-msgstr "Тэмпэратура: %.0f K\n"
+msgid "Temperature: %s\n"
+msgstr "Тэмпэратура: %s K\n"
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  ПЧРС"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Сапраўдны час"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Сапраўдны час"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Хада часу спыненая"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, c-format
 msgid "%.6g x faster"
 msgstr "%.6g × хутчэй"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, c-format
 msgid "%.6g x slower"
 msgstr "%.6g × павольней"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Прыпыненая)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
@@ -738,178 +710,176 @@ msgstr ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr "Часьціня кадраў %.1f к/с\n"
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, c-format
-msgid "Travelling (%s)\n"
-msgstr "Падарожнічаем (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+msgid "Travelling ({})\n"
+msgstr "Падарожнічаем ({})\n"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, c-format
+#: ../src/celestia/celestiacore.cpp:3291
 msgid "Travelling\n"
 msgstr "Падарожнічаем\n"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, c-format
 msgid "Track %s\n"
 msgstr "Сачыць за %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, c-format
 msgid "Follow %s\n"
 msgstr "Усьлед за %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Сынхранізаваць арбіту з %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Замацаваны %s -> %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, c-format
 msgid "Chase %s\n"
 msgstr "Даганяць %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr "ПЗ: %s (%.2fx)\n"
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, c-format
 msgid "Target name: %s"
 msgstr "Назва мэты: %s"
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr "%dx%d пры %.2f К.С  %s"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Paused"
 msgstr "Прыпынена"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Recording"
 msgstr "Запіс"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Пачаць/Паўза   F12 Спыніць"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Рэжым праўкі"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Абмінаем каталёґ сонечнай сыстэмы: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 msgid "Loading solar system catalog: {}\n"
 msgstr "Загрузка каталёґу сонечнай сыстэмы: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 msgid "Skipping {} catalog: {}\n"
 msgstr "Абмінаем каталёґ \"{}\": {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 msgid "Loading {} catalog: {}\n"
 msgstr "Загрузка каталёґу \"{}\": {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Памылка падчас чытаньня файла \"{}\": {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Памылка падчас чытаньня файла настаўленьняў."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Не ўдалося ініцыялізаваць бібліятэку SPICE."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Немагчыма прачытаць базу зорак."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Памылка адкрыцьця файла каталёґу глыбокага космасу {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Немагчыма прачытаць базу аб'ектаў глыбокага космасу {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Памылка падчас адкрыцьця каталёґу сонечнай сыстэмы {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 msgid "Error opening asterisms file {}.\n"
 msgstr "Памылка падчас адкрыцьця файла астэрызму {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Памылка падчас адкрыцьця файлаў зь межамі сузор'яў {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Не ўдалося ініцыялізаваць будаўнік"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Памылка падчас загрузкі шрыфта; тэкс ня будзе бачны.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 msgid "Error reading cross index {}\n"
 msgstr "Памылка чытаньня перакрыжаваных спасылак {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 msgid "Loaded cross index {}\n"
 msgstr "Загружаныя перакрыжаваныя спасылкі {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Памылка падчас чытаньня файла з назвамі зорак\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 msgid "Error opening {}\n"
 msgstr "Памылка адкрыцьця {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Памылка падчас чытаньня файла зорак\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 msgid "Error opening star catalog {}\n"
 msgstr "Памылка адкрыцьця каталёґу зорак {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr "Недапушчальны URL"
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr "Не атрымалася захапіць кадр!\n"
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 msgid "Unsupported image type: {}!\n"
 msgstr "Тып відарыса не падтрымліваецца: {}!\n"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr "Celestia не здолела ініцыялізаваць OpenGL 2.1.\n"
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 "Калі ласка, выкарыстоўвай назву файла, якая сначаецца на '.jpg' ці '.png'."
@@ -969,19 +939,19 @@ msgstr "Колькасьць інтэрпалятараў: %s\n"
 msgid "Max anisotropy filtering: %s\n"
 msgstr "Найбольшая анізатропная фільтрацыя: %s\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr "Аўтаматычная"
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr "Свая"
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr "Памылка атрыманьня шляху для файла часопіса!"
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
@@ -989,18 +959,18 @@ msgstr ""
 "Celestia ня можа працаваць, бо каталёґ за зьвесткамі адсутнічае, магчыма "
 "праз няправільнае ўсталяваньне."
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Нябесны каталёґ"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 msgid "Info Browser"
 msgstr "Аглядальнік зьвестак"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Сонечная сыстэма"
 
@@ -1010,19 +980,19 @@ msgstr "Сонечная сыстэма"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Зоркі"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr "Аб'екты глыбокага космасу"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Пошук падзей"
@@ -1031,109 +1001,106 @@ msgstr "Пошук падзей"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Час"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Накіроўныя"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 msgid "Full screen"
 msgstr "На ўвесь экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 msgid "Error opening bookmarks file"
 msgstr "Памылка падчас адкрыцьця файла закладак"
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 msgid "Error Saving Bookmarks"
 msgstr "Памылка падчас захоўваньня файла закладак"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 msgid "Save Image"
 msgstr "Захаваць відарыс"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr "Відарысы (*.png *.jpg)"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Захапіць відэа"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr "Відэа (*.avi)"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 msgid "Matroska Video (*.mkv)"
 msgstr "Відэа \"Матрошка\" (*.mkv)"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr "Разрозьненьне:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr "%1 × %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Часьціня кадраў:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr "Відэакодэк:"
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr "Бяз страт"
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr "Са стратамі (H.264)"
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr "Бітрэйт:"
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr "Зрабіць здымак экрана ў буфэр абмену"
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Скапіяваны URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 msgid "Pasting URL"
 msgstr "Устаўка URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Open Script"
 msgstr "Адкрыць сцэнар"
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Сцэнары Celestia (*.celx *.cel)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 msgid "New bookmark"
 msgstr "Новая закладка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1161,302 +1128,302 @@ msgstr ""
 "a><br>Праект GitHub: <a href=\"https://github.com/CelestiaProject/Celestia"
 "\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 msgid "Unknown compiler"
 msgstr "Невядомы кампілятар"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr "падтрымліваецца"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr "не падтрымліваецца"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Пра Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>Вэрсія %1:</b> %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Пастаўшчык:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Рэндэрэр:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "<b>Вэрсія %1: </b> %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "<b>Найбольшая колькасьць тэкстур:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>Найбольшы памер тэкстур:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "<b>Дыяпазон памераў пунктаў:</b> %1 - %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "<b>Крок памераў пунктаў:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "<b>Найбольшы памер кубічнае мапы:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "<b>Колькасьць інтэрпалятараў:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr "<b>Найбольшая анізатропная фільтрацыя:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Пашырэньні, якія падтрымліваюцца:</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 msgid "Renderer Info"
 msgstr "Зьвесткі пра рэндэрэр"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 msgid "&Grab image"
 msgstr "&Захапіць відарыс"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 msgid "Capture &video"
 msgstr "Захапіць &відэа"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr "Shift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr "&Капіяваць відарыс"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Адкрыць сцэнар…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr "&Настаўленьні…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Выйсьці"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Навіґацыя"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 msgid "Select Sun"
 msgstr "Вылучыць Сонца"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 msgid "Center Selection"
 msgstr "Цэтраваць вылучэньне"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Goto Selection"
 msgstr "Перайсьці да вылучэньня"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Перайсьці да аб'екта…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr "Капіяваць URL / тэкст кансолі"
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr "Уставіць URL / тэкст кансолі"
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Час"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 msgid "Set &time"
 msgstr "Задаць &час"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 msgid "&Display"
 msgstr "П&аказаць"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 msgid "Dee&p Sky Objects"
 msgstr "Аб'екты &глыбокага космасу"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 msgid "&Shadows"
 msgstr "&Цені"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Стыль зорак"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr "Разрозьненьне &тэкстур"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 msgid "&FPS control"
 msgstr "&Часьціня кадраў"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Закладкі"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Прагляд"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 msgid "&MultiView"
 msgstr "&Мультывід"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 msgid "Split view vertically"
 msgstr "Падзяліць па вэртыкалі"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 msgid "Split view horizontally"
 msgstr "Падзяліць па гарызанталі"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 msgid "Cycle views"
 msgstr "Зьмяніць актыўны прагляд"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 msgid "Single view"
 msgstr "Адзіны від"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 msgid "Delete view"
 msgstr "Выдаліць від"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Выдаліць"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 msgid "Frames visible"
 msgstr "Бачныя межы"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 msgid "Active frame visible"
 msgstr "Межы актыўнага прагляду"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 msgid "Synchronize time"
 msgstr "Сынхранізаваць час"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Даведка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 msgid "Celestia Manual"
 msgstr "Дапаможнік па Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "Зьвесткі OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 msgid "Add Bookmark..."
 msgstr "Дадаць закладку…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr "Упарадкаваць закладкі…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr "Задаць сваю часьціню кадраў"
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr "Часьціня"
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
@@ -1465,7 +1432,7 @@ msgstr ""
 "Загрузка файлаў зьвестак: %1\n"
 "\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Сцэнары"
@@ -1574,11 +1541,11 @@ msgstr "Паз"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Пазнакі"
 
@@ -1593,7 +1560,7 @@ msgstr "Суз"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Сузор'і"
 
@@ -1612,7 +1579,7 @@ msgstr "Арб"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Арбіты"
 
@@ -1626,18 +1593,18 @@ msgstr "Арбіты"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Плянэты"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Карлікавыя плянэты"
 
@@ -1650,16 +1617,16 @@ msgstr "Карлікавыя плянэты"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Месяцы"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Малыя месяцы"
 
@@ -1672,10 +1639,10 @@ msgstr "Малыя месяцы"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Астэроіды"
 
@@ -1688,10 +1655,10 @@ msgstr "Астэроіды"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Камэты"
 
@@ -1708,11 +1675,11 @@ msgstr "Камэты"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 msgctxt "plural"
 msgid "Spacecraft"
 msgstr "Караблі"
@@ -1728,7 +1695,7 @@ msgstr "Наз"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Назвы"
 
@@ -1738,9 +1705,9 @@ msgstr "Назвы"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Ґаляктыкі"
 
@@ -1748,8 +1715,8 @@ msgstr "Ґаляктыкі"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Шаравыя"
 
@@ -1768,9 +1735,9 @@ msgstr "Адкрытыя скопішчы"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Туманнасьці"
 
@@ -1782,48 +1749,48 @@ msgid "Locations"
 msgstr "Месцы"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Адкрытыя скопішчы"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Воблакі"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Сьвятло начной часткі"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Хвасты камэт"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Атмасфэры"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Цені ад колцаў"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Цені зацьменьняў"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Цені аблокаў"
 
@@ -1889,223 +1856,223 @@ msgstr "Гранічная аўтаяркасьць пры 45°: %L1"
 msgid "Magnitude limit: %L1"
 msgstr "Абмежаваньне велічыні: %L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Назва"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Адлегласьць (с.г.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Бачн. вел"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Абс. вел"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Тып"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 msgid "Closest Stars"
 msgstr "Найбліжэйшыя зоркі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 msgid "Brightest Stars"
 msgstr "Найярчэйшая зоркі"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 msgid "Filter"
 msgstr "Фільтар"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "З плянэтамі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 msgid "Multiple Stars"
 msgstr "Розныя зоркі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 msgid "Barycenters"
 msgstr "Барыцэнтры"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr "Спэктральны тып"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Абнавіць"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 msgid "Mark Selected"
 msgstr "Пазначыць вылучанае"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 msgid "Mark stars selected in list view"
 msgstr "Пазначыць зоркі, вылучаныя ў сьпісе прагляду"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark Selected"
 msgstr "Зьняць пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr "Зьняць пазнакі з зорак, вылучаных у сьпісе прагляду"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 msgid "Clear Markers"
 msgstr "Ачысьціць пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr "Прыбраць усе наяўныя пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Нічога"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Ромб"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Трохкутнік"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Квадрат"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Плюс"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Акружына"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Стрэлка ўлева"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Стрэлка ўправа"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Стрэлка ўверх"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Стрэлка ўніз"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr "Выберы выгляд пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr "Выберы памер пазнакі"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr "Пстрыкні каб выбраць колер пазнак"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr "Метка"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, qt-format
 msgid "%1 objects found"
 msgstr "адшукана %1 абʼектаў"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr "Пазначыць АГК, вылучаныя ў сьпісе прагляду"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr "Зьняць пазнакі з АГК, вылучаных у сьпісе прагляду"
 
@@ -2210,9 +2177,9 @@ msgstr "З паверхні %1"
 msgid "Behind %1"
 msgstr "Па-за %1"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
-msgstr "Celestia не здолела ініцыялізаваць OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
+msgstr "Celestia ня здолела ініцыялізаваць OpenGL 2.1."
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
 msgid "Error: no object selected!\n"
@@ -2375,81 +2342,86 @@ msgstr "<b>Д:</b> %L1%2 %L3' %L4\""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Ш:</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr "Пасьля --dir мусіць быць каталёґ"
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr "Пасьля --conf мусіць быць файл настаўленьняў"
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr "Пасьля --extrasdir мусіць быць каталёґ"
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr "Пасьля --url мусіць быць URL"
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr "Пасьля --log/-l мусіць быць назва файла"
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr "Недапушчальны парамэтар загаднага радку '%s'"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.1"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr "Чорнае цела D65"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr "Клясычныя колеры"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 msgid "Local format"
 msgstr "Мясцовы фармат"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 msgid "Time zone name"
 msgstr "Назва часавага поясу"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 msgid "UTC offset"
 msgstr "Зрух ад UTC"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, qt-format
 msgid "Start: %1"
 msgstr "Пачатак: %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr "Канец: %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
-msgstr "%.3f км"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
+msgstr "{:.3f} с.г."
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
-msgstr "%.3f м"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
+msgstr "{:.3f} АА"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr "{:.3f} км"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr "{:.3f} м"
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Адлегласьць: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Абс (бач) вел: "
 
@@ -2462,21 +2434,21 @@ msgid "&Select"
 msgstr "&Вылучыць"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Цэнтраваць"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Перайсьці"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Ісьці ўсьлед"
 
@@ -2489,12 +2461,12 @@ msgid "Visible"
 msgstr "Бачны"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Зьняць пазнаку"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 msgid "Select &Primary Body"
 msgstr "Выбраць &бацькоўскае цела"
 
@@ -2507,12 +2479,12 @@ msgid "Disk"
 msgstr "Дыск"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Дадаць пазнаку"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Арыенцірныя пазнакі"
 
@@ -2553,13 +2525,13 @@ msgid "Show &Terminator"
 msgstr "Паказаць &тэрмінатар"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Дадатковыя паверхні"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Нармальны"
 
@@ -2571,7 +2543,7 @@ msgstr "Нармальны"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr "Карлікавыя плянэты"
 
@@ -2582,14 +2554,14 @@ msgstr "Карлікавыя плянэты"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr "Малыя месяцы"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 msgid "Other objects"
 msgstr "Іншыя аб'екты"
 
@@ -2598,7 +2570,7 @@ msgid "Set Time"
 msgstr "Задаць час"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Часавы пояс: "
 
@@ -2654,7 +2626,7 @@ msgid "Set Seconds"
 msgstr "Задаць секунды"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Юліянская дата: "
 
@@ -2666,85 +2638,85 @@ msgstr "Задаць юліянскую дату"
 msgid "Set time"
 msgstr "Задаць час"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Барыцэнтар"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr "Зорка"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Плянэта"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr "Карлікавая плянэта"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Месяц"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 msgid "Minor moon"
 msgstr "Малы месяц"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Астэроід"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Камэта"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Карабель"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 msgid "Reference point"
 msgstr "Арыенцір"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 msgid "Component"
 msgstr "Складнік"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 msgid "Surface feature"
 msgstr "Дэталь паверхні"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr "Невядомая"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr "Астэроіды й камэты"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 msgid "Reference points"
 msgstr "Арыенціры"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr "Складнікі"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 msgid "Surface features"
 msgstr "Дэталі паверхні"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 msgid "Planets and moons"
 msgstr "Плянэты і месяцы"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr "Ґрупаваць аб'екты паводле клясы"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr "Пазначыць целы, вылучаныя ў сьпісе прагляду"
 
@@ -2860,7 +2832,7 @@ msgstr "Апісаньне:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Упарадкаваць закладкі"
 
@@ -2955,63 +2927,63 @@ msgstr "Паказваць арбіты"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 msgid "Fading orbits"
 msgstr "Зьнікаючыя арбіты"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr "Частковыя траекторыі"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Сеткі"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Экватарыяльная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Экліптычная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Ґаляктычная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Гарызантальная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Дыяґрамы"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Межы"
 
@@ -3192,39 +3164,39 @@ msgstr "Фармат адлюстраваньня даты:"
 msgid "Not an XBEL version 1.0 file."
 msgstr "Не зьяўляецца файлам XBEL вэрсіі 1.0."
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr "Няправільнае шаснаццаткавае значэньне \"{}\"\n"
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr "URL мусіць пачынацца з \"{}\"!\n"
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr "URL мусіць мець прынамсі рэжым і час!\n"
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Рэжым URL \"{}\" не падтрымліваецца!\n"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr "URL мусіць мець толькі адно цела\n"
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr "URL мусіць мець 2 целы\n"
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr "Недапушчальная вэрсія URL \"{}\"!\n"
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 msgid "Unsupported URL version: {}\n"
 msgstr "Вэрсія URL {} не падтрымліваецца\n"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr "Парамэтар URL мусіць выглядаць як ключ=значэньне\n"
 
@@ -3469,13 +3441,13 @@ msgstr "&Пра Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "Так"
 
@@ -3562,7 +3534,7 @@ msgid "Create in >>"
 msgstr "Стварыць у >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Новы каталёґ…"
 
@@ -3643,7 +3615,7 @@ msgid "Go to Object"
 msgstr "Перайсьці да аб'екта"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Перайсьці да"
 
@@ -3660,7 +3632,7 @@ msgid "Lat."
 msgstr "Шыр."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Адлегласьць"
 
@@ -3708,169 +3680,173 @@ msgstr "Найменшы памер дэталі"
 msgid "Size:"
 msgstr "Памер:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr "Кодэк:"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Перайменаваць…"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Перайменаваць закладку ці каталёґ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Новая назва"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Задаць час сымуляцыі"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Фармат: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Цяперашні час"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Каталёґ сонечнай сыстэмы"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Перайсьці да"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Аб'екты сонечнай сыстэмы"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Каталёґ зорак"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Найбліжэйшыя"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Найярчэйшыя"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "З плянэтамі"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Абнавіць"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Крытэр пошуку зорак"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Найбольшая колькасьць зорак у сьпісе"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Даведнік"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Выберы мэту прызначэньня:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Выборы прагляду"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Show:"
 msgstr "Паказваць:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Rings"
 msgstr "Кольцы"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 msgid "Display:"
 msgstr "Адлюстроўваць:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Лінія экліптыкі"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 msgid "Body / Orbit / Label display"
 msgstr "Паказваць аб'екты / арбіты / назвы"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Лацінскія назвы"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Тэкст зьвестак"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Сьцісла"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Падрабязна"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "423"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Кра"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Лют"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Сту"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Чэр"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Сак"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Тра"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Жні"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Сьн"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Ліп"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Ліс"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Кас"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Вер"
 
@@ -3886,7 +3862,7 @@ msgstr "Дата"
 msgid "Start"
 msgstr "Пачатак"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
@@ -3894,152 +3870,157 @@ msgstr ""
 "Адсутнічае файл ліцэнзіі!\n"
 "Глядзі http://www.gnu.org/copyleft/gpl.html"
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr "%d × %d"
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Ваконны рэжым"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Нябачныя"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "&Сынхранізаваць арбіту"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Зьвесткі"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Паказаць восі цела"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Паказаць восі сыстэмы каардынат"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Паказваць напрамак Сонца"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Паказваць вэктар хуткасьці"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Паказваць плянэтаґрафічную сетку"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Паказаць тэрмінатар"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Спадарожнікі"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Арбітальныя целы"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Немагчыма пераключыцца ў поўнаэкранны рэжым, працую ў ваконным рэжыме"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 msgid "Error"
 msgstr "Памылка"
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr "Не атрымалася зарэґістраваць клясу вакна."
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr "Фатальная памылка"
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr "Не атрымалася атрымаць патрэбны фармат піксэляў для працы OpenGL."
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr "Твая сыстэма не падтрымлівае OpenGL 2.1!"
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr "Не атрымалася вызваліць кантэкст прылады."
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr "Захаваць як - выберы файл, у які запісаць відарыс"
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr "Не атрымалася захаваць відарыс."
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr "Спыні захоп відэа перад пачаткам новага."
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr "Захаваць як - выберы файл, у які запісаць відэа"
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr "Невядомае пашырэньне файла выбранага для захопу відэа."
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr "Вызначанае пашырэньне файлу нераспазнанае."
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 msgid "Could not capture movie."
 msgstr "Не атрымалася захапіць відэа."
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 msgid "Celestia Command Line Error"
 msgstr "Памылка ў загадным радку Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Загрузка: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 msgid "Loading data files..."
 msgstr "Загрузка файлаў зьвестак…"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "be"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 msgid "Configuration file missing!"
 msgstr "Файл настаўленьняў адсутнічае!"
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
@@ -4047,21 +4028,21 @@ msgstr ""
 "Знойдзены стары файл абранага.\n"
 "Ці скапіяваць яго ў новае месца?"
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr "Ці капіяваць абранае?"
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr "Не атрымалася стварыць вакно праґрамы."
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Загрузка URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Вэрсія: "
 
@@ -4093,16 +4074,20 @@ msgstr "Не атрымалася адкрыць файл для захопу в
 msgid "Error writing PNG file '{}'\n"
 msgstr "Памылка запісу файла PNG {}\n"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Памылка падчас адкрыцьця файла сцэнара."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 msgid "Unknown error loading script"
 msgstr "Невядомая памылка падчас адкрыцьця сцэнара"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr "У радку {}: {}"
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4121,7 +4106,7 @@ msgstr ""
 "Ці давяраеш сцэнару й хочаш дазволіць гэта?\n"
 "y = так, ESC = спыніць сцэнар, іншая клявіша = не"
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4138,9 +4123,8 @@ msgstr ""
 "Ці давяраеш сцэнару й хочаш дазволіць гэта?"
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Памылка падчас адкрыцьця сцэнара «%s»"
+msgid "Error opening script {}"
+msgstr "Памылка падчас адкрыцьця сцэнара {}"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4148,9 +4132,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Памылка падчас ініцыялізацыі супраграмы сцэнара"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr "Памылка адкрыцьця LuaHook «%s»"
+msgid "Error opening LuaHook {}"
+msgstr "Памылка адкрыцьця LuaHook {}"
 
 #: ../src/celscript/lua/luascript.cpp:231
 msgid "Unknown error loading hook script"
@@ -4163,6 +4146,30 @@ msgstr "GetTimeZoneInformation() вернула невядомае значэн�
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 msgid "Error opening {} or .\n"
 msgstr "Памылка адкрыцьця {} ці .\n"
+
+#~ msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
+#~ msgstr "Ровень %i, %.5f с.г., %i вузлоў, %i  зорак\n"
+
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Спосаб рэндэрынґу: OpenGL 2.1"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Эфэкт «bloom» задзейнічаны"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Эфэкт «bloom» абязьдзейнены"
+
+#~ msgid "Exposure"
+#~ msgstr "Насьвятленьне"
+
+#~ msgid "Video (*.avi)"
+#~ msgstr "Відэа (*.avi)"
+
+#~ msgid "%.3f km"
+#~ msgstr "%.3f км"
+
+#~ msgid "%.3f m"
+#~ msgstr "%.3f м"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -2,31 +2,32 @@
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Hleb Valoshka <375gnu@gmail.com>, 2021
 # Georgi Georgiev (Жоро) <g.georgiev.shumen@gmail.com>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Georgi Georgiev (Жоро) <g.georgiev.shumen@gmail.com>, 2021\n"
-"Language-Team: Bulgarian (https://www.transifex.com/celestia/teams/93131/bg/)\n"
+"Language-Team: Bulgarian (https://www.transifex.com/celestia/teams/93131/"
+"bg/)\n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "ЛЧВ"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "СЧВ"
 
@@ -42,45 +43,47 @@ msgstr "{}:{} очаква се „Configuration“.\n"
 msgid "{}: Bad configuration file.\n"
 msgstr "{}: Неточен конфигурационен файл.\n"
 
+#.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
 #. for (int i = 0; i < nDSOs; ++i)
 #. {
 #. if(DSOs[i]->getAbsoluteMagnitude() == DSO_DEFAULT_ABS_MAGNITUDE)
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
+#.
 #: ../src/celengine/dsodb.cpp:377
 msgid "Loaded {} deep space objects\n"
 msgstr "Заредени са {} обекти от дълбокия космос\n"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Галактика (спецификация на Хъбъл: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Кълбовиден (размер на ядрото: %4.2f', плътност: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 msgid "Loading image from file {}\n"
 msgstr "Зареждане на изображение от файл {}\n"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Зареждане на модел: %s\n"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
+#, fuzzy
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 "   Данни за модела: %u върхове, %u примитиви, %u материали (%u уникални)\n"
 
-#: ../src/celengine/meshmanager.cpp:553
-#, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Грешка при зареждане на модел „%s“\n"
 
 #: ../src/celengine/nebula.cpp:39
@@ -95,108 +98,103 @@ msgstr "Разсеян куп"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Грешка в „.ssc“ файла (линия {}): {}\n"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr "Неправилна стойност на „GeomAlbedo“: {}\n"
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr "Неправилна стойност на „Reflectivity“: {}\n"
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr "Неправилна стойност на „BondAlbedo“: {}\n"
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "основното тяло „%s“ на „%s“ не е намерено.\n"
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "предупреждение за дублираща се дефиниция на %s %s\n"
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "неточна алтернативна повърхност"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "неточно местоположение"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Неточна заглавка за кръстосаното индексиране\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Неточна версия за кръстосаното индексиране\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 msgid "Loading cross index failed\n"
 msgstr "Зареждането на кръстосаното индексиране се провали\n"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 msgid "Loading cross index failed at record {}\n"
 msgstr "Зареждането на кръстосаното индексиране дава грешка при {}\n"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Неточен спектрален клас в звездната база от данни, звезда №{}\n"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 msgid "{} stars in binary database\n"
 msgstr "{} звезди в двоичната база от данни\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 msgid "Total star count: {}\n"
 msgstr "Общ брой на звездите: {}\n"
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Грешка в „.stc“ файла (линия {}): {}\n"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Невалидна звезда: неточен спектрален клас.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Невалидна звезда: липсва спектралния клас.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 msgid "Barycenter {} does not exist.\n"
 msgstr "Центърът на масата {} не съществува.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Невалидна звезда: липсва ректасцензията\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Невалидна звезда: липсва деклинацията.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Невалидна звезда: липсва разстоянието.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Невалидна звезда: липсва звездната величина.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Невалидна звезда: трябва да бъде зададена абсолютната (не видимата) звездна "
 "величина за звездата, близо до източника\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr "Ниво %i, %.5f сг, %i възли, %i звезди\n"
 
 #: ../src/celengine/texture.cpp:928
 msgid "Creating tiled texture. Width={}, max={}\n"
@@ -226,509 +224,490 @@ msgstr "Неподдържан байтов ред {}, очакван {}.\n"
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Неподдържано число {}, очаквано {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr "{} не съществува или не е папка\n"
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 msgid "Error reading favorites file {}.\n"
 msgstr "Грешка при четене на файла с фаворити {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr "Неуспешна проверка на папката за файла с фаворити {}\n"
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr "Неуспешно създаване на папката за файла с фаворити {}\n"
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Невалиден файлов формат"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Лимит на звездната величина: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Маркерите са включени"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Маркерите са изключени"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Отиди до повърхността"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Алт-азимуталният режим е включен"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Алт-азимуталният режим е изключен"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Стил на звездите: неясни точки"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Стил на звездите: точки"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Стил на звездите: мащабирани дискове"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Опашките на кометите са включени"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Опашките на кометите са изключени"
 
-#: ../src/celestia/celestiacore.cpp:1188
-msgid "Render path: OpenGL 2.1"
-msgstr "Възпроизвеждане с: „OpenGL 2.1“"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 msgid "Anti-aliasing enabled"
 msgstr "Изглаждането е включено"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 msgid "Anti-aliasing disabled"
 msgstr "Изглаждането е изключено"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Автоматичната звездна величина е включена"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Автоматичната звездна величина е изключена"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Отказ"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Времето и скрипта са спрени"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Времето е спряно"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Продължи"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr "Звезден цвят: Цветови стандарт D65"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr "Звезден цвят: Засилен"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Време за пътуване на светлината:  %.4f г"
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Време за пътуване на светлината:  %d м  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Време за пътуване на светлината:  %d ч  %d м  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Забавянето на светлината е включено"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Забавянето на светлината е изключено"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Забавянето на светлината е игнорирано"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Използване на нормални повърхностни текстури."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Използване на ограничени повърхностни текстури."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Следвай"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Време: Напред"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Време: Назад"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, c-format
 msgid "Time rate: %.6g"
 msgstr "Времева ставка: %.6g"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 msgid "Low res textures"
 msgstr "Текстури с ниско качество"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 msgid "Medium res textures"
 msgstr "Текстури със средно качество"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr "Текстури с високо качество"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Синхронизирай с орбитата"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Заключи"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Преследвай"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Лимит на звездната величина:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Автоматичен лимит на звездната величина при 45°:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Яркост на фоновата светлина:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Увеличение на светлината"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Блясъкът е включен"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Блясъкът е изключен"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Експозиция"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Грешка при „OpenGL“: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Изгледът е прекалено малък, за да бъде раздвоен"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Изгледът е добавен"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr "Мпк"
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr "кпк"
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "сг"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "ае"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 msgid "mi"
 msgstr "ми"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr "фт"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529
-#: ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/celestiacore.cpp:2534
-#: ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/celestiacore.cpp:2557
-#: ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 msgid "days"
 msgstr "дни"
 
-#: ../src/celestia/celestiacore.cpp:2562
-#: ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "hours"
 msgstr "часа"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 msgid "minutes"
 msgstr "минути"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 msgid "seconds"
 msgstr "секунди"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Период на въртене: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr "Маса: %.6g лб\n"
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr "Маса: %.6g кг\n"
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr "Маса: %.2f Юп\n"
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr "Маса: %.2f Зем\n"
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 msgid "ly/s"
 msgstr "сг/с"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 msgid "AU/s"
 msgstr "АЕ/с"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr "ми/с"
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr "фт/с"
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 msgid "km/s"
 msgstr "км/с"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 msgid "m/s"
 msgstr "м/с"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr "Скорост: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr "δ: %+d%s %02d' %.1f\"\n"
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr "α: %dч %02dм %.1fс\n"
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Видим диаметър: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Видима звездна величина: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Абсолютна звездна величина: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr "%.6f%c %.6f%c %s"
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Разстояние: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Център на масата на звездната система\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Абс. (видима) величина: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Яркост: %s слънца\n"
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Неутронна звезда"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Черна дупка"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, c-format
 msgid "Class: %s\n"
 msgstr "Спектрален клас: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2860
-#, c-format
-msgid "Surface temp: %s K\n"
+#: ../src/celestia/celestiacore.cpp:2905
+#, fuzzy, c-format
+msgid "Surface temp: %s\n"
 msgstr "Температура на повърхността: %s К\n"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Радиус: %s сл. рад.  (%s)\n"
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Радиус: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Налични са планетарни спътници\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Разстояние от центъра: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, c-format
+msgid "Radius: %s\n"
+msgstr "Радиус: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Фазов ъгъл: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr "Плътност: %.2f х 1000 лб/фт^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "Плътност: %.2f х 1000 кг/м^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2999
-#, c-format
-msgid "Temperature: %.0f K\n"
+#: ../src/celestia/celestiacore.cpp:3045
+#, fuzzy, c-format
+msgid "Temperature: %s\n"
 msgstr "Температура: %.0f K\n"
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Реално време"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Реално време"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Времето е спряно"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, c-format
 msgid "%.6g x faster"
 msgstr "%.6g пъти по-бързо"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, c-format
 msgid "%.6g x slower"
 msgstr "%.6g пъти по-бавно"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (На пауза)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
@@ -737,178 +716,177 @@ msgstr ""
 "ЧКС: %.1f, стат. на видимите звезди: [ %zu : %zu : %zu ], стат. на видимите "
 "ОДК: [ %zu : %zu : %zu ]\n"
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr "ЧКС: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Придвижване (%s)\n"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, c-format
+#: ../src/celestia/celestiacore.cpp:3291
 msgid "Travelling\n"
 msgstr "Придвижване\n"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, c-format
 msgid "Track %s\n"
 msgstr "Следвай %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, c-format
 msgid "Follow %s\n"
 msgstr "Следвай %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Синхронизирай с орбитата %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Заключи %s -> %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, c-format
 msgid "Chase %s\n"
 msgstr "Преследвай %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr "ЗП: %s (%.2f пъти)\n"
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, c-format
 msgid "Target name: %s"
 msgstr "Име на целта: %s"
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr "%dx%d при %.2f ЧКС  %s"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Paused"
 msgstr "На пауза"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Recording"
 msgstr "Записване"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 за Старт и Пауза    F12 за Спиране"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Режим на редактиране"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Пропускане на системен каталог: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 msgid "Loading solar system catalog: {}\n"
 msgstr "Зареждане на системен каталог: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 msgid "Skipping {} catalog: {}\n"
 msgstr "Пропускане на {} каталог: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 msgid "Loading {} catalog: {}\n"
 msgstr "Зареждане на {} каталог: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Грешка при четене на {} каталог: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Грешка при четене на конфигурационния файл."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Създаването на библиотеката „SPICE“ се провали."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Звездната база данни не може да бъде прочетена."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Грешка при отваряне на каталога за ОДН {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Базата от данни с ОДН не може да бъде прочетена {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Грешка при отваряне на системния каталог {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 msgid "Error opening asterisms file {}.\n"
 msgstr "Грешка при отваряне на астеризмите {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Грешка при отваряне на очертанията на съзвездията {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Неуспешно стартиране на възпроизвеждането"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Грешка при зареждане на шрифта, текстът няма да е видим.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 msgid "Error reading cross index {}\n"
 msgstr "Грешка при четене на кръстосаното индексиране {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 msgid "Loaded cross index {}\n"
 msgstr "Кръстосаното индексиране {} е заредено\n"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Грешка при четене на файла с имената на звездите\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 msgid "Error opening {}\n"
 msgstr "Грешка при отваряне на {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Грешка при четене на файла с звездите\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 msgid "Error opening star catalog {}\n"
 msgstr "Грешка при отваряне на звездния каталог {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr "Невалидна връзка"
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr "Неуспешно прихващане на кадъра!\n"
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 msgid "Unsupported image type: {}!\n"
 msgstr "Неподдържан формат на изображението: {}!\n"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr "„Celestia“ не успя да стартира „OpenGL“ 2.1.\n"
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr "Моля, използвайте име, завършващо с „.jpg“ или „.png“."
 
@@ -967,38 +945,38 @@ msgstr "Брой на интерполаторите: %s\n"
 msgid "Max anisotropy filtering: %s\n"
 msgstr "Максимално анизотропно филтриране: %s\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr "Автоматично"
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr "Персонализирано"
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr "Грешка при получаване на пътя за името на дневника!"
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
-"Celestia is unable to run because the data directory was not found, probably"
-" due to improper installation."
+"Celestia is unable to run because the data directory was not found, probably "
+"due to improper installation."
 msgstr ""
 "„Celestia“ не успя да стартира, защото папката с данни липсва, вероятната "
 "причина е неправилна инсталация."
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Небесна търсачка"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 msgid "Info Browser"
 msgstr "Информационна търсачка"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Слънчева система"
 
@@ -1008,20 +986,19 @@ msgstr "Слънчева система"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Звезди"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr "Обекти от дълбокото небе"
 
-#: ../src/celestia/qt/qtappwin.cpp:341
-#: ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Търсач на събития"
@@ -1030,433 +1007,429 @@ msgstr "Търсач на събития"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Време"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Водачи"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 msgid "Full screen"
 msgstr "Цял екран"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 msgid "Error opening bookmarks file"
 msgstr "Грешка при отваряне на отметките"
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 msgid "Error Saving Bookmarks"
 msgstr "Грешка при запазване на отметките"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 msgid "Save Image"
 msgstr "Запази изображение"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr "Изображения (*.png *.jpg)"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Прихвани видео"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr "Видео (*.avi)"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 msgid "Matroska Video (*.mkv)"
 msgstr "Видео формат „Матрьошка“ (*.mkv)"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr "Резолюция:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr "%1 x %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Честота на кадрите:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr "Видео кодек:"
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr "Без загуба"
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr "Със загуба (H.264)"
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr "Побитова скорост:"
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr "Изображението е прихванато към клипборда"
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Копирана връзка"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 msgid "Pasting URL"
 msgstr "Поставяне на връзка"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Open Script"
 msgstr "Отвори скрипт"
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Скриптове на „Celestia“ (*.celx *.cel)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 msgid "New bookmark"
 msgstr "Нова отметка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
-"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit "
-"<b>%1</b>.</p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt "
-"library: %5<br>NAIF kernels are %7<br>AVIF images are %8</p>Runtime Qt "
-"version: %6</p><p>Copyright (C) 2001-2021 by the Celestia Development "
-"Team.<br>Celestia is free software. You can redistribute it and/or modify it"
-" under the terms of the GNU General Public License as published by the Free "
-"Software Foundation; either version 2 of the License, or (at your option) "
-"any later version.</p><p>Main site: <a "
-"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
-"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</a><br>GitHub"
-" project: <a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kernels are %7<br>AVIF images are %8</p>Runtime Qt version: %6</"
+"p><p>Copyright (C) 2001-2021 by the Celestia Development Team.<br>Celestia "
+"is free software. You can redistribute it and/or modify it under the terms "
+"of the GNU General Public License as published by the Free Software "
+"Foundation; either version 2 of the License, or (at your option) any later "
+"version.</p><p>Main site: <a href=\"https://celestia.space/\">https://"
+"celestia.space/</a><br>Forum: <a href=\"https://celestia.space/forum/"
+"\">https://celestia.space/forum/</a><br>GitHub project: <a href=\"https://"
+"github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/"
+"Celestia</a></p></html>"
 msgstr ""
-"<html><h1>„Celestia“ 1.7</h1><p>В процес на разработка, компилация "
-"<b>%1</b>.</p><p>За %2 битови процесори<br>Използва %3 %4<br>Създадена е с "
-"„Qt“: %5<br>Ядрата „NAIF“ са %7<br>Изображенията „AVIF“ са %8</p>Версия на "
-"„Qt“: %6</p><p>Авторско право (C) 2001-2021, Екипа на "
-"„Celestia“.<br>„Celestia“ е безплатен софтуер. Може да се разпространява "
-"и/или променя под условията на „GNU General Public License“, който е "
-"публикуван от „Фондацията за свободен софтуер“, версия 2 или всяка по-нова "
-"версия на Лиценза (по Ваша преценка).</p><p>Сайт: <a "
-"href=\"https://celestia.space/\">https://celestia.space/</a><br>Форум: <a "
-"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</a><br>„GitHub“:"
-" <a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
+"<html><h1>„Celestia“ 1.7</h1><p>В процес на разработка, компилация <b>%1</b>."
+"</p><p>За %2 битови процесори<br>Използва %3 %4<br>Създадена е с „Qt“: "
+"%5<br>Ядрата „NAIF“ са %7<br>Изображенията „AVIF“ са %8</p>Версия на „Qt“: "
+"%6</p><p>Авторско право (C) 2001-2021, Екипа на „Celestia“.<br>„Celestia“ е "
+"безплатен софтуер. Може да се разпространява и/или променя под условията на "
+"„GNU General Public License“, който е публикуван от „Фондацията за свободен "
+"софтуер“, версия 2 или всяка по-нова версия на Лиценза (по Ваша преценка).</"
+"p><p>Сайт: <a href=\"https://celestia.space/\">https://celestia.space/</"
+"a><br>Форум: <a href=\"https://celestia.space/forum/\">https://celestia."
+"space/forum/</a><br>„GitHub“: <a href=\"https://github.com/CelestiaProject/"
+"Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 msgid "Unknown compiler"
 msgstr "Неизвестен компилатор"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr "поддържа се"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr "не се поддържа"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "За „Celestia“"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>%1 версия:</b> %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Доставчик:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Възпроизвеждане:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "<b>%1 Версия:</b> %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "<b>Максимален брой текстури едновременно:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>Максимален размер на текстурите:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "<b>Диапазон на размера на точките:</b> %1 - %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "<b>Гранулация на размера на точките:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "<b>Максимален размер на кубичната карта:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "<b>Брой на интерполаторите:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr "<b>Максимално анизотропно филтриране:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Поддържани разширения:</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 msgid "Renderer Info"
 msgstr "Информация за възпроизвеждането"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 msgid "&Grab image"
 msgstr "Запази изображение"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 msgid "Capture &video"
 msgstr "Прихвани видео"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr "Shift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr "Копиране на изображение"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Отвори скрипт..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr "Предпочитания..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Изход"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Навигация"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 msgid "Select Sun"
 msgstr "Избери Слънцето"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 msgid "Center Selection"
 msgstr "Центрирай селекцията"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Goto Selection"
 msgstr "Отиди до селекцията"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Отиди до обект..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr "Копирай връзка или конзолен текст"
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr "Постави връзка или конзолен текст"
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Време"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 msgid "Set &time"
 msgstr "Задай времето"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 msgid "&Display"
 msgstr "&Дисплей"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 msgid "Dee&p Sky Objects"
 msgstr "Обекти от дълбокото небе"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 msgid "&Shadows"
 msgstr "Сенки"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Стил на звездите"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr "Резолюция на текстурите"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 msgid "&FPS control"
 msgstr "Управление на ЧКС"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Отметки"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Изглед"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 msgid "&MultiView"
 msgstr "&Няколко изгледа"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 msgid "Split view vertically"
 msgstr "Раздели изгледа вертикално"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 msgid "Split view horizontally"
 msgstr "Раздели изгледа хоризонтално"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 msgid "Cycle views"
 msgstr "Превърти изгледите"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 msgid "Single view"
 msgstr "Единичен изглед"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 msgid "Delete view"
 msgstr "Изтрий изгледа"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Изтрий"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 msgid "Frames visible"
 msgstr "Видими кадри"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 msgid "Active frame visible"
 msgstr "Видим активен кадър"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 msgid "Synchronize time"
 msgstr "Синхронизирай времето"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Помощ"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 msgid "Celestia Manual"
 msgstr "Ръководство за „Celestia“"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "Информация за „OpenGL“"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 msgid "Add Bookmark..."
 msgstr "Добави отметка..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr "Организирай отметките..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr "Задай персонализирана ЧКС"
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr "Величина на ЧКС"
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
@@ -1465,7 +1438,7 @@ msgstr ""
 "Зареждане на файлове с данни: %1\n"
 "\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Скриптове"
@@ -1515,8 +1488,7 @@ msgid "System time at activation"
 msgstr "Системно време при активиране"
 
 #. i18n: file: ../src/celestia/qt/newbookmarkfolder.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. newBookmarkFolderDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
 #: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
@@ -1575,11 +1547,11 @@ msgstr "МРК"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Маркери"
 
@@ -1594,7 +1566,7 @@ msgstr "СЗВ"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Съзвездия"
 
@@ -1613,7 +1585,7 @@ msgstr "ОРБ"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Орбити"
 
@@ -1627,19 +1599,18 @@ msgstr "Орбити"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581
-#: ../src/celestia/qt/rc.cpp:75 ../src/celestia/qt/rc.cpp:157
-#: ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Планети"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Планети джуджета"
 
@@ -1652,17 +1623,16 @@ msgstr "Планети джуджета"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583
-#: ../src/celestia/qt/rc.cpp:81 ../src/celestia/qt/rc.cpp:163
-#: ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Луни"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Астероидни спътници"
 
@@ -1675,11 +1645,10 @@ msgstr "Астероидни спътници"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742
-#: ../src/celestia/qt/rc.cpp:87 ../src/celestia/qt/rc.cpp:169
-#: ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Астероиди"
 
@@ -1692,11 +1661,10 @@ msgstr "Астероиди"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750
-#: ../src/celestia/qt/rc.cpp:90 ../src/celestia/qt/rc.cpp:172
-#: ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Комети"
 
@@ -1713,12 +1681,11 @@ msgstr "Комети"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746
-#: ../src/celestia/qt/rc.cpp:94 ../src/celestia/qt/rc.cpp:176
-#: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 msgctxt "plural"
 msgid "Spacecraft"
 msgstr "Космически апарати"
@@ -1734,7 +1701,7 @@ msgstr "НДП"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Надписи"
 
@@ -1744,9 +1711,9 @@ msgstr "Надписи"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Галактики"
 
@@ -1754,8 +1721,8 @@ msgstr "Галактики"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Кълбовидни"
 
@@ -1774,9 +1741,9 @@ msgstr "Разсеяни купове"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Мъглявини"
 
@@ -1788,48 +1755,48 @@ msgid "Locations"
 msgstr "Местоположения"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Разсеяни купове"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Облаци"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Нощни светлини"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Опашки на комети"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Атмосфери"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Сенки от пръстени"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Сенки от затъмнения"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Сенки от облаци"
 
@@ -1895,223 +1862,223 @@ msgstr "Автоматичен лимит на звездната величин
 msgid "Magnitude limit: %L1"
 msgstr "Лимит на звездната величина: %L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Име"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Разстояние (сг)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Видима величина"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Абс. величина"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Тип"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 msgid "Closest Stars"
 msgstr "Най-близки звезди"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 msgid "Brightest Stars"
 msgstr "Най-ярки звезди"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 msgid "Filter"
 msgstr "Филтър"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "С планети"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 msgid "Multiple Stars"
 msgstr "Няколко звезди"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 msgid "Barycenters"
 msgstr "Центрове на масата"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr "Спектрален клас"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Опресни"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 msgid "Mark Selected"
 msgstr "Маркирай избраните"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 msgid "Mark stars selected in list view"
 msgstr "Маркирай избраните звезди"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark Selected"
 msgstr "Размаркирай избраните"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr "Размаркирай избраните звезди"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 msgid "Clear Markers"
 msgstr "Изчисти маркерите"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr "Премахни всички съществуващи маркери"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Нищо"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Диамант"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Триъгълник"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Квадрат"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Плюс"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "Х"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Кръг"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Стрелка наляво"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Стрелка надясно"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Стрелка нагоре"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Стрелка надолу"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr "Избери символ на маркера"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr "Избери размер на маркера"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr "Кликнете за да изберете цвят на маркера"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr "Надпис"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, qt-format
 msgid "%1 objects found"
 msgstr "%1 намерени обекта"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr "Маркирай избраните ОДК"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr "Размаркирай избраните ОДК"
 
@@ -2216,8 +2183,9 @@ msgstr "От повърхността на %1"
 msgid "Behind %1"
 msgstr "Зад %1"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+#, fuzzy
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "„Celestia“ не успя да стартира „OpenGL“ 2.1."
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2381,81 +2349,86 @@ msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr "Очаква се име на папката след параметъра „--dir“"
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr "Очаква се име на конфигурационния файл след параметъра „--conf“"
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr "Очаква се име на папката след параметъра „--extrasdir“"
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr "Очаква се връзка след параметъра „--url“"
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr "Очаква се име на файла след параметъра „--log/-l“"
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr "Невалидна опция на командния ред „%s“"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 msgid "OpenGL 2.1"
 msgstr "„OpenGL“ 2.1"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr "Цветови стандарт D65"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr "Класически цветове"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 msgid "Local format"
 msgstr "Местен формат"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 msgid "Time zone name"
 msgstr "Име на часовата зона"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 msgid "UTC offset"
 msgstr "Отклонение по „UTC“"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, qt-format
 msgid "Start: %1"
 msgstr "Начало: %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr "Край: %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
-msgstr "%.3f км"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
+msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
-msgstr "%.3f м"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
+msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Разстояние: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Абс. (видима) величина: "
 
@@ -2468,21 +2441,21 @@ msgid "&Select"
 msgstr "Избери"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "Центрирай"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "Отиди"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "Следвай"
 
@@ -2495,12 +2468,12 @@ msgid "Visible"
 msgstr "Видим"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "Размаркирай"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 msgid "Select &Primary Body"
 msgstr "Избери главно тяло"
 
@@ -2513,12 +2486,12 @@ msgid "Disk"
 msgstr "Диск"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "Маркирай"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "Отправна система"
 
@@ -2559,13 +2532,13 @@ msgid "Show &Terminator"
 msgstr "Покажи терминатора"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "Алтернативни повърхности"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Нормално"
 
@@ -2577,7 +2550,7 @@ msgstr "Нормално"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr "Планети джуджета"
 
@@ -2588,14 +2561,14 @@ msgstr "Планети джуджета"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591
-#: ../src/celestia/qt/rc.cpp:84 ../src/celestia/qt/rc.cpp:166
-#: ../src/celestia/qt/rc.cpp:233 ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr "Астероидни спътници"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 msgid "Other objects"
 msgstr "Други обекти"
 
@@ -2604,7 +2577,7 @@ msgid "Set Time"
 msgstr "Задай времето"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Часова зона: "
 
@@ -2660,7 +2633,7 @@ msgid "Set Seconds"
 msgstr "Задай секундите"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Юлианова дата: "
 
@@ -2672,85 +2645,85 @@ msgstr "Задай Юлианова дата"
 msgid "Set time"
 msgstr "Задай времето"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Център на масата"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr "Звезда"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Планета"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr "Планета джудже"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Луна"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 msgid "Minor moon"
 msgstr "Астероиден спътник"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Астероид"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Комета"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Космически апарат"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 msgid "Reference point"
 msgstr "Отправна точка"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 msgid "Component"
 msgstr "Компонент"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 msgid "Surface feature"
 msgstr "Повърхностна характеристика"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr "Астероиди и комети"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 msgid "Reference points"
 msgstr "Отправни точки"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr "Елементи"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 msgid "Surface features"
 msgstr "Повърхностни характеристики"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 msgid "Planets and moons"
 msgstr "Планети и луни"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr "Групирай обектите по класове"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr "Маркирай избраните тела"
 
@@ -2864,10 +2837,9 @@ msgid "Description:"
 msgstr "Описание:"
 
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. organizeBookmarksDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Организирай отметките"
 
@@ -2962,63 +2934,63 @@ msgstr "Покажи орбитите"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 msgid "Fading orbits"
 msgstr "Избледняване на орбитите"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr "Частични траектории"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Мрежи"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Екваториална"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Еклиптична"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Галактическа"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Хоризонтална"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Диаграми"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Очертания"
 
@@ -3199,39 +3171,39 @@ msgstr "Формат на датата:"
 msgid "Not an XBEL version 1.0 file."
 msgstr "Не е файл с версия 1.0 на „XBEL“."
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr "Неправилна шестнадесетична стойност „{}“\n"
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr "Връзката трябва да започва с „{}“!\n"
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr "Връзката трябва да съдържа поне режим и време!\n"
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Неподдържан режим на връзката „{}“!\n"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr "Връзката трябва да съдържа само едно тяло\n"
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr "Връзката трябва да съдържа 2 тела\n"
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr "Невалидна версия на връзката „{}“!\n"
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 msgid "Unsupported URL version: {}\n"
 msgstr "Неподдържана версия на връзката: {}\n"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr "Параметърът на връзката трябва да изглежда така: key=value\n"
 
@@ -3476,13 +3448,13 @@ msgstr "За „Celestia“"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "ОК"
 
@@ -3567,7 +3539,7 @@ msgid "Create in >>"
 msgstr "Създай в >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Нова папка..."
 
@@ -3648,7 +3620,7 @@ msgid "Go to Object"
 msgstr "Отиди до обект"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Отиди до"
 
@@ -3665,7 +3637,7 @@ msgid "Lat."
 msgstr "Шир."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Разстояние"
 
@@ -3713,169 +3685,173 @@ msgstr "Минимален размер на характеристиките с
 msgid "Size:"
 msgstr "Размер:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Преименувай..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Преименувай отметка или папка"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Ново име"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Задай времето за симулация"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Формат: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Задай към текущото време"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Търсачка на Слънчевата система"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "Отиди до"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Обекти в Слънчевата система"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Звездна търсачка"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Най-близки"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Най-ярки"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "С планети"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "Опресни"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Критерии за търсене на звезди"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Максимален брой на звездите"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Екскурзовод"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Избери дестинация:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Опции на изгледа"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Show:"
 msgstr "Покажи:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Rings"
 msgstr "Пръстени"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 msgid "Display:"
 msgstr "Покажи:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Еклиптична линия"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 msgid "Body / Orbit / Label display"
 msgstr "Покажи телата, орбитите или надписите"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Латински имена"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Информация"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Сбита"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Подробна"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "0402"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Апр"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Феб"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Яну"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Юни"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Мар"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Май"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Авг"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Дек"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Юли"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Ное"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Окт"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Сеп"
 
@@ -3891,7 +3867,7 @@ msgstr "Дата"
 msgid "Start"
 msgstr "Старт"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
@@ -3899,154 +3875,159 @@ msgstr ""
 "Лицензът липсва!\n"
 "Вижте http://www.gnu.org/copyleft/gpl.html"
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, fuzzy, c-format
+msgid "%d x %d"
+msgstr "%1 x %2"
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "В прозорец"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Невидими"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "Синхронизирай с орбитата"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "Информация"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Покажи осите на телата"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Покажи осите на кадъра"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Покажи посоката на Слънцето"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Покажи вектора на ускорението"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Покажи планетографската мрежа"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Покажи терминатора"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "Сателити"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Орбитиращи тела"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Неуспешно превключване в режим на цял екран от режим в прозорец"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 msgid "Error"
 msgstr "Грешка"
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr "Неуспешно регистриране на прозоречния клас."
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr "Фатална грешка"
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 "Не може да бъде избран подходящ формат на пикселите за възпроизвеждане с "
 "„OpenGL“."
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr "Вашата система не поддържа „OpenGL“ 2.1!"
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr "Неуспешно извличане на контекста на устройството."
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr "Запази като – Прихванато изображение"
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr "Изображението не може да бъде запазено."
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr "Спри текущото прихващане на видео, преди започване на следващото."
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr "Запази като – Прихванато видео"
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr "Зададено е неизвестно разширение на файла за прихващане на видео."
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr "Зададеното разширение на файла не е разпознато."
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 msgid "Could not capture movie."
 msgstr "Видеото не може да бъде прихванато."
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 msgid "Celestia Command Line Error"
 msgstr "Грешка в командния ред на „Celestia“"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Зареждане: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 msgid "Loading data files..."
 msgstr "Зареждане на файлове с данни..."
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "bg"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 msgid "Configuration file missing!"
 msgstr "Конфигурационният файл липсва!"
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
@@ -4054,21 +4035,21 @@ msgstr ""
 "Открит е стар файл с фаворити.\n"
 "Копиране към новото местоположение?"
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr "Копиране на фаворитите?"
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr "Неуспешно създаване на прозореца на приложението."
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Зареждане на връзка"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Версия: "
 
@@ -4100,16 +4081,20 @@ msgstr "Прихванатото изображение „{}“ не може �
 msgid "Error writing PNG file '{}'\n"
 msgstr "Грешка при записване на „PNG“ изображението „{}“\n"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Грешка при отваряне на скрипта."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 msgid "Unknown error loading script"
 msgstr "Неизвестна грешка при зареждането на скрипта"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4129,7 +4114,7 @@ msgstr ""
 "\n"
 "„y“ = да, „ESC“ = спиране на скрипта, всички останали клавиши = не"
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4146,8 +4131,8 @@ msgstr ""
 "Сигурни ли сте, че искате да продължите?"
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
 msgstr "Грешка при отваряне на скрипта „%s“"
 
 #: ../src/celscript/lua/luascript.cpp:107
@@ -4156,8 +4141,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Корутинното стартиране на скрипта се провали"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Грешка при отваряне на куката на Lua „%s“"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4171,3 +4156,27 @@ msgstr "„GetTimeZoneInformation()“ отчита неизвестна сто�
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 msgid "Error opening {} or .\n"
 msgstr "Грешка при отваряне на {} или .\n"
+
+#~ msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
+#~ msgstr "Ниво %i, %.5f сг, %i възли, %i звезди\n"
+
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Възпроизвеждане с: „OpenGL 2.1“"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Блясъкът е включен"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Блясъкът е изключен"
+
+#~ msgid "Exposure"
+#~ msgstr "Експозиция"
+
+#~ msgid "Video (*.avi)"
+#~ msgstr "Видео (*.avi)"
+
+#~ msgid "%.3f km"
+#~ msgstr "%.3f км"
+
+#~ msgid "%.3f m"
+#~ msgstr "%.3f м"

--- a/po/celestia.pot
+++ b/po/celestia.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr ""
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr ""
 
@@ -49,34 +49,31 @@ msgstr ""
 msgid "Loaded {} deep space objects\n"
 msgstr ""
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr ""
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 msgid "Loading image from file {}\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:461
-#, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+msgid "Loading model: {}\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+msgid "Error loading model '{}'\n"
 msgstr ""
 
 #: ../src/celengine/nebula.cpp:39
@@ -91,105 +88,100 @@ msgstr ""
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 msgid "Loading cross index failed\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 msgid "Loading cross index failed at record {}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 msgid "{} stars in binary database\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 msgid "Total star count: {}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 msgid "Error in .stc file (line {}): {}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 msgid "Barycenter {} does not exist.\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
-msgstr ""
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
 msgstr ""
 
 #: ../src/celengine/texture.cpp:928
@@ -220,683 +212,661 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 msgid "Error reading favorites file {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr ""
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1188
-msgid "Render path: OpenGL 2.1"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 msgid "Anti-aliasing enabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 msgid "Anti-aliasing disabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr ""
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, c-format
 msgid "Time rate: %.6g"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 msgid "Low res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 msgid "Medium res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 msgid "mi"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "hours"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 msgid "minutes"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 msgid "seconds"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+msgid "Rotation period: {} {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 msgid "ly/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 msgid "AU/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 msgid "km/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 msgid "m/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+msgid "Speed: {} {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, c-format
 msgid "Apparent diameter: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, c-format
 msgid "Distance: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+msgid "Luminosity: {}x Sun\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, c-format
 msgid "Class: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+msgid "Radius: {} Rsun  ({})\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+msgid "Radius: {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, c-format
+msgid "Radius: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, c-format
 msgid "%.6g x faster"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, c-format
 msgid "%.6g x slower"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+msgid "Travelling ({})\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, c-format
+#: ../src/celestia/celestiacore.cpp:3291
 msgid "Travelling\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, c-format
 msgid "Track %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, c-format
 msgid "Follow %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, c-format
 msgid "Chase %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, c-format
 msgid "Target name: %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Paused"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Recording"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 msgid "Skipping solar system catalog: {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 msgid "Loading solar system catalog: {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 msgid "Skipping {} catalog: {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 msgid "Loading {} catalog: {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 msgid "Error reading {} catalog file: {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 msgid "Error opening solar system catalog {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 msgid "Error opening asterisms file {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 msgid "Error reading cross index {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 msgid "Loaded cross index {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 msgid "Error opening {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 msgid "Error opening star catalog {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 msgid "Unsupported image type: {}!\n"
 msgstr ""
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -955,36 +925,36 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr ""
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 msgid "Info Browser"
 msgstr ""
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr ""
 
@@ -994,19 +964,19 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr ""
@@ -1015,109 +985,106 @@ msgstr ""
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr ""
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 msgid "Full screen"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 msgid "Error opening bookmarks file"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 msgid "Error Saving Bookmarks"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 msgid "Save Image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 msgid "Matroska Video (*.mkv)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 msgid "Pasting URL"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Open Script"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 msgid "New bookmark"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1134,309 +1101,309 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 msgid "Unknown compiler"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 msgid "Renderer Info"
 msgstr ""
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 msgid "&Grab image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 msgid "Capture &video"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr ""
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 msgid "Select Sun"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 msgid "Center Selection"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Goto Selection"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 msgid "Set &time"
 msgstr ""
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 msgid "&Display"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 msgid "Dee&p Sky Objects"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 msgid "&Shadows"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 msgid "&FPS control"
 msgstr ""
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr ""
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr ""
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 msgid "&MultiView"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 msgid "Split view vertically"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 msgid "Split view horizontally"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 msgid "Cycle views"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 msgid "Single view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 msgid "Delete view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 msgid "Frames visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 msgid "Active frame visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 msgid "Synchronize time"
 msgstr ""
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 msgid "Celestia Manual"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 msgid "Add Bookmark..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr ""
@@ -1545,11 +1512,11 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr ""
 
@@ -1564,7 +1531,7 @@ msgstr ""
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr ""
 
@@ -1583,7 +1550,7 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr ""
 
@@ -1597,18 +1564,18 @@ msgstr ""
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr ""
 
@@ -1621,16 +1588,16 @@ msgstr ""
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr ""
 
@@ -1643,10 +1610,10 @@ msgstr ""
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr ""
 
@@ -1659,10 +1626,10 @@ msgstr ""
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr ""
 
@@ -1679,11 +1646,11 @@ msgstr ""
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 msgctxt "plural"
 msgid "Spacecraft"
 msgstr ""
@@ -1699,7 +1666,7 @@ msgstr ""
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr ""
 
@@ -1709,9 +1676,9 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr ""
 
@@ -1719,8 +1686,8 @@ msgstr ""
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr ""
 
@@ -1739,9 +1706,9 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr ""
 
@@ -1753,48 +1720,48 @@ msgid "Locations"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr ""
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr ""
 
@@ -1860,223 +1827,223 @@ msgstr ""
 msgid "Magnitude limit: %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr ""
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 msgid "Closest Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 msgid "Brightest Stars"
 msgstr ""
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 msgid "Filter"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 msgid "Multiple Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 msgid "Barycenters"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr ""
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 msgid "Mark Selected"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 msgid "Mark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark Selected"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 msgid "Clear Markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
-msgstr ""
-
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
-msgid "None"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:584
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:504
-#: ../src/celestia/qt/qtselectionpopup.cpp:244
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
-msgid "Diamond"
+#: ../src/celestia/win32/res/resource_strings.cpp:232
+msgid "None"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:585
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:505
-#: ../src/celestia/qt/qtselectionpopup.cpp:245
+#: ../src/celestia/qt/qtselectionpopup.cpp:244
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
-msgid "Triangle"
+msgid "Diamond"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:586
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:506
-#: ../src/celestia/qt/qtselectionpopup.cpp:246
+#: ../src/celestia/qt/qtselectionpopup.cpp:245
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
-msgid "Square"
+msgid "Triangle"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:587
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:507
-#: ../src/celestia/qt/qtselectionpopup.cpp:248
+#: ../src/celestia/qt/qtselectionpopup.cpp:246
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
-msgid "Plus"
+msgid "Square"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:588
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:508
-#: ../src/celestia/qt/qtselectionpopup.cpp:249
+#: ../src/celestia/qt/qtselectionpopup.cpp:248
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
-msgid "X"
+msgid "Plus"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:589
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:509
-#: ../src/celestia/qt/qtselectionpopup.cpp:254
+#: ../src/celestia/qt/qtselectionpopup.cpp:249
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
-msgid "Circle"
+msgid "X"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:590
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:510
-#: ../src/celestia/qt/qtselectionpopup.cpp:250
+#: ../src/celestia/qt/qtselectionpopup.cpp:254
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
-msgid "Left Arrow"
+msgid "Circle"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:591
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:511
-#: ../src/celestia/qt/qtselectionpopup.cpp:251
+#: ../src/celestia/qt/qtselectionpopup.cpp:250
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
-msgid "Right Arrow"
+msgid "Left Arrow"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:592
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:512
-#: ../src/celestia/qt/qtselectionpopup.cpp:252
+#: ../src/celestia/qt/qtselectionpopup.cpp:251
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
-msgid "Up Arrow"
+msgid "Right Arrow"
 msgstr ""
 
 #: ../src/celestia/qt/qtcelestialbrowser.cpp:593
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:513
-#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtselectionpopup.cpp:252
 #: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+msgid "Up Arrow"
+msgstr ""
+
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
+#: ../src/celestia/qt/qtselectionpopup.cpp:253
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, qt-format
 msgid "%1 objects found"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr ""
 
@@ -2181,8 +2148,8 @@ msgstr ""
 msgid "Behind %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2346,81 +2313,86 @@ msgstr ""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 msgid "OpenGL 2.1"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 msgid "Local format"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 msgid "Time zone name"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 msgid "UTC offset"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, qt-format
 msgid "Start: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr ""
 
@@ -2433,21 +2405,21 @@ msgid "&Select"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr ""
 
@@ -2460,12 +2432,12 @@ msgid "Visible"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 msgid "Select &Primary Body"
 msgstr ""
 
@@ -2478,12 +2450,12 @@ msgid "Disk"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr ""
 
@@ -2524,13 +2496,13 @@ msgid "Show &Terminator"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr ""
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr ""
 
@@ -2542,7 +2514,7 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr ""
 
@@ -2553,14 +2525,14 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 msgid "Other objects"
 msgstr ""
 
@@ -2569,7 +2541,7 @@ msgid "Set Time"
 msgstr ""
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr ""
 
@@ -2625,7 +2597,7 @@ msgid "Set Seconds"
 msgstr ""
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr ""
 
@@ -2637,85 +2609,85 @@ msgstr ""
 msgid "Set time"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 msgid "Minor moon"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 msgid "Reference point"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 msgid "Component"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 msgid "Surface feature"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 msgid "Reference points"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 msgid "Surface features"
 msgstr ""
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 msgid "Planets and moons"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -2831,7 +2803,7 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr ""
 
@@ -2926,63 +2898,63 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 msgid "Fading orbits"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr ""
 
@@ -3163,39 +3135,39 @@ msgstr ""
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 msgid "Unsupported URL version: {}\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3440,13 +3412,13 @@ msgstr ""
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr ""
 
@@ -3531,7 +3503,7 @@ msgid "Create in >>"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr ""
 
@@ -3612,7 +3584,7 @@ msgid "Go to Object"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr ""
 
@@ -3629,7 +3601,7 @@ msgid "Lat."
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr ""
 
@@ -3677,169 +3649,173 @@ msgstr ""
 msgid "Size:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
-msgid "Rename..."
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
 msgstr ""
 
 #: ../src/celestia/win32/res/resource_strings.cpp:159
+msgid "Rename..."
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Show:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Rings"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 msgid "Display:"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 msgid "Body / Orbit / Label display"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr ""
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr ""
 
@@ -3855,178 +3831,183 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 msgid "Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 msgid "Could not capture movie."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 msgid "Celestia Command Line Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 msgid "Loading data files..."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 msgid "Configuration file missing!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr ""
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr ""
 
@@ -4058,16 +4039,20 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr ""
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr ""
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 msgid "Unknown error loading script"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4079,7 +4064,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4090,8 +4075,7 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
+msgid "Error opening script {}"
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:107
@@ -4100,8 +4084,7 @@ msgid "Script coroutine initialization failed"
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, c-format
-msgid "Error opening LuaHook '%s'"
+msgid "Error opening LuaHook {}"
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:231

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-08-10 19:42+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -54,35 +54,34 @@ msgstr "Fehler beim Einlesen der Konfigurationsdatei."
 msgid "Loaded {} deep space objects\n"
 msgstr " Deep-Space-Objekte"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxie (Hubble-Typ: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Kugelsternhaufen (Kernradius: %4.2f', King-Konzentration: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Lade Bild aus Datei "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Lade Modell: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Fehler beim Laden des Modells '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +97,110 @@ msgstr "Offene Sternhaufen"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Fehler in .ssc-Datei (Zeile "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "Warnung: mehrfache Definition von "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "fehlerhafte Alternative Oberfläche"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "fehlerhafter (Stand-)Ort"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Falsches Header-Format im Cross-Index\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Falsche Version des Cross-Index\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Laden des Cross-Index fehlgeschlagen bei Eintrag "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Laden des Cross-Index fehlgeschlagen bei Eintrag "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Falscher Spektraltyp in Sternkatalog, Stern #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " Sterne im binären Sternkatalog\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Gesamtzahl der Sterne: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Fehler in .stc-Datei (Zeile "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ungültiger Eintrag: Spektraltyp fehlerhaft.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ungültiger Eintrag: Spektraltyp fehlt.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " existiert nicht.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ungültiger Stern: Fehlender Wert für 'right ascension'\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Ungültiger Stern: Fehlender Wert für 'declination'.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Ungültiger Stern: Fehlender Wert für 'distance'.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ungültiger Stern: Fehlender Wert für 'magnitude'.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Unültiger Stern: Absolute (nicht scheinbare) Magnitude für Stern nahe dem "
 "Ursprung benötigt\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -241,721 +235,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Unterstützte Erweiterungen:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Fehler beim Einlesen der Favoriten-Datei."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Falscher Dateityp"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Grenz-Magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Markierungen eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Markierungen ausgeschaltet"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Gehe auf die Oberfläche"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-Azimut-Modus eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-Azimut-Modus ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Stern-Darstellung: verschwommene Punkte"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Stern-Darstellung: Punkte"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Stern-Darstellung: skalierte Scheiben"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Kometenschweife eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Kometenschweife ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Renderpfad: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Alt-Azimut-Modus eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Alt-Azimut-Modus ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Auto-Magnitude eingeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Auto-Magnitude ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Zeit und Skript wurden angehalten"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Zeit wurde angehalten"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Fortsetzen"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Sterndarstellung"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Sterndarstellung"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Lichtlaufzeit:  %.4f Jahre "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Lichtlaufzeit:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Lichtlaufzeit:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Lichtlaufzeit berücksichtigt"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Lichtlaufzeit ausgeschaltet"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Lichtlaufzeit nicht berücksichtigt"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Benutze interpretierende Oberflächentexturen."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Benutze \"Limit of knowledge\"-Oberflächentexturen."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Folgen"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Zeit: vorwärts"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Zeit: rückwärts"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Zeitrate"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Synchr. Orbit"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Verbinden"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Nacheilen"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Grenz-Magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Auto-Magnitude-Grenzwert bei 45 Grad:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Streulicht:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Lichtverstärkung"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Überstrahlung eingeschaltet"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Überstrahlung ausgeschaltet"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Belichtung"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL-Fehler: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Ansicht zu klein zum Aufteilen"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Ansicht hinzugefügt"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "Lj"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "AE"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " Tage"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " Stunden"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " Minuten"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " Sekunden"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " Lj/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " AE/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Geschwindigkeit: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Scheinbarer Durchmesser: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Scheinbare Magnitude: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolute Magnitude: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Entfernung: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Schwerezentrum des Sternsystems\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Absolute (scheinb.) Mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Leuchtkraft: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Neutronenstern"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Schwarzes Loch"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasse: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Oberflächentemp.: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Planetare Begleiter vorhanden\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Entfernung vom Zentrum: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Radius: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Phasenwinkel: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatur: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Echtzeit"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Echtzeit"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Zeit angehalten"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "2x schneller"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "2x langsamer"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Angehalten)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Objekt wird angeflogen "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Objekt wird angeflogen "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Zentriert halten: "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Folge "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synchr. Orbit: "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Nacheilen: "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Name des Ziels: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "  Angehalten"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  Aufnahme"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pause    F12 Beenden"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Editier-Modus"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Lade Sonnensystem-Katalog: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Lade Sonnensystem-Katalog: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Lade Sonnensystem-Katalog: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Lade Sonnensystem-Katalog: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Fehler beim Einlesen der Favoriten-Datei."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Fehler beim Einlesen der Konfigurationsdatei."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Initialisierung der SPICE-Bibliothek ist fehlgeschlagen."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Konnte Stern-Datenbank nicht einlesen."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Fehler beim Öffnen des DSO-Katalogs."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Konnte Stern-Datenbank nicht einlesen."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Fehler beim Öffnen des Sonnensystem-Katalogs.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Fehler beim Öffnen der Asterismen-Datei."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Fehler beim Öffnen der Sternbildgrenzen-Dateien."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Initialisierung des Renderers fehlgeschlagen"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Fehler beim Laden der Schriftdaten, keine Textanzeige möglich.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Fehler beim Einlesen des Cross-Index "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Cross-Index eingelesen "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Fehler beim Einlesen der Sternnamen-Datei\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Fehler beim Öffnen von "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Fehler beim Einlesen der Stern-Datei\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Fehler beim Öffnen des Sternkataloges "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Unterstützte Erweiterungen:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1014,37 +992,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Himmels-Browser"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Himmels-Browser"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Sonnensystem"
 
@@ -1054,19 +1032,19 @@ msgstr "Sonnensystem"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Sterne"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr "Deep-Space-Objekte"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1076,121 +1054,117 @@ msgstr "Finsternis-Suche"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Zeit"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Interessante Ziele"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Vollbild"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Fehler beim Öffnen der Asterismen-Datei."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Lesezeichen verwalten"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Speichern unter:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " ist keine PNG-Datei.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Video aufzeichnen"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Video aufzeichnen"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Video aufzeichnen"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr "Auflösung: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Bildrate:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL kopiert"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Lade URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Skript laden..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Neue Trennlinie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1207,339 +1181,339 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Unbekannter Fehler beim Öffnen des Skripts"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Unterstützte Erweiterungen:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Unterstützte Erweiterungen:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Über Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading Language</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL-Version: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Maximale Anzahl simultaner Texturen: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Maximale Texturgröße: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Bereich der Punktgröße: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Bereich der Punktgröße: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Maximale Cube-Map-Texturgröße: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Renderer: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Datei"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Bildschirmfoto erstellen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Video aufzeichnen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr "Shift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopiere URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Skript laden..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr "&Einstellungen..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "B&eenden"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigation"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Auswählen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "Auswahl &zentrieren\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Auswahl: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Gehe zu..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Zeit"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Zeitquelle:"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Anzeige"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Deep-Space-Objekte"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Wolkenschatten"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Sterndarstellung"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr "Auflösung der &Texturen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Steuerung"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Lesezeichen"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Ansicht"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Mehrfachansicht"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Ansicht vertikal aufteilen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Ansicht horizontal aufteilen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Zur nächsten Ansicht wechseln"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Einzelansicht"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Ansicht entfernen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Entfernen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Rahmen sichtbar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktiver Rahmen sichtbar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Zeitquelle:"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Hilfe"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia-Einstellungen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "OpenGL-Informationen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Name: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr "Lesezeichen verwalten"
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Lade "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Skripte"
@@ -1659,11 +1633,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Markierungen"
 
@@ -1679,7 +1653,7 @@ msgstr "Copyright (C) 2001-2017, Celestia Development Team"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Sternbilder"
 
@@ -1700,7 +1674,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Orbit-Linien"
 
@@ -1714,18 +1688,18 @@ msgstr "Orbit-Linien"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planeten"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Zwergplaneten"
 
@@ -1738,16 +1712,16 @@ msgstr "Zwergplaneten"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Monde"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Kleine Monde"
 
@@ -1760,10 +1734,10 @@ msgstr "Kleine Monde"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroiden"
 
@@ -1776,10 +1750,10 @@ msgstr "Asteroiden"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Kometen"
 
@@ -1796,11 +1770,11 @@ msgstr "Kometen"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1818,7 +1792,7 @@ msgstr "10x Schne&ller\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Bezeichnungen"
 
@@ -1828,9 +1802,9 @@ msgstr "Bezeichnungen"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaxien"
 
@@ -1838,8 +1812,8 @@ msgstr "Galaxien"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Kugelsternhaufen"
 
@@ -1859,9 +1833,9 @@ msgstr "Kugelsternhaufen"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nebel"
 
@@ -1873,48 +1847,48 @@ msgid "Locations"
 msgstr "(Stand-)Orte"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Offene Sternhaufen"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Wolken"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Lichter auf der Nachtseite"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Kometenschweife"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosphären"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Ringschatten"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Finsternis-Schatten"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Wolkenschatten"
 
@@ -1986,237 +1960,237 @@ msgstr "Auto-Magnitude-Grenzwert bei 45 Grad:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Grenz-Magnitude: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Name"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Scheinb. Mag."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Abs. Mag."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Sterne anzeigen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Sterne"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Sterne filtern"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Mit Planeten"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Sterne anzeigen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Schwerezentrum"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Falscher Spektraltyp in Sternkatalog, Stern #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Markierung setzen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maximale Anzahl von Sternen in der Liste"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Markierung setzen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Markierungen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Keiner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Raute"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Dreieck"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Quadrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Kreis"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Pfeil nach links"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Pfeil nach rechts"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Pfeil nach oben"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Pfeil nach unten"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "&Objekt auswählen..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Größe:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "&Objekt auswählen..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Merkmale beschriften"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Deep-Space-Objekte"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Markierung setzen"
@@ -2331,8 +2305,8 @@ msgstr "Lade Bild aus Datei "
 msgid "Behind %1"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2501,86 +2475,91 @@ msgstr "Größe: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Sterndarstellung"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Lokales Format"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Name: "
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC-Versatz"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Start"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Entfernung: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Abs. (scheinb.) Mag.: "
 
@@ -2593,21 +2572,21 @@ msgid "&Select"
 msgstr "&Auswählen"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Zentrieren"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Gehe zu"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Folgen"
 
@@ -2621,12 +2600,12 @@ msgid "Visible"
 msgstr "Aktiver Rahmen sichtbar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Markierung aufheben"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Anzeigemodus auswählen"
@@ -2640,12 +2619,12 @@ msgid "Disk"
 msgstr "Scheibe"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Markierung setzen"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Referenzvektoren"
 
@@ -2693,13 +2672,13 @@ msgid "Show &Terminator"
 msgstr "Zeige Orte"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Alternative Oberflächen"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normal"
 
@@ -2711,7 +2690,7 @@ msgstr "Normal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr "Zwergplaneten"
 
@@ -2722,14 +2701,14 @@ msgstr "Zwergplaneten"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr "Kleine Monde"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Deep-Space-Objekte"
@@ -2740,7 +2719,7 @@ msgid "Set Time"
 msgstr "Zeitquelle:"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Zeitzone: "
 
@@ -2804,7 +2783,7 @@ msgid "Set Seconds"
 msgstr " Sekunden"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Julianisches Datum: "
 
@@ -2818,95 +2797,95 @@ msgstr "Datum: "
 msgid "Set time"
 msgstr "Zeitquelle:"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Schwerezentrum"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr "Stern"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr "Zwergplanet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Mond"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Kleine Monde"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroid"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Komet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Raumfahrzeuge"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Referenzvektoren"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Berechne"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Gehe auf die Oberfläche"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Unbekannter Fehler beim Öffnen des Skripts"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr "Asteroiden und Kometen"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "Verschwommene Punkte"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Besonderheiten"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planeten"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Deep-Space-Objekte"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3028,7 +3007,7 @@ msgstr "Beschreibung:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Lesezeichen verwalten"
 
@@ -3128,7 +3107,7 @@ msgstr "Zeige Orbits"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Landeplätze"
@@ -3136,56 +3115,56 @@ msgstr "Landeplätze"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr "Partielle Flugbahnen"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Koordinatennetze"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Äquatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ekliptikal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galaktisch"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Linien"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Grenzen"
 
@@ -3374,41 +3353,41 @@ msgstr "Datum: "
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Unterstützte Erweiterungen:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Unterstützte Erweiterungen:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3657,13 +3636,13 @@ msgstr "Über &Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3749,7 +3728,7 @@ msgid "Create in >>"
 msgstr "Erzeuge in >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Neuer Ordner..."
 
@@ -3830,7 +3809,7 @@ msgid "Go to Object"
 msgstr "Gehe zu"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Gehe zu"
 
@@ -3847,7 +3826,7 @@ msgid "Lat."
 msgstr "Breitengrad"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Entfernung"
 
@@ -3896,173 +3875,177 @@ msgstr "Minimale Größe beschrifteter Merkmale"
 msgid "Size:"
 msgstr "Größe:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Umbenennen..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Lesezeichen oder Ordner umbenennen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Neuer Name"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Setze Simulationszeit"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Format: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Setze auf aktuelle Zeit"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Sonnensystem-Browser"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Gehe zu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Objekte im Sonnensystem"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Sternkatalog"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Nächste"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Hellste"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "Mit planeten"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Aktualisieren"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Suchkriterien für Sterne"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Maximale Anzahl von Sternen in der Liste"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Interessante Ziele"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Ziel auswählen:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Anzeigeoptionen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Anzeigen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Anzeige"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Ekliptikal"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Orbits / Bezeichnungen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Lateinische Namen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Infotext"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Knapp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Ausführlich"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "407"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mär"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dez"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Sep"
 
@@ -4078,184 +4061,189 @@ msgstr "Datum"
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Fenstermodus"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Unsichtbare Objekte"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "S&ynchr. Orbit"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Körperachsen anzeigen"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Koordinatenachsen anzeigen"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Richtung zur Sonne anzeigen"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Geschwindigkeitsvektor anzeigen"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Gradnetz des Planeten anzeigen"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Terminator anzeigen"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satelliten"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Umlaufende Objekte"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Fehler beim Laden der Schriftdaten, keine Textanzeige möglich.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Fehler: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Video aufzeichnen"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Celestia-Steuerung"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Lade: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Lade "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "de"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Fehler beim Einlesen der Konfigurationsdatei."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Lade URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Version: "
 
@@ -4291,17 +4279,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Fehler beim Lesen der PNG-Bilddatei "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Fehler beim Öffnen der Skript-Datei."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Unbekannter Fehler beim Öffnen des Skripts"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4313,7 +4305,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4324,9 +4316,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Fehler beim Öffnen des Skripts '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Fehler beim Öffnen des Skripts"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4334,8 +4326,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Initialisierung der Skript-Koroutine ist fehlgeschlagen"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Fehler beim Öffnen des Skripts '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4351,6 +4343,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Fehler beim Öffnen von "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Renderpfad: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Überstrahlung eingeschaltet"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Überstrahlung ausgeschaltet"
+
+#~ msgid "Exposure"
+#~ msgstr "Belichtung"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Video aufzeichnen"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Fehler beim Öffnen des Skripts '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6730,9 +6742,6 @@ msgstr "Fehler beim Öffnen von "
 #~ msgid "GLSL version: "
 #~ msgstr "GLSL-Version: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Fehler beim Öffnen des Skripts"
-
 #~ msgid "Error loading script"
 #~ msgstr "Fehler beim Laden des Skripts"
 
@@ -7269,9 +7278,6 @@ msgstr "Fehler beim Öffnen von "
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Oberflächentemp.:"
-
-#~ msgid "Radius: "
-#~ msgstr "Radius: "
 
 #~ msgid "Rsun"
 #~ msgstr "Rsol"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:45+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -54,35 +54,34 @@ msgstr "Σφάλμα κατά την ανάγνωση του αρχείου ρυ
 msgid "Loaded {} deep space objects\n"
 msgstr " αντικείμενα βαθέως ουρανού"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Γαλαξίας (Τύπος Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Φόρτωση εικόνας από αρχείο"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Φόρτωση μοντέλου: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Σφάλμα κατά τη φόρτωση του μοντέλου '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +97,110 @@ msgstr "Ανοιχτό σμήνος "
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Σφάλμα στο αρχείο .ssc (γραμμή "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "προειδοποιήση ανατύπωση ορισμού από "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "λανθασμένη εναλλακτική επιφάνεια"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "λανθασμένη τοποθεσία"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Λανθασμένη επικεφαλίδα για διασταυρωμένο ευρετήριο\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Λανθασμένη έκδοση για διασταυρωτό ευρετήριο\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Η φόρτωση διασταυρωμένου ευρετηρίου απέτυχε κατά την εγγραφή "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Η φόρτωση διασταυρωμένου ευρετηρίου απέτυχε κατά την εγγραφή "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Κακό φασματοσκοπικό είδος στη βάση δεδομένων των αστεριών, αστέρι #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " αστέρες στη δυαδική βάση δεδομένων\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Συνολικό πλήθος αστέρων: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Σφάλμα στο αρχείο .stc (γραμμή"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Άκυρο αστέρι: κακός φασματικός τύπος.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Άκυρο αστέρι: λείπει φασματικός τύπος.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " δεν υπάρχει.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Άκυρο αστέρι:λείπει ορθή αναφορά\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Άκυρο αστέρι:λείπει η κλίση.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Άκυρο αστέρι:λείπει η απόσταση.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Άκυρο αστέρι:λείπει το μέγεθος.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Λανθασμένος αστέρας: πρέπει να καθοριστεί απόλυτο (και όχι φαινόμενο) "
 "μέγεθος για τον αστέρα\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -241,722 +235,706 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Υποστηριζόμενες Επεκτάσεις:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου αγαπημένων."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Μη αποδεκτό είδος αρχείου"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Όριο μεγέθους: %.2f "
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Δείκτες ενεργοποιημένοι"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Δείκτες απενεργοποιημένοι"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Μετάβαση στην επιφάνεια"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Κατάσταση Alt-azimuth ενεργοποιήθηκε"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Κατάσταση Alt-azimuth απενεργοποιήθηκε"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Είδος αστέρων: ασαφή σημεία"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Είδος αστέρων: σημεία"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Είδος αστέρων: δίσκοι υπό κλίμακα"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Εμφάνιση ουράς κομητών"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Απόκρυψη ουράς κομητών"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Μονοπάτι αποτύπωσης: OpenGL 2.0 "
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Κατάσταση Alt-azimuth ενεργοποιήθηκε"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Κατάσταση Alt-azimuth απενεργοποιήθηκε"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Αυτόματο μέγεθος ενεργοποιημένο"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Αυτόματο μέγεθος απενεργοποιημένο "
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Ο χρόνος και το σενάριο έχουν σταματήσει"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Ο χρόνος είναι σταματημένος"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Επανάληψη"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Συνολικό πλήθος αστέρων: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Συνολικό πλήθος αστέρων: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Χρόνος μετακίνησης του φωτός:  %.4f yr "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Χρόνος μετακίνησης του φωτός:  %d min  %.1f s "
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Χρόνος μετακίνησης του φωτός:  %d h  %d min  %.1f s "
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Συμπεριλαμβάνεται η καθυστέρηση του χρόνου μετακίνησης του φωτός"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Δεν συμπεριλαμβάνεται η καθυστέρηση του χρόνου μετακίνησης του φωτός"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Αγνοείται η καθυστέρηση του χρόνου μετακίνησης του φωτός"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Χρήση κανονικών υφών επιφάνειας."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Χρήση περιορισμένης γνώσης για τις υφές επιφάνειας. "
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Παρακολούθηση"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Χρόνος: Μπροστά"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Χρόνος: Πίσω"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Ρυθμός χρόνου"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Υφές"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Υφές"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Υφές"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Συγχρονισμός Τροχιάς"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Κλείδωμα"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Καταδίωξη"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Όριο μεγέθους: %.2f "
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Αυτόματο όριο μέγέθους στις 45 μοίρες: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Επίπεδο περιβάλλοντος φωτός:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Light gain"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Bloom ενεργοποιημένο"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Bloom απενεργοποιημένο"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Έκθεση"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Σφάλμα GL:"
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Προβολή πολύ μικρή για να διαιρεθεί"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Προσθήκη προβολής"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "εφ"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "αμ"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " μ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "χμ"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " μ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " μέρες"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " ώρες"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " λεπτά"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " δευτερόλεπτα"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " εφ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " ΑΜ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " χμ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " μ/δ"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Ταχύτητα:"
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Φαινόμενη διάμετρος: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Φαινόμενο μέγεθος: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Απόλυτο μέγεθος:"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Απόσταση: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Βαρύκεντρο συστήματος αστέρων\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Απόλυτο(φαινόμενο)μέγεθος: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Φωτεινότητα: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Αστέρας νετρονίων"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Μαύρη τρύπα"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Τάξη: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Θερμοκρασία επιφάνειας:"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Planetary companions present\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Απόσταση από το κέντρο: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Ακτίνα: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Θερμοκρασία: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Πραγματικός χρόνος"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Πραγματικός χρόνος "
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Ο χρόνος έχει σταματήσει"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " πιο γρήγορα"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " πιο αργά"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr "(Σταματημένο)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Ταξιδεύοντας"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Ταξιδεύοντας"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Τροχιά"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "&Παρακολούθηση"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Συγχρονισμός Τροχιάς"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Καταδίωξη"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Όνομα στόχου:"
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "  Σταματημένο"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  Εγγραφή"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Εκκίνηση/Παύση    F12 Σταμάτημα "
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Κατάσταση Επεξεργασίας"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Φόρτωση καταλόγου του ηλιακού συστήματος: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Φόρτωση καταλόγου του ηλιακού συστήματος: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Φόρτωση καταλόγου του ηλιακού συστήματος: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Φόρτωση καταλόγου του ηλιακού συστήματος: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου αγαπημένων."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου ρυθμίσεων."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Η αρχικοποίηση της βιβλιοθήκης SPICE απέτυχε."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Δεν ήταν δυνατή η ανάγνωση της βάσης δεδομένων των αστέρων."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του καταλόγου deepsky"
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Δεν ήταν δυνατή η ανάγνωση της βάσης δεδομένων των αστέρων."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του καταλόγου του πλανητικού συστήματος .\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του αρχείου αστερισμών."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Σφάλμα κατά το άνοιγμα των αρχείων των συνόρων των αστερισμών."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Σφάλμα κατά την αρχικοποίηση της μεθόδου αποτύπωσης"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr ""
 "Σφάλμα κατά την φόρτωση της γραμματοσειράς, το κείμενο δε θα είναι ορατό.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Σφάλμα κατά την ανάγνωση του ευρετηρίου "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Φορτώθηκε το ευρετήριο"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου με τα ονόματα των αστεριών\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Σφάλμα κατά το άνοιγμα"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου αστεριών\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Σφάλμα κατά το άνοιγμα του καταλόγου αστέρων "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Υποστηριζόμενες Επεκτάσεις:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1015,37 +993,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Ουράνιος Πλοηγητής"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Ουράνιος Πλοηγητής"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Ηλιακό Σύστημα"
 
@@ -1055,20 +1033,20 @@ msgstr "Ηλιακό Σύστημα"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Άστρα"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " αντικείμενα βαθέως ουρανού"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1078,122 +1056,118 @@ msgstr "Εύρεση Έκλειψης "
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Χρόνος "
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Ταξιδιωτικός Οδηγός"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Πλήρης Οθόνη"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Σύλληψη &Ταινίας...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Σφάλμα κατά το άνοιγμα του αρχείου αστερισμών."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Προσθήκη Σελιδοδεικτών..."
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Αποθήκευση Ως:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " δεν είναι αρχείο PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Σύλληψη Βίντεο"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Σύλληψη Βίντεο"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Σύλληψη Βίντεο"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Ανάλυση:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Ρυθμός καρέ:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Το URL αντιγράφτηκε"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Φόρτωση URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Άνοιγμα Σεναρίου..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Δημιουργία νέου φακέλου σελιδοδείκτη σε αυτή τη λίστα"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1210,349 +1184,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Υποστηριζόμενες Επεκτάσεις:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Υποστηριζόμενες Επεκτάσεις:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Περί Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>Γλώσσα Shading OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Έκδοση GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Μέγιστος αριθμός ταυτόχρονων υφών:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Μέγιστο μέγεθος υφών:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Απόσταση point size: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Απόσταση point size: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Μέγιστο μέγεθος cube map:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Μέθοδος αποτύπωσης:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Αρχείο"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Σύλληψη Εικόνας"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Σύλληψη &Εικόνας...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Σύλληψη Βίντεο"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Σύλληψη &Ταινίας...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Αντιγραφή URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Άνοιγμα Σεναρίου..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Προτιμήσεις Celestia "
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Έ&ξοδος"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Εξομάλυνση Γραμμών\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Πλοήγηση"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Επιλογή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Κεντράρισμα Επιλογής\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Επιλογή: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Μετάβαση στο Αντικείμενο..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Χρόνος "
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Καθορισμός Χρόνου..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Προβολή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Σημειωμένα αντικείμενα"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Εμφάνιση Σκιών από Σύννεφα"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Τ&ύπος Αστέρα"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Ανάλυση Υφής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Πλήκτρα χειρισμού"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "Σ&ελιδοδείκτες "
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Προβολή"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Πολλαπλή Προβολή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Κάθετος Οπτικός Διαχωρισμός Προβολής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Οριζόντιος &Διαχωρισμός\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Οριζόντιος Οπτικός Διαχωρισμός Προβολής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Κάθετος Δ&ιαχωρισμός\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Κυκλική διάταξη Προβολής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Μοναδική Προβολή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Μοναδική Προβολή\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Διαγραφή Προβολής"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Εμφάνιση Πλαισίων"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Εμφάνιση Πλαισίων Ενεργή"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Συγχρονισμός Χρόνου"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Βοήθεια"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Προτιμήσεις Celestia "
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "Πληροφορίες OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Προσθήκη Σελιδοδείκτη"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Οργάνωση Σελιδοδεικτών..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Φόρτωση"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Σενάρια"
@@ -1675,11 +1649,11 @@ msgstr " μ/δ"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Δείκτες"
 
@@ -1695,7 +1669,7 @@ msgstr "&Κεντράρισμα Επιλογής\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Αστερισμοί"
 
@@ -1717,7 +1691,7 @@ msgstr "Εντάξει"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Τροχιές"
 
@@ -1731,18 +1705,18 @@ msgstr "Τροχιές"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Πλάνητες"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Νάνοι Πλανήτες"
 
@@ -1755,16 +1729,16 @@ msgstr "Νάνοι Πλανήτες"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Δορυφόροι"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Μικροί Δορυφόροι"
 
@@ -1777,10 +1751,10 @@ msgstr "Μικροί Δορυφόροι"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Αστεροειδείς"
 
@@ -1793,10 +1767,10 @@ msgstr "Αστεροειδείς"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Κομήτες"
 
@@ -1813,11 +1787,11 @@ msgstr "Κομήτες"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1835,7 +1809,7 @@ msgstr "10x Πιο &Γρήγορα\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Ετικέτες"
 
@@ -1845,9 +1819,9 @@ msgstr "Ετικέτες"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Γαλαξίες"
 
@@ -1855,8 +1829,8 @@ msgstr "Γαλαξίες"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Σφαιροειδή"
 
@@ -1876,9 +1850,9 @@ msgstr "Ανοιχτά Σμήνη "
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Νεφελώματα"
 
@@ -1890,48 +1864,48 @@ msgid "Locations"
 msgstr "Τοποθεσίες"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Ανοιχτά Σμήνη "
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Σύννεφα"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Νυχτερινός Φωτισμός "
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Ουρές Κομητών"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Ατμόσφαιρα"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Σκιές δακτυλίων"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Σκιές έκλειψης"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Σκιές από Σύννεφα"
 
@@ -2004,237 +1978,237 @@ msgstr "Αυτόματο όριο μέγέθους στις 45 μοίρες: %.2
 msgid "Magnitude limit: %L1"
 msgstr "Όριο μεγέθους: %.2f "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Όνομα"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Φαιν. Μέγεθος "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Απόλ. Μέγεθος "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Είδος"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Εμφάνιση Αστέρων"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Άστρα"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Φιλτράρισμα Αστέρων"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Με τους Πλανήτες "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Εμφάνιση Αστέρων"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Βαρύκεντρο"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Κακό φασματοσκοπικό είδος στη βάση δεδομένων των αστεριών, αστέρι #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Ανανέωση"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Σημείωση"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Μέγιστος Αριθμός Αστέρων που Εμφανίζονται στη Λίστα"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Σημείωση"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Δείκτες"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Κανένα"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Ρόμβος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Τρίγωνο"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Τετράγωνο"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Πλεον"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Κύκλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Αριστερό Βέλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Δεξί Βέλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Πάνω Βέλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Κάτω Βέλος"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Επιλογή &Αντικειμένου..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Μέγεθος:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Επιλογή &Αντικειμένου..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Ετικέτες  Δυνατοτήτων"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Αντικείμενα"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Σημείωση"
@@ -2349,8 +2323,8 @@ msgstr "Φόρτωση εικόνας από αρχείο"
 msgid "Behind %1"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2519,86 +2493,91 @@ msgstr "Μέγεθος: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Τ&ύπος Αστέρα"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Τοπική Μορφή"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Όνομα Ζώνης Ώρας "
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Αντιστάθμιση UTC"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Εκκίνηση"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Απόσταση: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Απόλυτο (φαινόμενο) μέγεθος: "
 
@@ -2611,21 +2590,21 @@ msgid "&Select"
 msgstr "&Επιλογή"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Κέντρο"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Μετάβαση"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Παρακολούθηση"
 
@@ -2639,12 +2618,12 @@ msgid "Visible"
 msgstr "Εμφάνιση Πλαισίων Ενεργή"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Αποσημείωση"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Επιλογή Κατάστασης Προβολής"
@@ -2658,12 +2637,12 @@ msgid "Disk"
 msgstr "Δίσκος"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Σημείωση"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Σημεία Αναφοράς"
 
@@ -2711,13 +2690,13 @@ msgid "Show &Terminator"
 msgstr "Εμφάνιση Terminator"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Εναλλαγή Επιφανειών"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Κανονικό"
 
@@ -2729,7 +2708,7 @@ msgstr "Κανονικό"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Νάνοι Πλανήτες"
@@ -2741,15 +2720,15 @@ msgstr "Νάνοι Πλανήτες"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Μικροί Δορυφόροι"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Αντικείμενα"
@@ -2760,7 +2739,7 @@ msgid "Set Time"
 msgstr "Καθορισμός Χρόνου..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Ζώνη Ώρας: "
 
@@ -2825,7 +2804,7 @@ msgid "Set Seconds"
 msgstr " δευτερόλεπτα"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Ιουλιανή Ημερομηνία:"
 
@@ -2839,98 +2818,98 @@ msgstr "Ιουλιανή Ημερομηνία:"
 msgid "Set time"
 msgstr "Καθορισμός Χρόνου..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Βαρύκεντρο"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Κακό φασματοσκοπικό είδος στη βάση δεδομένων των αστεριών, αστέρι #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Πλανήτης "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Νάνος Πλανήτης"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Σελήνη"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Μικροί Δορυφόροι"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Αστεροειδής "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Κομήτης "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Διαστημόπλοιο"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Σημεία Αναφοράς"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Υπολογισμός"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Μετάβαση στην επιφάνεια"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Αστεροειδείς"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Σημεία Αναφοράς"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Άλλες δυνατότητες"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Πλάνητες"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Αντικείμενα"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3063,7 +3042,7 @@ msgstr "Ανάλυση:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Οργάνωση Σελιδοδεικτών "
 
@@ -3170,7 +3149,7 @@ msgstr "Εμφάνιση Τροχιών"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Τοποθεσίες Προσγείωσης "
@@ -3178,7 +3157,7 @@ msgstr "Τοποθεσίες Προσγείωσης "
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Ατελείς τροχιές"
@@ -3186,49 +3165,49 @@ msgstr "Ατελείς τροχιές"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Πλέγματα"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Ισημερινή"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ελλειπτικά"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Γαλαξιακό"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Οριζόντια"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Διαγράμματα"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Σύνορα"
 
@@ -3430,41 +3409,41 @@ msgstr "Προβολή"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Υποστηριζόμενες Επεκτάσεις:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Υποστηριζόμενες Επεκτάσεις:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3714,13 +3693,13 @@ msgstr "Περ&ί Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "Εντάξει"
 
@@ -3808,7 +3787,7 @@ msgid "Create in >>"
 msgstr "Δημιουργία σε >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Νέος Φάκελος... "
 
@@ -3889,7 +3868,7 @@ msgid "Go to Object"
 msgstr "Μετάβαση στο Αντικείμενο "
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Μετάβαση"
 
@@ -3906,7 +3885,7 @@ msgid "Lat."
 msgstr "Πλάτ."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Απόσταση"
 
@@ -3956,174 +3935,178 @@ msgstr "Ελάχιστο Χαρακτηριστικό Μέγεθος"
 msgid "Size:"
 msgstr "Μέγεθος:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Μετονομασία..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Μετονομασία Σελιδοδείκτη ή Φακέλου"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Νέο Όνομα"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Καθορισμός Χρόνου Προσομοίωσης"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Μορφή: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Καθορισμός Τρέχοντος Χρόνου"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Πλοηγός Ηλιακού Συστήματος"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Μετάβαση"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Αντικείμενα Ηλιακού Συστήματος"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Ουράνιος Πλοηγητής"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Κοντινότερος"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Λαμπρότερο"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "Με τους πλανήτες "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Ανανέωση"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Κριτήρια Αναζήτησης Αστέρων"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Μέγιστος Αριθμός Αστέρων που Εμφανίζονται στη Λίστα"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Ταξιδιωτικός Οδηγός"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Επιλέξτε τον προορισμό σας:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Επιλογές Προβολής"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Εμφάνιση"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Ρυθμίσεις"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Προβολή"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 #, fuzzy
 msgid "Ecliptic Line"
 msgstr ", γραμμή"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Τροχιές  / Ετικέτες"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Λατινικά Ονόματα"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Πληροφοριακό Κείμενο"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Περιεκτικός "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Διεξοδικός"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "408"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Απρ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Φεβ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Ιαν"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Ιούν"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Μαρ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Μάι"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Αύγ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Δεκ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Ιούλ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Νοέ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Οκτ "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Σεπ"
 
@@ -4139,185 +4122,190 @@ msgstr "Ημερομηνία"
 msgid "Start"
 msgstr "Εκκίνηση"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Κατάσταση Παραθύρου"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Αόρατα"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "&Συγχρονισμός Τροχιάς"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Πληροφορίες"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Εμφάνιση Αξόνων Σωμάτων"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Εμφάνιση Αξόνων Καρέ"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Εμφάνιση Κατεύθυνσης Ήλιου"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Εμφάνιση Ανυσμάτων Ταχύτητας"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Εμφάνιση Πλέγματος Πλανητογραφίας"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Εμφάνιση Terminator"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Δορυφόροι"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Σώματα σε Τροχιά"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr ""
 "Σφάλμα κατά την φόρτωση της γραμματοσειράς, το κείμενο δε θα είναι ορατό.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Σφάλμα: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Σύλληψη Βίντεο"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Πλήκτρα Χειρισμού Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Φόρτωση:"
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Φόρτωση"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "el"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου ρυθμίσεων."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Φόρτωση URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Έκδοση:"
 
@@ -4353,17 +4341,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου εικόνας PNG "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Σφάλμα κατά το άνοιγμα του αρχείου σεναρίων."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Άγνωστο σφάλμα κατά το άνοιγμα του σεναρίου"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4375,7 +4367,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4386,9 +4378,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4396,8 +4388,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Αποτυχία αρχικοποίησης σεναρίου"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4413,6 +4405,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Σφάλμα κατά το άνοιγμα"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Μονοπάτι αποτύπωσης: OpenGL 2.0 "
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Bloom ενεργοποιημένο"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Bloom απενεργοποιημένο"
+
+#~ msgid "Exposure"
+#~ msgstr "Έκθεση"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Σύλληψη Βίντεο"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6428,9 +6440,6 @@ msgstr "Σφάλμα κατά το άνοιγμα"
 #~ msgid "GLSL version: "
 #~ msgstr "Έκδοση GLSL: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Σφάλμα κατά το άνοιγμα του σεναρίου"
-
 #~ msgid "Error loading script"
 #~ msgstr "Σφάλμα κατά τη φόρτωση του σεναρίου"
 
@@ -6968,9 +6977,6 @@ msgstr "Σφάλμα κατά το άνοιγμα"
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Θερμοκρασία επιφάνειας: "
-
-#~ msgid "Radius: "
-#~ msgstr "Ακτίνα: "
 
 #~ msgid "Rsun"
 #~ msgstr "Rsun"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:45+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Hora de verano"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -54,36 +54,35 @@ msgstr "Error al leer el archivo de configuración"
 msgid "Loaded {} deep space objects\n"
 msgstr " objetos de espacio profundo"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxia (tipo de Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Cúmulo globular (radio del núcleo: %4.2f', concentración según King: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Cargando imagen del archivo "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Cargando modelo: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Error cargando modelo '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -99,115 +98,110 @@ msgstr "Cúmulo abierto"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Error en el archivo .ssc (línea "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "alerta, doble definición de "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "superficie alternativa equivocada"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "punto de referencia erróneo"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Encabezamiento del índice cruzado erróneo\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Versión errónea del índice cruzado\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "La carga del índice cruzado ha fallado en el registro "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "La carga del índice cruzado ha fallado en el registro "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Tipo espectral equivocado en la base de datos estelares, estrella #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " estrellas en la base de datos de binarias\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Número total de estrellas: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Error en el archivo .stc (línea "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Estrella inválida: tipo espectral inválido.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Estrella inválida: tipo espectral no disponible.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " no existe.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Estrella inválida: ascensión recta no disponible\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Estrella inválida: declinación no disponible.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Estrella inválida: distancia no disponible.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Estrella invalida: magnitud no disponible.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Estrella inválida: la magnitud absoluta (no la aparente) debe especificarse "
 "para una estrella cercana al origen\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -242,721 +236,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Extensiones aceptadas: "
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Error leyendo el archivo de favoritos."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Tipo de archivo inválido"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitud límite: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Marcadores activados"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Marcadores desactivados"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Ir a la superficie"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Modo Alt-Azimutal habilitado"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Modo Alt-Azimutal dehabilitado"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Estilo de estrellas: puntos difusos"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Estilo de estrellas: puntos"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Estilo de estrellas: discos a escala"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Colas de cometas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Colas de cometas desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Representación gráfica: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Modo Alt-Azimutal habilitado"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Modo Alt-Azimutal dehabilitado"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Magnitudes automáticas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Magnitudes automáticas desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Tiempo y script en pausa"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Tiempo en pausa"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Continuar"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Número total de estrellas: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Número total de estrellas: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Tiempo de viaje de un rayo de luz:  %.4f yr "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Tiempo de viaje de un rayo de luz:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Tiempo de viaje de un rayo de luz:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Demora temporal incluida"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Demora temporal desactivada"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Demora temporal ignorada"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Uso de texturas de superficie normales"
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Usando texturas de superficie del mundo conocido"
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Tiempo: Hacia adelante"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Tiempo: Hacia atrás"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Cuadros por segundo"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Órbita sincrónica"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Trabar"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Perseguir"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitud límite: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Límite de automag a 45 grados:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Luz Ambiental: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Ganancia de luz"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Bloom activado"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Bloom desactivado"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Exposición"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Error GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Vista demasiada pequeña para ser dividida"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Vista agregada"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "años luz"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "UA"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " días"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " horas"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minutos"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " segundos"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Velocidad: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diámetro aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitud aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitud absoluta: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distancia: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Baricentro del sistema estelar\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag. abs. (aparente): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosidad: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Estrella de neutrones"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Agujero negro"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Clase: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Temp. superficial: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Radio: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Radio: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Existen compañeros planetarios\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distancia desde el centro: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Radio: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Ángulo de fase: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tiempo real"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Tiempo real"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Tiempo detenido"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " más rápido"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " más lento"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Pausa)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "CPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Viajando "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Viajando "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Rastrear "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Orbita sincrónica "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Perseguir "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Nombre del blanco: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr " Pausa"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr " Grabando"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Empezar/Pausar    F12 Detener"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Modo de edición"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Cargando el catálogo del sistema solar: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Cargando el catálogo del sistema solar: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Cargando el catálogo del sistema solar: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Cargando el catálogo del sistema solar: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Error leyendo el archivo de favoritos."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Error al leer el archivo de configuración"
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Falla en la inicialización de la biblioteca SPICE."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Imposible leer la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Error al abrir catálogo estelar "
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Imposible leer la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Error al abrir el catálogo del sistema solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Error abriendo archivo de asterismos."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Error abriendo el archivo de límites de las constelaciones."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Error al inicializar renderer"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Error al cargar fuente; el texto no será visible.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Error al leer el índice cruzado "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Índice cruzado cargado "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Error al leer archivo de nombres estelares\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Error abriendo"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Error al leer archivo de estrellas\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Error al abrir catálogo estelar "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensiones aceptadas: "
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1015,37 +993,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Navegador celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navegador celeste"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Sistema Solar"
 
@@ -1055,20 +1033,20 @@ msgstr "Sistema Solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Estrellas"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " objetos de espacio profundo"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1078,123 +1056,119 @@ msgstr "Buscador de eclipses"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Tiempo"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Guía"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Pantalla completa"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Capturar video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Error abriendo archivo de asterismos."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Añadir señalador..."
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Guardar como: "
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " no es un archivo PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Capturar video"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Capturar video"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Capturar video"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolución: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Cuadros por segundo: "
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Cargando URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "Abrir script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Crear una nueva carpeta de señaladores en este menú"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1211,350 +1185,350 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Error desconocido abriendo script"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Extensiones aceptadas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Extensiones aceptadas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 #, fuzzy
 msgid "About Celestia"
 msgstr "Acerca de Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>Lenguaje de sombreado OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>OpenGL 1.1 sin extensiones</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 sin extensiones</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Versión GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Máximas texturas simultáneas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Máximo tamaño de textura: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Rango de tamaño de punto: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Rango de tamaño de punto: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Máximo tamaño de mapa cúbico: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>OpenGL 1.1 sin extensiones</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Visualizador: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Archivo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Capturar imagen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Capturar imagen...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Capturar video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Capturar video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Abrir script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferencias de Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Salir"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Anti-aliasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navegación"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "Centrar selección\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selección: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ir a objeto..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Tiempo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Establecer fecha y hora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Pantalla"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Objetos marcados"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Mostrar sombras de nubes"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Estilo de estrellas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Resolución de texturas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controles"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Señaladores"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "Ve&r"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Vista múltiple"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividir vista verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividir vista horizontalmente\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividir vista horizontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dividir vista verticalmente\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Intercambiar vistas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Vista única"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Vista única\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Borrar vista"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Marcos visibles"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Marco activo visible"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizar hora"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "A&yuda"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Preferencias de Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "Información OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Añadir señalador"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizar señaladores..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Cargando "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
@@ -1677,11 +1651,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Marcadores"
 
@@ -1697,7 +1671,7 @@ msgstr "Centrar selección\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Constelaciones"
 
@@ -1719,7 +1693,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Órbitas"
 
@@ -1733,18 +1707,18 @@ msgstr "Órbitas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planetas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Planetas enanos"
 
@@ -1757,16 +1731,16 @@ msgstr "Planetas enanos"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Satélites"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Satélites menores"
 
@@ -1779,10 +1753,10 @@ msgstr "Satélites menores"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroides"
 
@@ -1795,10 +1769,10 @@ msgstr "Asteroides"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Cometas"
 
@@ -1815,11 +1789,11 @@ msgstr "Cometas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1837,7 +1811,7 @@ msgstr "10x más rápido\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Etiquetas"
 
@@ -1847,9 +1821,9 @@ msgstr "Etiquetas"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaxias"
 
@@ -1857,8 +1831,8 @@ msgstr "Galaxias"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Cúmulos globulares"
 
@@ -1878,9 +1852,9 @@ msgstr "Cúmulos abiertos"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nebulosas"
 
@@ -1892,48 +1866,48 @@ msgid "Locations"
 msgstr "Ubicaciones"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Cúmulos abiertos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Nubes"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Luces nocturnas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Colas de cometas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmósferas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Sombras de anillos"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Sombras de eclipses"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Sombras de nubes"
 
@@ -2006,237 +1980,237 @@ msgstr "Límite de automag a 45 grados:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Magnitud límite: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Nombre"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Mag. aparente"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Mag. absoluta"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Mostrar estrellas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Estrellas"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrar estrellas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Con planetas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Mostrar estrellas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentro "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Tipo espectral equivocado en la base de datos estelares, estrella #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Máximo de estrellas en la lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Ninguna"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Diamante"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Triángulo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Cuadrado"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Suma"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Círculo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Flecha izquierda"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Flecha derecha"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Flecha arriba"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Flecha abajo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Seleccionar objeto..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Tamaño: "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Seleccionar objeto..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Etiquetar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objetos"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marcar"
@@ -2351,8 +2325,8 @@ msgstr "Cargando imagen del archivo "
 msgid "Behind %1"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2521,86 +2495,91 @@ msgstr "Tamaño: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Estilo de estrellas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Formato local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Zona horaria"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Corrimiento UTC"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Comenzar"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Distancia: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Mag. abs. (aparente): "
 
@@ -2613,21 +2592,21 @@ msgid "&Select"
 msgstr "&Seleccionar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centrar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Ir"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Seguir"
 
@@ -2641,12 +2620,12 @@ msgid "Visible"
 msgstr "Marco activo visible"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Desmarcar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Seleccione modo de visualización"
@@ -2660,12 +2639,12 @@ msgid "Disk"
 msgstr "Disco"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Marcar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Marcas de referencia"
 
@@ -2713,13 +2692,13 @@ msgid "Show &Terminator"
 msgstr "Mostrar terminador"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "Superficies &Alternativas"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normal"
 
@@ -2731,7 +2710,7 @@ msgstr "Normal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Planetas enanos"
@@ -2743,15 +2722,15 @@ msgstr "Planetas enanos"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Satélites menores"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Objetos"
@@ -2762,7 +2741,7 @@ msgid "Set Time"
 msgstr "Establecer fecha y hora..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Zona horaria: "
 
@@ -2827,7 +2806,7 @@ msgid "Set Seconds"
 msgstr " segundos"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Fecha Juliana"
 
@@ -2841,98 +2820,98 @@ msgstr "Fecha Juliana"
 msgid "Set time"
 msgstr "Establecer fecha y hora..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Baricentro "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Tipo espectral equivocado en la base de datos estelares, estrella #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planeta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Planeta enano"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Luna"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Satélites menores"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroide"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Cometa"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Naves espaciales"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Marcas de referencia"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Calcular"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Ir a la superficie"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Error desconocido abriendo script"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteroides"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Marcas de referencia"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Otros"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planetas"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objetos"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3065,7 +3044,7 @@ msgstr "Resolución: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organizar marcadores"
 
@@ -3172,7 +3151,7 @@ msgstr "Mostrar órbitas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Sitios de aterrizaje"
@@ -3180,7 +3159,7 @@ msgstr "Sitios de aterrizaje"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Trayectorias parciales"
@@ -3188,49 +3167,49 @@ msgstr "Trayectorias parciales"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Grillas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Ecuatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Eclíptica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galáctica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagramas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Mostrar fronteras"
 
@@ -3432,41 +3411,41 @@ msgstr "Pantalla"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Extensiones aceptadas: "
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Extensiones aceptadas: "
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3721,13 +3700,13 @@ msgstr "Acerca de Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3813,7 +3792,7 @@ msgid "Create in >>"
 msgstr "Crear en >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Nueva carpeta..."
 
@@ -3894,7 +3873,7 @@ msgid "Go to Object"
 msgstr "Ir a objeto"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 #, fuzzy
 msgid "Go To"
 msgstr "&Ir"
@@ -3912,7 +3891,7 @@ msgid "Lat."
 msgstr "Lat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Distancia"
 
@@ -3962,176 +3941,180 @@ msgstr "Tamaño mínimo para etiquetar"
 msgid "Size:"
 msgstr "Tamaño: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Renombrar..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Renombrar marcador o carpeta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Nuevo nombre"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Establecer hora"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formato: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Establecer hora actual"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Navegador del Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Ir"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Objetos del Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Navegador estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Más cercanas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Más brillantes"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Con planetas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 #, fuzzy
 msgid "&Refresh"
 msgstr "Refrescar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Criterios de búsqueda estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Máximo de estrellas en la lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Guía"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Establezca su destino:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 #, fuzzy
 msgid "View Options"
 msgstr "Opciones"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Mostrar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Pantalla"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Eclíptica"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Órbitas / Etiquetas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Nombres latinos"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Información"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Sucinta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Completa"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "40a"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Abr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Ene"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "May"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dic"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Oct"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Sep"
 
@@ -4147,184 +4130,189 @@ msgstr "Fecha"
 msgid "Start"
 msgstr "Comenzar"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Modo de ventana"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Invisibles"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "&Orbita sincrónica"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Información"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Mostrar ejes del cuerpo"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Mostrar ejes del marco"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Mostrar dirección al Sol"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Mostrar vector velocidad"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Mostrar grilla planetaria"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Mostrar terminador"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satélites"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Cuerpos en órbita"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Error al cargar fuente; el texto no será visible.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Error: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Capturar video"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Controles"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Cargando: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Cargando "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "es"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Error al leer el archivo de configuración"
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Cargando URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versión: "
 
@@ -4360,17 +4348,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Error al leer un archivo PNG "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Error abriendo archivo de script"
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Error desconocido abriendo script"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4382,7 +4374,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4393,9 +4385,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Error abriendo script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Error abriendo script "
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4403,8 +4395,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Falla de inicialización de co-rutina de script"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Error abriendo script '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4420,6 +4412,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Error abriendo"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Representación gráfica: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Bloom activado"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Bloom desactivado"
+
+#~ msgid "Exposure"
+#~ msgstr "Exposición"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Capturar video"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Error abriendo script '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6799,9 +6811,6 @@ msgstr "Error abriendo"
 #~ msgid "GLSL version: "
 #~ msgstr "Versión GLSL: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Error abriendo script "
-
 #~ msgid "Error loading script"
 #~ msgstr "Error cargando script"
 
@@ -7336,9 +7345,6 @@ msgstr "Error abriendo"
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Temp. de la superficie: "
-
-#~ msgid "Radius: "
-#~ msgstr "Radio: "
 
 #~ msgid "Rsun"
 #~ msgstr "R solar"

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2019-02-14 21:33+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: French (https://www.transifex.com/celestia/teams/93131/fr/)\n"
@@ -21,11 +21,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "heure d’été"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "heure d’hiver"
 
@@ -56,37 +56,36 @@ msgstr "Erreur lors de la lecture du fichier de configuration."
 msgid "Loaded {} deep space objects\n"
 msgstr ""
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxie (type Hubble : %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Amas globulaire (rayon du noyau : %4.2f', distribution de King : %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Erreur lors de la lecture du fichier de favoris."
 
-#: ../src/celengine/meshmanager.cpp:461
-#, c-format
-msgid "Loading model: %s\n"
-msgstr ""
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
+msgstr "Erreur lors de la lecture du catalogue du Système solaire.\n"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, c-format
-msgid "Error loading model '%s'\n"
-msgstr ""
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
+msgstr "Erreur lors de la lecture du fichier de favoris."
 
 #: ../src/celengine/nebula.cpp:39
 msgid "Nebula"
@@ -100,111 +99,106 @@ msgstr "Amas ouvert"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "mauvaise surface alternative"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "mauvais point de repère"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "En-tête de l’index croisé invalide\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Mauvaise version de l’index croisé\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Mauvaise version de l’index croisé\n"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Mauvaise version de l’index croisé\n"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 msgid "{} stars in binary database\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 msgid "Total star count: {}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 msgid "Error in .stc file (line {}): {}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Étoile invalide : type spectral invalide.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Étoile invalide : type spectral manquant.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr "Le répertoire \"extras\" %1 n’existe pas"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Étoile invalide : ascension droite manquante\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Étoile invalide : déclinaison manquante.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Étoile invalide : distance manquante.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Étoile invalide : magnitude manquante.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Étoile invalide : la magnitude absolue (et non pas apparente) doit être "
 "spécifiée pour les étoiles proches de l’origine\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 msgid "Creating tiled texture. Width={}, max={}\n"
@@ -237,702 +231,680 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Extensions supportées : "
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Erreur lors de la lecture du fichier de favoris."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Type de fichier invalide"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitude limite : %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Marqueurs activés"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Marqueurs désactivés"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Aller à la surface"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Mode Alt-Azimuthal activé"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Mode Alt-Azimuthal désactivé"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Style des étoiles : points flous"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Style des étoiles : points"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Style des étoiles : échelle de disques"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Queues des comètes activées"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Queues des comètes désactivées"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Chemin de rendu : OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 msgid "Anti-aliasing enabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 msgid "Anti-aliasing disabled"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Magnitudes automatiques activées"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Magnitudes automatiques désactivées"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Temps et script en pause"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Temps en pause"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Reprendre"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr ""
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Temps de trajet de la lumière : %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Temps de trajet de la lumière : %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Temps de trajet de la lumière inclus"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Temps de trajet de la lumière désactivé"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Temps de trajet de la lumière ignoré"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Utilisation des textures de surface normales"
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Utilisation des textures de surface du monde connu"
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Suivre"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Temps : Avancer"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Temps : Reculer"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, c-format
 msgid "Time rate: %.6g"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 msgid "Low res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 msgid "Medium res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Orbite synchrone"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Bloquer"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Pourchasser"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Magnitude automatique à 45° : %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Niveau de la lumière ambiante : %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Gain de luminosité"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Effet Bloom activé"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Effet Bloom désactivé"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Exposition lumineuse"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Erreur OpenGL :"
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Vue trop petite pour être scindée"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Vue ajoutée"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "al"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "ua"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 msgid "mi"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "hours"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 msgid "minutes"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 msgid "seconds"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+msgid "Rotation period: {} {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 msgid "ly/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 msgid "AU/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 msgid "km/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 msgid "m/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+msgid "Speed: {} {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, c-format
 msgid "Apparent diameter: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, c-format
 msgid "Distance: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Barycentre du système stellaire\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag. abs (app) : %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+msgid "Luminosity: {}x Sun\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Étoile à neutrons"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Trou noir"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, c-format
 msgid "Class: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2860
-#, c-format
-msgid "Surface temp: %s K\n"
+#: ../src/celestia/celestiacore.cpp:2905
+#, fuzzy, c-format
+msgid "Surface temp: %s\n"
+msgstr "Temp. de surface : "
+
+#: ../src/celestia/celestiacore.cpp:2910
+msgid "Radius: {} Rsun  ({})\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, c-format
-msgid "Radius: %s Rsun  (%s)\n"
-msgstr ""
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
+msgstr "Rayon : "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, c-format
-msgid "Radius: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Compagnons planétaires présents\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, c-format
+msgid "Radius: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Angle de phase : %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
-#, c-format
-msgid "Temperature: %.0f K\n"
-msgstr ""
+#: ../src/celestia/celestiacore.cpp:3045
+#, fuzzy, c-format
+msgid "Temperature: %s\n"
+msgstr "Moteur de rendu : "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Temps réel"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "- Temps réel"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Temps arrêté"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, c-format
 msgid "%.6g x faster"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, c-format
 msgid "%.6g x slower"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr "  (en pause)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+msgid "Travelling ({})\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, c-format
+#: ../src/celestia/celestiacore.cpp:3291
 msgid "Travelling\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, c-format
 msgid "Track %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, c-format
 msgid "Follow %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, c-format
 msgid "Chase %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Nom de la cible : "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Paused"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Recording"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Démarrer/Pause     F12 Arrêter"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Mode d’édition"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Erreur lors de la lecture du catalogue du Système solaire.\n"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Erreur lors de la lecture du catalogue du Système solaire.\n"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Erreur lors de la lecture du catalogue du Système solaire.\n"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Erreur lors de la lecture du catalogue du Système solaire.\n"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Erreur lors de la lecture du fichier de favoris."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Erreur lors de la lecture du fichier de configuration."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "L’initialisation de la bibliothèque SPICE a échoué."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Impossible de lire la base de données des étoiles."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Erreur lors de l’ouverture du fichier de script."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Impossible de lire la base de données des étoiles."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Erreur lors de la lecture du catalogue du Système solaire.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Erreur lors de l’ouverture du fichier d’astérismes."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Erreur lors de l’ouverture du fichier des limites des constellations."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Échec de l’initialisation du moteur de rendu"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr ""
 "Erreur lors du chargement de la police de caractère ; le texte ne sera pas "
 "affiché.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Erreur lors de la lecture du fichier de favoris."
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Mauvaise version de l’index croisé\n"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Erreur lors de la lecture du fichier des noms d’étoiles\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Erreur lors de l’ouverture du script"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Erreur lors de la lecture du fichier d’étoiles\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Erreur lors de la lecture du catalogue du Système solaire.\n"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensions supportées : "
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -991,36 +963,36 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Navigateur céleste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 msgid "Info Browser"
 msgstr ""
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Système solaire"
 
@@ -1030,19 +1002,19 @@ msgstr "Système solaire"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Étoiles"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr ""
@@ -1051,109 +1023,106 @@ msgstr ""
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Temps"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 msgid "Full screen"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 msgid "Error opening bookmarks file"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 msgid "Error Saving Bookmarks"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 msgid "Save Image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Acquisition Vidéo"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 msgid "Matroska Video (*.mkv)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Vitesse d’affichage : "
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL copiée"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 msgid "Pasting URL"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Open Script"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 msgid "New bookmark"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1170,311 +1139,311 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 msgid "Unknown compiler"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "À propos de Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "Fournisseur : "
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "Moteur de rendu : "
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Version : "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Nombre max de textures : "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Taille de texture max. : "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Plage de taille de point : "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Plage de taille de point : "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Taille de texture cubique max. : "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "Extensions supportées : "
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Moteur de rendu : "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Fichier"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 msgid "&Grab image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 msgid "Capture &video"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Ouvrir script"
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Quitter"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr ""
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigation"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 msgid "Select Sun"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 msgid "Center Selection"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Goto Selection"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Allez à ..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Temps"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 msgid "Set &time"
 msgstr ""
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 msgid "&Display"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 msgid "Dee&p Sky Objects"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 msgid "&Shadows"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "St&yle des étoiles"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 msgid "&FPS control"
 msgstr ""
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr ""
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Vue"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 msgid "&MultiView"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 msgid "Split view vertically"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 msgid "Split view horizontally"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 msgid "Cycle views"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 msgid "Single view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 msgid "Delete view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 msgid "Frames visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 msgid "Active frame visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 msgid "Synchronize time"
 msgstr ""
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Aide"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 msgid "Celestia Manual"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 msgid "Add Bookmark..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
@@ -1583,11 +1552,11 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Marqueurs"
 
@@ -1602,7 +1571,7 @@ msgstr ""
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Constellations"
 
@@ -1621,7 +1590,7 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Orbites"
 
@@ -1635,18 +1604,18 @@ msgstr "Orbites"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planètes"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Planètes naines"
 
@@ -1659,16 +1628,16 @@ msgstr "Planètes naines"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Lunes"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Lunes mineures"
 
@@ -1681,10 +1650,10 @@ msgstr "Lunes mineures"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Astéroïdes"
 
@@ -1697,10 +1666,10 @@ msgstr "Astéroïdes"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Comètes"
 
@@ -1717,11 +1686,11 @@ msgstr "Comètes"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1738,7 +1707,7 @@ msgstr ""
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Noms"
 
@@ -1748,9 +1717,9 @@ msgstr "Noms"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaxies"
 
@@ -1758,8 +1727,8 @@ msgstr "Galaxies"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Amas globulaires"
 
@@ -1778,9 +1747,9 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nébuleuses"
 
@@ -1792,48 +1761,48 @@ msgid "Locations"
 msgstr "Points de repère"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Amas ouverts"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Nuages"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Lumières nocturnes"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Queues des comètes"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosphères"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Ombres des anneaux"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Ombres des éclipses"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Ombres des nuages"
 
@@ -1899,224 +1868,224 @@ msgstr ""
 msgid "Magnitude limit: %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Nom"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Distance (al)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Mag. app."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Mag. abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Type"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 msgid "Closest Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 msgid "Brightest Stars"
 msgstr ""
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 msgid "Filter"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Avec planètes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 msgid "Multiple Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 msgid "Barycenters"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr ""
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Rafraîchir"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 msgid "Mark Selected"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 msgid "Mark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "Démarquer &tous"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 msgid "Clear Markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Aucun"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Losange"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Triangle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Carré"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Cercle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Flèche vers la gauche"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Flèche vers la droite"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Flèche vers le haut"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Flèche vers le bas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, qt-format
 msgid "%1 objects found"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr ""
 
@@ -2221,8 +2190,8 @@ msgstr ""
 msgid "Behind %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2388,82 +2357,87 @@ msgstr ""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 msgid "Local format"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 msgid "Time zone name"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 msgid "UTC offset"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Début"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Distance : "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Mag. abs (app): "
 
@@ -2476,21 +2450,21 @@ msgid "&Select"
 msgstr "&Sélectionner"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centrer"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Aller à"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Suivre"
 
@@ -2503,12 +2477,12 @@ msgid "Visible"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Démarquer"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Sélection du mode d’affichage"
@@ -2522,12 +2496,12 @@ msgid "Disk"
 msgstr "Disque"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Marquer"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "Marques de &référence"
 
@@ -2568,13 +2542,13 @@ msgid "Show &Terminator"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "Surfaces &alternatives"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normale"
 
@@ -2586,7 +2560,7 @@ msgstr "Normale"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr ""
 
@@ -2597,14 +2571,14 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 msgid "Other objects"
 msgstr ""
 
@@ -2613,7 +2587,7 @@ msgid "Set Time"
 msgstr ""
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Fuseau horaire : "
 
@@ -2669,7 +2643,7 @@ msgid "Set Seconds"
 msgstr ""
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Date julienne : "
 
@@ -2681,85 +2655,85 @@ msgstr ""
 msgid "Set time"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planète"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Lune"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 msgid "Minor moon"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Astéroïde"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Comète"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Astronefs"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 msgid "Reference point"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 msgid "Component"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 msgid "Surface feature"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 msgid "Reference points"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 msgid "Surface features"
 msgstr ""
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 msgid "Planets and moons"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -2875,7 +2849,7 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Réaranger les signets"
 
@@ -2970,63 +2944,63 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 msgid "Fading orbits"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Grilles"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Équatoriale"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Écliptique"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galactique"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horizontale"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Lignes"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Limites"
 
@@ -3207,41 +3181,41 @@ msgstr ""
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Extensions supportées : "
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Extensions supportées : "
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3486,13 +3460,13 @@ msgstr "À propos de &Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3577,7 +3551,7 @@ msgid "Create in >>"
 msgstr "Créer dans >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Nouveau dossier..."
 
@@ -3658,7 +3632,7 @@ msgid "Go to Object"
 msgstr "Aller à l’objet"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Aller à"
 
@@ -3675,7 +3649,7 @@ msgid "Lat."
 msgstr "Lat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Distance"
 
@@ -3723,174 +3697,178 @@ msgstr "Taille minimum des points de repère"
 msgid "Size:"
 msgstr "Taille : "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Renommer..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Renommer le signet ou le répertoire"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Nouveau nom"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Définir l’heure de simulation"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Format : "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Mettre à l’heure courante"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Navigateur de Système solaire"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Aller à"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Objets du Système solaire"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Navigateur céleste"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Plus proches"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Plus brillantes"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Avec planètes"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Rafraîchir"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Critères de recherche d’étoiles"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Nombre maximum d’étoiles à afficher"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Guide de découverte"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Sélectionner votre destination :"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Options"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Afficher"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Affichage"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Ligne de l’écliptique"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Orbites et noms"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Noms en latin"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Texte d’information"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Concis"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Complet"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "40c"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Avr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Fév"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Juin"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Août"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Déc"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Juil"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Oct"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Sep"
 
@@ -3906,181 +3884,186 @@ msgstr "Date"
 msgid "Start"
 msgstr "Début"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Mode fenêtré"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Invisibles"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "Orbite s&ynchrone"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Afficher les axes de l’objet"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Afficher les axes du repère"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Afficher la direction du Soleil"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Afficher le vecteur vitesse"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Afficher la grille planétographique"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Afficher le terminateur"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satellites"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Objets en orbite"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 msgid "Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 msgid "Could not capture movie."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Commande de Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Chargement : "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Erreur lors de la lecture du fichier d’étoiles\n"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "fr"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Erreur lors de la lecture du fichier de configuration."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Chargement de l’URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Version : "
 
@@ -4115,17 +4098,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Erreur lors de la lecture du fichier de favoris."
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Erreur lors de l’ouverture du fichier de script."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Erreur inconnue lors de l’ouverture du script"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4137,7 +4124,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4148,9 +4135,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Erreur lors de l’ouverture du script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Erreur lors de l’ouverture du script"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4158,9 +4145,9 @@ msgid "Script coroutine initialization failed"
 msgstr "L’initialisation de la co-routine de script a échoué"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr ""
+#, fuzzy
+msgid "Error opening LuaHook {}"
+msgstr "Erreur lors de l’ouverture du script"
 
 #: ../src/celscript/lua/luascript.cpp:231
 msgid "Unknown error loading hook script"
@@ -4174,6 +4161,22 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Erreur lors de l’ouverture du script"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Chemin de rendu : OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Effet Bloom activé"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Effet Bloom désactivé"
+
+#~ msgid "Exposure"
+#~ msgstr "Exposition lumineuse"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Erreur lors de l’ouverture du script '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6467,9 +6470,6 @@ msgstr "Erreur lors de l’ouverture du script"
 #~ msgid "GLSL version: "
 #~ msgstr "Version GLSG : "
 
-#~ msgid "Error opening script"
-#~ msgstr "Erreur lors de l’ouverture du script"
-
 #~ msgid "Error loading script"
 #~ msgstr "Erreur lors du chargement du script"
 
@@ -7000,12 +7000,6 @@ msgstr "Erreur lors de l’ouverture du script"
 #~ msgid "Directory %1 does not exist, using default %2"
 #~ msgstr ""
 #~ "Le répertoire %1 n’existe pas, utilisation du répertoire par défaut %2"
-
-#~ msgid "Surface Temp: "
-#~ msgstr "Temp. de surface : "
-
-#~ msgid "Radius: "
-#~ msgstr "Rayon : "
 
 #~ msgid "Rsun"
 #~ msgstr "Rsoleil"

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:46+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -54,36 +54,35 @@ msgstr "Erro lendo o arquivo de configuración."
 msgid "Loaded {} deep space objects\n"
 msgstr " obxecto do espazo profundo"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxia (Tipo Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Cúmulo globular (radio do núcleo: %4.2f', concentración segundo King: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Cargando imaxe dende o arquivo"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Cargando modelo:"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Erro ó carga-lo modelo '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -99,115 +98,110 @@ msgstr "Cúmulo aberto"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Erro no arquivo .ssc (liña"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "aviso de definición duplicada de"
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "Superficie alternativa de mala calidade"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "punto de referencia erróneo."
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Encabezamento corrupto do índice cruzado\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Versión errónea do índice cruzado\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "A carga del índice cruzado fallou no rexistro "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "A carga del índice cruzado fallou no rexistro "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Tipo espectral erróneo na base de datos das estrelas, estrela #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " estrelas na base de datos binaria\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Número total de estrelas:"
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Erro no arquivo .stc (liña"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Estrela non válida: tipo espectral erróneo.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Estrela non válida: falta o tipo espectral.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " non existe.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Estrela non válida: falta a ascensión recta\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Estrela non válida: falta a declinación.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Estrela non válida: falta a distancia.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Estrela non válida: falta a magnitude.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Estrela non válida: a magnitude absoluta (non a aparente) debe ser "
 "especificada para a estrela preto da orixe\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -242,721 +236,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Extensións aceptadas:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Erro lendo o arquivo de favoritos"
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Tipo de arquivo inválido "
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Límite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Marcadores habilitados"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Marcadores deshabilitados"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Ir á superficie"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Modo Alt-acimut activado"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Modo Alt-acimut desactivado"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Estilo das estrelas: puntos difusos"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Estilo das estrelas: puntos"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Estilo das estrelas: discos a escala"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Colas dos cometas habilitadas"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Colas dos cometas deshabilitadas"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Procesador gráfico: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Marcadores habilitados"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Marcadores deshabilitados"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Auto-magnitude habilitada"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Auto-magnitude deshabilitada"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "O tempo e o script están detidos"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Tempo en pausa"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Continuar"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "&Navegador Estelar"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "&Navegador Estelar"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Viaxar á velocidade da luz: %.4f an"
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Viaxar á velocidade da luz: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Viaxar á velocidade da luz: %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Viaxar á velocidade da luz con demora temporal incluí­da"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Desactiva-la demora temporal ó viaxar á velocidade da luz"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Inora-la demora temporal ó viaxar á velocidade da luz"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Usa-las texturas normais das superficies."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Usar ata o límite do coñecemento as texturas das superficies."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Tempo: Cara adiante"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Tempo: Cara atrás"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Taxa do tempo"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Órbita Sinc"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Bloquear"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Perseguir"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Límite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Límite da auto magnitude a 45 graos:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Luz Ambiental: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Ganancia de luz"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Bloom activado"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Bloom desactivado"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Exposición"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Erro GL:"
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "A vista é demasiado pequena para ser dividida"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Vista engadida"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "al"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "ua"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " días"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " horas"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minutos"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr "Establecer"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Período de rotación:"
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Velocidade:"
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diámetro aparente:"
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitude aparente:"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitude absoluta:"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distancia: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Centro de masas do sistema estelar\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag abs (ap): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosidade: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Estrela de neutróns"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Burato negro"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Clase:"
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Temp. superficial:"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Radio:"
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Radio:"
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Compañeiros planetarios presentes\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distancia dende o centro:"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Radio:"
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Taxa do tempo"
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Tempo parado"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " máis rápido"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " máis lento"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Pausado)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Viaxando"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Viaxando"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Rastrexar"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "&Seguir"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Órbita Sincrónica"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Perseguir"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Nome do destino:"
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "   Pausa"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  Grabando"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Iniciar/Pausar    F12 Deter"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Modo de edición"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Cargando o catálogo do Sistema Solar:"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Cargando o catálogo do Sistema Solar:"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Cargando o catálogo do Sistema Solar:"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Cargando o catálogo do Sistema Solar:"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Erro lendo o arquivo de favoritos"
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Erro lendo o arquivo de configuración."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "A inicialización da librerí­a SPICE fallou."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Non se puido le-la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Erro o abri-lo arquivo do catálogo de obxectos do espazo profundo."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Non se puido le-la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Erro o abri-lo arquivo do catálogo do Sistema Solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Erro o abri-lo arquivo de asterismos."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Erro o abri-los arquivos dos bordes das constelacións."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Erro o tentar inicia-lo procesado gráfico"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Erro o carga-la fonte; o texto non será visible.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Erro o le-lo índice cruzado "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Índice cruzado cargado "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Erro o le-lo arquivo dos nomes das estrelas\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Erro na apertura"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Erro o le-lo arquivo das estrelas\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Erro o abri-lo catálogo de estrelas"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensións aceptadas:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1015,37 +993,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Navegador Celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navegador Celeste"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Sistema Solar"
 
@@ -1055,20 +1033,20 @@ msgstr "Sistema Solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " obxecto do espazo profundo"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1078,7 +1056,7 @@ msgstr "Buscador de eclipses"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 #, fuzzy
 msgid "Time"
 msgstr "&Hora"
@@ -1086,115 +1064,111 @@ msgstr "&Hora"
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Guía do Tour"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Pantalla Completa"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Capturar &Vídeo...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Erro o abri-lo arquivo de asterismos."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Marcadores"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Gravar Imaxe"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " non é un arquivo PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Capturar Ví­deo"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Capturar Ví­deo"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Capturar Ví­deo"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolución:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Taxa de fotogramas:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL Copiada"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Cargando URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Abri-lo Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Crear un novo cartafol de marcadores neste menú"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1211,348 +1185,348 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Erro descoñecido ó abri-lo script"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Extensións aceptadas:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Extensións aceptadas:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Acerca de Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 1.1 sen extensións</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>OpenGL 1.1 sen extensións</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 sen extensións</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Versión do GLSL:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Nº max. de texturas simultáneas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Tamaño max. da textura:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Rango de tamaño do punto:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Rango de tamaño do punto:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Tamaño max. do mapa cúbico:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "Extensións aceptadas:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Visualizador:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Arquivo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Gravar Imaxe"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Capturar &Imaxe...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Capturar Ví­deo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Capturar &Vídeo...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "&Centrase sobre a Selección\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Abri-lo Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferencias de Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Saír"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Anti-aliasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navegación"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrase sobre a Selección\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selección:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ir o Obxecto..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Hora"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Escolle-la Hora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Pantalla"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Obxectos marcados"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Sombras dos Aneis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Estilo das Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Resolución da Textura"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controis"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Marcadores"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Vista"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "&Vista"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividi-la Vista Verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividir &Horizontalmente\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividi-la Vista Horizontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "&Dividir Verticalmente\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Vista Cí­clica"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Vista Simple"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Vista Simple\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Borra-la Vista"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Marcos Visibles"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Marco Activo Visible"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Tempo Sincronizado"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "A&xuda"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "Información OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Engadir Marcador"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organiza-los Marcadores..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Cargando"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
@@ -1675,11 +1649,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Marcadores"
 
@@ -1695,7 +1669,7 @@ msgstr "Copyright (C) 2001-2009, Celestia Development Team"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Constelacións"
 
@@ -1717,7 +1691,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Órbitas"
 
@@ -1731,18 +1705,18 @@ msgstr "Órbitas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planetas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Planetas Ananos"
 
@@ -1755,16 +1729,16 @@ msgstr "Planetas Ananos"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Lúas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Lúas Menores"
 
@@ -1777,10 +1751,10 @@ msgstr "Lúas Menores"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroides"
 
@@ -1793,10 +1767,10 @@ msgstr "Asteroides"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Cometas"
 
@@ -1813,11 +1787,11 @@ msgstr "Cometas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1835,7 +1809,7 @@ msgstr "10x &Máis Rápido\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Nomes"
 
@@ -1845,9 +1819,9 @@ msgstr "Nomes"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaxias"
 
@@ -1855,8 +1829,8 @@ msgstr "Galaxias"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Cúmulos Globulares"
 
@@ -1876,9 +1850,9 @@ msgstr "Cúmulos Abertos"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nebulosas"
 
@@ -1890,48 +1864,48 @@ msgid "Locations"
 msgstr "Lugares"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Cúmulos Abertos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Nubes"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Contaminación Lumí­nica"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Colas dos Cometas "
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosferas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Sombras dos Aneis"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Sombras dos Eclipses "
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Sombras das Nubes"
 
@@ -2004,239 +1978,239 @@ msgstr "Límite da auto magnitude a 45 graos:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Límite de magnitude: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Distancia (al)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Mag. ap."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Mag. abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "A máis brillante"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 #, fuzzy
 msgid "With Planets"
 msgstr "Con planetas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Centro de masas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Tipo espectral erróneo na base de datos das estrelas, estrela #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 #, fuzzy
 msgid "Refresh"
 msgstr "Ac&tualizar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Nº Máximo de Estrelas Amosadas na Lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Ningún"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Diamante"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Triángulo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Cadrado"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Círculo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Frecha Esquerda"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Frecha Dereita"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Frecha Arriba"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Frecha Abaixo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Tamaño:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Características dos Nomes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "' non atopado.\n"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marcar"
@@ -2351,9 +2325,12 @@ msgstr "Dende:"
 msgid "Behind %1"
 msgstr "Duración: %1"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+#, fuzzy
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
+"Celestia non puido inicializa-las extensións OpenGL. A calidade dos gráficos "
+"poderase ver reducida. Só está dispoñible a ruta para o procesador básico"
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
 msgid "Error: no object selected!\n"
@@ -2521,86 +2498,91 @@ msgstr "Tamaño: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "&Estilo das Estrelas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Formato Local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Zona Horaria"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Ver en UTC"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Comezo"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Distancia: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Mag. (ap.) absoluta:"
 
@@ -2613,21 +2595,21 @@ msgid "&Select"
 msgstr "&Seleccionar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centrar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Ir a"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Seguir"
 
@@ -2641,12 +2623,12 @@ msgid "Visible"
 msgstr "Marco Activo Visible"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Desmarcar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Selecciona-lo Modo da Pantalla"
@@ -2660,12 +2642,12 @@ msgid "Disk"
 msgstr "Disco"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Marcar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 #, fuzzy
 msgid "&Reference Marks"
 msgstr "&Vectores de Referencia"
@@ -2714,13 +2696,13 @@ msgid "Show &Terminator"
 msgstr "Amosa-lo Terminador"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "Superficies &Alternativas"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normal"
 
@@ -2732,7 +2714,7 @@ msgstr "Normal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Planetas Ananos"
@@ -2744,15 +2726,15 @@ msgstr "Planetas Ananos"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Lúas Menores"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Outros"
@@ -2763,7 +2745,7 @@ msgid "Set Time"
 msgstr "Escolle-la Hora..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Zona Horaria:"
 
@@ -2828,7 +2810,7 @@ msgid "Set Seconds"
 msgstr "Establecer"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Data Xuliana:"
 
@@ -2842,98 +2824,98 @@ msgstr "Data Xuliana:"
 msgid "Set time"
 msgstr "Escolle-la Hora..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Centro de masas"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Tipo espectral erróneo na base de datos das estrelas, estrela #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planeta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Planeta anano"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Lúa"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Lúas Menores"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroide"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Cometa"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Sonda espacial"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Vectores de Referencia"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Computar"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Ir á superficie"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Erro descoñecido ó abri-lo script"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteroides"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Vectores de Referencia"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Outras características"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planetas"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Clase:"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3066,7 +3048,7 @@ msgstr "Resolución:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organizar marcadores"
 
@@ -3174,7 +3156,7 @@ msgstr "Amosa-las Órbitas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Lugares de Aterraxe"
@@ -3182,7 +3164,7 @@ msgstr "Lugares de Aterraxe"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Traxectorias Parciais"
@@ -3190,49 +3172,49 @@ msgstr "Traxectorias Parciais"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Grella"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Ecuatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Eclíptica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galáctica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagramas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Bordes"
 
@@ -3434,41 +3416,41 @@ msgstr "Pantalla"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Extensións aceptadas:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Extensións aceptadas:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3718,13 +3700,13 @@ msgstr "&Acerca de Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3811,7 +3793,7 @@ msgid "Create in >>"
 msgstr "Crear en >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Novo Cartafol..."
 
@@ -3892,7 +3874,7 @@ msgid "Go to Object"
 msgstr "Ir o obxecto"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Ir a"
 
@@ -3909,7 +3891,7 @@ msgid "Lat."
 msgstr "Lat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Distancia"
 
@@ -3958,174 +3940,178 @@ msgstr "Tamaño mínimo para etiquetar"
 msgid "Size:"
 msgstr "Tamaño:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Renomear..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Renomea-lo Marcador ou o Cartafol"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Novo Nome"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Escolle-la Hora da Simulación"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formato:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Escolle-la Hora Actual"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Navegador do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Ir a"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Obxectos do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Navegador Estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "A máis próxima"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "A máis brillante"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "Con planetas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "Ac&tualizar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Criterio para a Procura de Estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Nº Máximo de Estrelas Amosadas na Lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Guía do Tour"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Escolle o teu destino:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Opcións da Vista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Amosar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Pantalla"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 #, fuzzy
 msgid "Ecliptic Line"
 msgstr ", liña"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Órbitas / Nomes"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Nomes en Latín"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Reducida"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Completa"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "0456"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Abr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Xan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Xuñ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Xul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Out"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Set"
 
@@ -4141,184 +4127,189 @@ msgstr "Data"
 msgid "Start"
 msgstr "Comezo"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Modo de Xanelas"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Invisibles"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "&Orbita Sinc"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Amosa-los Eixos do Corpo"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Amosa-los Eixos do Marco"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Amosa-la Dirección do Sol"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Amosa-lo Vector da Velocidade"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Amosa-la Grella Planetaria"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Amosa-lo Terminador"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satélites"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Corpos en Órbita"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Erro o carga-la fonte; o texto non será visible.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Erro: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Capturar Ví­deo"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Controis de Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Cargando:"
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Cargando"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "gl"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Erro lendo o arquivo de configuración."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Cargando URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versión:"
 
@@ -4354,17 +4345,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Erro lendo o arquivo PNG"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Erro abrindo o arquivo do script."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Erro descoñecido ó abri-lo script"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4376,7 +4371,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4387,9 +4382,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Erro abrindo o script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Erro o abri-lo script"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4397,8 +4392,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Fallou a  inicialización da corutina do script"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Erro abrindo o script '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4414,6 +4409,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Erro na apertura"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Procesador gráfico: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Bloom activado"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Bloom desactivado"
+
+#~ msgid "Exposure"
+#~ msgstr "Exposición"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Capturar Ví­deo"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Erro abrindo o script '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6725,15 +6740,6 @@ msgstr "Erro na apertura"
 #~ msgstr "Erro descoñecido ó abri-lo script"
 
 #, fuzzy
-#~ msgid ""
-#~ "Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-#~ "quality will be reduced."
-#~ msgstr ""
-#~ "Celestia non puido inicializa-las extensións OpenGL. A calidade dos "
-#~ "gráficos poderase ver reducida. Só está dispoñible a ruta para o "
-#~ "procesador básico"
-
-#, fuzzy
 #~ msgid "Max simultaneous textures"
 #~ msgstr "Nº max. de texturas simultáneas: "
 
@@ -6810,9 +6816,6 @@ msgstr "Erro na apertura"
 
 #~ msgid "GLSL version: "
 #~ msgstr "Versión do GLSL:"
-
-#~ msgid "Error opening script"
-#~ msgstr "Erro o abri-lo script"
 
 #~ msgid "Error loading script"
 #~ msgstr "Erro o carga-lo script"
@@ -7359,9 +7362,6 @@ msgstr "Erro na apertura"
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Temp. Superficial:"
-
-#~ msgid "Radius: "
-#~ msgstr "Radio:"
 
 #~ msgid "Rsun"
 #~ msgstr "Rsolares"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:47+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Nyári idő"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "Téli idő"
 
@@ -54,35 +54,34 @@ msgstr "Hiba a konfigurációs fájl olvasásakor."
 msgid "Loaded {} deep space objects\n"
 msgstr "Mélyég objektumok"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxis (Hubble type: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Gömbhalmaz (mag sugara: %4.2f', King koncentráció: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Kép betöltése fájlból"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Modell betöltése: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Hiba a modell betöltésekor '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +97,110 @@ msgstr "Nyílt galaxishalmazok"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Hiba az .ssc fájlban (sor"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "Vigyázat,duplikált definíció "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "hibás alternatív felületek"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "Hibás hely"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Bad header for cross index\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Rossz keresztindex verzió\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Hiba a rekord keresztindex betöltésekor"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Hiba a rekord keresztindex betöltésekor"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Rossz spektráltípus a csillag adatbázisban "
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr "csillagok a bináris adatbázisban\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Csillagok száma: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Hiba az .stc fájlban (sor"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Érvénytelen csillag: hibás spektrál típus.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Érvénytelen csillag: hibás spektrális típus.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr "nem létező.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Érvénytelen csillag: missing right ascension\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Érvénytelen csillag: hiányzó deklináció. \n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Érvénytelen csillag: hiányzó távolság. \n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Érvénytelen csillag: hiányzó magnitúdó.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Érvénytelen csillag: az abszolút (nem a látszó fényesség) magnitúdot meg "
 "kell adni a közelli csillagnál\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -241,721 +235,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Supported Extensions:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Hiba a \"favorites\" fájl olvasásakor."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Érvénytelen fájltípus"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudó korlát: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Jelölők bekapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Jelölők kikapcsolva"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Ugrás a felszínre"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-Aizmuth mód be"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-Aizmuth mód ki"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Csillagok megjelenítése: elmosódott pontok"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Csillagok megjelenítése: pontok"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Csillagok megjelenítése: méretarányos pöttyök"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Üstököscsóvák bekapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Üstököscsóvák kikapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Megjelenítési mód: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Jelölők bekapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Jelölők kikapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Önműködő fényességállítás be"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Önműködő fényességállítás ki"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Vissza"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Idő és szkript megállítása"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Idő megállítva"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Tovább"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Csillag &böngésző..."
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Csillag &böngésző..."
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Utazási idő fénysebességgel:  %.4f yr "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Utazás ideje fénysebességgel:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Utazás fénysebességgel:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Utazás fénysebességgel: bekapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Utazás fénysebességgel: kikapcsolva"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Utazás fénysebességgel: mellőzve "
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Normál felületi textúrák alkalmazása."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Ismereteink határa textúrák "
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Követ"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Idő: Előre"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Idő: Vissza"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Idő múlása: "
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Textúrák"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Textúrák"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Textúrák"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Pálya szinkr."
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Rögzít"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Követés"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudó korlát: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Önműködő fényességállítás 45 foknál:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Környező fények:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Megvilágítás javulása"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Bloom hatás bekapcsolva"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Bloom hatás kikapcsolva"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Megvilágítottság"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "OpenGL hiba: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "A felosztáshoz túl kicsi nézet"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Hozzáadott nézet"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "fényév"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "CSE"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr "nap"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr "óra"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr "perc"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr "másodpercek"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " fényév/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Sebesség:  "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Látszólagos átmérő: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Látszólagos fényesség"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Abszolút fényesség: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Távolság: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Csillagrendszer tömegközéppontja\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Absz. (látszó) fényesség: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Fényesség: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Neutroncsillag"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Fekete lyuk"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Osztály:"
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Felszíni hőm.: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Kapcsolódó égitestek\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Távolság a középponttól:  "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Sugár: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fázisszög: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Hőmérséklet: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Helyi idő"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Helyi idő"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Idő leállítva"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "gyorsabb"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "lassabb"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr "Idő megállítása"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Utazás"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Utazás"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Vontat"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Követ "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Pálya szinkr."
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Üldöz"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Cél neve: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr " Szünet"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "Felvétel"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Szünet    F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Edit Mode"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Naprendszer katalógus betöltése:"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Naprendszer katalógus betöltése:"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Naprendszer katalógus betöltése:"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Naprendszer katalógus betöltése:"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Hiba a \"favorites\" fájl olvasásakor."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Hiba a konfigurációs fájl olvasásakor."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Hiba a SPICE könyvtár inicializálásakor."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Csillag adatbázis nem olvasható."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Hiba a mélyég katalógus megnyitásakor"
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Csillag adatbázis nem olvasható."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Hiba a naprendszer katalógus megnyitásakor.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Hiba az asterisms fájl megnyitásakor."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Hiba a constellation boundaries fájl megnyitásakor."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Hiba a renderelő inicializálásánál"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Hiba a font betöltésekor, a szöveg nem jeleníthető meg.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Hiba a keresztindex olvasásakor"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Cross index betöltve"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Hiba a csillagok nevét tartalmazó fájl megnyitásakor\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Hiba a megnyitáskor"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Hiba a stars fájl olvasásakor\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Hiba a csillag katalógus megnyitásakor"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Supported Extensions:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1014,37 +992,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Égi objektumok"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Égi objektumok"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Naprendszer"
 
@@ -1054,20 +1032,20 @@ msgstr "Naprendszer"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Csillagok"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr "Mélyég objektumok"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1077,122 +1055,118 @@ msgstr "Fogyatkozás-kereső"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Idő"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Idegenvezetés"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Tejles képernyő"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "&Mozgókép felvétele...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Hiba az asterisms fájl megnyitásakor."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Könyvjelzők"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Mentés másként:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "nem PNG fájl.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Video felvétele"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Video felvétele"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Video felvétele"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Felbontás:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Képkocka/másodperc: "
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL másolása"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "URL betöltése:"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Szkript megnyitása..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Új könyvjelzőmappa létrehozása ebben a menüben"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1209,350 +1183,350 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Ismeretlen hiba a szkript megnyitásakor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Supported Extensions:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Supported Extensions:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Celestia névjegye"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>Kiterjesztések nélküli OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Kiterjesztések nélküli OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Kiterjesztések nélküli OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL verzió:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Max simultaneous textures: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Max texture size: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Point size range: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Point size range: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Max cube map size: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "Supported Extensions:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Megjelenítés"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Fájl"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Kép elmentése"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Képernyő-fényképezés...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Video felvétele"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "&Mozgókép felvétele...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "URL másolása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Szkript megnyitása..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia beállítások"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Kilépés"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Élsimítás (Antialiasing)\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigáció"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "Kiválaszt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "Kijelölt égitest középre\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Kijelölés: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ugrás a kijelölt égitesthez..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "Idő "
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Idő beállítása..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Megjelenítés"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Égitestek"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Gyűrűárnyékok"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Csillagok megjelenítése"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Textúra felbontás"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "Gyorsbillentyűk"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 #, fuzzy
 msgid "&Bookmarks"
 msgstr "Könyvjelzők"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "Nézet"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Több Nézet"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Nézet vízszintes felosztása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Nézet vízszintes felosztása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Nézet függőleges felosztása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Nézet függőleges felosztása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Következő nézet"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Egyablakos nézet"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Egyablako&s nézet"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Nézet törlése"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Keret mutatása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktív nézet kerete látható"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Idő szinkronizálása"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Súgó"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "OpenGL adatok"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Könyvjelzők hozzáadása"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "Könyvjelzők rendezése..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Betöltés"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Szkriptek"
@@ -1675,11 +1649,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Jelölők"
 
@@ -1695,7 +1669,7 @@ msgstr "Kijelölt égitest középre\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Csillagképek"
 
@@ -1717,7 +1691,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Pályák"
 
@@ -1731,18 +1705,18 @@ msgstr "Pályák"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Bolygók"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Törpe bolygók"
 
@@ -1755,16 +1729,16 @@ msgstr "Törpe bolygók"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Holdak"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Kis holdak"
 
@@ -1777,10 +1751,10 @@ msgstr "Kis holdak"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Kisbolygók"
 
@@ -1793,10 +1767,10 @@ msgstr "Kisbolygók"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Üstökösök"
 
@@ -1813,11 +1787,11 @@ msgstr "Üstökösök"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1835,7 +1809,7 @@ msgstr "10x Gyorsabb\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Címkék"
 
@@ -1845,9 +1819,9 @@ msgstr "Címkék"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaxisok"
 
@@ -1855,8 +1829,8 @@ msgstr "Galaxisok"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Gömbhalmazok"
 
@@ -1876,9 +1850,9 @@ msgstr "Nyílt galaxishalmazok"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nebulák"
 
@@ -1890,48 +1864,48 @@ msgid "Locations"
 msgstr "Helyek"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Nyílt galaxishalmazok"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Felhők"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Éjjeli oldal fényei"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Üstököscsóvák"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Légkör"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Gyűrűárnyékok"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Fogyatkozás-árnyékok"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Felhőárnyékok"
 
@@ -2004,237 +1978,237 @@ msgstr "Önműködő fényességállítás 45 foknál:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudó korlát: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Név"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Távolság (fényév): "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Látsz. magn."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Absz. magn."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Típus"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Csillagok"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Legfényesebb"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Csillagok szűrése"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Bolygókkal"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Csillagok"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Tömegközéppont"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Rossz spektráltípus a csillag adatbázisban "
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "Jelöl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "A listázandó csillagok maximális száma"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "Jelöl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Jelölők"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Semmi"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Gyémánt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Háromszög"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Négyzet"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plusz"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Kör"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Balra nyíl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Jobbra nyíl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Felfelé nyíl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Lefelé nyíl"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Kiválaszt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Méret:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Kiválaszt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Tereptárgyak címkéi"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Égitestek"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "Jelöl"
@@ -2349,8 +2323,8 @@ msgstr "Mettől:"
 msgid "Behind %1"
 msgstr "Időtartam: %1"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2519,86 +2493,91 @@ msgstr "Méret: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Csillagok megjelenítése"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Helyi formátum"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Időzóna neve: "
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC eltérés"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Indítás"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Absz. (app) fény:"
 
@@ -2611,21 +2590,21 @@ msgid "&Select"
 msgstr "Kiválaszt"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "Középre"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "U&grás"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 #, fuzzy
 msgid "&Follow"
 msgstr "Követ "
@@ -2640,12 +2619,12 @@ msgid "Visible"
 msgstr "Aktív nézet kerete látható"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "Jelölés törlése"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Képernyő üzemmód kiválasztása"
@@ -2659,12 +2638,12 @@ msgid "Disk"
 msgstr "Korong"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "Jelöl"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Referencia vektorok"
 
@@ -2712,13 +2691,13 @@ msgid "Show &Terminator"
 msgstr "Lezáró mutatása"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Alternatív Felületek"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Alap"
 
@@ -2730,7 +2709,7 @@ msgstr "Alap"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Törpe bolygók"
@@ -2742,15 +2721,15 @@ msgstr "Törpe bolygók"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Kis holdak"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Égitestek"
@@ -2761,7 +2740,7 @@ msgid "Set Time"
 msgstr "Idő beállítása..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Időzóna: "
 
@@ -2826,7 +2805,7 @@ msgid "Set Seconds"
 msgstr "másodpercek"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Julián dátum:"
 
@@ -2840,98 +2819,98 @@ msgstr "Julián dátum:"
 msgid "Set time"
 msgstr "Idő beállítása..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Tömegközéppont"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Rossz spektráltípus a csillag adatbázisban "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Bolygó"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Törpe bolygó"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Hold"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Kis holdak"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Kisbolygó"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Üstökös"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Űrhajók"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Referencia vektorok"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Számítás"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Ugrás a felszínre"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Ismeretlen hiba a szkript megnyitásakor"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Kisbolygók"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Referencia vektorok"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Egyéb tereptárgyak"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Bolygók"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Égitestek"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3064,7 +3043,7 @@ msgstr "Felbontás:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Könyvjelzők rendezése"
 
@@ -3171,7 +3150,7 @@ msgstr "Pályák mutatása"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Leszállóhelyek"
@@ -3179,7 +3158,7 @@ msgstr "Leszállóhelyek"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Részleges pályák"
@@ -3187,49 +3166,49 @@ msgstr "Részleges pályák"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Rácsok"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Egyenlítői"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ekliptikus"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galaktikus"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Nézet függőleges felosztása"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagrammok"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Határok"
 
@@ -3431,41 +3410,41 @@ msgstr "Megjelenítés"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Supported Extensions:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Supported Extensions:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3717,13 +3696,13 @@ msgstr "&Celestia névjegye"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3809,7 +3788,7 @@ msgid "Create in >>"
 msgstr "Létrehoz >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Új mappa..."
 
@@ -3891,7 +3870,7 @@ msgid "Go to Object"
 msgstr "Ugrás az égitesthez: "
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Ugrás"
 
@@ -3909,7 +3888,7 @@ msgid "Lat."
 msgstr "Szélesség"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 #, fuzzy
 msgid "Distance"
 msgstr "Távolság: "
@@ -3959,174 +3938,178 @@ msgstr "Legkisebb megjelenített tereptárgy mérete"
 msgid "Size:"
 msgstr "Méret:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Átnevezés..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Könyvjelző/Mappa átnevezése"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Új név"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Szimuláció idő beállítása"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formátum:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Helyi idő beállítása"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Naprendszer böngésző"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Ugrás"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Égitestek a Naprendszerben"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Csillag böngésző"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Legközelebbi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Legfényesebb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Bolygókkal"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "F&rissítés"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Csillag keresése"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "A listázandó csillagok maximális száma"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Idegenvezetés"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Úticél kiválasztása"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Megjelenítési beállítások"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Mutat"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Megjelenítés"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Ekliptikus vonal"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Pályák / Címkék"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Latin nevek"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Adatok"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Tömör"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Bőséges"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "40e"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Ápr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Febr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jún"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Márc"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Máj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Júl"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Szept"
 
@@ -4142,184 +4125,189 @@ msgstr "Dátum"
 msgid "Start"
 msgstr "Indítás"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Ablakos mód"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Láthatatlan objektumok"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "Pálya szinkronizálása"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Adatok"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Objektumok tengelyének mutatása"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Váz tegelyeinek mutatása"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Nap irányának mutatása"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Sebességvektor mutatása"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Planetáris háló mutatása"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Lezáró mutatása"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "Mellékbolygók"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Keringő Égitestek"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Hiba a font betöltésekor, a szöveg nem jeleníthető meg.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Hiba: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Video felvétele"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Celestia gyorsbillentyűk"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Betöltés: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Betöltés"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "hu"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Hiba a konfigurációs fájl olvasásakor."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "URL betöltése:"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Verzió:"
 
@@ -4355,17 +4343,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Hiba a PNG képfájlban"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Hiba a szkript fájl megnyitásakor."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Ismeretlen hiba a szkript megnyitásakor"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4377,7 +4369,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4388,9 +4380,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Hiba a szkript megnyitásakor '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Hiba a szkript betöltésekor"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4398,8 +4390,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Hiba a co-routin szkript inicializálásánál"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Hiba a szkript megnyitásakor '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4415,6 +4407,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Hiba a megnyitáskor"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Megjelenítési mód: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Bloom hatás bekapcsolva"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Bloom hatás kikapcsolva"
+
+#~ msgid "Exposure"
+#~ msgstr "Megvilágítottság"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Video felvétele"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Hiba a szkript megnyitásakor '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6794,9 +6806,6 @@ msgstr "Hiba a megnyitáskor"
 #~ msgid "GLSL version: "
 #~ msgstr "GLSL verzió:"
 
-#~ msgid "Error opening script"
-#~ msgstr "Hiba a szkript betöltésekor"
-
 #~ msgid "Error loading script"
 #~ msgstr "Hiba a szkript betöltésekor"
 
@@ -7333,9 +7342,6 @@ msgstr "Hiba a megnyitáskor"
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Felszíni hőm.:"
-
-#~ msgid "Radius: "
-#~ msgstr "Sugár: "
 
 #~ msgid "Rsun"
 #~ msgstr "RNap"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2020-05-17 14:47+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Ora legale"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -55,38 +55,38 @@ msgstr "Errore di lettura del file di configurazione."
 msgid "Loaded {} deep space objects\n"
 msgstr " oggetti dello spazio profondo"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galassia (Tipo Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Ammasso globulare (raggio del nucleo: %4.2f', distribuzione di King: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Sto caricando l'immagine dal file "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Caricamento del modello: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
+#, fuzzy
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 "   Statistiche del modello: %u vertici, %u primitivi, %u materiali (%u "
 "unico)\n"
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Errore nel caricamento del modello '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -102,115 +102,110 @@ msgstr "Ammasso aperto"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Errore nel file .ssc (linea "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "corpo principale '%s' di '%s' non trovato.\n"
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "attenzione, definizione duplicata di "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "Superficie alternativa errata"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "luogo errato"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Intestazione errata per l'indice incrociato\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Versione errata per l'indice incrociato\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Il caricamento dell'indice incrociato è fallito al record "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Il caricamento dell'indice incrociato è fallito al record "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Tipo spettrale errato nel database delle stelle, stella nº"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " stelle nel database binario\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Numero totale di stelle: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Errore nel file .stc (linea "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Stella non valida: tipo spettrale errato.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Stella non valida: manca il tipo spettrale.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " non esiste.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Stella non valida: manca l'ascensione retta.\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Stella non valida: manca la declinazione.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Stella non valida: manca la distanza.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Stella non valida: manca la magnitudine\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Stella non valida: deve essere specificata la magnitudine assoluta (non "
 "apparente) per stelle vicine all'origine\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr "Livello %i,% .5f ly, %i nodi, %i stelle\n"
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -247,721 +242,705 @@ msgstr "Ordine byte previsto %i, non supportato%i.\n"
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Numero previsto di cifre %i, non supportato%i.\n"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Errore di lettura dei file preferiti."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Tipo di file non valido"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudine limite: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Marcatori abilitati"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Marcatori disabilitati"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Vai alla superficie"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Modalità altazimutale abilitata"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Modalità altazimutale disabilitata"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Stile stelle: punti sfocati"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Stile stelle: punti"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Stile stelle: dischi in scala"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Code delle comete abilitate"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Code delle comete disabilitate"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Tipo di Render: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Marcatori abilitati"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Marcatori disabilitati"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Auto-magnitudine abilitata"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Auto-magnitudine disabilitata"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Tempo e script sono in pausa"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Tempo in pausa"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Riparti"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Navigatore stellare... (&r)"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Navigatore stellare... (&r)"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Tempo di viaggio della luce:  %.4f anni "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Tempo di viaggio della luce:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Tempo di viaggio della luce:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Ritardo per il tempo di viaggio della luce incluso"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Ritardo per il tempo di viaggio della luce eliminato"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Ritardo per il tempo di viaggio della luce ignorato"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Mappe di superfici normali in uso."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Mappe di superficie al limite della conoscenza in uso."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Segui"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Tempo: avanti"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Tempo: indietro"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Rateo del tempo"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Mappe"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Mappe"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Mappe"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Sincronizza l'orbita"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Blocca"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Insegui"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudine limite: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Limite automatico di magnitudine a 45 gradi:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Livello luce ambientale: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Guadagno di luminosità"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Effetto Bloom abilitato"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Effetto Bloom disabilitato"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Esposizione"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Errore GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Vista troppo piccola per poterla dividere"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Vista aggiunta"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "al"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "ua"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "Km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " giorni"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " ore"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minuti"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " secondi"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Periodo di rotazione: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, fuzzy, c-format
 msgid "Mass: %.6g lb\n"
 msgstr "Massa: %.2f Me\n"
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, fuzzy, c-format
 msgid "Mass: %.6g kg\n"
 msgstr "Massa: %.2f Me\n"
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, fuzzy, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr "Massa: %.2f Me\n"
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr "Massa: %.2f Me\n"
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " Km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Velocità: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diametro apparente: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitudine apparente: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitudine assoluta: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distanza: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Baricentro del sistema stellare\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Magnitudine assoluta (app.): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosità: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Stella di neutroni"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Buco nero"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Classe: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Temp. superf.: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Raggio: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Raggio: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Sistema planetario presente\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distanza dal centro: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Raggio: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Angolo di fase: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, fuzzy, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr "Densità: %.2f x 1000 kg/m^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "Densità: %.2f x 1000 kg/m^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  Tempo Locale"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tempo reale"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Tempo reale"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Tempo arrestato"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " più veloce "
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " più lento"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (In Pausa)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "In viaggio "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "In viaggio "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Aggancia "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Segui "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Sincronizza Orbita"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "BloccA %s -> %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Insegui "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Nome dell'obiettivo: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "In pausa"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  In registrazione"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 avvia/pausa    F12 Ferma"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Modifica modalità"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Caricamento del catalogo del sistema solare: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Caricamento del catalogo del sistema solare: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Caricamento del catalogo del sistema solare: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Caricamento del catalogo del sistema solare: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Errore di lettura dei file preferiti."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Errore di lettura del file di configurazione."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Inizializzazione della libreria SPICE fallita."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Impossibile leggere il database delle stelle."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Errore di apertura del catalogo Deepsky."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Impossibile leggere il database delle stelle."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Errore in apertura del catalogo del sistema solare.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Errore in apertura del file asterismi."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Errore in apertura del file dei confini delle costellazioni."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Inizializzazione del renderer fallita"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Errore nel caricamento del font. Il testo non sarà visibile.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Errore di lettura dell'indice incrociato "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Indice incrociato caricato "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Errore di lettura del file dei nomi delle stelle\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Errore in apertura di "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Errore di lettura del file delle stelle\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Errore di apertura del catalogo delle stelle "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Estensioni supportate:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1020,19 +999,19 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr "Automatico"
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 #, fuzzy
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
@@ -1041,19 +1020,19 @@ msgstr ""
 "Impossibile eseguire Celestia perché la directory di dati non è stata "
 "trovata, probabilmentea causa di installazione errata."
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Navigatore celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navigatore celeste"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Sistema solare"
 
@@ -1063,20 +1042,20 @@ msgstr "Sistema solare"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Stelle"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " oggetti dello spazio profondo"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1086,123 +1065,119 @@ msgstr "Cercatore di eclissi"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Tempo"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Visita guidata"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Schermo intero"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Cattura video... (&M)\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Errore in apertura del file asterismi."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Segnalibri (&b)"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Salva come:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " non è un file PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Cattura video"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Cattura video"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Cattura video"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Risoluzione:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Fotogrammi/secondo:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL copiato"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Caricamento dell'URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "Apri Script... (&O)"
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Crea una nuova cartella di segnalibri in questo menu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1219,349 +1194,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Sconosciuto"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Estensioni supportate:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Estensioni supportate:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "A proposito di Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 1.1 non esteso</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>OpenGL 1.1 non esteso</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 non esteso</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Versione GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Numero max mappe simultanee: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Dimensione max mappa: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Gamma della dimensione dei punti: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Gamma della dimensione dei punti: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Dim. max mappa cubica: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Equatoriale"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "Estensioni supportate:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Renderer:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "File (&F)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Cattura immagine"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Cattura immagine...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Cattura video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Cattura video... (&M)\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copia l'URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Apri Script... (&O)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferenze Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Esci (&x)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "Navigazione (&N)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "Seleziona (&S)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "Centra la selezione (&C)\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selezione: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Vai all'oggetto..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "Tempo (&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Imposta l'ora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Display"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Oggetti"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Ombre degli anelli"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Stile delle stelle (&y)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Risoluzione mappe (&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "Controlli (&C)"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "Segnalibri (&b)"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "Vista (&V)"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Vista multipla"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividi lo schermo verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividi orizzontalmente (&H)\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividi lo schermo orizzontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dividi verticalmente (&V)\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Vista successiva"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Vista singola"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "vista singola (&S)\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Cancella la vista"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Cancella"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Bordi visibili"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Visualizza bordo vista attiva"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizza il tempo"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Aiuto (&H)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "Informazioni su OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Aggiungi un segnalibro (&A)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "Organizza i segnalibri... (&O)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr "Impostazione predefinita FPS"
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr "ValorE FPS"
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Caricamento "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
@@ -1687,11 +1662,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Marcatori"
 
@@ -1707,7 +1682,7 @@ msgstr "Centra la selezione (&C)\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Costellazioni"
 
@@ -1729,7 +1704,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Orbite"
 
@@ -1743,18 +1718,18 @@ msgstr "Orbite"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Pianeti"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Pianeti nani"
 
@@ -1767,16 +1742,16 @@ msgstr "Pianeti nani"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Lune"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Lune minori"
 
@@ -1789,10 +1764,10 @@ msgstr "Lune minori"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroidi"
 
@@ -1805,10 +1780,10 @@ msgstr "Asteroidi"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Comete"
 
@@ -1825,11 +1800,11 @@ msgstr "Comete"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1847,7 +1822,7 @@ msgstr "10x più veloce (&F)\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Nomi"
 
@@ -1857,9 +1832,9 @@ msgstr "Nomi"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galassie"
 
@@ -1867,8 +1842,8 @@ msgstr "Galassie"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Ammassi globulari"
 
@@ -1888,9 +1863,9 @@ msgstr "Ammassi aperti"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nebulose"
 
@@ -1902,48 +1877,48 @@ msgid "Locations"
 msgstr "Luoghi"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Ammassi aperti"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Nubi"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Luci notturne"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Code delle comete"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosfere"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Ombre degli anelli"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Ombre delle eclissi"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Ombre delle nubi"
 
@@ -2016,237 +1991,237 @@ msgstr "Limite automatico di magnitudine a 45 gradi:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudine limite: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Distanza (al)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Mag. app."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Mag. ass."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Stelle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Più brillanti"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtro stelle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Con pianeti"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Stelle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentro"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Tipo spettrale errato nel database delle stelle, stella nº"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "Marca (&M) "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Numero massimo di stelle in lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "Marca (&M) "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr "Deseleziona le stelle selezionate nella vista elenco"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcatori"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr "Rimuovi tutti i marcatori esistenti"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Nessuno"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Losanga"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Triangolo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Quadrato"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Più"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Cerchio"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Freccia sinistra"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Freccia destra"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Freccia su"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Freccia giù"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Seleziona (&S)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Dimensione:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Seleziona (&S)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Etichetta le caratteristiche"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Oggetti"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr "Contrassegna i DSO selezionati nella vista elenco"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "Marca (&M) "
@@ -2361,9 +2336,12 @@ msgstr "Da:"
 msgid "Behind %1"
 msgstr "Durata: %1"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+#, fuzzy
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
+"Celestia non è stato in grado di inizializzare le estensioni OpenGL (errore "
+"i). Grafica la qualità sarà ridotta."
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
 msgid "Error: no object selected!\n"
@@ -2531,86 +2509,91 @@ msgstr "Dimensione: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensione: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Stile delle stelle (&y)"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Formato locale"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Nome fuso orario: "
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Differenza tempo civile"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Avvio"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Distanza: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Magnitudine assoluta (app.): "
 
@@ -2623,21 +2606,21 @@ msgid "&Select"
 msgstr "Seleziona (&S)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "Centra (&C)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "Vai a (&G)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "Segui (&F)"
 
@@ -2651,12 +2634,12 @@ msgid "Visible"
 msgstr "Visualizza bordo vista attiva"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "Rimuovi il marcatore (&u) "
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Seleziona la modalità video"
@@ -2670,12 +2653,12 @@ msgid "Disk"
 msgstr "Disco"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "Marca (&M) "
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "Marchi di riferimento (&R)"
 
@@ -2723,13 +2706,13 @@ msgid "Show &Terminator"
 msgstr "Mostra il terminatore"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "Superfici alternative (&A)"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normale"
 
@@ -2741,7 +2724,7 @@ msgstr "Normale"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Pianeti nani"
@@ -2753,15 +2736,15 @@ msgstr "Pianeti nani"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Lune minori"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Oggetti"
@@ -2772,7 +2755,7 @@ msgid "Set Time"
 msgstr "Imposta l'ora..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Fuso orario: "
 
@@ -2833,7 +2816,7 @@ msgid "Set Seconds"
 msgstr " Imposta Secondi"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Data Giuliana: "
 
@@ -2846,95 +2829,95 @@ msgstr "imposta Data Giuliana: "
 msgid "Set time"
 msgstr "Imposta l'ora..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Baricentro"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr "Stella"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Pianeta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Pianeta nano"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Luna"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Lune minori"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroide"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Cometa"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Veicoli Sspaziali"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "Marchi di riferimento (&R)"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Calcola"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Vai alla superficie"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteroidi"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "Marchi di riferimento (&R)"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr "Componenti"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Altre caratteristiche"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Pianeti"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Oggetti"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr "Contrassegna i corpi selezionati nella vista elenco"
 
@@ -3067,7 +3050,7 @@ msgstr "Risoluzione:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organizza i segnalibri"
 
@@ -3174,7 +3157,7 @@ msgstr "Mostra le orbite"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Zone d'atterraggio"
@@ -3182,7 +3165,7 @@ msgstr "Zone d'atterraggio"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Traiettorie parziali"
@@ -3190,49 +3173,49 @@ msgstr "Traiettorie parziali"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Griglie"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Equatoriale"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Eclittica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galattico"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Orizzontale"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagrammi"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Confini"
 
@@ -3434,41 +3417,41 @@ msgstr "Display"
 msgid "Not an XBEL version 1.0 file."
 msgstr "Non è un file XBEL versione 1.0."
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Estensioni supportate:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Estensioni supportate:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3717,13 +3700,13 @@ msgstr "A proposito di Celestia (&A)"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3811,7 +3794,7 @@ msgid "Create in >>"
 msgstr "Crea in >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Nuova cartella..."
 
@@ -3892,7 +3875,7 @@ msgid "Go to Object"
 msgstr "Vai all'Oggetto"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Vai a"
 
@@ -3909,7 +3892,7 @@ msgid "Lat."
 msgstr "Lat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Distanza"
 
@@ -3958,174 +3941,178 @@ msgstr "Dimensione minima caratteristiche etichettate"
 msgid "Size:"
 msgstr "Dimensione:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Rinomina..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Rinomina il segnalibro o la cartella"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Nuovo nome"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Imposta il tempo di simulazione"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formato:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Imposta all'ora corrente"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Navigatore del sistema solare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "Vai a (&G)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Oggetti del sistema solare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Navigatore stellare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Più vicini"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Più brillanti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Con pianeti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "Aggiorna (&R)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Criteri di ricerca delle stelle"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Numero massimo di stelle in lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Visita guidata"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Seleziona la destinazione:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Opzioni di visualizzazione"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Visualizza"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Display"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Eclittica"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Orbite / Nomi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Nomi latini"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Testo informativo"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Conciso"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Dettagliato"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "410"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Gen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Giu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mag"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dic"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Lug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Ott"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Set"
 
@@ -4141,187 +4128,192 @@ msgstr "Data"
 msgid "Start"
 msgstr "Avvio"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Modalità finestra"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Invisibili"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "Sincronizza l'orbita (&Y)"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "Informazioni (&I)"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Mostra gli assi dei Corpi"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Mostra gli assi dei bordi"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Mostra la direzione del Sole"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Mostra il vettore velocità"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Mostra la griglia planetografica"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Mostra il terminatore"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "Satelliti (&S)"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Corpi orbitanti"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Errore nel caricamento del font. Il testo non sarà visibile.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Errore: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr "Errore irreversibile"
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 #, fuzzy
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 "Il tuo sistema non lo supporta\n"
 "%@"
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Cattura Video"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Controlli di Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Caricamento di: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Caricamento "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "it"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Errore di lettura del file di configurazione."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Caricamento dell'URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versione: "
 
@@ -4357,17 +4349,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Errore di lettura del file di immagine PNG "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Errore di apertura del file script."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Errore sconosciuto in apertura dello script"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4387,7 +4383,7 @@ msgstr ""
 "\n"
 "y = sì, ESC = annulla script, qualsiasi altra chiave = no"
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4404,9 +4400,9 @@ msgstr ""
 "Ti fidi dello script e vuoi eseguirlo?"
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Errore di apertura dello script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Errore durante l'apertura dello script"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4414,8 +4410,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Inizializzazione fallita della coroutine dello script"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Errore di apertura dello script '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4431,6 +4427,29 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Errore in apertura di "
+
+#~ msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
+#~ msgstr "Livello %i,% .5f ly, %i nodi, %i stelle\n"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Tipo di Render: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Effetto Bloom abilitato"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Effetto Bloom disabilitato"
+
+#~ msgid "Exposure"
+#~ msgstr "Esposizione"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Cattura video"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Errore di apertura dello script '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6762,13 +6781,6 @@ msgstr "Errore in apertura di "
 #~ msgid "Unknown error opening script"
 #~ msgstr "Errore sconosciuto in apertura dello script"
 
-#~ msgid ""
-#~ "Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-#~ "quality will be reduced."
-#~ msgstr ""
-#~ "Celestia non è stato in grado di inizializzare le estensioni OpenGL "
-#~ "(errore i). Grafica la qualità sarà ridotta."
-
 #, fuzzy
 #~ msgid "Max simultaneous textures"
 #~ msgstr "Numero max mappe simultanee: "
@@ -6917,9 +6929,6 @@ msgstr "Errore in apertura di "
 
 #~ msgid "GLSL version: "
 #~ msgstr "Versione GLSL: "
-
-#~ msgid "Error opening script"
-#~ msgstr "Errore durante l'apertura dello script"
 
 #~ msgid "Error loading script"
 #~ msgstr "Errore durante il caricamento dello script"
@@ -7458,9 +7467,6 @@ msgstr "Errore in apertura di "
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Temp. superficiale: "
-
-#~ msgid "Radius: "
-#~ msgstr "Raggio: "
 
 #~ msgid "Rsun"
 #~ msgstr "Rsole"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2020-07-05 21:01+0900\n"
 "Last-Translator: Sui Ota <aqua@aqsp.net>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.3.1\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "夏時間"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "標準時"
 
@@ -54,35 +54,35 @@ msgstr "設定ファイルの読み込みでエラーが発生しました。"
 msgid "Loaded {} deep space objects\n"
 msgstr "%i個の遠距離天体を読み込みました\n"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "銀河 (ハッブル型: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "球状星団 (コア半径: %4.2f', キング濃度: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "画像ファイル %sを読み込んでいます\n"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "3Dモデルファイル %sを読み込んでいます\n"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
+#, fuzzy
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr "   モデル統計: %u vertices, %u primitives, %u materials (%u unique)\n"
 
-#: ../src/celengine/meshmanager.cpp:553
-#, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "3Dモデルファイル %sの読み込みに失敗しました\n"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +98,110 @@ msgstr "散開星団"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr ".sscファイルにエラーがあります (行 %d): "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "‘%s’ (‘%s’の母天体)が見つかりません。\n"
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "%s %sが重複して定義されています\n"
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "正しくないAltSurface"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "正しくない地名"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "クロスインデックスのヘッダが正しくありません\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "クロスインデックスのバージョンが正しくありません\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "レコード %uでクロスインデックスの読み込みに失敗しました\n"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "レコード %uでクロスインデックスの読み込みに失敗しました\n"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "恒星データベースに正しくないスペクトル型があります。 #%u\n"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr "%d個の恒星がバイナリデータベースから読み込まれました\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "恒星総数: %d\n"
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr ".stcファイルにエラーがあります。(行 %i): %s\n"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "無効な恒星です: スペクトル型が正しくありません。\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "無効な恒星です: スペクトル型がありません。\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr "重心 %sは存在しません。\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "無効な恒星です: 赤経がありません。\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "無効な恒星です: 赤緯がありません。\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "無効な恒星です: 距離がありません。\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "無効な恒星です: 等級がありません。\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "無効な恒星です: 原点付近の恒星には、実視等級ではなく、絶対等級が設定されてい"
 "る必要があります。\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr "レベル %i, %.5f光年, ノード数 %i, 恒星数 %i \n"
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -243,701 +238,684 @@ msgstr "サポートされていないバイトオーダー %iです。%iが必�
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "サポートされていない桁数 %iです。%iが必要です。\n"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "お気に入りファイルの読み込みでエラーが発生しました。"
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "無効なファイルタイプ"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "限界等級: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "マーカー: ON"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "マーカー: OFF"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "天体表面へ移動"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "高度角・方位角モード: ON"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "高度角・方位角モード: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "恒星表示: ぼやけた点"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "恒星表示: 点"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "恒星表示: 等級に応じた円"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "彗星の尾: ON"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "彗星の尾: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "レンダリングパス: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 msgid "Anti-aliasing enabled"
 msgstr "アンチエイリアス: ON"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 msgid "Anti-aliasing disabled"
 msgstr "アンチエイリアス: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "自動限界等級調整: ON"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "自動限界等級調整: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "時間・スクリプト: 停止"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "時間: 停止"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "再開"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr "恒星色: Blackbody D65"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr "恒星色: エンハンスド"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "光速到達時間: %.4f 年"
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "光速到達時間: %d 分  %.1f 秒"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "光速到達時間: %d 時間  %d 分  %.1f 秒"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "光速考慮: ON"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "光速考慮: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "光速考慮は無視されます"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "通常テクスチャを使用しています。"
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "limit of knowledgeテクスチャを使用しています。"
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "天球同期"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "時間の流れ: 順方向"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "時間の流れ: 逆方向"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, c-format
 msgid "Time rate: %.6g"
 msgstr "時間の速さ: %.6g"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 msgid "Low res textures"
 msgstr "テクスチャ: 低解像度"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 msgid "Medium res textures"
 msgstr "テクスチャ: 中解像度"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr "テクスチャ: 高解像度"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "自転同期"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "2天体同期"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "公転同期"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "限界等級: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "視野45°での限界等級: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "周辺光の強さ: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "光度利得"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "ブルーム効果: ON"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "ブルーム効果: OFF"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "露出"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GLエラー: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "ビューが小さすぎます"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "ビューを分割"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr "Mpc"
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr "kpc"
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "光年"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "天文単位"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr "m"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 msgid "days"
 msgstr "日"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "hours"
 msgstr "時間"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 msgid "minutes"
 msgstr "分"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 msgid "seconds"
 msgstr "秒"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "自転周期: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, fuzzy, c-format
 msgid "Mass: %.6g lb\n"
 msgstr "重量: 地球の%.2f 倍\n"
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, fuzzy, c-format
 msgid "Mass: %.6g kg\n"
 msgstr "重量: 地球の%.2f 倍\n"
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, fuzzy, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr "重量: 地球の%.2f 倍\n"
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr "重量: 地球の%.2f 倍\n"
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 msgid "ly/s"
 msgstr "光年/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 msgid "AU/s"
 msgstr "天文単位/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 msgid "km/s"
 msgstr "km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 msgid "m/s"
 msgstr "m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr "速度: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "視直径: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "視等級: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "絶対等級: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, fuzzy, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr "%.6f%c %.6f%c %f km"
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, c-format
 msgid "Distance: %s\n"
 msgstr "距離: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "重心\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "絶対等級: %.2f 視等級: %.2f\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "光度: 太陽の%s 倍\n"
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "中性子星"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "ブラックホール"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, c-format
 msgid "Class: %s\n"
 msgstr "スペクトル型: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2860
-#, c-format
-msgid "Surface temp: %s K\n"
+#: ../src/celestia/celestiacore.cpp:2905
+#, fuzzy, c-format
+msgid "Surface temp: %s\n"
 msgstr "表面温度: %s K\n"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "半径: 太陽の%s 倍 (%s km)\n"
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "半径: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "惑星が存在\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "中心からの距離: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, c-format
+msgid "Radius: %s\n"
+msgstr "半径: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "位相角: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, fuzzy, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr "密度: %.2f×1000 kg/m³\n"
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "密度: %.2f×1000 kg/m³\n"
 
-#: ../src/celestia/celestiacore.cpp:2999
-#, c-format
-msgid "Temperature: %.0f K\n"
+#: ../src/celestia/celestiacore.cpp:3045
+#, fuzzy, c-format
+msgid "Temperature: %s\n"
 msgstr "温度: %.0f K\n"
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr " 光速"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "等倍速"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-等倍速"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "停止中"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, c-format
 msgid "%.6g x faster"
 msgstr "%.6g 倍速"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, c-format
 msgid "%.6g x slower"
 msgstr "1/%.6g 倍速"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (停止中)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "移動中 (%s)\n"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, c-format
+#: ../src/celestia/celestiacore.cpp:3291
 msgid "Travelling\n"
 msgstr "移動中\n"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, c-format
 msgid "Track %s\n"
 msgstr "%s を中央保持\n"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, c-format
 msgid "Follow %s\n"
 msgstr "%s に天球同期\n"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "%s に自転同期\n"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "%s から%s に同期\n"
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, c-format
 msgid "Chase %s\n"
 msgstr "%s に公転同期\n"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr "視野: %s (%.2fx)\n"
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "天体名を入力してください: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, fuzzy, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr "%d×%d at %f fps  %s"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Paused"
 msgstr "停止中"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Recording"
 msgstr "録画中"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 録画開始/一時停止    F12 停止"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "編集モード"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "恒星系カタログを読み込んでいます: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "恒星系カタログを読み込んでいます: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "%sカタログを読み込んでいます: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "%sカタログを読み込んでいます: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "お気に入りファイルの読み込みでエラーが発生しました。"
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "設定ファイルの読み込みでエラーが発生しました。"
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "SPICEライブラリの初期化に失敗しました。"
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "恒星データベースを読み込めません。"
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "遠距離天体カタログ %sのオープンでエラーが発生しました。\n"
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "遠距離天体データベース %sを読み込めません。 \n"
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "恒星系カタログ %sのオープンでエラーが発生しました。\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "星座線ファイル %sのオープンでエラーが発生しました。\n"
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "星座境界線ファイル %sのオープンでエラーが発生しました。\n"
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "レンダラーの初期化に失敗しました"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "フォントの読み込みでエラーが発生しました。テキストが表示されません。\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "クロスインデックスファイル %sの読み込みでエラーが発生しました\n"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "クロスインデックスファイル %sを読み込みました\n"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "恒星名ファイルの読み込みでエラーが発生しました\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "%sのオープンでエラーが発生しました。\n"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "恒星ファイルの読み込みでエラーが発生しました\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "恒星カタログ %sのオープンでエラーが発生しました\n"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "サポートされた拡張:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -996,19 +974,19 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr "自動"
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr "カスタム"
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 #, fuzzy
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
@@ -1017,18 +995,18 @@ msgstr ""
 "データディレクトリが見つからないためCelestiaを起動できません。インストールが"
 "正しくない事が考えられます。"
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "天体ブラウザ"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 msgid "Info Browser"
 msgstr "情報ブラウザ"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "太陽系"
 
@@ -1038,19 +1016,19 @@ msgstr "太陽系"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "恒星"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr "遠距離天体"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "天体現象を検索"
@@ -1059,110 +1037,107 @@ msgstr "天体現象を検索"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "時間"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "ガイド"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 msgid "Full screen"
 msgstr "全画面表示"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 msgid "Error opening bookmarks file"
 msgstr "ブックマークファイルのオープンでエラーが発生しました"
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 msgid "Error Saving Bookmarks"
 msgstr "ブックマークの保存に失敗しました"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 msgid "Save Image"
 msgstr "画像を保存"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr "画像 (*.png *.jpg)"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "動画キャプチャ"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr "動画 (*.avi)"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "動画 (*.avi)"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr "解像度:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr "%1×%2"
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "フレームレート:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr "キャプチャされたスクリーンショットをクリップボードにコピーしました"
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URLをコピー"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 msgid "Pasting URL"
 msgstr "URLをペースト"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Open Script"
 msgstr "スクリプトを開く"
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Celestiaスクリプト (*.celx *.cel)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 msgid "New bookmark"
 msgstr "新しいブックマーク"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, fuzzy, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1188,307 +1163,307 @@ msgstr ""
 "CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</"
 "a><br></html>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "不明"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "サポート"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "サポート"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Celestiaについて"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGLバージョン: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "ベンダー: %@"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>レンダラー: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "<b>GLSLバージョン: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "最大同時テクスチャ数: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>最大テクスチャサイズ: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "ポイントサイズレンジ: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "ポイントサイズレンジ: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "最大キューブマップサイズ: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "<b>近点引数:</b> %L1%2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, fuzzy, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr "最大同時テクスチャ数: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>拡張:</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "レンダラー: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "ファイル(&F)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 msgid "&Grab image"
 msgstr "画面を保存(&G)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 msgid "Capture &video"
 msgstr "動画キャプチャー(&V)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr "Shift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr "画像をコピー(&C)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "スクリプトを開く(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr "環境設定(&P)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "終了(&X)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "ナビゲーション(&N)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 msgid "Select Sun"
 msgstr "太陽を選択"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 msgid "Center Selection"
 msgstr "選択した天体を画面中央へ"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Goto Selection"
 msgstr "選択した天体へ移動"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "天体へ移動..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "時間(&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 msgid "Set &time"
 msgstr "時刻を設定(&T)"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 msgid "&Display"
 msgstr "表示(&D)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 msgid "Dee&p Sky Objects"
 msgstr "遠距離天体(&P)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 msgid "&Shadows"
 msgstr "影(&S)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "恒星表示方法(&Y)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr "テクスチャ解像度(&R)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 msgid "&FPS control"
 msgstr "FPSコントロール(&F)"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "ブックマーク(&B)"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "画面(&V)"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 msgid "&MultiView"
 msgstr "マルチビュー(&M)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 msgid "Split view vertically"
 msgstr "ビューを左右に分割"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 msgid "Split view horizontally"
 msgstr "ビューを上下に分割"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 msgid "Cycle views"
 msgstr "ビューを切替"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr "タブ"
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 msgid "Single view"
 msgstr "アクティブなビュー以外を削除"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 msgid "Delete view"
 msgstr "アクティブなビューを削除"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "削除"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 msgid "Frames visible"
 msgstr "フレームを表示"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 msgid "Active frame visible"
 msgstr "アクティブなフレームを表示"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 msgid "Synchronize time"
 msgstr "各ビューで時刻を同期"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "ヘルプ(&H)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 msgid "Celestia Manual"
 msgstr "Celestiaマニュアル(Wikibooks, 英語)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "OpenGL情報"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 msgid "Add Bookmark..."
 msgstr "ブックマークを追加..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr "ブックマークを編集..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr "カスタムFPSを設定"
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr "FPS値"
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
@@ -1497,7 +1472,7 @@ msgstr ""
 "次を読み込んでいます: %1\n"
 "\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "スクリプト一覧"
@@ -1609,11 +1584,11 @@ msgstr "M"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "マーカー"
 
@@ -1628,7 +1603,7 @@ msgstr "C"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "星座"
 
@@ -1647,7 +1622,7 @@ msgstr "O"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "軌道"
 
@@ -1661,18 +1636,18 @@ msgstr "軌道"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "惑星"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "準惑星"
 
@@ -1685,16 +1660,16 @@ msgstr "準惑星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "衛星"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "小衛星"
 
@@ -1707,10 +1682,10 @@ msgstr "小衛星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "小惑星"
 
@@ -1723,10 +1698,10 @@ msgstr "小惑星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "彗星"
 
@@ -1743,11 +1718,11 @@ msgstr "彗星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1764,7 +1739,7 @@ msgstr "L"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "名称"
 
@@ -1774,9 +1749,9 @@ msgstr "名称"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "銀河"
 
@@ -1784,8 +1759,8 @@ msgstr "銀河"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "球状星団"
 
@@ -1804,9 +1779,9 @@ msgstr "散開星団"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "星雲"
 
@@ -1818,48 +1793,48 @@ msgid "Locations"
 msgstr "地名"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "散開星団"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "雲"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "夜側の光"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "彗星の尾"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "大気"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "輪の影"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "食の影"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "雲の影"
 
@@ -1925,223 +1900,223 @@ msgstr "視野45°での自動限界等級: %L1"
 msgid "Magnitude limit: %L1"
 msgstr "限界等級: %L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "天体名"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "視等級"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "絶対等級"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "スペクトル型"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 msgid "Closest Stars"
 msgstr "近い恒星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 msgid "Brightest Stars"
 msgstr "明るい恒星"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 msgid "Filter"
 msgstr "見える恒星の調整"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "惑星が存在"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 msgid "Multiple Stars"
 msgstr "多重星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 msgid "Barycenters"
 msgstr "重心"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr "スペクトル型"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "更新"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 msgid "Mark Selected"
 msgstr "マーカーを付ける"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 msgid "Mark stars selected in list view"
 msgstr "リスト中の恒星にマーカーをつける"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark Selected"
 msgstr "マーカー消去"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr "リスト中の構成のマーカーを解除"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 msgid "Clear Markers"
 msgstr "マーカーを消去"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr "すべてのマーカーを消去"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "無し"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "菱形(◇)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "三角形(△)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "正方形(□)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "十字"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "×字"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "円(○)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "左矢印(←)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "右矢印(→)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "上矢印(↑)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "下矢印(↓)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr "マーカーシンボルを選択"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr "マーカーサイズを選択"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr "クリックしてマーカーの色を選択"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr "ラベル"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, qt-format
 msgid "%1 objects found"
 msgstr "%1 個の天体が見つかりました"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr "リスト中の遠距離天体にマーカーを付ける"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr "リスト中の遠距離天体のマーカーを解除"
 
@@ -2246,9 +2221,12 @@ msgstr "%1 の表面から"
 msgid "Behind %1"
 msgstr "%1 の後方"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+#, fuzzy
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
+"CelestiaはOpenGL拡張の初期化に失敗しました(エラー %i)。グラフィック品質が低下"
+"します。"
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
 msgid "Error: no object selected!\n"
@@ -2413,82 +2391,87 @@ msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr "Blackbody D65"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr "従来の色表示"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 msgid "Local format"
 msgstr "ローカル形式"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 msgid "Time zone name"
 msgstr "タイムゾーン名"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 msgid "UTC offset"
 msgstr "協定世界時との差"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "開始"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "距離: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "絶対(視)等級: "
 
@@ -2501,21 +2484,21 @@ msgid "&Select"
 msgstr "天体を選択(&S)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "画面中央(&C)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "移動(&G)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "天球同期(&F)"
 
@@ -2528,12 +2511,12 @@ msgid "Visible"
 msgstr "可視"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "マーカーを解除(&U)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "画面解像度を選択"
@@ -2547,12 +2530,12 @@ msgid "Disk"
 msgstr "円(●)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "マーカー(&M)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "ガイド表示(&R)"
 
@@ -2593,13 +2576,13 @@ msgid "Show &Terminator"
 msgstr "明暗境界線を表示(&T)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "AltSurface(&A)"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "通常"
 
@@ -2611,7 +2594,7 @@ msgstr "通常"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr "準惑星"
 
@@ -2622,14 +2605,14 @@ msgstr "準惑星"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr "小衛星"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 msgid "Other objects"
 msgstr "その他の天体"
 
@@ -2638,7 +2621,7 @@ msgid "Set Time"
 msgstr "時刻を設定"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "タイムゾーン: "
 
@@ -2694,7 +2677,7 @@ msgid "Set Seconds"
 msgstr "秒を設定"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "ユリウス日: "
 
@@ -2706,86 +2689,86 @@ msgstr "ユリウス日を設定"
 msgid "Set time"
 msgstr "時刻を設定"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "重心"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr "恒星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "惑星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr "準惑星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "月"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 msgid "Minor moon"
 msgstr "小衛星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "小惑星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "彗星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "人工天体"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 msgid "Reference point"
 msgstr "参照点"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 msgid "Component"
 msgstr "コンポーネント"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 msgid "Surface feature"
 msgstr "地表の形状"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr "不明"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr "小惑星・彗星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 msgid "Reference points"
 msgstr "参照点"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr "コンポーネント"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 msgid "Surface features"
 msgstr "地表の形状"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "惑星の輪"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr "天体をクラスでグループ化"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr "リスト中の天体にマーカーを付ける"
 
@@ -2901,7 +2884,7 @@ msgstr "解像度:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "ブックマークを編集"
 
@@ -2996,63 +2979,63 @@ msgstr "軌道を表示"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 msgid "Fading orbits"
 msgstr "軌道のフェーディング表示"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr "軌道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "座標"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "赤道座標"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "黄道座標"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "銀河座標"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "地平座標"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "星座線"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "星座境界線"
 
@@ -3233,41 +3216,41 @@ msgstr "日付表示形式:"
 msgid "Not an XBEL version 1.0 file."
 msgstr "XBEL バージョン1.0ファイルではありません。"
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "サポートされた拡張:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "サポートされた拡張:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3512,13 +3495,13 @@ msgstr "Celestiaについて(&A)"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3604,7 +3587,7 @@ msgid "Create in >>"
 msgstr "フォルダ選択 >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "新規フォルダ..."
 
@@ -3685,7 +3668,7 @@ msgid "Go to Object"
 msgstr "天体へ移動"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "移動"
 
@@ -3702,7 +3685,7 @@ msgid "Lat."
 msgstr "緯度"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "距離"
 
@@ -3750,170 +3733,174 @@ msgstr "表示限界"
 msgid "Size:"
 msgstr "サイズ:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "名前を変更..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "ブックマークやフォルダの名前を変更"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "変更後の名前"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "時刻の設定"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "形式: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "現在の時刻に設定"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "太陽系ブラウザ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "移動(&G)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "天体名"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "恒星ブラウザ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "近い恒星"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "明るい恒星"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "惑星が存在する恒星"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "更新(&R)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "リスト表示オプション"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "リストに表示する恒星の最大数"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "ツアーガイド"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "目的地を選択してください:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "表示オプション"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Show:"
 msgstr "表示:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "キングストン"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 msgid "Display:"
 msgstr "表示:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "黄道面"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 msgid "Body / Orbit / Label display"
 msgstr "天体 / 軌道 / 名称"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "ラテン名"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "天体情報表示"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "普通"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "多い"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "411"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "4"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "2"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "1"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "6"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "3"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "5"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "8"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "12"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "7"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "11"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "10"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "9"
 
@@ -3929,188 +3916,193 @@ msgstr "日付"
 msgid "Start"
 msgstr "開始"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, fuzzy, c-format
+msgid "%d x %d"
+msgstr "%1×%2"
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "ウィンドウ表示"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "不可視天体"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "自転同期(&Y)"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "天体情報(&I)"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "自転座標系の軸を表示"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "公転座標系の軸を表示"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "太陽の方向を表示"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "速度ベクトルを表示"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "経緯線を表示"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "明暗境界線を表示"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "衛星(&S)"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "周回天体"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr ""
 "フルスクリーンモードを正常に終了できませんでした。Celestiaを終了します。"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "致命的なエラー"
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr "致命的なエラー"
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 #, fuzzy
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr "使用中のシステムは%@をサポートしていません"
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "動画キャプチャ"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Celestia操作方法"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "ロード中: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr ""
 "次を読み込んでいます: %1\n"
 "\n"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "ja"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "設定ファイルの読み込みでエラーが発生しました。"
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "URLを読み込んでいます..."
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "バージョン: "
 
@@ -4146,17 +4138,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "PNG画像ファイル %sの読み込みでエラーが発生しました\n"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "スクリプトファイルのオープンでエラーが発生しました。"
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "hookスクリプトのオープンで不明なエラーが発生しました"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4176,7 +4172,7 @@ msgstr ""
 "\n"
 "y: はい、ESC: キャンセル、その他のキー: いいえ"
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4193,9 +4189,9 @@ msgstr ""
 "スクリプトを信頼して許可しますか？"
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "スクリプトファイル'%s'のオープンでエラーが発生しました。"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "スクリプトのオープンでエラーが発生しました"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4203,8 +4199,8 @@ msgid "Script coroutine initialization failed"
 msgstr "スクリプトコルーチンの初期化に失敗しました"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "LuaHook '%s'のオープンでエラーが発生しました"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4219,6 +4215,28 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "%sのオープンでエラーが発生しました。\n"
+
+#~ msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
+#~ msgstr "レベル %i, %.5f光年, ノード数 %i, 恒星数 %i \n"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "レンダリングパス: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "ブルーム効果: ON"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "ブルーム効果: OFF"
+
+#~ msgid "Exposure"
+#~ msgstr "露出"
+
+#~ msgid "Video (*.avi)"
+#~ msgstr "動画 (*.avi)"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "スクリプトファイル'%s'のオープンでエラーが発生しました。"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6674,13 +6692,6 @@ msgstr "%sのオープンでエラーが発生しました。\n"
 #~ msgstr "スクリプトのオープンで不明なエラーが発生しました"
 
 #~ msgid ""
-#~ "Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-#~ "quality will be reduced."
-#~ msgstr ""
-#~ "CelestiaはOpenGL拡張の初期化に失敗しました(エラー %i)。グラフィック品質が"
-#~ "低下します。"
-
-#~ msgid ""
 #~ "Celestia is unable to run because the CelestiaResources folder was not "
 #~ "found, probably due to improper installation."
 #~ msgstr ""
@@ -6708,9 +6719,6 @@ msgstr "%sのオープンでエラーが発生しました。\n"
 
 #~ msgid "GLSL version: "
 #~ msgstr "GLSLバージョン: "
-
-#~ msgid "Error opening script"
-#~ msgstr "スクリプトのオープンでエラーが発生しました"
 
 #~ msgid "Error loading script"
 #~ msgstr "スクリプトの読み込みでエラーが発生しました"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:48+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "일광절약시간"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "표준시간"
 
@@ -54,35 +54,34 @@ msgstr "설정 파일 읽는 중 오류가 발생했습니다."
 msgid "Loaded {} deep space objects\n"
 msgstr " 먼 우주 천체(DSO)"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "은하(형태: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "구상 성단 (핵 반경: %4.2f', King 집중도: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "이미지 파일 읽는 중: "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "모델 읽는 중: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "모델 읽기 오류: "
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +97,110 @@ msgstr "산개성단"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr ". ssc 파일에 에러가 있습니다. (행 "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "중복 정의: "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "AltSurface 오류"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "지명 오류"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "크로스 인덱스 헤더 오류\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "크로스 인덱스 버젼 오류\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "크로스 인덱스 읽기 실패:레코드 "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "크로스 인덱스 읽기 실패:레코드 "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "잘못된 항성 분광형, 항성 #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " 개 항성을 읽었습니다.\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "항성 총수: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr ".stc 파일 오류 (행 "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "잘못된 항성: 분광형 오류\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "잘못된 항성: 분광형이 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " 파일을 찾을 수 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "잘못된 항성: 적경이 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "잘못된 항성: 적위가 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "잘못된 항성: 거리가 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "잘못된 항성: 등급이 없습니다.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "잘못된 항성: 원점부근의 항성은 겉보기 등급이 아니라 절대등급이 설정되어 있어"
 "야 합니다.\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -241,721 +235,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "지원되는 확장"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "북마크 파일 읽는 중 오류가 발생하였습니다."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "잘못된 파일형식"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "한계등급: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "마커: ON"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "마커: OFF"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "천체 표면으로 이동"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "고도각·방위각 모드 켜기"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "고도각·방위각 모드 끄기"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "항성표시: 희미한 점"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "항성표시: 점"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "항성표시: 등급에 따른 원"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "혜성꼬리: ON"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "혜성꼬리: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "렌더링 패스: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "고도각·방위각 모드 켜기"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "고도각·방위각 모드 끄기"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "자동 한계등급 조정: ON"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "자동 한계등급 조정: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "취소"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "시간·스크립트: 정지"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "시간: 정지"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "계속"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "항성 총수: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "항성 총수: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "광속도달시간: %.4f 년"
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "광속도달시간: %d 분  %.1f 초"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "광속도달시간: %d 시간  %d 분  %.1f 초"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "광속고려: ON"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "광속고려: OFF"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "광속고려는 무시됩니다."
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "일반 텍스처를 사용"
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "limit of knowledge 텍스처를 사용"
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "천체 추적"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "시간흐름: 순방향"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "시간흐름: 역방향"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "초당 프레임수:"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "보통"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "보통"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "보통"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "자전 동기"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "2천체 참조 동기"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "공전 동기"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "한계등급: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "시야 45°에서의 한계 등급: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "주변빛의 세기:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "광도 이득"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "블룸 필터 적용"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "블룸 필터 해제"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "노출"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL에러: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "화면이 너무 작습니다."
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "화면 분할"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "광년"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "AU"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " 일"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " 시간"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " 분"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " 초"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "자전주기: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " ly/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "속도: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "시직경: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "겉보기 등급: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "절대등급: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "거리: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "중심\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "절대등급: %.2f 겉보기 등급: %.2f\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "밝기: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "중성자 별"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "블랙홀"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "분광형: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "표면온도: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "반지름: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "반지름: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "행성 존재\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "중심에서의 거리: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "반지름: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "위상각: : %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "온도: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  광속"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "실시간"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-실시간"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "시간멈춤"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " 배속"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " 분의 1배속"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr "(멈춤)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "이동중 "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "이동중 "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "화면중앙에 유지: "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "추적: "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "자전 동기: "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "공전 동기: "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "천체명을 입력하세요: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr " 멈춤"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr " 동영상 저장중"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 녹화시작/일시정지    F12 정지"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "편집 모드"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "항성계 카탈로그 로딩중: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "항성계 카탈로그 로딩중: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "항성계 카탈로그 로딩중: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "항성계 카탈로그 로딩중: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "북마크 파일 읽는 중 오류가 발생하였습니다."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "설정 파일 읽는 중 오류가 발생했습니다."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "SPICE 라이브러리 초기화에 실패했습니다."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "항성 데이타베이스를 읽을 수 없습니다."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "항성 카탈로그 파일 읽는 중 에러: "
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "항성 데이타베이스를 읽을 수 없습니다."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "항성계 카탈로그의 여는 중 오류 발생.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "별자리 파일 여는 중 오류가 발생했습니다."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "별자리 경계선 파일을 여는 중 오류가 발생"
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "렌더링 엔진 초기화 실패"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "폰트 읽기 에러, 텍스트가 표시되지 않습니다.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "크로스 인덱스 파일 읽기 에러: "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "크로스 인덱스 파일 읽음: "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "항성이름 파일 읽는 중 에러\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "파일 열기 오류: "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "항성 파일 읽는 중 에러\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "항성 카탈로그 파일 읽는 중 에러: "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "지원되는 확장"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1014,37 +992,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "천체브라우저"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "천체브라우저"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "태양계"
 
@@ -1054,20 +1032,20 @@ msgstr "태양계"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "항성"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " 먼 우주 천체(DSO)"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1077,123 +1055,119 @@ msgstr "식 찾기"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "현재 시각"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "길잡이"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "전체화면"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "동영상 캡춰(&M)...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "별자리 파일 여는 중 오류가 발생했습니다."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "북마크 추가(&A)"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "다른 이름으로 저장:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " 는 PNG파일이 아닙니다.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "비디오 캡춰"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "비디오 캡춰"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "비디오 캡춰"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "해상도"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 #, fuzzy
 msgid "Frame rate:"
 msgstr "초당 프레임수:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL 복사"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "URL 로딩중"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "스크립트 열기(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "메뉴에 새 폴더 추가"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1210,349 +1184,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "지원되는 확장"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "지원되는 확장"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "셀레스티아에 대하여"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading Language</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>미확장 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>미확장 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL 버전: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "최대 동시 텍스처수"
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "최대 텍스처 크기: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "포인트 크기 범위"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "포인트 크기 범위"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "최대 큐브 맵 크기: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>미확장 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "렌더링 엔진:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "파일(&F)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "이미지 캡춰"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "이미지 캡춰(&I)...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "비디오 캡춰"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "동영상 캡춰(&M)...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "URL 복사"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "스크립트 열기(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "셀레스티아 설정"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "종료(&X)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "앤티앨리어싱\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "네비게이션(&N)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "천체 선택(&S)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "선택한 천체를 가운데로(&C)\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "선택: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "천체로 이동"
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "시간(&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "시간 설정..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "표시"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "선택한 천체"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "구름 그림자 보기"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "항성 모양(&Y)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "해상도"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "사용법(&C)"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "북마크(&B)"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "창(&V)"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "멀티뷰"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "수직분할"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "수평분할(&H)\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "수평분할"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "수직분할(&V)\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "화면 전환"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "단일창"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "단일 창(&S)\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "활성창 닫기"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "삭제"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "분할선 보기"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "활성창 분할선 보기"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "시간 동기화"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "도움말(&H)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "셀레스티아 설정"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "OpenGL정보"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "북마크 추가(&A)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "북마크 구성(&O)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "로딩중: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "스크립트"
@@ -1675,11 +1649,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "마커"
 
@@ -1695,7 +1669,7 @@ msgstr "선택한 천체를 가운데로(&C)\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "별자리"
 
@@ -1717,7 +1691,7 @@ msgstr "확인"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "궤도"
 
@@ -1731,18 +1705,18 @@ msgstr "궤도"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "행성"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "왜소행성"
 
@@ -1755,16 +1729,16 @@ msgstr "왜소행성"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "위성"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "소 위성"
 
@@ -1777,10 +1751,10 @@ msgstr "소 위성"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "소행성"
 
@@ -1793,10 +1767,10 @@ msgstr "소행성"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "혜성"
 
@@ -1813,11 +1787,11 @@ msgstr "혜성"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1835,7 +1809,7 @@ msgstr "10x 빠르게(&F)\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "이름"
 
@@ -1845,9 +1819,9 @@ msgstr "이름"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "은하"
 
@@ -1855,8 +1829,8 @@ msgstr "은하"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "구상성단"
 
@@ -1876,9 +1850,9 @@ msgstr "산개성단"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "성운"
 
@@ -1890,48 +1864,48 @@ msgid "Locations"
 msgstr "지명"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "산개성단"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "구름"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "야간맵"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "혜성꼬리"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "대기"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "고리 그림자"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "식 그림자"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "구름 그림자"
 
@@ -2004,237 +1978,237 @@ msgstr "시야 45°에서의 한계 등급: %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "한계등급: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "이름"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "겉보기 등급"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "절대 등급"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "분광형"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "항성 보기"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "항성"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "항성 표시 조정"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "행성 존재"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "항성 보기"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "무게중심"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "잘못된 항성 분광형, 항성 #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "새로고침"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "마커(&M)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "표시 항성수"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "마커(&M)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "마커"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "없음"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "마름모(◇)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "삼각형(△)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "사각형(□)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "십자"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X자"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "원(○)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "왼쪽화살표(←)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "오른쪽화살표(→)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "위쪽화살표(↑)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "아랫쪽화살표(↓)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "천체 선택(&O)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "동영상 크기:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "천체 선택(&O)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "지명 보기"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "천체"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "마커(&M)"
@@ -2349,8 +2323,8 @@ msgstr "이미지 파일 읽는 중: "
 msgid "Behind %1"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2519,86 +2493,91 @@ msgstr "크기: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "항성 모양(&Y)"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "현지 시간"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "표준시간대"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC 오프셋"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "시작"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "거리: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "절대(겉보기)등급: "
 
@@ -2611,21 +2590,21 @@ msgid "&Select"
 msgstr "천체 선택(&S)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "가운데로(&C)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "이동(&G)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "추적(&F)"
 
@@ -2639,12 +2618,12 @@ msgid "Visible"
 msgstr "활성창 분할선 보기"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "마커 해제(&U)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "화면모드 선택"
@@ -2658,12 +2637,12 @@ msgid "Disk"
 msgstr "원(●)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "마커(&M)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "벡터 참조(&R)"
 
@@ -2711,13 +2690,13 @@ msgid "Show &Terminator"
 msgstr "밤낮 경계선 보기"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "표면 교체(&A)"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "일반"
 
@@ -2729,7 +2708,7 @@ msgstr "일반"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "왜소행성"
@@ -2741,15 +2720,15 @@ msgstr "왜소행성"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "소 위성"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "천체"
@@ -2760,7 +2739,7 @@ msgid "Set Time"
 msgstr "시간 설정..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "시간대: "
 
@@ -2825,7 +2804,7 @@ msgid "Set Seconds"
 msgstr " 초"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "쥴리안 일자"
 
@@ -2839,98 +2818,98 @@ msgstr "쥴리안 일자"
 msgid "Set time"
 msgstr "시간 설정..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "무게중심"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "잘못된 항성 분광형, 항성 #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "행성"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "왜소행성"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "달"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "소 위성"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "소행성"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "혜성"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "우주선"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "벡터 참조(&R)"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "계산"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "천체 표면으로 이동"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "소행성"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "벡터 참조(&R)"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "기타"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "행성"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "천체"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3063,7 +3042,7 @@ msgstr "해상도"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "북마크 구성"
 
@@ -3170,7 +3149,7 @@ msgstr "궤도 보기"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "착륙지점"
@@ -3178,7 +3157,7 @@ msgstr "착륙지점"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "부분 궤적"
@@ -3186,49 +3165,49 @@ msgstr "부분 궤적"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "그리드"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "적도"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "황도"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "은하"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "수평분할"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "도형"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "별자리 경계선 보기"
 
@@ -3430,41 +3409,41 @@ msgstr "표시"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "지원되는 확장"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "지원되는 확장"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3714,13 +3693,13 @@ msgstr "셀레스티아에 대하여(&A)"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 #, fuzzy
 msgid "OK"
 msgstr "확인"
@@ -3807,7 +3786,7 @@ msgid "Create in >>"
 msgstr "위치지정 >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "새폴더..."
 
@@ -3890,7 +3869,7 @@ msgid "Go to Object"
 msgstr "천체로 이동"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "이동"
 
@@ -3907,7 +3886,7 @@ msgid "Lat."
 msgstr "위도"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "거리"
 
@@ -3956,174 +3935,178 @@ msgstr "최소표시"
 msgid "Size:"
 msgstr "동영상 크기:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "이름 바꾸기"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "북마크, 폴더 이름 바꾸기"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "새 이름"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "시간 설정"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "초당 프레임수:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "현재시간으로 설정"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "태양계 브라우저"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "이동(&G)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "천체 이름"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "항성 브라우저"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "거리순"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "등급순"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "행성존재"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "새로고침(&R)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "항성 검색 기준"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "표시 항성수"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "길잡이"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "목적지를 선택하세요:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 #, fuzzy
 msgid "View Options"
 msgstr "보기설정"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "표시"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "킹스턴"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "표시"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "황도"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "궤도 / 이름"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "라틴 별자리명"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "천체 정보 표시"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "보통"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "많이"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "412"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "4"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "2"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "1"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "6"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "3"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "5"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "8"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "12"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "7"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "11"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "10"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "9"
 
@@ -4139,185 +4122,190 @@ msgstr "날짜"
 msgid "Start"
 msgstr "시작"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "윈도우 모드"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "안보임"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "자전 동기(&Y)"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "천체정보(&I)"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "천체 축 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "프레임 축 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "태양 방향 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "속도 벡터 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "행성그리드 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "밤낮 경계선 보기"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "위성"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "순환 천체"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "폰트 읽기 에러, 텍스트가 표시되지 않습니다.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "에러: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "비디오 캡춰"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "셀레스티아 사용법"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 #, fuzzy
 msgid "Loading: "
 msgstr "로딩중: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "로딩중: "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "ko"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "설정 파일 읽는 중 오류가 발생했습니다."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "URL 로딩중"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "버전: "
 
@@ -4353,17 +4341,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "PNG파일 읽기 오류: "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "스크립트 파일 여는 중 오류가 발생하였습니다."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "스크립트 파일 여는 중 알수없는 오류가 발생하였습니다."
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4375,7 +4367,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4386,9 +4378,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "스크립트 파일'%s'에서 에러가 발생했습니다."
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "스크립트 파일 열기 오류"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4396,8 +4388,8 @@ msgid "Script coroutine initialization failed"
 msgstr "스크립트 coroutine의 초기화에 실패하였습니다."
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "스크립트 파일'%s'에서 에러가 발생했습니다."
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4413,6 +4405,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "파일 열기 오류: "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "렌더링 패스: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "블룸 필터 적용"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "블룸 필터 해제"
+
+#~ msgid "Exposure"
+#~ msgstr "노출"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "비디오 캡춰"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "스크립트 파일'%s'에서 에러가 발생했습니다."
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6789,9 +6801,6 @@ msgstr "파일 열기 오류: "
 #~ msgid "GLSL version: "
 #~ msgstr "GLSL 버전: "
 
-#~ msgid "Error opening script"
-#~ msgstr "스크립트 파일 열기 오류"
-
 #~ msgid "Error loading script"
 #~ msgstr "스크립트 파일 로딩 오류"
 
@@ -7325,9 +7334,6 @@ msgstr "파일 열기 오류: "
 #, fuzzy
 #~ msgid "Surface Temp: "
 #~ msgstr "표면온도: "
-
-#~ msgid "Radius: "
-#~ msgstr "반지름: "
 
 #~ msgid "Rsun"
 #~ msgstr "Rsun(태양=1)"

--- a/po/lt.po
+++ b/po/lt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia lt\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2020-07-14 06:47+0300\n"
 "Last-Translator: Mantas Kriaučiūnas <baltix@gmail.com>\n"
 "Language-Team: \n"
@@ -12,11 +12,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -48,36 +48,35 @@ msgstr "Klaida nuskaitant konfigūracijos failą."
 msgid "Loaded {} deep space objects\n"
 msgstr " gilaus dangaus objektai"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaktikos (Hubble tipas: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Kamuoliniai (branduolio spindulys: %4.2f', pagrindinė koncentracija: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Įkeliamas paveikslas iš failo "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Įkeliamas modelis: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Klaida kraunant modelį '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -93,115 +92,110 @@ msgstr "Padrikasis spiečius"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Klaida .ssc faile (eilutė  "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "Įspėjimas, besidubliuojantis apibūdinimas objekto "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "blogas alternatyvus paviršius"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "bloga vieta"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Bloga antraštė cross rodikliui\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Bloga versija cross rodikliui\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Įvyko klaida įkeliant ir įrašant cross rodiklius"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Įvyko klaida įkeliant ir įrašant cross rodiklius"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Blogas spektrinis tipas žvaigždžių  bazėje, žvaigždė #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr "žvaigždžių dvejetainėje bazėje yra\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Viso žvaigždžių: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Klaida .stc faile (eilutėje  "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Negaliojanti žvaigždė: blogas spektrinis tipas.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Negaliojanti žvaigždė: prarastas spektrinis tipas.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " neegzistuoja.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Negaliojanti žvaigždė: prarasta prieeiga\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Negaliojanti žvaigždė: prarasta deklinacija.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Negaliojanti žvaigždė: prarastas atstumas.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Negaliojanti žvaigždė: prarastas ryškis.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Negaliojanti žvaigždė: turi būti nurodytas absoliutus (neįžiūrimas) "
 "žvaigždės ryškis\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -235,715 +229,699 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Klaida nuskaitant mėgiamiausių failą."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Netinkamas failo tipas"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Ryškumo limitas: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Žymekliai įjungti"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Žymekliai išjungti"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Aplankyti paviršių"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-azimuth režimas įjungtas"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-azimuth režimas išjungtas"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Žvaigždžių tipas: išplaukę taškai"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Žvaigždžių tipas: taškai"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Žvaigždžių tipas: grūdėti diskai"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Kometų uodegos įjungtos"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Kometų uodegos išjungtos"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Atvaizdavimas: OpenGL ."
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Grafinis glotninimas"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Grafinis glotninimas"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Auto-ryškis įjungta"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Auto-ryškis išjungta"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Atsisakyti"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Laikas ir scenarijus sustabdyti"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Laikas sustabdytas"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Tęsti"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr ""
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Šviesos kelionės trukmė:  %.4f yr "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Šviesos kelionės trukmė: %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Šviesos kelionės trukmė: %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Šviesos kelionės delsimas įtraukti"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Šviesos kelionės delsimas išjungtas"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Šviesos kelionės delsimas ignoruojamas"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Naudojamos normalios paviršiaus tekstūros."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Naudojamos ribotų žinių paviršiaus tekstūros."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Sekti"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Laikas: pirmyn"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Laikas: atgal"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Laiko norma"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Rodyti savybes"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Maksimalus tekstūrų kiekis:"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Sinchronizuoti orbitą"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Užrakinti"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Surišti"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Ryškumo limitas: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Auto ryškio limitas ties 45 laipsniais:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Aplinkos šviesos lygis:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Šviesos lygis"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Bloom įjungtas"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Bloom išjungtas"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Ekspozicija"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL klaida: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Vaizdas per mažas padalinimui"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Vaizdas įtrauktas"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "šm"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "av"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 msgid "mi"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr "dienos"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr "valandos"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr "minutės"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " sekundės"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Apsisukimo periodas: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " šm/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " AV/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Greitis: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Regimasis skersmuo:"
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Regimasis ryškis:"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absoliutus ryškis:"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Atstumas: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Žvaigždžių sistemos baricentras\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs (app) ryšk: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Šviesumas:"
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Neutroninė žvaigždė"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Juodoji bedugnė"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasė: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Paviršiaus temp.: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Skersmuo: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Skersmuo: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Dabartiniai planetų palydovai\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Atstumas nuo centro: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Skersmuo: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fazės kampas: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatūra: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Realus laikas"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Realus laikas"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Laikas sustabdytas"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " greičiau"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " lėčiau"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Sustabdyta)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Keliaujama "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Keliaujama "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Takas"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Sekti "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Sinchronizuoti orbitą"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Persekioti"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Taikinio pavadinimas:"
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr " Sustabdyta"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr " Įrašymas"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Pradėti/Pauzė    F12 Sustabdyti"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Redagavimo režimas"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Įkeliamas saulės sistemos katalogas:"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Įkeliamas saulės sistemos katalogas:"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Įkeliamas saulės sistemos katalogas:"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Įkeliamas saulės sistemos katalogas:"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Klaida nuskaitant mėgiamiausių failą."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Klaida nuskaitant konfigūracijos failą."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Nesėkmingas SPICE bibliotekos inicijavimas."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Neįmanoma nuskaityti žvaigždžių duomenų bazės."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Klaida atveriant gilaus dangaus katalogo failą."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Neįmanoma nuskaityti žvaigždžių duomenų bazės."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Klaida atveriant saulės sistemos katalogą.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Klaida atveriant asterisms failą."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Klaida atveriant žvaigždynų failą."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Nesėkmingas atvaizdavimo inicijavimas"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Klaida įkeliant simbolius; tekstas nebus matomas.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Klaida skaitant cross rodiklius"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Pakrautas cross rodiklis"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Klaida nuskaitant žvaigždžių pavadinimų failą\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Klaida atveriant"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Klaida nuskaitant žvaigždžių failą\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Klaida atveriant žvaigždžių katalogą "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 msgid "Unsupported image type: {}!\n"
 msgstr ""
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1002,37 +980,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Dangaus naršyklė"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Žvaigždžių naršyklė"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Saulės sistema"
 
@@ -1042,20 +1020,20 @@ msgstr "Saulės sistema"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Žvaigždės"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr "Rodyti objektus"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1065,119 +1043,116 @@ msgstr "Užtemimų paiška"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Laikas"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Kelionė su gidu"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Pilnas ekranas"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Klaida įkeliant atvaizdo failą "
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Rūšiuoti žymeles"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Įrašyti paveikslėlį į failą"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Įrašyti video"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr ""
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 msgid "Matroska Video (*.mkv)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Raiška: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Rėmelio norma:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Kopijuojamas URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Įkeliamas URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "Atverti scenarijų."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 #, fuzzy
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Celestia scenarijai"
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Žymelės"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1194,335 +1169,335 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 msgid "Unknown compiler"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Apie Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "Tiekėjas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "Plokštė:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Versija: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Maksimalus tekstūrų kiekis:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Maksimalus tekstūros dydis:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Taško dydžio diapazonas:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Taško dydžio diapazonas:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Maksimalus žemėlapio dydis:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Plokštė:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, fuzzy, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr "Maksimalus tekstūrų kiekis:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "Palaikomos plėtros:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Plokštė:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Failas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Padaryti ekr. atvaizdą"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Įrašyti video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Atidaryti scenarijų..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "&Informaciniai ženklai"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "I&šeiti"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr ""
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "Ž&valgymas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "Pasirinkti _Saulę"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "_Pasirinktą į centrą"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr "_Aplankyti pasirinktą"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Aplankyti objektą..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Laikas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Nustatyti laiką"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Rodyti"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Rodyti objektus"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Žiedų šešėliai"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Žvaigždžių st&iliai"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Tekstūrų rezoliucijos"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Valdymas"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Žymelės"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Rodymas"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Multivaizdas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Padalinti vaizdą vertikaliai"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Padalinti vaizdą horizontaliai"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Ciklinis vaizdas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Vientisas vaizdas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Ištrinti vaizdą"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Trinti"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Matomas rėmelis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Matomas aktyvus rėmelis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sinchronizuoti laiką"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Pagalba"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "OpenGL info"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Įtraukti žymeles..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Rūšiuoti žymeles..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Įkeliamas paveikslas iš failo "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scenarijai"
@@ -1640,11 +1615,11 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Žymekliai"
 
@@ -1659,7 +1634,7 @@ msgstr ""
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Žvaigždynai"
 
@@ -1680,7 +1655,7 @@ msgstr "Gerai"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Orbitos"
 
@@ -1694,18 +1669,18 @@ msgstr "Orbitos"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planetos"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Nykštukinės planetos"
 
@@ -1718,16 +1693,16 @@ msgstr "Nykštukinės planetos"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Palydovai"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Mažieji palydovai"
 
@@ -1740,10 +1715,10 @@ msgstr "Mažieji palydovai"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroidai"
 
@@ -1756,10 +1731,10 @@ msgstr "Asteroidai"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Kometos"
 
@@ -1776,11 +1751,11 @@ msgstr "Kometos"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1797,7 +1772,7 @@ msgstr ""
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Pavadinimai"
 
@@ -1807,9 +1782,9 @@ msgstr "Pavadinimai"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaktikos"
 
@@ -1817,8 +1792,8 @@ msgstr "Galaktikos"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Kamuoliniai spiečiai"
 
@@ -1838,9 +1813,9 @@ msgstr "Padrikasis spiečius"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Ūkai"
 
@@ -1852,48 +1827,48 @@ msgid "Locations"
 msgstr "Vietovės"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Padrikieji spiečiai"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Debesys"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Naktinė pusė"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Kometų uodegos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosfera"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Žiedų šešėliai"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Užtemimų šešėliai"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Debesų šešėliai"
 
@@ -1965,232 +1940,232 @@ msgstr "Auto ryškio limitas ties 45 laipsniais:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Ryškumo limitas: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Pavadinimas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Atstumas (šm)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "App. ryšk"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Abs. ryšk"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Tipas"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Filtruoti žvaigždes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Ryškiausias"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtruoti žvaigždes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Su planetomis"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Filtruoti žvaigždes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentrai"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr ""
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Atnaujinti"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "Žymekliai įjungti"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maksimalus žvaigždžių rodomas sąrašas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "Nuimti &žymenis"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Žymekliai"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Nėra"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Deimantas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Trikampis"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Aikštė"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plius"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Apskritimas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Rodyklę kairėn"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Rodyklę dešinėn"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Rodyklę aukštyn"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Rodyklę žemyn"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr "Pavadinimai"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "' nerasta."
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr ""
 
@@ -2302,8 +2277,8 @@ msgstr "Aplankyti paviršių"
 msgid "Behind %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2471,85 +2446,90 @@ msgstr ""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Vietinis formatas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Laiko juostos pavadinimas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC kompensacija"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Pradžia"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Atstumas: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Abs (app) ryšk: "
 
@@ -2562,21 +2542,21 @@ msgid "&Select"
 msgstr "&Parinkti"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centruoti"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Aplankyti"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Sekti"
 
@@ -2590,12 +2570,12 @@ msgid "Visible"
 msgstr "Nematomi"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Nuimti žym."
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Pasirinkti ekrano režimą"
@@ -2609,12 +2589,12 @@ msgid "Disk"
 msgstr "Diskas"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Žymėti"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Informaciniai ženklai"
 
@@ -2662,13 +2642,13 @@ msgid "Show &Terminator"
 msgstr "Rodyti terminatorių"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Alternatyvus paviršius"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normalus"
 
@@ -2680,7 +2660,7 @@ msgstr "Normalus"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Nykštukinės planetos"
@@ -2692,15 +2672,15 @@ msgstr "Nykštukinės planetos"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Mažieji palydovai"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Pažymėti objektai"
@@ -2710,7 +2690,7 @@ msgid "Set Time"
 msgstr "Nustatyti laiką"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Laiko juosta:"
 
@@ -2774,7 +2754,7 @@ msgid "Set Seconds"
 msgstr " sekundės"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Julijaus data: "
 
@@ -2788,94 +2768,94 @@ msgstr "Julijaus data: "
 msgid "Set time"
 msgstr "Nustatyti laiką"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Baricentrai"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Pradžia"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planeta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Nykštukinės planetos"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Mėnulis"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Mažieji palydovai"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroidai"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Kometos"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Kosminiai aparatai"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Informaciniai ženklai"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Skaičiuoti"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Paviršiaus temp.: "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteroidai"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Informaciniai ženklai"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Kitos savybės"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 msgid "Planets and moons"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3004,7 +2984,7 @@ msgstr "Trukmė"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Rūšiuoti žymeles"
 
@@ -3111,7 +3091,7 @@ msgstr "Rodyti orbitas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Nusileidimo vietos"
@@ -3119,7 +3099,7 @@ msgstr "Nusileidimo vietos"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Dalinės trajektorijos"
@@ -3127,49 +3107,49 @@ msgstr "Dalinės trajektorijos"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Tinkleliai"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Pusiaujo"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ekliptika"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galaktika"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horizontaliai"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagramos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Ribos"
 
@@ -3370,39 +3350,39 @@ msgstr ""
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 msgid "Unsupported URL version: {}\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3650,13 +3630,13 @@ msgstr "&Apie Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "Gerai"
 
@@ -3742,7 +3722,7 @@ msgid "Create in >>"
 msgstr "Sukurti į >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Naujas aplankas..."
 
@@ -3825,7 +3805,7 @@ msgid "Go to Object"
 msgstr "Aplankyti objektą"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Aplankyti"
 
@@ -3842,7 +3822,7 @@ msgid "Lat."
 msgstr "Plat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Atstumas"
 
@@ -3896,176 +3876,180 @@ msgstr "Minimalus pavadinimo ypatybės dydis"
 msgid "Size:"
 msgstr "Dydis:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Pervadinti..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Pervadinti žymelę arba aplanką"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Naujas pavadinimas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Nustatykite modeliavimo laiką"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formatas: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Nustatyti dabartinį laiką"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Saulės sistemos naršyklė"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Aplankyti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Saulės sistemos objektai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Žvaigždžių naršyklė"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Artimiausi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 #, fuzzy
 msgid "Brightest"
 msgstr "Ryškiausias"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "Su planetomis"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Atnaujinti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Žvaigždžių paieškos kriterijus"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Maksimalus žvaigždžių rodomas sąrašas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Kelionė su gidu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Pasirinkit kelionės tikslą:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Rodymo nustatymai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Rodyti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingstonas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Rodyti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 #, fuzzy
 msgid "Ecliptic Line"
 msgstr "Ekliptikos linija"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Orbitos / Pavadinimai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 #, fuzzy
 msgid "Latin Names"
 msgstr "Lotyniški pavadinimai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Informacinis tekstas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Glaustas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Pilnas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "WinKalbID"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Bal"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Vas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Saus"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Bir"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Kov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Gegužė"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Rugp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Gru"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Lie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Lap"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Spa"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Rugs"
 
@@ -4081,184 +4065,189 @@ msgstr "Data"
 msgid "Start"
 msgstr "Pradžia"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Lango režimas"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Nematomi"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "S&inch orbitą"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Rodyti kūno ašis"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Rodyti rėmelio ašis"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Rodyti saulės kryptį"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Rodyti greičio vektorių"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Rodyti planetografinį tinklelį"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Rodyti terminatorių"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Palydovai"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Kūnai orbitoje"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Klaida: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Klaida"
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Sukurti &filmą...\tShift+F10"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Celestia valdymas"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Įkeliama: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Įkeliamas paveikslas iš failo "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "lt"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Klaida nuskaitant konfigūracijos failą."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Įkeliamas URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versija: "
 
@@ -4294,17 +4283,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Klaida įrašant '%s'.\n"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Klaida atveriant scenarijaus failą."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Nežinoma klaida atidarant scenarijų"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4316,7 +4309,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4327,9 +4320,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Klaida atveriant scenarijų '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Klaida atveriant scenarijų"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4337,8 +4330,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Scenarijaus coroutine iniciacijos nepavyko"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Klaida atveriant scenarijų '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4354,6 +4347,22 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Klaida atveriant"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Atvaizdavimas: OpenGL ."
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Bloom įjungtas"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Bloom išjungtas"
+
+#~ msgid "Exposure"
+#~ msgstr "Ekspozicija"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Klaida atveriant scenarijų '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6807,9 +6816,6 @@ msgstr "Klaida atveriant"
 
 #~ msgid "GLSL version: "
 #~ msgstr "GLSL versija: "
-
-#~ msgid "Error opening script"
-#~ msgstr "Klaida atveriant scenarijų"
 
 #~ msgid "Error loading script"
 #~ msgstr "Klaida įkeliant scenarijų"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:49+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
 "2);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -55,35 +55,34 @@ msgstr "Kļūda nolasot konfigurācijas failu."
 msgid "Loaded {} deep space objects\n"
 msgstr " dziļā kosmosa objekti"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaktika (Habla tips: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Lodveida (kodola radiuss: %4.2f', Kinga koncetrācija: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Ielādē attēlu no faila"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Ielādē modeli: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Kļūda ielādējot modeli '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -99,115 +98,110 @@ msgstr "Vaļējās kopas"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Kļūda .ssc filā(līnijā "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "uzmanību dubulta definīcija "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "nederīga alternatīvā virsma"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "nederīga vieta"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Kopējam indeksam bojāta galvane\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Kopējam indekstam nederīga versija\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Kopējā indeksa ielāde apstājās pie ieraksta "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Kopējā indeksa ielāde apstājās pie ieraksta "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Nepareiza spektra klase datubāzē zvaigznei #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " zvaizgnes binārajā datubāzē\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Kopējais zvaigzņu skaits: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Kļūda .stc failā (līnijā "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Kļūdaina zvaigzne: nederīga spektra klase.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Kļūdaina zvaigzne: nav norādīta spektra klase.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " neeksistē.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Nederīga zvaigznes: trūkst rektascensijas\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Nederīga zvaigzne: trūkst deklinācijas.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Nederīga zvaigzne: trūkst distances.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Nederīga zvaigzne: trūkst zvaigžņlieluma.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Nederīga zvaigzne: jānorāda absolūtais nevis redzamais zvaigžņlielums "
 "zvaigznej izvelsmes vietas tuvumā\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -242,721 +236,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Atbalstītie paplašinājumi:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Visas NV verteksu programmas veiksmīgi ielādētas."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Nepareizs faila veids"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Limitējošais zvaigžņlielums iestādīts uz: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Marķieri aktivizēti"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Marķieri izslēgti"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Nolaisties uz virsmas"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Azimutālais režīms ieslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Azimutālais režīms izslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Zvaigznes: kā izplūduši punktiņi"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Zvaigznes: kā punkti"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Zvaigznes: kā mērogoti diski"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Komētu astes aktivizētas"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Komētu astes deaktivizētas"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Renderēšanas ceļš: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Azimutālais režīms ieslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Azimutālais režīms izslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Automātiskie zvaigžņlielumi aktivizēti"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Automātiskie zvaigžņlielumi atslēgti"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Laiks un skripts apturēti (pauze)"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Laiks ir apstādināts (pauze)"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Turpināt"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Kopējais zvaigzņu skaits: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Kopējais zvaigzņu skaits: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Gaismas ceļošanas ilgums:  %.4f gadi "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Gaismas ceļošanas ilgums: %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Gaismas ceļošanas ilgums:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Ierēķināts gaismas ceļošanas ilgums"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Gaismas ceļošanas ilgums atslēgts"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Gaismas ceļošanas ilgums ignorēts"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Izmanto normālās virsmu tekstūras"
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Izmanto zināmā robežu tekstūras."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Sekot"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Laiks: uz priekšu"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Laiks: atpakaļ"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Laika ātrums"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Tekstūras"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Tekstūras"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Tekstūras"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Sinhronizēt orbītu"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Sabloķēt"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Novērot"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Limitējošais zvaigžņlielums iestādīts uz: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Automātiskais magnitūdas limits ir 45 grādi: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Fona gaismas daudzums:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Gaismas pastiprinājums"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Nerādīt komētu astes"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Rādīt jomētu astes"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Ekspozīcija"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL kļūda: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Skats par mazu lai sadalītu"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Pievienots skatījums"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "ly"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "au"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " dienas"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " stundas"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minūtes"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " sekundes"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " ly/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Ātrums: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Redzamais diametrs: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Redzamais spožums: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolūtais spožums: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distance: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Zvaigžņu sistēmas baricentrs\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Absolūtais (redz.) spožums: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Starjauda: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Neitronu zvaigzne"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Melnais caurums"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klase: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Virsmas temperatūra: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Šai sistēmā ir planētas\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Attālums no centra:"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Radiuss: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fāzes lenķis: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatūra: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Reālais laiks"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Reālais laiks"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Laiks apturēts"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "ātrāk"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "lēnāk"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Pauze)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Ceļā"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Ceļā"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Tur skatu uz objektu "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seko objektam"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Sinhronajā orbītītā ap objektu "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Novēro objektu "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Izvēlamā objekta nosaukums: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "Pauze"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "Ieraksta"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Sākt/Pauze    F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Rediģēšanas režīms"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Ielādē zvaigžņu sistēmas katalogu: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Ielādē zvaigžņu sistēmas katalogu: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Ielādē zvaigžņu sistēmas katalogu: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Ielādē zvaigžņu sistēmas katalogu: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Visas NV verteksu programmas veiksmīgi ielādētas."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Kļūda nolasot konfigurācijas failu."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "SPICE bibliotēkas inicializācija neizdevās."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Nevar ielasīt zvaigžņu datubāzi."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Kļūda atverot deespky kataloga failu."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Nevar ielasīt zvaigžņu datubāzi."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Kļūda atverot zvaigžņu sistēmas katalogu.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Kļūda atverot asterismu failu."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Kļūda atverot zvaigznāju robežu failus."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Nevarēja inicializēt renderētāju"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Kļūda ielādējot fontus; teksts nebūs redzams.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Kļuda lasot kopējo indeksu "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Kopējais indekss ielādēts "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Kļūda ielasot zvaigžņu nosaukumu failu\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Kļūda atverot "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Kļūda ielasot zvaigžņu failu\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Kļūda atverot zvaigžņu katalogu "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Atbalstītie paplašinājumi:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1015,37 +993,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Debesu pārlūks"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Debesu pārlūks"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Saules sistēma"
 
@@ -1055,20 +1033,20 @@ msgstr "Saules sistēma"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Zvaigznes"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " dziļā kosmosa objekti"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1078,123 +1056,119 @@ msgstr "Aptumsumu meklētājs"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Laiks"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Ceļojumu gids"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Pilns ekrāns"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Uzņemt filmu &filmu...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Kļūda atverot asterismu failu."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Pievienot grāmatzīmes"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Saglabāt kā:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " nav PNG fails. \n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Ierakstīt video"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Ierakstīt video"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Ierakstīt video"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Izšķirtspēja: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Kadru skaits:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Iekopēja URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Ielādē URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Atvērt scenāriju..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Radīt jaunu grāmatzīmju mapi šai izvēlnē"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1211,349 +1185,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Nenosakāma kļūda atverot skriptu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Atbalstītie paplašinājumi:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Atbalstītie paplašinājumi:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Par Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 ēnojuma valoda</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Nepaplašināts OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Nepaplašināts OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL Versija: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Maksimālais tekstūru skaits vienlaicīgi: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Maksimālais tekstūras izmērs: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Punktu mērogošanas attālums: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Punktu mērogošanas attālums: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Maksimālais tekstūras izmērs: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Nepaplašināts OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Renderētājs: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Faili"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Paņemt attēlu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Saglabāt ekrāna &attēlu...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Ierakstīt video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Uzņemt filmu &filmu...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Iekopēt URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Atvērt scenāriju..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia iestatījumi"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "I&ziet no programmas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Kropļojumnovērse\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigācija"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Izvēlēties"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "Iecentrēt izvēlēto\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Izvēlēts: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Iet uz objektu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Laiks"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Iestādīt laiku..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Rādīt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Marķētie objekti"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Rādīt mākoņu ēnas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Zvaigznes izskatās kā"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Izšķirtspēja"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Kontroles"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Grāmatzīmes"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Skats"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "MultiView"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Sadalīt skatu vertikāli"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Sadalīt &horizontāli\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Sadalīt skatu horizontāli"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Sadalīt &vertikāli\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Cikliskais skats"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Viens skatījums"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Viens skatījums\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Izdzēst skatījumu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Dzēst"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Redzamie rāmji"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktīvais rāmis redzams"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sinhronizēt laiku"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Palīdzība"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia iestatījumi"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "OpenGL informācija"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Pievienot grāmatzīmi"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizēt grāmatzīmes"
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Ielādē "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scenāriji"
@@ -1676,11 +1650,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Marķierus"
 
@@ -1696,7 +1670,7 @@ msgstr "Iecentrēt izvēlēto\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Zvaigznājus"
 
@@ -1718,7 +1692,7 @@ msgstr "Labi"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Orbītas"
 
@@ -1732,18 +1706,18 @@ msgstr "Orbītas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planētām"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Pundurplanētas"
 
@@ -1756,16 +1730,16 @@ msgstr "Pundurplanētas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Pavadoņiem"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Pavadoņiem"
 
@@ -1778,10 +1752,10 @@ msgstr "Pavadoņiem"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroīdiem"
 
@@ -1794,10 +1768,10 @@ msgstr "Asteroīdiem"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Komētām"
 
@@ -1814,11 +1788,11 @@ msgstr "Komētām"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1836,7 +1810,7 @@ msgstr "10x Ā&trāk\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Nosaukumus"
 
@@ -1846,9 +1820,9 @@ msgstr "Nosaukumus"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaktikas"
 
@@ -1856,8 +1830,8 @@ msgstr "Galaktikas"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Lodveida"
 
@@ -1877,9 +1851,9 @@ msgstr "Vaļējās kopas"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Miglājus"
 
@@ -1891,48 +1865,48 @@ msgid "Locations"
 msgstr "Vietas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Vaļējās kopas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Mākoņus"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Pilsētu gaismas ēnas pusē"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Komētu astes"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosfēras"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Rinķu ēnas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Aptumsumu ēnas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Mākoņu ēnas"
 
@@ -2005,237 +1979,237 @@ msgstr "Automātiskais magnitūdas limits ir 45 grādi: %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Limitējošais zvaigžņlielums iestādīts uz: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Nosaukums"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Redz.spož."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Abs.spož."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Tips"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Rādīt zvaigznes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Zvaigznes"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrēt zvaigznes no"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Ar planētām"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Rādīt zvaigznes"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentrs"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Nepareiza spektra klase datubāzē zvaigznei #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Atjaunināt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Iezīmēt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maksimālais zvaigžņu skaits sarakstā"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Iezīmēt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marķierus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "nav"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Rombs"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Trijstūris"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Kvadrāts"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Pluss"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Rinķis"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Kreisā bulta"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Labā bulta"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Bulta uz augšu"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Bulta uz leju"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Izvēlēties &objektu..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Izmērs:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Izvēlēties &objektu..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Nosaukt struktūras"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objekti"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Iezīmēt"
@@ -2350,8 +2324,8 @@ msgstr "Ielādē attēlu no faila"
 msgid "Behind %1"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2520,86 +2494,91 @@ msgstr "Izmērs: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Zvaigznes izskatās kā"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Vietējais formāts"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Laika zona"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC nobīde"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Sākt"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Distance: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Abs.(redz.) mag: "
 
@@ -2612,21 +2591,21 @@ msgid "&Select"
 msgstr "&Izvēlēties"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Iecentrēt"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Doties uz"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Sekot"
 
@@ -2640,12 +2619,12 @@ msgid "Visible"
 msgstr "Aktīvais rāmis redzams"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Atcelt iezīmēto"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Izvēlēties displeja režīmu"
@@ -2659,12 +2638,12 @@ msgid "Disk"
 msgstr "Disks"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Iezīmēt"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Atskaites vietas"
 
@@ -2712,13 +2691,13 @@ msgid "Show &Terminator"
 msgstr "Show Terminator"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Alternatīvās virsmas"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normāls"
 
@@ -2730,7 +2709,7 @@ msgstr "Normāls"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Pundurplanētas"
@@ -2742,15 +2721,15 @@ msgstr "Pundurplanētas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Pavadoņiem"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Objekti"
@@ -2761,7 +2740,7 @@ msgid "Set Time"
 msgstr "Iestādīt laiku..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Laika zona: "
 
@@ -2826,7 +2805,7 @@ msgid "Set Seconds"
 msgstr " sekundes"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Juliāna diena: "
 
@@ -2840,98 +2819,98 @@ msgstr "Juliāna diena: "
 msgid "Set time"
 msgstr "Iestādīt laiku..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Baricentrs"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Nepareiza spektra klase datubāzē zvaigznei #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planēta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Pundurplanēta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Mēness"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Pavadoņiem"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroīds"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Komēta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Mākslīgie pavadoņi"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Atskaites vietas"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Aprēķināt"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Nolaisties uz virsmas"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Nenosakāma kļūda atverot skriptu"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteroīdiem"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Atskaites vietas"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Citas struktūras"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planētām"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objekti"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3064,7 +3043,7 @@ msgstr "Izšķirtspēja: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Kārtot grāmatzīmes"
 
@@ -3171,7 +3150,7 @@ msgstr "Rādīt orbītas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Piezemēšanās vietas"
@@ -3179,7 +3158,7 @@ msgstr "Piezemēšanās vietas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Daļējas trajektorijas"
@@ -3187,49 +3166,49 @@ msgstr "Daļējas trajektorijas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Tīkli"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Ekvatoriālais"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ekliptika"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galaktiskās"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Sadalīt skatu horizontāli"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Shēmas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Rādīt robežas"
 
@@ -3431,41 +3410,41 @@ msgstr "Rādīt"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Atbalstītie paplašinājumi:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Atbalstītie paplašinājumi:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3716,13 +3695,13 @@ msgstr "&Par Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "Labi"
 
@@ -3808,7 +3787,7 @@ msgid "Create in >>"
 msgstr "Izveidot iekš >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Jauna mape..."
 
@@ -3889,7 +3868,7 @@ msgid "Go to Object"
 msgstr "Iet uz objektu"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Iet uz"
 
@@ -3906,7 +3885,7 @@ msgid "Lat."
 msgstr "Platums"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Attālums"
 
@@ -3955,174 +3934,178 @@ msgstr "Minimālais izmērs nosaucamajām struktūrām"
 msgid "Size:"
 msgstr "Izmērs:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Pārsaukt..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Pārsaukt grāmatzīmi vai mapi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Jauns nosaukums"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Iestādīt simlācijas laiku"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formāts: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Pārslēgt uz tagadni"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Saules sistēmas pārlūks"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Iet uz"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Saules sistēmas objekti"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Zvaigžņu pārlūks"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Tuvākais"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Spožākās"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Ar planētām"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Atjaunot"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Zvaigžņu meklēšanas kritēriji"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Maksimālais zvaigžņu skaits sarakstā"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Ceļojumu gids"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Izvēlieties galamērķi:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Skata opcijas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Rādīt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingstona"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Rādīt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Ekliptika"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Orbītas un nosaukumi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Latīņu nosaukumus"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Informatīvais teksts"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "īss"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "pilnīgs"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "0426"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jūn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Jūl"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Sep"
 
@@ -4138,184 +4121,189 @@ msgstr "Datums"
 msgid "Start"
 msgstr "Sākt"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Logu režīms"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Neredzamajiem"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "&Synhronizēt ar orbītu"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Informācija"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Rādīt ķermeņu asis"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Rādīt &rāmju asis"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Rādīt Saules virzienu"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Rādīt ātruma vektoru"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Rādīt planetogrāfisko tīklu"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Show Terminator"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Pavadoņi"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Apriņķojošie objekti"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Kļūda ielādējot fontus; teksts nebūs redzams.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Kļūda: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Ierakstīt video"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Celestia kontrolēšana"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Ielādē: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Ielādē "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "lv"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Kļūda nolasot konfigurācijas failu."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Ielādē URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versija: "
 
@@ -4351,17 +4339,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Kļūda ielādējot PNG attēla failu"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Kļūda atverot skripta failu."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Nenosakāma kļūda atverot skriptu"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4373,7 +4365,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4384,9 +4376,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Kļūda atverot skriptu '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Kļūda atverot scenāriju"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4394,8 +4386,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Skripta korutīnas inicializācija neizdevās"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Kļūda atverot skriptu '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4411,6 +4403,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Kļūda atverot "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Renderēšanas ceļš: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Nerādīt komētu astes"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Rādīt jomētu astes"
+
+#~ msgid "Exposure"
+#~ msgstr "Ekspozīcija"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Ierakstīt video"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Kļūda atverot skriptu '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6684,9 +6696,6 @@ msgstr "Kļūda atverot "
 #~ msgid "GLSL version: "
 #~ msgstr "GLSL Versija: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Kļūda atverot scenāriju"
-
 #~ msgid "Error loading script"
 #~ msgstr "Kļūda ielādējot scenāriju"
 
@@ -7222,9 +7231,6 @@ msgstr "Kļūda atverot "
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Virsmas temp.: "
-
-#~ msgid "Radius: "
-#~ msgstr "Radiuss: "
 
 #~ msgid "Rsun"
 #~ msgstr "RSaules"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:50+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Zomertijd"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -54,35 +54,34 @@ msgstr "Fout tijdens het lezen van het configuratiebestand."
 msgid "Loaded {} deep space objects\n"
 msgstr "diep ruimte objecten"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Sterrenstelsel (Hubble type: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Bolvormig (kernradius: %4.2f', King concentratie: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Bezig met laden van afbeelding uit bestand"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Model laden: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Fout tijdens laden van model '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +97,110 @@ msgstr "Open sterrenhoop"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Fout in .ssc bestand (regel "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "waarschuwing dubbele definitie van "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "slecht alternatief oppervlak"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "Slechte lokatie"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Slechte koppen voor kruis-index\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Slechte versie voor kruis-index\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Laden van kruis-index faalde bij ingang "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Laden van kruis-index faalde bij ingang "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Slecht spectraal type in sterrendatabase, ster #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " sterren in binaire database\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Totaal aantal sterren:"
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Fout in .stc bestand (regel"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ongeldige ster: slecht spectraal type.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ongeldige ster: spectraal type niet aanwezig.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr "bestaat niet.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ongeldige ster: ontbrekende rechte klimming\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Ongeldige ster: ontbrekende declinatie.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Ongeldige ster: ontbrekende afstand.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ongeldige ster: ontbrekende schijnbare helderheid.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Ongeldige ster: absolute (niet waargenomen) schijnbare helderheid moet "
 "opgegeven worden voor ster nabij oorsprong\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -241,721 +235,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Ondersteunde extensies:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Fout tijdens lezen van favorieten bestand."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Ongeldig bestandstype"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Schijnbare helderheid limiet: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Markeringen actief"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Markeringen non-actief"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Ga naar oppervlakte"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-Azimut modus aan"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-Azimut modus uit"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Ster stijl: vage punten"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Ster stijl: punten"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Ster stijl: geschaalde schijven"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Komeetstaarten weergeven"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Komeetstaarten niet weergeven"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "3D Weergave methode: NVIDIA GeForce FX"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Alt-Azimut modus aan"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Alt-Azimut modus uit"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Auto-schijnbare helderheid geactiveerd"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Auto-schijnbare helderheid gedeactiveerd"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Tijd en script zijn gepauzeerd"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Tijd is gepauzeerd"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Hervatten"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Totaal aantal sterren:"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Totaal aantal sterren:"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Licht reistijd: %.4f jaar"
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Lichtsnelheid reistijd: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Lichtsnelheid reistijd: %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Lichtsnelheid reizen vertraging inclusief"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Lichtsnelheid reizen vertraging uitgezet"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Lichtsnelheid reizen vertraging negeerd"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Gebruik normale oppervlakte texturen."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Gebruik limiet van kennis oppervlakte texturen."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Achtervolg"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Tijd: Vooruit"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Tijd: Achteruit"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Tijdratio"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturen"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Synchronizeer omloopbaan"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Vastzetten"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Opjagen"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Schijnbare helderheid limiet: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Automatische schijnbare helderheid limiet bij 45 graden: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Omgevingslicht niveau:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "lichtopbrengst"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Bloom aan"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Bloom uit"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Blootstelling"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL fout:"
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Weergave te klein om gedeelt te worden"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Toegevoegde weergave"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "lj"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "au"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr "dagen"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr "uren"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr "minuten"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr "seconden"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " lj/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Snelheid: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Observeerbare diameter: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Schijnbare helderheid: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolute helderheid: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Afstand: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Massamiddelpunt van zonnestelsel\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs. (schijnb.) helderheid:  %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Helderheid: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Neutronenster"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Zwart gat"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasse: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Oppervlaktetemperatuur: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Straal: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Straal: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Planitaire metgezellen aanwezig\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Afstand van centrum: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Straal: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fasehoek: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatuur: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Lokale Tijd"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Lokale Tijd"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Tijd gestopt"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "sneller"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "langzamer"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr "Gepauzeerd"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS:"
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Reizen "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Reizen "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "volgen"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Achtervolg "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synchronizeer omloopbaan"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Opjagen "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Doel naam: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "Opnemen"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pause F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Bewerk modus"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Laden van zonnestelsel catalogus: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Laden van zonnestelsel catalogus: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Laden van zonnestelsel catalogus: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Laden van zonnestelsel catalogus: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Fout tijdens lezen van favorieten bestand."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Fout tijdens het lezen van het configuratiebestand."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Initializatie van SPICE bibliotheek faalde."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Kan sterrendatabase niet lezen."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Fout bij openen deepsky catalogusbestand."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Kan sterrendatabase niet lezen."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Fout tijdens openen van zonnestelselcatalogus.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Fout tijdens openen van niet-officiële sterrenbeelden bestand."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Fout tijdens openen van bestanden met sterrenbeeldgrenzingen."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Kon 3D weergave methode niet initialiseren"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Fout tijdens laden van lettertype, tekst zal niet zichtbaar zijn.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Fout tijdens lezen van cross-index"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Laden van cross-index"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Fout tijdens lezen van bestand met namen van sterren\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Fout tijdens openen"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Fout tijdens lezen van bestand met sterren\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Fout tijdens lezen van sterrencatalogus"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Ondersteunde extensies:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1014,37 +992,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Hemelse Browser"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Hemelse Browser"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Zonnestelsel"
 
@@ -1054,20 +1032,20 @@ msgstr "Zonnestelsel"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Sterren"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr "diep ruimte objecten"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1077,122 +1055,118 @@ msgstr "Eclips Vinder"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Tijd"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Rondleiding"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Schermvullend"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "&Film opslaan...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Fout tijdens openen van niet-officiële sterrenbeelden bestand."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Bladwijzers &toevoegen..."
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Opslaan als:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "is geen PNG bestand.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Video opnemen"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Video opnemen"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Video opnemen"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolutie:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Frame snelheid:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Gekopieerde URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Laden van URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Open script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Maak een nieuwe bladwijzermap in dit menu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1209,349 +1183,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Onbekende fout tijdens openen van script bestand."
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Ondersteunde extensies:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Ondersteunde extensies:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Over Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading Taal</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL versie: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Max gelijktijdig geladen texturen: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Max textuurgrootte: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Punt grootte bereik: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Punt grootte bereik: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Max kubuskaart grootte: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "3D weergave: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Bestand"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Kopieer plaatje"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "&Afbeelding opslaan...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Video opnemen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "&Film opslaan...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopieer URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Open script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia instellingen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Af&sluiten"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigatie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Selecteer"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centreer selectie\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selectie: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ga naar object..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Tijd"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Stel tijd in..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Scherm"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Gemarkeerde objecten"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Wolkenschaduwen weergeven"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "S&terrenstijl"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Textuurresolutie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Toetsencombinaties"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "B&ladwijzers"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Weergave"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "MeerdereVensters"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Splits weergave verticaal"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Deel weergave &horizontaal\tCrtl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Splits weergave horizontaal"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Deel weergave &verticaal\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Doorloop weergave"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Enkelvoudige weergave"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Enkelvoudige weergave\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Verwijder weergave"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Frames zichtbaar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Actief frame zichtbaar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Synchronizeer tijd"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Help"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia instellingen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "OpenGL info"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Bladwijzer &toevoegen"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "Bladwijzers &beheren..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Laden "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
@@ -1674,11 +1648,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Markeringen"
 
@@ -1694,7 +1668,7 @@ msgstr "&Centreer selectie\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Sterrenbeelden"
 
@@ -1716,7 +1690,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Omloopbanen"
 
@@ -1730,18 +1704,18 @@ msgstr "Omloopbanen"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planeten"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Dwergplaneten"
 
@@ -1754,16 +1728,16 @@ msgstr "Dwergplaneten"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Manen"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Kleine manen"
 
@@ -1776,10 +1750,10 @@ msgstr "Kleine manen"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Planetoiden"
 
@@ -1792,10 +1766,10 @@ msgstr "Planetoiden"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Kometen"
 
@@ -1812,11 +1786,11 @@ msgstr "Kometen"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1834,7 +1808,7 @@ msgstr "10x &Sneller\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Labels"
 
@@ -1844,9 +1818,9 @@ msgstr "Labels"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Sterrenstelsels"
 
@@ -1854,8 +1828,8 @@ msgstr "Sterrenstelsels"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Bolvormige sterrenhopen"
 
@@ -1875,9 +1849,9 @@ msgstr "Open sterrenhoop"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nevels"
 
@@ -1889,48 +1863,48 @@ msgid "Locations"
 msgstr "Lokaties"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Open sterrenhoop"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Wolken"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Lichten aan nachtzijde"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Komeetstaarten"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Dampkringen"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Ringschaduwen"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Eclipsschaduwen"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Wolkenschaduwen"
 
@@ -2003,237 +1977,237 @@ msgstr "Automatische schijnbare helderheid limiet bij 45 graden: %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Schijnbare helderheid limiet: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Naam"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Schijnb. Mag."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Abs. Mag."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Type"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Sterren weergeven"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Sterren"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filter Sterren"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Met planeten"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Sterren weergeven"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Massamiddelpunt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Slecht spectraal type in sterrendatabase, ster #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Ververs"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Markeer"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maximum aantal sterren dat in de lijst weergegeven wordt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Markeer"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Markeringen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Geen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Diamant"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Driehoek"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Vierkant"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Cirkel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Pijl links"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Pijl rechts"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Pijl omhoog"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Pijl omlaag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Selecteer &object..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Grootte:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Selecteer &object..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Labelfeatures"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objecten"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Markeer"
@@ -2348,8 +2322,8 @@ msgstr "Bezig met laden van afbeelding uit bestand"
 msgid "Behind %1"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2518,86 +2492,91 @@ msgstr "Grootte: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "S&terrenstijl"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Lokaal formaat"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Tijdzonenaam"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "UTC Offset"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Start"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Afstand: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Abs. (schijnb.) mag: "
 
@@ -2610,21 +2589,21 @@ msgid "&Select"
 msgstr "&Selecteer"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centreren"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Ga Naar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Achtervolg"
 
@@ -2638,12 +2617,12 @@ msgid "Visible"
 msgstr "Actief frame zichtbaar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Verwijder Markering"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Selecteer weergavemodus"
@@ -2657,12 +2636,12 @@ msgid "Disk"
 msgstr "Schijf"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Markeer"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Referentiemarkeringen"
 
@@ -2710,13 +2689,13 @@ msgid "Show &Terminator"
 msgstr "Dag/Nacht-grens weergeven"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "Alternatieve &oppervlakten"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normaal"
 
@@ -2728,7 +2707,7 @@ msgstr "Normaal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Dwergplaneten"
@@ -2740,15 +2719,15 @@ msgstr "Dwergplaneten"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Kleine manen"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Objecten"
@@ -2759,7 +2738,7 @@ msgid "Set Time"
 msgstr "Stel tijd in..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Tijdzone: "
 
@@ -2824,7 +2803,7 @@ msgid "Set Seconds"
 msgstr "seconden"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Juliaanse datum:"
 
@@ -2838,97 +2817,97 @@ msgstr "Juliaanse datum:"
 msgid "Set time"
 msgstr "Stel tijd in..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Massamiddelpunt"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Slecht spectraal type in sterrendatabase, ster #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planeet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Dwergplaneet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Maan"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Kleine manen"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Planetode"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Komeet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Ruimtevaartuig"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Referentiemarkeringen"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Bereken"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Ga naar oppervlakte"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Onbekende fout tijdens openen van script bestand."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Planetoiden"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Referentiemarkeringen"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Andere features"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planeten"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objecten"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3061,7 +3040,7 @@ msgstr "Resolutie:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Bladwijzers beheren"
 
@@ -3168,7 +3147,7 @@ msgstr "Omloopbanen weergeven"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Landingsplaatsen"
@@ -3176,7 +3155,7 @@ msgstr "Landingsplaatsen"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Gedeeltelijke omloopbanen"
@@ -3184,49 +3163,49 @@ msgstr "Gedeeltelijke omloopbanen"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Rasters"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Equatoriaal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Zonneweg"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galactisch"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horizontaal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagrammen"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Grenzen"
 
@@ -3428,41 +3407,41 @@ msgstr "Scherm"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Ondersteunde extensies:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Ondersteunde extensies:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3711,13 +3690,13 @@ msgstr "Over &Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 #, fuzzy
 msgid "OK"
 msgstr "OK"
@@ -3804,7 +3783,7 @@ msgid "Create in >>"
 msgstr "Maken in >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Nieuwe map..."
 
@@ -3885,7 +3864,7 @@ msgid "Go to Object"
 msgstr "Ga naar object"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Ga naar"
 
@@ -3902,7 +3881,7 @@ msgid "Lat."
 msgstr "Lat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Afstand "
 
@@ -3951,174 +3930,178 @@ msgstr "Minimaal gelabelde feature grootte"
 msgid "Size:"
 msgstr "Grootte:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Hernoemen..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Hernoem bladwijzer of map"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Nieuwe naam"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Zet simulatietijd"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formaat:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Zet naar huidige tijd"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Zonnestelsel verkenner"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Ga naar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Zonnestelsel objecten"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Sterrenbrowser"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Dichtstbijzijnde"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Helderste (Schijnb.)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Met planeten"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Ververs"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Sterren zoekcriteria"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Maximum aantal sterren dat in de lijst weergegeven wordt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Rondleiding"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Selecteer uw bestemming:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Weergaveopties"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Toon"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Scherm"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Zonneweg"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Omloopbanen / Labels"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Latijnse namen"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Informatietekst"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Beknopt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Volledig"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "413"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mrt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mei"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Oct"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Sep"
 
@@ -4134,184 +4117,189 @@ msgstr "Datum"
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Venster modus"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Onzichtbaren"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "S&ynchronizeer Omloopbaan"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Toon lichaamsassen"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Toon frame-assen"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Toon Zon richting"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Toon snelheidsvector"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Planetografisch raster weergeven"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Dag/Nacht-grens weergeven"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satellieten"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Lichamen in omloopbaan"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Fout tijdens laden van lettertype, tekst zal niet zichtbaar zijn.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Fout:"
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Video opnemen"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Toetsencombinaties binnen Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Laden: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Laden "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "nl"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Fout tijdens het lezen van het configuratiebestand."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Laden van URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versie: "
 
@@ -4347,17 +4335,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Fout bij lezen van PNG afbeeldingsbestand"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Fout tijdens openen van script bestand."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Onbekende fout tijdens openen van script bestand."
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4369,7 +4361,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4380,9 +4372,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Fout tijdens openen van scriptbestand '%s'."
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Fout tijdens openen van scriptbestand."
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4390,8 +4382,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Script co-routine initialisatie faalde"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Fout tijdens openen van scriptbestand '%s'."
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4407,6 +4399,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Fout tijdens openen"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "3D Weergave methode: NVIDIA GeForce FX"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Bloom aan"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Bloom uit"
+
+#~ msgid "Exposure"
+#~ msgstr "Blootstelling"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Video opnemen"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Fout tijdens openen van scriptbestand '%s'."
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6786,9 +6798,6 @@ msgstr "Fout tijdens openen"
 #~ msgid "GLSL version: "
 #~ msgstr "GLSL versie: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Fout tijdens openen van scriptbestand."
-
 #~ msgid "Error loading script"
 #~ msgstr "Fout tijdens laden van scriptbestand."
 
@@ -7326,9 +7335,6 @@ msgstr "Fout tijdens openen"
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Oppervlaktetemp: "
-
-#~ msgid "Radius: "
-#~ msgstr "Straal: "
 
 #~ msgid "Rsun"
 #~ msgstr "Rsun"

--- a/po/no.po
+++ b/po/no.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:50+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Sommertid"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "Standardtid"
 
@@ -54,35 +54,34 @@ msgstr "Feil ved lesing av konfigurasjonsfil."
 msgid "Loaded {} deep space objects\n"
 msgstr " deep space objekter"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galakse (Hubble-type: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Kulehop (kjerneradius: %4.2f', King konsentrasjon: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Laster bilde fra fil "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Laster modell: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Feil ved innlasting av modell '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +97,110 @@ msgstr "Åpen stjernehop"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Feil i .ssc-fil (linje "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "advarsel for dobbelt definisjon av "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "feilaktig alternativ overflate"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "feil sted"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Feilaktig overskriftsformat i kryssindeks\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Feilaktig versjon for kryssindeks\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Lasting av krysssindeks feilet ved post "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Lasting av krysssindeks feilet ved post "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Feilaktig spektraltype i stjernedatabase, stjerne #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " stjerner i binærdatabase\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Totale antall stjerner: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Feil i .stc-fil (linje "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ugyldig stjerne: feilaktig spektraltype.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ugyldig stjerne: mangler spektraltype.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " eksisterer ikke.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ugyldig stjerne: mangler rektascensjon\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Ugyldig stjerne: mangler deklinasjon.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Ugyldig stjerne: mangler avstand.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ugyldig stjerne: mangler magnitude.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Ugyldig stjerne: absolutt (ikke tilsynelatende) magnitude må spesifiseres "
 "for stjerne nær utspring\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -241,721 +235,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Støttede utvidelser:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Feil ved lesing av favorittfil."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Ugyldig filtype"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudegrense: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Markører aktiverte"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Markører deaktiverte"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Gå til overflate"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-azimut modus aktivert"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-azimut modus deaktivert"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Stjernestil: Uklare punkter"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Stjernestil: Punkter"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Stjernestil: Skalerte skiver"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Komethaler aktiverte"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Komethaler deaktiverte"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Opptegning: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Alt-azimut modus aktivert"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Alt-azimut modus deaktivert"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Auto-magnitude aktivert"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Auto-magnitude deaktivert"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Tid og skript er midlertidig stoppet"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Tiden er midlertidig stoppet"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Gjenoppta"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Totale antall stjerner: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Totale antall stjerner: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Lysreisetid:  %.4f år "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Lysreisetid:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Lysreisetid:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Lysreiseforsinkelse inkludert"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Lysreiseforsinkelse slått av"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Lysreiseforsinkelse ignorert"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Bruker normale overflateteksturer."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Bruker 'limit of knowledge' overflateteksturer."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Følg"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Tid: Fram"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Tid: Tilbake"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Tidsfrekvens"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Teksturer"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Teksturer"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Teksturer"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Synkron omløpsbane"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Lås"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Gå etter"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudegrense: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Auto-magnitudegrense på 45 grader:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Omgivende lysnivå: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Lysforsterkning"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Overstråling aktivert"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Overstråling deaktivert"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Eksponering"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL-feil: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Visning for liten til å deles opp"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Tillagt visning"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "lå"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "au"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " dager"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " timer"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minutter"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr "Still tid..."
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Rotasjonsperiode: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " lå/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Hastighet: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Tilsynelatende diameter: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Tilsynelatende magnitude: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolutt magnitude: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Avstand: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Stjernesystemets massesentrum\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs (tils.) mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Lysstyrke: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Nøytronstjerne"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Svart hull"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasse: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Oveflatetemp.: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Radius: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Planetære satellitter tilstede\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Avstand fra senter: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Radius: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Tidsfrekvens"
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Sanntid"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Sanntid"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Tid stoppet"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr "raskere"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr "langsommere"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (pause)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Reiser "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Reiser "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Spor"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "&Følg"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synkron omløpsbane "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Gå etter"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Målnavn: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "  Pause"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  Opptak"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pause     F12 Stopp"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Redigeringsmodus"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Laster solsystemkatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Laster solsystemkatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Laster solsystemkatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Laster solsystemkatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Feil ved lesing av favorittfil."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Feil ved lesing av konfigurasjonsfil."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Initiering av SPICE-biblioteket feilet"
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Kan ikke lese stjernedatabase."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Feil ved åpning av deep-sky-katalog "
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Kan ikke lese stjernedatabase."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Feil ved åpning av solsystemskatalog.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Feil ved åpning av asterismefil."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Feil ved åpning av stjernebildegrense-filer."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Feilet i å initialisere opptegninger"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Feil ved lasting av skrift; tekst blir ikke synlig.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Feil ved lesing av kryssindeks"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Lastet inn kryssindeks"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Feil ved lesing av stjernenavn-fil\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Feil ved åpning av "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Feil ved lesing av stjerne-fil\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Feil ved åpning av stjernekatalog "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Støttede utvidelser:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1014,37 +992,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Objektfinner"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Objektfinner"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Solsystemet"
 
@@ -1054,20 +1032,20 @@ msgstr "Solsystemet"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Stjerner"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " deep space objekter"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1077,7 +1055,7 @@ msgstr "Formørkelses-finner"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 #, fuzzy
 msgid "Time"
 msgstr "&Tid"
@@ -1085,115 +1063,111 @@ msgstr "&Tid"
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Turguide"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Full skjerm"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "&Ta film...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Feil ved åpning av asterismefil."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Legg til bokmerker..."
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Ta bilde"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "er ikke en PNG-fil.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Ta opp video"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Ta opp video"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Ta opp video"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Oppløsning: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Bildefrekvens:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Kopiert URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Laster url"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "Å&pne skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Opprett en ny bokmerkemappe i denne meny"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1210,348 +1184,348 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Ukjent feil ved åpning av skript"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Støttede utvidelser:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Støttede utvidelser:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Om Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading Language</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL-versjon: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Maks samtidige teksturer: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Maks teksturstørrelse: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Punktstørrelses-område: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Punktstørrelses-område: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Maks kubekartstørrelse: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Ekvatorial"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Opptegner: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Fil"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Ta bilde"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Ta &bilde...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Ta opp video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "&Ta film...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopier URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "&Sentrer valgt objekt\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Å&pne skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia innstillinger"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Avslutt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Kantutjevning\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigering"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Velg"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Sentrer valgt objekt\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Valg: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Gå til objekt..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Tid"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Still tid..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Vis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr " deep space objekter"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Vis sky-skygger"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Stj&ernestil"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Teksturens oppløsning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Styring"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Bokmerker"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Vis"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "&Vis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Del visning vertikalt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Del &horisontalt\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Del visning horisontalt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Del &vertikalt\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Syklusvisning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Enkel visning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Enkel visning\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Slett visning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Slett"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Synlige rammer"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktive ramme synlig"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Synkroniser tid"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Hjelp"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia innstillinger"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "OpenGL-Info"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Legg til bokmerke"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organiser bokmerker..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Laster"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Skript"
@@ -1674,11 +1648,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Markører"
 
@@ -1694,7 +1668,7 @@ msgstr "Copyright © 2001-2009, Celestias utviklingsgruppe"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Stjernebilder"
 
@@ -1716,7 +1690,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Omløpsbaner"
 
@@ -1730,18 +1704,18 @@ msgstr "Omløpsbaner"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planeter"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Dvergplaneter"
 
@@ -1754,16 +1728,16 @@ msgstr "Dvergplaneter"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Måner"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Mindre måner"
 
@@ -1776,10 +1750,10 @@ msgstr "Mindre måner"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroider"
 
@@ -1792,10 +1766,10 @@ msgstr "Asteroider"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Kometer"
 
@@ -1812,11 +1786,11 @@ msgstr "Kometer"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1834,7 +1808,7 @@ msgstr "10x &raskere\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Påskrifter"
 
@@ -1844,9 +1818,9 @@ msgstr "Påskrifter"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galakser"
 
@@ -1854,8 +1828,8 @@ msgstr "Galakser"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Kulehoper"
 
@@ -1875,9 +1849,9 @@ msgstr "Åpne stjernehoper"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Stjernetåker"
 
@@ -1889,48 +1863,48 @@ msgid "Locations"
 msgstr "Steder"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Åpne stjernehoper"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Skyer"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Nattside-lys"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Komethaler"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosfærer"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Ring-skygger"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Formørkelsesskygger"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Sky-skygger"
 
@@ -2003,239 +1977,239 @@ msgstr "Auto-magnitudegrense på 45 grader:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudegrense: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Navn"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Avstand (lå)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Tils. mag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Abs. mag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Vis stjerner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Stjerner"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrer stjerner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 #, fuzzy
 msgid "With Planets"
 msgstr "Med planeter"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Vis stjerner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Massesentrum"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Feilaktig spektraltype i stjernedatabase, stjerne #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 #, fuzzy
 msgid "Refresh"
 msgstr "&Gjenoppfrisk"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marker"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maksimale antall stjerner vist i liste"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marker"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Markører"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Diamant"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Triangel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Kvadrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Pluss"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Sirkel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Venstrepil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Høyrepil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Opp-pil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Ned-pil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Velg &objekt..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Størrelse:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Velg &objekt..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Sett påskrift på detaljer"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "' ikke funnet.\n"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marker"
@@ -2350,9 +2324,12 @@ msgstr "Laster bilde fra fil "
 msgid "Behind %1"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+#, fuzzy
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
+"Celestia var ikke istand til å initialisere OpenGL utvidelser. Grafikk-"
+"kvalitet blir redusert. Bare enkel opptegning blir tilgjengelig"
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
 msgid "Error: no object selected!\n"
@@ -2520,86 +2497,91 @@ msgstr "Størrelse: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Stj&ernestil"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Lokalt format"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Tidssonenavn"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Avvikelse fra UTC"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Start"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Avstand: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Abs (tils.) mag: "
 
@@ -2612,21 +2594,21 @@ msgid "&Select"
 msgstr "&Velg"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Sentrer"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Gå til"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Følg"
 
@@ -2640,12 +2622,12 @@ msgid "Visible"
 msgstr "Aktive ramme synlig"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Fjern markering"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Velg visningsmodus"
@@ -2659,12 +2641,12 @@ msgid "Disk"
 msgstr "Disk"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Marker"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 #, fuzzy
 msgid "&Reference Marks"
 msgstr "&Referanse-vektorer"
@@ -2713,13 +2695,13 @@ msgid "Show &Terminator"
 msgstr "Vis terminator"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Alternative overflater"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normal"
 
@@ -2731,7 +2713,7 @@ msgstr "Normal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Dvergplaneter"
@@ -2743,15 +2725,15 @@ msgstr "Dvergplaneter"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Mindre måner"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Andre detaljer"
@@ -2762,7 +2744,7 @@ msgid "Set Time"
 msgstr "Still tid..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Tidssone: "
 
@@ -2827,7 +2809,7 @@ msgid "Set Seconds"
 msgstr "Still tid..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Juliansk dato: "
 
@@ -2841,98 +2823,98 @@ msgstr "Juliansk dato: "
 msgid "Set time"
 msgstr "Still tid..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Massesentrum"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Feilaktig spektraltype i stjernedatabase, stjerne #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Dvergplanet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Måne"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Mindre måner"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroid"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Komet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Romfartøy"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Referanse-vektorer"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Beregn"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Gå til overflate"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Ukjent feil ved åpning av skript"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteroider"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Referanse-vektorer"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Andre detaljer"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planeter"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Klasse: "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3065,7 +3047,7 @@ msgstr "Oppløsning: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organiser bokmerker"
 
@@ -3173,7 +3155,7 @@ msgstr "Vis omløpsbaner"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Landingsplasser"
@@ -3181,7 +3163,7 @@ msgstr "Landingsplasser"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Delvise baner"
@@ -3189,49 +3171,49 @@ msgstr "Delvise baner"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Rutenett"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Ekvatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ekliptikken"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galaktisk"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horisontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagrammer"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Grenser"
 
@@ -3433,41 +3415,41 @@ msgstr "Vis"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Støttede utvidelser:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Støttede utvidelser:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3717,13 +3699,13 @@ msgstr "Om &Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3810,7 +3792,7 @@ msgid "Create in >>"
 msgstr "Opprett i >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Ny mappe..."
 
@@ -3891,7 +3873,7 @@ msgid "Go to Object"
 msgstr "Gå til objekt"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Gå til"
 
@@ -3908,7 +3890,7 @@ msgid "Lat."
 msgstr "Br.gr."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Avstand"
 
@@ -3957,174 +3939,178 @@ msgstr "Minste størrelse på detaljer med påskrift"
 msgid "Size:"
 msgstr "Størrelse:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Endre navn..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Endre navn på bokmerke eller mappe"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Nytt navn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Still inn simuleringstid"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Format: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Still inn til gjeldende tid"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Solsystemviser"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Gå til"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Solsystemobjekter"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Stjerneviser"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Nærmeste"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Lyssterkest"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "Med planeter"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Gjenoppfrisk"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Stjernesøk-kriterie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Maksimale antall stjerner vist i liste"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Turguide"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Velg ditt mål:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Visningsalternativ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Vis"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Vis"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 #, fuzzy
 msgid "Ecliptic Line"
 msgstr ", linje"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Omløpsbaner / Påskrifter"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Latinske navn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Informasjonsstekst"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Knapp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Utførlig"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "414"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Des"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Sep"
 
@@ -4140,184 +4126,189 @@ msgstr "Dato"
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Vindusmodus"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Usynlige"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "S&ynkr. omløpsbane"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Vis legeme-akser"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Vis ramme-akser"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Vis solretning"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Vis hastighetsvektor"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Vis planetografisk rutenett"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Vis terminator"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satellitter"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Legemer i bane"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Feil ved lasting av skrift; tekst blir ikke synlig.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Feil: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Ta opp video"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Celestia styring"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Laster: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Laster"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "no"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Feil ved lesing av konfigurasjonsfil."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Laster url"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versjon: "
 
@@ -4353,17 +4344,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Feil ved lesing av PNG-bildefil "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Feil ved åpning av skriptfil."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Ukjent feil ved åpning av skript"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4375,7 +4370,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4386,9 +4381,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Feil ved åpning av skript '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Feil ved åpning av skript"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4396,8 +4391,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Initiering av skriptets medrutine feilet"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Feil ved åpning av skript '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4413,6 +4408,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Feil ved åpning av "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Opptegning: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Overstråling aktivert"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Overstråling deaktivert"
+
+#~ msgid "Exposure"
+#~ msgstr "Eksponering"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Ta opp video"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Feil ved åpning av skript '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -5632,14 +5647,6 @@ msgstr "Feil ved åpning av "
 #~ msgstr "Ukjent feil ved åpning av skript"
 
 #, fuzzy
-#~ msgid ""
-#~ "Celestia was unable to initialize OpenGL extensions (error %i). Graphics "
-#~ "quality will be reduced."
-#~ msgstr ""
-#~ "Celestia var ikke istand til å initialisere OpenGL utvidelser. Grafikk-"
-#~ "kvalitet blir redusert. Bare enkel opptegning blir tilgjengelig"
-
-#, fuzzy
 #~ msgid "Max simultaneous textures"
 #~ msgstr "Maks samtidige teksturer: "
 
@@ -5715,9 +5722,6 @@ msgstr "Feil ved åpning av "
 
 #~ msgid "GLSL version: "
 #~ msgstr "GLSL-versjon: "
-
-#~ msgid "Error opening script"
-#~ msgstr "Feil ved åpning av skript"
 
 #~ msgid "Error loading script"
 #~ msgstr "Feil ved lasting av skript"
@@ -6261,9 +6265,6 @@ msgstr "Feil ved åpning av "
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Overflatetemperatur: "
-
-#~ msgid "Radius: "
-#~ msgstr "Radius: "
 
 #~ msgid "Rsun"
 #~ msgstr "Rsol"

--- a/po/pl.po
+++ b/po/pl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2019-02-14 21:31+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: Polish (https://www.transifex.com/celestia/teams/93131/pl/)\n"
@@ -24,11 +24,11 @@ msgstr ""
 "%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -59,36 +59,35 @@ msgstr "Błąd odczytu pliku konfiguracyjnego."
 msgid "Loaded {} deep space objects\n"
 msgstr ""
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaktyka (typ Hubble’a: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Gromada kulista (promień jądra: %4.2f', koncentracja Kinga: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Błąd odczytu pliku ulubionych."
 
-#: ../src/celengine/meshmanager.cpp:461
-#, c-format
-msgid "Loading model: %s\n"
-msgstr ""
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
+msgstr "Błąd otwierania katalogu układu słonecznego.\n"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, c-format
-msgid "Error loading model '%s'\n"
-msgstr ""
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
+msgstr "Błąd odczytu pliku ulubionych."
 
 #: ../src/celengine/nebula.cpp:39
 msgid "Nebula"
@@ -102,111 +101,106 @@ msgstr "Gromada otwarta "
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "zła zastępcza powierzchnia"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "zła lokalizacja"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Zły nagłówek indeksu skrośnego\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Zła wersja indeksu skrośnego\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Zła wersja indeksu skrośnego\n"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Zła wersja indeksu skrośnego\n"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 msgid "{} stars in binary database\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 msgid "Total star count: {}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 msgid "Error in .stc file (line {}): {}\n"
 msgstr ""
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Nieprawidłowa gwiazda: zły typ spektralny.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Nieprawidłowa gwiazda: brak typu spektralnego.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr "Katalog z dodatkami %1 nie istnieje"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Nieprawidłowa gwiazda: brak poprawnej rektascencji\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Nieprawidłowa gwiazda: brak deklinacji\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Nieprawidłowa gwiazda: brak odległości\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Nieprawidłowa gwiazda: brak wielkości\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Nieprawidłowa gwiazda: bezwzględna (nie pozorna) wielkość musi być określona "
 "dla gwiazdy w pobliżu pochodzenia\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 msgid "Creating tiled texture. Width={}, max={}\n"
@@ -239,700 +233,678 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Obsługiwane rozszerzenia:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Błąd odczytu pliku ulubionych."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Nieprawidłowy typ pliku"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Limit wielkości: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Markery włączone"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Markery wyłączone"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Idź do powierzchni"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Tryb alt-azymutalny włączony"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Tryb alt-azymutalny wyłączony"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Styl gwiazd: rozmyte punkty"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Styl gwiazd: punkty"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Styl gwiazd: skalowane tarcze"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Ogony komet włączone"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Ogony komet wyłączone"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Ścieżka renderowania: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 msgid "Anti-aliasing enabled"
 msgstr "Wygładzanie włączone"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 msgid "Anti-aliasing disabled"
 msgstr "Wygładzanie wyłączone"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Wielkość automatyczna włączona"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Wielkość automatyczna wyłączona"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Czas i skrypt zostały wstrzymane"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Czas jest wstrzymany"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Wznów"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr "Kolor gwiazd: ciało czarne D65"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr "Kolor gwiazd: wzmocniony"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Czas podróży światła:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Czas podróży światła:  %d g  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Włączone opóźnienie czasu podróży światła"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Wyłączone opóźnienie czasu podróży światła"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Zignorowane opóźnienie czasu podróży światła"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Korzystaj z normalnych tekstur powierzchni."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Korzystaj z tekstur powierzchni przy ograniczonej wiedzy."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Śledź"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Czas: do przodu"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Czas: wstecz"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, c-format
 msgid "Time rate: %.6g"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 msgid "Low res textures"
 msgstr "Tekstury niskiej rozdzielczości"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 msgid "Medium res textures"
 msgstr "Tekstury średniej rozdzielczości"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr "Tekstury wysokiej rozdzielczości"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Synchronizacja orbity"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Zablokuj"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Goń"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Automatyczny limit wielkości przy 45 stopniach:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Poziom oświetlenia otoczenia:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Lekkie wzmocnienie"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Bloom włączony"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Bloom wyłączony"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Ekspozycja"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Błąd GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Widok zbyt mały, aby został podzielony"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Dodano widok"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "lś"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "j.a."
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 msgid "mi"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "hours"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 msgid "minutes"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 msgid "seconds"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+msgid "Rotation period: {} {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 msgid "ly/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 msgid "AU/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 msgid "km/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 msgid "m/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+msgid "Speed: {} {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, c-format
 msgid "Apparent diameter: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, c-format
 msgid "Distance: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Barycentrum systemu gwiezdnego\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag. abs (poz): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+msgid "Luminosity: {}x Sun\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Gwiazda neuronowa"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Czarna dziura"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, c-format
 msgid "Class: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2860
-#, c-format
-msgid "Surface temp: %s K\n"
+#: ../src/celestia/celestiacore.cpp:2905
+#, fuzzy, c-format
+msgid "Surface temp: %s\n"
+msgstr "Temp. powierzchni:"
+
+#: ../src/celestia/celestiacore.cpp:2910
+msgid "Radius: {} Rsun  ({})\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, c-format
-msgid "Radius: %s Rsun  (%s)\n"
-msgstr ""
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
+msgstr "Promień: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, c-format
-msgid "Radius: %s\n"
-msgstr ""
-
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Obecne towarzysze planetarne\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, c-format
+msgid "Radius: %s\n"
+msgstr ""
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Kąt fazowy: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
-#, c-format
-msgid "Temperature: %.0f K\n"
-msgstr ""
+#: ../src/celestia/celestiacore.cpp:3045
+#, fuzzy, c-format
+msgid "Temperature: %s\n"
+msgstr "Renderer: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Czas rzeczywisty"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Czas rzeczywisty"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Czas zatrzymany"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, c-format
 msgid "%.6g x faster"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, c-format
 msgid "%.6g x slower"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Wstrzymano)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+msgid "Travelling ({})\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, c-format
+#: ../src/celestia/celestiacore.cpp:3291
 msgid "Travelling\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, c-format
 msgid "Track %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, c-format
 msgid "Follow %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, c-format
 msgid "Chase %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Nazwa celu: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Paused"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Recording"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pauza    F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Tryb edycji"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Błąd otwierania katalogu układu słonecznego.\n"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Błąd otwierania katalogu układu słonecznego.\n"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Błąd otwierania katalogu układu słonecznego.\n"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Błąd otwierania katalogu układu słonecznego.\n"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Błąd odczytu pliku ulubionych."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Błąd odczytu pliku konfiguracyjnego."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Nie udało się wczytać biblioteki SPICE."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Nie można odczytać bazy danych gwiazd."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Błąd otwierania pliku skryptu."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Nie można odczytać bazy danych gwiazd."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Błąd otwierania katalogu układu słonecznego.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Błąd podczas otwierania pliku astronomów."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Błąd otwierania plików granic gwiazdozbiorów."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Nie udało się zainicjować renderera"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Błąd ładowania czcionki; tekst nie będzie widoczny.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Błąd odczytu pliku ulubionych."
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Zła wersja indeksu skrośnego\n"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Błąd wczytania pliku nazwy gwiazd\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Błąd otwarcia skryptu"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Błąd odczytu pliku gwiazd\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Błąd otwierania katalogu układu słonecznego.\n"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Obsługiwane rozszerzenia:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -991,19 +963,19 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 #, fuzzy
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
@@ -1012,18 +984,18 @@ msgstr ""
 "Celestia nie może się uruchomić, gdyż brakuje katalogu z danymi, "
 "przypuszczalnie na skutek niewłaściwej instalacji."
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Przeglądarka kosmosu"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 msgid "Info Browser"
 msgstr "Przeglądarka informacji"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Układ słoneczny"
 
@@ -1033,19 +1005,19 @@ msgstr "Układ słoneczny"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Gwiazdy"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr "Obiekty głębokiego nieba"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Wyszukiwarka wydarzeń"
@@ -1054,110 +1026,107 @@ msgstr "Wyszukiwarka wydarzeń"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Czas"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Przewodniki"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 msgid "Full screen"
 msgstr "Pełny ekran"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 msgid "Error opening bookmarks file"
 msgstr "Błąd podczas otwierania pliku zakładek"
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 msgid "Error Saving Bookmarks"
 msgstr "Błąd zapisu zakładek"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 msgid "Save Image"
 msgstr "Zapisz obraz"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr "Obrazy (*.png *.jpg)"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Przechwyć wideo"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr "Wideo (*.avi)"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Wideo (*.avi)"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr "Rozdzielczość:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Tempo klatek:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr "Skopiowano zrzut ekranu do schowka"
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Skopiowany URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 msgid "Pasting URL"
 msgstr "Wklejanie URLa"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Open Script"
 msgstr "Otwórz skrypt"
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Skrypty Celestii (*.celx *.cel)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 msgid "New bookmark"
 msgstr "Nowa zakładka"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, fuzzy, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1183,311 +1152,311 @@ msgstr ""
 "CelestiaProject/Celestia<a href=\"https://github.com/CelestiaProject/Celestia"
 "\"><br></a>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 msgid "Unknown compiler"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "O Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>Wersja OpenGL:</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "Dostawca: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "Renderer: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "<b>Wersja GLSL:</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Maksymalna jednoczesna ilość tekstur: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>Maksymalny rozmiar tekstury: </b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Zakres rozmiaru punktu: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Zakres rozmiaru punktu: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Maks. rozmiar mapy kostki: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Rozszerzenia:</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Renderer: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Plik"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 msgid "&Grab image"
 msgstr "&Przechwyć obraz"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 msgid "Capture &video"
 msgstr "Przechwyć &wideo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr "&Kopiuj obraz"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Otwórz skrypt..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr "&Ustawienia..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Wyjście"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr ""
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Nawigacja"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 msgid "Select Sun"
 msgstr "Zaznacz Słońce"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 msgid "Center Selection"
 msgstr "Wyśrodkuj zaznaczenie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Goto Selection"
 msgstr "Idź do zaznaczenia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Przejdź &do obiektu..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Czas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 msgid "Set &time"
 msgstr "Ustaw &czas"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 msgid "&Display"
 msgstr "&Wyświetlanie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 msgid "Dee&p Sky Objects"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 msgid "&Shadows"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "W&ygląd gwiazd"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 msgid "&FPS control"
 msgstr ""
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Zakładki"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Widok"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 msgid "&MultiView"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 msgid "Split view vertically"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 msgid "Split view horizontally"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 msgid "Cycle views"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 msgid "Single view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 msgid "Delete view"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 msgid "Frames visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 msgid "Active frame visible"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 msgid "Synchronize time"
 msgstr ""
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Pomo&c"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 msgid "Celestia Manual"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "Informacje o OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 msgid "Add Bookmark..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "&Skrypty"
@@ -1596,11 +1565,11 @@ msgstr ""
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Markery"
 
@@ -1615,7 +1584,7 @@ msgstr ""
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Gwiazdozbiory"
 
@@ -1634,7 +1603,7 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Orbity"
 
@@ -1648,18 +1617,18 @@ msgstr "Orbity"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planety"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Planety karłowate"
 
@@ -1672,16 +1641,16 @@ msgstr "Planety karłowate"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Księżyce"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Drobne księżyce"
 
@@ -1694,10 +1663,10 @@ msgstr "Drobne księżyce"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroidy"
 
@@ -1710,10 +1679,10 @@ msgstr "Asteroidy"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Komety"
 
@@ -1730,11 +1699,11 @@ msgstr "Komety"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1751,7 +1720,7 @@ msgstr ""
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Nazwy"
 
@@ -1761,9 +1730,9 @@ msgstr "Nazwy"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaktyki"
 
@@ -1771,8 +1740,8 @@ msgstr "Galaktyki"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Gromady kuliste"
 
@@ -1791,9 +1760,9 @@ msgstr "Gromady otwarte"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Mgławice"
 
@@ -1805,48 +1774,48 @@ msgid "Locations"
 msgstr "Miejsca"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Gromady otwarte"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Chmury"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Światła nocnej strony"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Ogony komet"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosfery"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Cienie pierścieni"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Cienie zaćmień"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Cienie chmur"
 
@@ -1912,224 +1881,224 @@ msgstr "Automatyczny limit jasności przy 45 stopniach: %L1"
 msgid "Magnitude limit: %L1"
 msgstr "Limit jasności: %L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Nazwa"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Odległość (lś)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Poz. wielk."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Abs. wielk."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 msgid "Closest Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 msgid "Brightest Stars"
 msgstr ""
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 msgid "Filter"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Z planetami"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 msgid "Multiple Stars"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 msgid "Barycenters"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr ""
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 msgid "Mark Selected"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 msgid "Mark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "Odznacz &wszystko"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 msgid "Clear Markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Brak tekstu"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Romb"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Trójkąt"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Kwadrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Koło"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Strzałka w lewo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Strzałka w prawo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Strzałka w górę"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Strzałka w dół"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, qt-format
 msgid "%1 objects found"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr ""
 
@@ -2234,9 +2203,12 @@ msgstr ""
 msgid "Behind %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+#, fuzzy
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
+"Celestia nie mogła zainicjować rozszerzeń OpenGL (błąd %1). Jakość grafiki "
+"będzie zmniejszona."
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
 msgid "Error: no object selected!\n"
@@ -2401,82 +2373,87 @@ msgstr ""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 msgid "Local format"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 msgid "Time zone name"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 msgid "UTC offset"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Start"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Odległość: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Wiel. abs (poz): "
 
@@ -2489,21 +2466,21 @@ msgid "&Select"
 msgstr "&Wybierz"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centruj"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Przejdź do"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Śledź"
 
@@ -2516,12 +2493,12 @@ msgid "Visible"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Odznacz"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Wybierz tryb ekranu"
@@ -2535,12 +2512,12 @@ msgid "Disk"
 msgstr "Dysk"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Zaznacz"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "Punkty &odniesienia"
 
@@ -2581,13 +2558,13 @@ msgid "Show &Terminator"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Alternatywne powierzchnie"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Standardowo"
 
@@ -2599,7 +2576,7 @@ msgstr "Standardowo"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr ""
 
@@ -2610,14 +2587,14 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr ""
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 msgid "Other objects"
 msgstr ""
 
@@ -2626,7 +2603,7 @@ msgid "Set Time"
 msgstr ""
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Strefa czasowa: "
 
@@ -2682,7 +2659,7 @@ msgid "Set Seconds"
 msgstr ""
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Data Juliańska: "
 
@@ -2694,85 +2671,85 @@ msgstr ""
 msgid "Set time"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Barycentrum"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planeta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Księżyc"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 msgid "Minor moon"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroida"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Kometa"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Pojazd kosmiczny"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 msgid "Reference point"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 msgid "Component"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 msgid "Surface feature"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 msgid "Reference points"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 msgid "Surface features"
 msgstr ""
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 msgid "Planets and moons"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -2888,7 +2865,7 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organizuj zakładki"
 
@@ -2983,63 +2960,63 @@ msgstr ""
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 msgid "Fading orbits"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Siatka"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Równikowy"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ekliptczna"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galaktyczna"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Pozioma"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Schematy"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Granice"
 
@@ -3220,41 +3197,41 @@ msgstr ""
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Obsługiwane rozszerzenia:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Obsługiwane rozszerzenia:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3499,13 +3476,13 @@ msgstr "&O Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3592,7 +3569,7 @@ msgid "Create in >>"
 msgstr "Utwórz w >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Nowy folder..."
 
@@ -3673,7 +3650,7 @@ msgid "Go to Object"
 msgstr "Przejdź do objektu"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Przejdź do"
 
@@ -3690,7 +3667,7 @@ msgid "Lat."
 msgstr "Szerokość"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Odległość"
 
@@ -3738,174 +3715,178 @@ msgstr "Minimalna wielkość wpisanych miejsc"
 msgid "Size:"
 msgstr "Rozmiar:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Zmień nazwę..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Zmień nazwę zakładki lub folderu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Nowa nazwa"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Ustaw czas symulacji"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Format: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Ustaw do aktualnego czasu"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Przeglądarka układu słonecznego"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Przejdź do"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Obiekty układu słonecznego"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Przeglądarka gwiazd"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Najbliższe"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Najjaśniejsze"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Z planetami"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Odśwież"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Filtr wyszukiwania gwiazd"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Maks. ilość gwiazd wyświetlana w liście"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Przewodnik"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Wybierz twój cel:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Opcje widoku"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Pokaż"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Wyświetlanie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Ekliptyka"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Orbity / Nazwy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Łacińskie nazwy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Informacje tekstowe"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Krótkie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Szczegółowe"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "415"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Kwi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Lut"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Sty"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Cze"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Maj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Sie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Gru"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Lip"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Lis"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Paź"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Wrz"
 
@@ -3921,181 +3902,186 @@ msgstr "Data"
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Tryb okna"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Niewidzialne"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "S&ynchronizacja orbity"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Informacja"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Pokaż osie ciała"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Pokaż osie ramek"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Pokaż kierunek słońca"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Pokaż wektor prędkości"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Pokaż siatkę planetarną"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Pokaż terminatora"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satelity"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Orbitujące ciała"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 msgid "Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 msgid "Could not capture movie."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Kontrole Celestii"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Ładowanie: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Błąd odczytu pliku gwiazd\n"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "pl"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Błąd odczytu pliku konfiguracyjnego."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Ładowanie URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Wersja:"
 
@@ -4130,17 +4116,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Błąd odczytu pliku ulubionych."
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Błąd otwierania pliku skryptu."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Nieznany błąd podczas otwierania skryptu"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4159,7 +4149,7 @@ msgstr ""
 "\n"
 "y = tak, Esc = anuluj skrypt, inne klawisze = nie"
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4175,9 +4165,9 @@ msgstr ""
 "Czy masz zaufanie do skryptu i pozwolisz mu na to?"
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Błąd otwierania skryptu '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Błąd otwarcia skryptu"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4185,9 +4175,9 @@ msgid "Script coroutine initialization failed"
 msgstr "Zainicjowanie skryptu współprogramu nie powiodło się"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, c-format
-msgid "Error opening LuaHook '%s'"
-msgstr ""
+#, fuzzy
+msgid "Error opening LuaHook {}"
+msgstr "Błąd otwarcia skryptu"
 
 #: ../src/celscript/lua/luascript.cpp:231
 msgid "Unknown error loading hook script"
@@ -4201,6 +4191,25 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Błąd otwarcia skryptu"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Ścieżka renderowania: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Bloom włączony"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Bloom wyłączony"
+
+#~ msgid "Exposure"
+#~ msgstr "Ekspozycja"
+
+#~ msgid "Video (*.avi)"
+#~ msgstr "Wideo (*.avi)"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Błąd otwierania skryptu '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6498,13 +6507,6 @@ msgstr "Błąd otwarcia skryptu"
 #~ "Celestia nie może wystartować, gdyż brakuje katalogu z zasobami, "
 #~ "przypuszczalnie na skutek niewłaściwej instalacji."
 
-#~ msgid ""
-#~ "Celestia was unable to initialize OpenGL extensions (error %1). Graphics "
-#~ "quality will be reduced."
-#~ msgstr ""
-#~ "Celestia nie mogła zainicjować rozszerzeń OpenGL (błąd %1). Jakość "
-#~ "grafiki będzie zmniejszona."
-
 #~ msgid "Copy &URL"
 #~ msgstr "Kopiuj &URL"
 
@@ -6516,9 +6518,6 @@ msgstr "Błąd otwarcia skryptu"
 
 #~ msgid "GLSL version: "
 #~ msgstr "Wersja GLSL: "
-
-#~ msgid "Error opening script"
-#~ msgstr "Błąd otwarcia skryptu"
 
 #~ msgid "Error loading script"
 #~ msgstr "Błąd ładowania skryptu"
@@ -7055,12 +7054,6 @@ msgstr "Błąd otwarcia skryptu"
 
 #~ msgid "Directory %1 does not exist, using default %2"
 #~ msgstr "Katalog %1 nie istnieje, użyty domyślny %2"
-
-#~ msgid "Surface Temp: "
-#~ msgstr "Temp. powierzchni:"
-
-#~ msgid "Radius: "
-#~ msgstr "Promień: "
 
 #~ msgid "Rsun"
 #~ msgstr "Rsłońce"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:52+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Hora de Verão"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -54,35 +54,34 @@ msgstr "Erro ao ler o ficheiro de configuração."
 msgid "Loaded {} deep space objects\n"
 msgstr " objectos de céu profundo"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galáxia (classe de Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Globular (raio do núcleo: %4.2f', concentração King: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "A carregar imagem do ficheiro "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Carregando o modelo: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Erro ao carregar o modelo '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +97,110 @@ msgstr "Aglomerados Abertos"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Erro no ficheiro .ssc (linha"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "aviso de definição duplicada de "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "superfície alternativa inválida"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "localização inválida"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Cabeçalho inválido para o índice remissivo\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Versão inválida para o índice remissivo\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "O carregamento do índice remissivo falhou no registo "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "O carregamento do índice remissivo falhou no registo "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr "estrelas na base de dados de binárias\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Total de estrelas: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Erro no ficheiro .stc (linha"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Estrela inválida: classe espectral inválida.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Estrela inválida: classe espectral ausente.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " não existe.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Estrela inválida: ascensão recta ausente\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Estrela inválida: declinação ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Estrela inválida: distância ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Estrela inválida: magnitude ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Estrela inválida: terá que especificar a magnitude absoluta (não a aparente) "
 "para a estrela perto da origem \n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -241,721 +235,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Erro ao ler o ficheiro de favoritos."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Tipo de ficheiro inválido"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Marcas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Marcas desactivadas"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Ir para a superfície"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Modo altazimutal activado"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Modo altazimutal desactivado"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Forma das estrelas: Pontos Indistintos"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Forma das estrelas: Pontos"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Forma das estrelas: Discos à escala"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Caudas de cometa activadas"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Caudas de cometa desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Caminho de Renderização: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Marcas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Marcas desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Magnitude automática activada"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Magnitude automática desactivada"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "O tempo e o script estão em pausa"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "O tempo está em pausa"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Retomar"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "N&avegador Estelar..."
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "N&avegador Estelar..."
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Tempo de viagem da luz: %.4f anos "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Tempo de viagem da luz: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Tempo de viagem da luz: %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Atraso da viagem da luz incluído"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Atraso da viagem da luz desligado"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Atraso da viagem da luz ignorado"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Usando texturas de superfície normais."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Usando texturas no limite do conhecimento de superfície "
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Tempo: para a frente"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Tempo: para trás"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Velocidade do tempo"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Órbita Geoest."
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Fixar"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Limite de magnitude automática a 45 graus: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Luz Ambiente: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Ganho de luz"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Florescência activada"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Florescência desactivada"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Exposição"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Erro de GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Vista demasiado pequena para ser dividida"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Panorama acrescentado"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "a.l."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "ua"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " dias"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " horas"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minutos"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr "segundos"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Velocidade: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diâmetro aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitude aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitude absoluta: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distância: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Baricentro do sistema estelar\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag abs (apa): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosidade: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Estrela de neutrões"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Buraco negro"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Classe: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Temp à superfície:"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Companheiros planetários presentes\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distância do centro: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Raio: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Ângulo de fase: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Tempo parado"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " mais depressa"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " mais devagar"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Pausado)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "A viajar"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "A viajar"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Seguir a rota "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Órbita Geoest. "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Nome do alvo: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr " Pausa"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr " A gravar"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Iniciar/Pausar    F12 Parar"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Modo de edição"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Erro ao ler o ficheiro de favoritos."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Erro ao ler o ficheiro de configuração."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Inicialização da livraria SPICE falhou."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Erro ao abrir o catálogo de céu profundo. "
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Erro ao abrir o catálogo do Sistema Solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Erro ao abrir o ficheiro dos asterismos."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Erro ao abrir o ficheiro das fronteiras das constelações."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Falha na inicialização do motor de renderização"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Erro ao carregar a fonte; o texto não será visível.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Erro ao ler o índice remissivo "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Índice remissivo carregado "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Erro ao ler o ficheiro com o nome das estrelas\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Erro ao abrir "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Erro ao ler o ficheiro das estrelas\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Erro ao abrir o catálogo de estrelas "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1014,37 +992,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Navegador Celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "&Informação"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Sistema Solar"
 
@@ -1054,20 +1032,20 @@ msgstr "Sistema Solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " objectos de céu profundo"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1077,122 +1055,118 @@ msgstr "Buscador de eclipses"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Hora"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Guia de Excursão"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Ecrã inteiro"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Capturar &Filme...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Erro ao abrir o ficheiro dos asterismos."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Marcadores"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Gravar como:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " não é um ficheiro PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Capturar Vídeo"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolução: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Imagens por segundo:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL copiado"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "A carregar o URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Abrir Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Criar uma nova pasta de marcadores neste menu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1209,349 +1183,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Erro desconhecido ao abrir o script"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Acerca do Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Versão GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Nº máx. de texturas em simultâneo: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Tamanho máx. de texturas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Intervalo do tamanho dos pontos"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Intervalo do tamanho dos pontos"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Tamanho máx. de texturas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Motor de Renderização: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Ficheiro"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Capturar Imagem"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Capturar &Imagem...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Capturar &Filme...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Abrir Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferências do Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "S&air"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navegação"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrar na Selecção\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selecção: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ir para Objecto..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Hora"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Definir a Hora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Visualização"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Objectos"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Sombras dos Anéis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Fo&rma das Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Resolução das Texturas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controles"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Marcadores"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Panorama"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Multipanorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividir o Panorama Verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividir &Horizontalmente\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividir o Panorama Horizontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dividir &Verticalmente\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Alternar o Panorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Panorama individual"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Panorama &Individual\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Apagar Panorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Bordas Visíveis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Borda Activa Visível"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizar Hora"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Ajuda"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "Informação do OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Adicionar marcador"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizar Marcadores..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "A carregar "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
@@ -1674,11 +1648,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Marcas"
 
@@ -1694,7 +1668,7 @@ msgstr "&Centrar na Selecção\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Constelações"
 
@@ -1716,7 +1690,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Órbitas"
 
@@ -1730,18 +1704,18 @@ msgstr "Órbitas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planetas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Planetas Anões"
 
@@ -1754,16 +1728,16 @@ msgstr "Planetas Anões"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Luas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Luas Menores"
 
@@ -1776,10 +1750,10 @@ msgstr "Luas Menores"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteróides"
 
@@ -1792,10 +1766,10 @@ msgstr "Asteróides"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Cometas"
 
@@ -1812,11 +1786,11 @@ msgstr "Cometas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1834,7 +1808,7 @@ msgstr "10x Mais &Rápido\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Legendas"
 
@@ -1844,9 +1818,9 @@ msgstr "Legendas"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galáxias"
 
@@ -1854,8 +1828,8 @@ msgstr "Galáxias"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Globulares"
 
@@ -1875,9 +1849,9 @@ msgstr "Enxames Abertos"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nebulosas"
 
@@ -1889,48 +1863,48 @@ msgid "Locations"
 msgstr "Localizações"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Enxames Abertos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Nuvens"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Luzes do Lado Nocturno"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Caudas dos Cometas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosferas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Sombras dos Anéis"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Sombras dos Eclipses"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Sombras das Nuvens"
 
@@ -2003,237 +1977,237 @@ msgstr "Limite de magnitude automática a 45 graus: %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Distância (a.l.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Mag apa."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Mag abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Mais Brilhante"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Com Planetas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentro"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Nº Máximo de Estrelas Apresentado na Lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Diamante"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Triângulo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Quadrado"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Mais"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Círculo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Seta Esquerda"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Seta Direita"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Seta para Cima"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Seta para Baixo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Tamanho:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Legendar as Feições"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objectos"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marcar"
@@ -2348,8 +2322,8 @@ msgstr "De:"
 msgid "Behind %1"
 msgstr "Duração: %1"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2518,86 +2492,91 @@ msgstr "Tamanho: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Fo&rma das Estrelas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Formato Local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Fuso Horário"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Desvio em relação ao GMT"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Início"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Mag abs (apa): "
 
@@ -2610,21 +2589,21 @@ msgid "&Select"
 msgstr "&Seleccionar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centrar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Ir para"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Seguir"
 
@@ -2638,12 +2617,12 @@ msgid "Visible"
 msgstr "Borda Activa Visível"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Desmarcar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Escolher o Modo de Visualização"
@@ -2657,12 +2636,12 @@ msgid "Disk"
 msgstr "Disco"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Marcar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Pontos de Referência"
 
@@ -2710,13 +2689,13 @@ msgid "Show &Terminator"
 msgstr "Mostrar o Terminador"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Superfícies alternativas"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normal"
 
@@ -2728,7 +2707,7 @@ msgstr "Normal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Planetas Anões"
@@ -2740,15 +2719,15 @@ msgstr "Planetas Anões"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Luas Menores"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Objectos"
@@ -2759,7 +2738,7 @@ msgid "Set Time"
 msgstr "Definir a Hora..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Fuso Horário: "
 
@@ -2824,7 +2803,7 @@ msgid "Set Seconds"
 msgstr "segundos"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Data Juliana: "
 
@@ -2838,97 +2817,97 @@ msgstr "Data Juliana: "
 msgid "Set time"
 msgstr "Definir a Hora..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Baricentro"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planeta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Planeta Anão"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Lua"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Luas Menores"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteróide"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Cometa"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Naves espaciais"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Pontos de Referência"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Calcular"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Ir para a superfície"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Erro desconhecido ao abrir o script"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteróides"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Pontos de Referência"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Outras feições"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planetas"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objectos"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3061,7 +3040,7 @@ msgstr "Resolução: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organizar Marcadores"
 
@@ -3168,7 +3147,7 @@ msgstr "Mostrar Órbitas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Sítios de Aterragem"
@@ -3176,7 +3155,7 @@ msgstr "Sítios de Aterragem"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Trajectórias Parciais"
@@ -3184,49 +3163,49 @@ msgstr "Trajectórias Parciais"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Grelhas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Equatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Eclíptica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galáctico"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagramas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Mostrar Fronteiras"
 
@@ -3428,41 +3407,41 @@ msgstr "Visualização"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3713,13 +3692,13 @@ msgstr "&Acerca do Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3805,7 +3784,7 @@ msgid "Create in >>"
 msgstr "Criar em >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Nova Pasta..."
 
@@ -3886,7 +3865,7 @@ msgid "Go to Object"
 msgstr "Ir para Objecto"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Ir Para"
 
@@ -3903,7 +3882,7 @@ msgid "Lat."
 msgstr "Lat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Distância"
 
@@ -3952,174 +3931,178 @@ msgstr "Tamanho Mínimo da Feição Legendada"
 msgid "Size:"
 msgstr "Tamanho:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Renomear..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Renomear Marcador ou Pasta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Novo Nome"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Definir Hora da Simulação"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formato: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Actualizar para a Hora Actual"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Navegador do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Ir Para"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Objectos do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Navegador Estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Mais Próxima"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Mais Brilhante"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Com Planetas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Refrescar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Critério de Busca de Estrelas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Nº Máximo de Estrelas Apresentado na Lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Guia de Excursão"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Escolha o seu destino:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Opções de Visualização"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Mostrar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Visualização"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Eclíptica"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Órbitas / Legendas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Nomes em Latim"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Conciso"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Completo"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "0816"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Abr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Fev"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dez"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Out"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Set"
 
@@ -4135,184 +4118,189 @@ msgstr "Data"
 msgid "Start"
 msgstr "Início"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Modo em janela"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Invisíveis"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "Ó&rbita Geoest."
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Informação"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Mostrar Eixos"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Mostrar os Eixos das Bordas"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Mostrar a Direcção do Sol"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Mostrar o Vector de Velocidade"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Mostrar a Grelha Planetográfica"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Mostrar o Terminador"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satélites"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Corpos em órbita"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Erro ao carregar a fonte; o texto não será visível.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Erro: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Controlos do Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "A carregar: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "A carregar "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "pt"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Erro ao ler o ficheiro de configuração."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "A carregar o URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versão: "
 
@@ -4348,17 +4336,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Erro ao ler o ficheiro de imagem PNG "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Erro ao abrir o ficheiro de script."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Erro desconhecido ao abrir o script"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4370,7 +4362,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4381,9 +4373,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Erro ao abrir o script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Erro ao abrir o script"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4391,8 +4383,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Falha na inicialização da co-rotina do script"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Erro ao abrir o script '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4408,6 +4400,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Erro ao abrir "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Caminho de Renderização: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Florescência activada"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Florescência desactivada"
+
+#~ msgid "Exposure"
+#~ msgstr "Exposição"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Capturar Vídeo"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Erro ao abrir o script '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6787,9 +6799,6 @@ msgstr "Erro ao abrir "
 #~ msgid "GLSL version: "
 #~ msgstr "Versão GLSL: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Erro ao abrir o script"
-
 #~ msgid "Error loading script"
 #~ msgstr "Erro ao carregar o script"
 
@@ -7326,9 +7335,6 @@ msgstr "Erro ao abrir "
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Temp à Superfície: "
-
-#~ msgid "Radius: "
-#~ msgstr "Raio: "
 
 #~ msgid "Rsun"
 #~ msgstr "RSol"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 20:52+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Hora de Verão"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -54,35 +54,34 @@ msgstr "Erro ao ler o ficheiro de configuração."
 msgid "Loaded {} deep space objects\n"
 msgstr " objectos de céu profundo"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galáxia (classe de Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Globular (raio do núcleo: %4.2f', concentração King: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "A carregar imagem do ficheiro "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Carregando o modelo: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Erro ao carregar o modelo '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +97,110 @@ msgstr "Aglomerados Abertos"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Erro no ficheiro .ssc (linha"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "aviso de definição duplicada de "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "superfície alternativa inválida"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "localização inválida"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Cabeçalho inválido para o índice remissivo\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Versão inválida para o índice remissivo\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "O carregamento do índice remissivo falhou no registo "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "O carregamento do índice remissivo falhou no registo "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr "estrelas na base de dados de binárias\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Total de estrelas: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Erro no ficheiro .stc (linha"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Estrela inválida: classe espectral inválida.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Estrela inválida: classe espectral ausente.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " não existe.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Estrela inválida: ascensão recta ausente\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Estrela inválida: declinação ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Estrela inválida: distância ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Estrela inválida: magnitude ausente.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Estrela inválida: terá que especificar a magnitude absoluta (não a aparente) "
 "para a estrela perto da origem \n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -241,721 +235,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Erro ao ler o ficheiro de favoritos."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Tipo de ficheiro inválido"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Marcas activadas"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Marcas desactivadas"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Ir para a superfície"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Modo altazimutal activado"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Modo altazimutal desactivado"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Forma das estrelas: Pontos Indistintos"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Forma das estrelas: Pontos"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Forma das estrelas: Discos à escala"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Caudas de cometa activadas"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Caudas de cometa desactivadas"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Caminho de Renderização: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Modo altazimutal ativado"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Modo altazimutal desativado"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Magnitude automática activada"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Magnitude automática desactivada"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "O tempo e o script estão em pausa"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "O tempo está em pausa"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Retomar"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Total de estrelas: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Total de estrelas: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Tempo de viagem da luz: %.4f anos "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Tempo de viagem da luz: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Tempo de viagem da luz: %d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Atraso da viagem da luz incluído"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Atraso da viagem da luz desligado"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Atraso da viagem da luz ignorado"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Usando texturas de superfície normais."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Usando texturas no limite do conhecimento de superfície "
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Tempo: para a frente"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Tempo: para trás"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Velocidade do tempo"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturas"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Alto"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Órbita Geoest."
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Fixar"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Seguir"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Limite de magnitude automática a 45 graus: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Luz Ambiente: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Ganho de luz"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Florescência activada"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Florescência desactivada"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Exposição"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Erro de GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Vista demasiado pequena para ser dividida"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Panorama acrescentado"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "a.l."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "ua"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " dias"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " horas"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minutos"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr "segundos"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " UA/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Velocidade: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diâmetro aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitude aparente: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitude absoluta: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distância: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Baricentro do sistema estelar\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag abs (apa): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosidade: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Estrela de neutrões"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Buraco negro"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Classe: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Temp à superfície:"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Raio: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Companheiros planetários presentes\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distância do centro: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Raio: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Ângulo de fase: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Tempo real"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Tempo parado"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " mais depressa"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " mais devagar"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Pausado)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "A viajar"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "A viajar"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Seguir a rota "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Órbita Geoest. "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Nome do alvo: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr " Pausa"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr " A gravar"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Iniciar/Pausar    F12 Parar"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Modo de edição"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "A carregar o catálogo do Sistema Solar: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Erro ao ler o ficheiro de favoritos."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Erro ao ler o ficheiro de configuração."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Inicialização da livraria SPICE falhou."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Erro ao abrir o catálogo de céu profundo. "
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Erro ao abrir o catálogo do Sistema Solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Erro ao abrir o ficheiro dos asterismos."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Erro ao abrir o ficheiro das fronteiras das constelações."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Falha na inicialização do motor de renderização"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Erro ao carregar a fonte; o texto não será visível.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Erro ao ler o índice remissivo "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Índice remissivo carregado "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Erro ao ler o ficheiro com o nome das estrelas\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Erro ao abrir "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Erro ao ler o ficheiro das estrelas\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Erro ao abrir o catálogo de estrelas "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1014,37 +992,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Navegador Celeste"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navegador Celeste"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Sistema Solar"
 
@@ -1054,20 +1032,20 @@ msgstr "Sistema Solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " objectos de céu profundo"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1077,122 +1055,118 @@ msgstr "Buscador de eclipses"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Hora"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Guia de Excursão"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Ecrã inteiro"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Capturar &Filme...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Erro ao abrir o ficheiro de imagem "
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Marcadores"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Gravar como:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " não é um arquivo PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Capturar Vídeo"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Resolução: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Imagens por segundo:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL copiado"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Carregando o URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Abrir Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Adicionar Nova Pasta de Marcadores"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1209,349 +1183,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Erro desconhecido ao abrir o script"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Acerca do Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>Linguagem de Sombreamento OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Versão GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Nº máx. de texturas em simultâneo: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Tamanho máx. de texturas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Intervalo do tamanho dos pontos"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Intervalo do tamanho dos pontos"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Tamanho máx. de texturas: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Motor de Renderização: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Ficheiro"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Capturar Imagem"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Capturar &Imagem...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Capturar &Filme...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiar URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Abrir Script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferências do Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "S&air"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navegação"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Selecionar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrar na Selecção\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selecção: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Ir para Objecto..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Hora"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Definir a Hora..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Visualização"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Objectos"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Mostrar Sombras das Nuvens"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Fo&rma das Estrelas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Resolução das Texturas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controles"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Marcadores"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Panorama"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Multipanorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dividir o Panorama Verticalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dividir &Horizontalmente\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dividir o Panorama Horizontalmente"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dividir &Verticalmente\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Alternar o Panorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Panorama individual"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Panorama &Individual\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Apagar Panorama"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Bordas Visíveis"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Borda Activa Visível"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizar Hora"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Ajuda"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Preferências do Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "Informação do &Open GL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "Adicionar Marcardor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizar Marcadores..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Carregando"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripts"
@@ -1674,11 +1648,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Marcas"
 
@@ -1694,7 +1668,7 @@ msgstr "&Centrar na Seleção\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Constelações"
 
@@ -1716,7 +1690,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Órbitas"
 
@@ -1730,18 +1704,18 @@ msgstr "Órbitas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planetas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Planetas Anões"
 
@@ -1754,16 +1728,16 @@ msgstr "Planetas Anões"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Luas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Luas Menores"
 
@@ -1776,10 +1750,10 @@ msgstr "Luas Menores"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteróides"
 
@@ -1792,10 +1766,10 @@ msgstr "Asteróides"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Cometas"
 
@@ -1812,11 +1786,11 @@ msgstr "Cometas"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1834,7 +1808,7 @@ msgstr "10x Mais &Rápido\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Legendas"
 
@@ -1844,9 +1818,9 @@ msgstr "Legendas"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galáxias"
 
@@ -1854,8 +1828,8 @@ msgstr "Galáxias"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Globulares"
 
@@ -1875,9 +1849,9 @@ msgstr "Enxames Abertos"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nebulosas"
 
@@ -1889,48 +1863,48 @@ msgid "Locations"
 msgstr "Localizações"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Enxames Abertos"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Nuvens"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Luzes do Lado Nocturno"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Caudas dos Cometas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosferas"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Sombras dos Anéis"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Sombras dos Eclipses"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Sombras das Nuvens"
 
@@ -2003,237 +1977,237 @@ msgstr "Limite de magnitude automática a 45 graus: %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Limite de magnitude: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Nome"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Distância (a.l.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Mag apa."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Mag abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Tipo"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Mostrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Estrelas"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Com Planetas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Mostrar Estrelas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentro "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Classe espectral inválida na base de dados de estrelas, estrela #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Nº Máximo de Estrelas Apresentado na Lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marcar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Diamante"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Triângulo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Quadrado"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Mais"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Círculo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Seta Esquerda"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Seta Direita"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Seta para Cima"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Seta para Baixo"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Tamanho:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "&Seleccionar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Legendar as Feições"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objetos"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marcar"
@@ -2348,8 +2322,8 @@ msgstr "Carregando imagem do arquivo"
 msgid "Behind %1"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2518,86 +2492,91 @@ msgstr "Tamanho: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Fo&rma das Estrelas"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Formato Local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Fuso Horário"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Desvio em relação ao GMT"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Início"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Mag abs (apa): "
 
@@ -2610,21 +2589,21 @@ msgid "&Select"
 msgstr "&Seleccionar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centrar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Ir para"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Seguir"
 
@@ -2638,12 +2617,12 @@ msgid "Visible"
 msgstr "Bordas Visíveis"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Desmarcar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Escolher o Modo de Visualização"
@@ -2657,12 +2636,12 @@ msgid "Disk"
 msgstr "Disco"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Marcar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Pontos de Referência"
 
@@ -2710,13 +2689,13 @@ msgid "Show &Terminator"
 msgstr "Mostrar o Terminador"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Superfícies alternativas"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normal"
 
@@ -2728,7 +2707,7 @@ msgstr "Normal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Planetas Anões"
@@ -2740,15 +2719,15 @@ msgstr "Planetas Anões"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Luas Menores"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Objetos"
@@ -2759,7 +2738,7 @@ msgid "Set Time"
 msgstr "Definir a Hora..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Fuso Horário: "
 
@@ -2824,7 +2803,7 @@ msgid "Set Seconds"
 msgstr "segundos"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Data Juliana: "
 
@@ -2838,98 +2817,98 @@ msgstr "Data Juliana: "
 msgid "Set time"
 msgstr "Definir a Hora..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Baricentro "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Estrela de neutrões"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planeta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Planeta Anão"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Lua"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Luas Menores"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteróide"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Cometa"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Naves espaciais"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Pontos de Referência"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Calcular"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Tamanho Mínimo da Feição Legendada"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Erro desconhecido ao abrir o script"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteróides"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Pontos de Referência"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Outras feições"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planetas"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objetos"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3062,7 +3041,7 @@ msgstr "Resolução: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organizar Marcadores"
 
@@ -3169,7 +3148,7 @@ msgstr "Mostrar Órbitas"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Sítios de Aterragem"
@@ -3177,7 +3156,7 @@ msgstr "Sítios de Aterragem"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Trajectórias Parciais"
@@ -3185,49 +3164,49 @@ msgstr "Trajectórias Parciais"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Grelhas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Equatorial"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Eclíptica"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galáctico"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagramas"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Mostrar Fronteiras"
 
@@ -3429,41 +3408,41 @@ msgstr "Formato: "
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3712,13 +3691,13 @@ msgstr "&Acerca do Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3804,7 +3783,7 @@ msgid "Create in >>"
 msgstr "Criar em >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Nova Pasta..."
 
@@ -3885,7 +3864,7 @@ msgid "Go to Object"
 msgstr "Ir para Objecto"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Ir Para"
 
@@ -3902,7 +3881,7 @@ msgid "Lat."
 msgstr "Lat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Distância"
 
@@ -3951,174 +3930,178 @@ msgstr "Tamanho Mínimo da Feição Legendada"
 msgid "Size:"
 msgstr "Tamanho:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Renomear..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Renomear Marcador ou Pasta"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Novo Nome"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Definir Hora da Simulação"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formato: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Actualizar para a Hora Actual"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Navegador do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Ir Para"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Objectos do Sistema Solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Navegador Estelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Mais Próxima"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Mais Brilhante"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Com Planetas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Refrescar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Critério de Busca de Estrelas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Nº Máximo de Estrelas Apresentado na Lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Guia de Excursão"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Escolha o seu destino:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Opções de Visualização"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Mostrar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Visualização"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Eclíptica"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Órbitas / Legendas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Nomes em Latim"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Conciso"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Completo"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "0816"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Abr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Fev"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Ago"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dez"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Out"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Set"
 
@@ -4134,184 +4117,189 @@ msgstr "Data"
 msgid "Start"
 msgstr "Início"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Modo em janela"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Invisíveis"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "Ó&rbita Geoest."
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Informação"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Mostrar Eixos"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Mostrar os Eixos das Bordas"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Mostrar a Direcção do Sol"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Mostrar o Vector de Velocidade"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Mostrar a Grelha Planetográfica"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Mostrar o Terminador"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satélites"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Corpos em órbita"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Erro ao carregar a fonte; o texto não será visível.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Erro: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Capturar Vídeo"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Controlos do Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "A carregar: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Carregando"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "pt"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Erro ao ler o ficheiro de configuração."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "A carregar o URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versão: "
 
@@ -4347,17 +4335,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Erro ao ler o ficheiro de imagem PNG "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Erro ao abrir o ficheiro de script."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Erro desconhecido ao abrir o script"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4369,7 +4361,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4380,9 +4372,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Erro ao abrir o script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Erro ao abrir o script"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4390,8 +4382,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Falha na inicialização da co-rotina do script"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Erro ao abrir o script '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4407,6 +4399,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Erro ao abrir "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Caminho de Renderização: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Florescência activada"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Florescência desactivada"
+
+#~ msgid "Exposure"
+#~ msgstr "Exposição"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Capturar Vídeo"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Erro ao abrir o script '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6786,9 +6798,6 @@ msgstr "Erro ao abrir "
 #~ msgid "GLSL version: "
 #~ msgstr "Versão GLSL: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Erro ao abrir o script"
-
 #~ msgid "Error loading script"
 #~ msgstr "Erro ao carregar o script"
 
@@ -7325,9 +7334,6 @@ msgstr "Erro ao abrir "
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Temp à Superfície: "
-
-#~ msgid "Radius: "
-#~ msgstr "Raio: "
 
 #~ msgid "Rsun"
 #~ msgstr "RSol"

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 21:00+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
 "2:1));\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "ora de vară"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "ora de iarnă"
 
@@ -55,35 +55,34 @@ msgstr "Eroare la citirea fişierului de configurare."
 msgid "Loaded {} deep space objects\n"
 msgstr " obiect cerestru îndepărtat"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxie (tip Hubble: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Încărcarea imaginei din fişier "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Încărcarea modelului: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Eroare la încărcarea modelului '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -101,115 +100,110 @@ msgstr "Randarizează numele roiurilor deschise"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Eroare in fişierul .scc (linia "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "Atenţie, definiţie dublă pentru "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "textură alternativă invalidă"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "locaţie invalidă"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Antet invalid pentru indexul încrucişat\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Versiune invalidă pentru indexul incrucişat\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Încărcarea indexului încrucişat a eşual la înregistrarea "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Încărcarea indexului încrucişat a eşual la înregistrarea "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Tip spectral invalid în baza de date stelară, steaua #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr "stele în baza de date binară\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Număr total de stele: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Eroare în fişierul .stc (linia "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Stea invalidă: tip spectral invalid.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Stea invalidă: tipul spectral lipseste.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " nu există.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Stea invalidă: lipseşte ascensiunea dreaptă\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Stea invalidă: lipseşte declinaţia.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Stea invalidă: lipseşte distanţa.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Stea invalidă: lipseşte magnitudinea.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Stea invalidă: magnitudinea absolută (nu cea aparentă) trebuie specificată "
 "pentru o stea aproape de origine\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -244,721 +238,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Extensii suportate: "
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Eroare la citirea fişierului."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Tipul fişierului este invalid"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudinea limită: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Marcaje activate"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Marcaje dezactivate"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Mergi la suprafaţa"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Modul alt-azimuth activat"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Modul alt-azimuth dezactivat"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Stilul stelelor: puncte vagi"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Stilul stelelor: puncte"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Stilul stelelor: discuri la scală"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Coada cometelor activată"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Coada cometelor dezactivată"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Calea de ranbarizare: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Modul alt-azimuth activat"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Modul alt-azimuth dezactivat"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Magnitudinea automată activată"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Magnitudinea automată dezactivată"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Anulare"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Timpul şi scriptul sunt pe pauză"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Timpul este pe pauză"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Revenire"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Număr total de stele: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Număr total de stele: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Timpul de călătorie al luminii: %.4f al"
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Timpul de călătorie al luminii: %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Timpul de călătorie al luminii: %d o %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Include întârzierea de timp necesar luminii pentru călătorie"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Întârzierea de timp necesar luminii pentru călătorie oprită"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Ignoră întârzierea de timp necesar luminii pentru călătorie"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Utilizează texturi normale pentru suprafaţă."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Utilizează texturi limitate de cunoaşterea actuala pentru suprafaţă."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Urmează"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Timpul: Crescător"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Timpul: Descrescător"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Rata timpului"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturi"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturi"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturi"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Orbitare sincronă"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Blocheaza"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Urmareşte"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudinea limită: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Magnitudinea limită automată pentru 45 de grade: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Nivelul luminii ambientale: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Amplificare luminoasă"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Efectul Bloom activat"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Efectul Bloom dezactivat"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Expunere"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Eroare GL:"
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Vedere prea mică pentru a fi împărţită"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Vedere adăugată"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "al"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "ua"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " zile"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " ore"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minute"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr "Seteaza timpul"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " al/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " ua/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Viteza: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Diametru aparent: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Magnitudine aparentă: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Magnitudine absolută: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distanţă: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Baricentrul sistemului stelar\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mag abs. (aparentă): %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Luminozitate: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Stea de neutroni"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Gaura neagra"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Clasa: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Temperatura la suprafaţă: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Raza: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Raza: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Însoţitor planetar prezent\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distanţa de la centru: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Raza: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Timp real"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Timp real"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Timp oprit"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " mai repede"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " mai încet"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Pauză)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "IPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Pe drum"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Pe drum"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Rută"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Urmează "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Orbită sincronă"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Urmăreşte"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Numele ţintei: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "  Pauză"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  Înregistrează"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pauză    F12 Stop"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Mod de editare"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Încărcarea catalogului sistemului solar: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Încărcarea catalogului sistemului solar: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Încărcarea catalogului sistemului solar: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Încărcarea catalogului sistemului solar: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Eroare la citirea fişierului."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Eroare la citirea fişierului de configurare."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Iniţializarea librăriei SPICE a eşuat."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Baza de date stelara nu poate fi citită."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Eroare la deschiderea catalogului cu obiecte cerestre îndepărtate."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Baza de date stelara nu poate fi citită."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Eroare la deschiderea catalogului sistemului solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Eroare la deschiderea fişierului asterisms."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Eroare la deschiderea fişierelor cu limitele constelaţiilor."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Eşuare la iniţializarea motorului de randarizare"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Eroare la încarcarea fontului; textul nu va fi vizibil.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Eroare la citirea indexului încrucişat "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Indexul incrucişat a fost încărcat "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Eroare la deschiderea fişierului cu numele stelelor\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Eroare la deschiderea "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Eroare la citirea fişierului pentru stele\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Eroare la deschiderea catalogului stelar "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensii suportate: "
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1017,37 +995,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Navigator celest"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Navigator celest"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Sistem solar"
 
@@ -1057,20 +1035,20 @@ msgstr "Sistem solar"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Stele"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " obiect cerestru îndepărtat"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1080,122 +1058,118 @@ msgstr "Caută eclipse"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Timp"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Tur de iniţiere..."
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Pe tot ecranul"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Captură &video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Eroare la deschiderea fişierului asterisms."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Adaugă marcaje..."
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Salvează ca:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr "nu este un fişier PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Captură video"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Captură video"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Captură video"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Rezoluţie: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Viteza de randarizare:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL-ul copiat"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Încarcare URL-ul"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Deschide script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Crează un dosar nou pentru marcaje în meniul curent"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1212,349 +1186,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Eroare necunoscută la deschiderea scriptului"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Extensii suportate: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Extensii suportate: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Despre Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>Limbajul de randarizare OpenGL 2.0</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>OpenGL 1.1 neextins</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 neextins</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Versiune GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Număr maxim de texturi simultane:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Mărimea maximă a texturii: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Plaja dimensiunilor pentru puncte: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Plaja dimensiunilor pentru puncte: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Mărimea maximă a texturii cubice: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>OpenGL 1.1 neextins</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Motor de randarizare: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Fişier"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Captură imagine"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Captură &imagine...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Captură video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Captură &video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Copiază URL-ul"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Deschide script..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Preferinţe pentru Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "I&eşire"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Antialiasing\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigare"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Selectează"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrează selecţia\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Selecţia: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Mergi la obiect..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Timp"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Seteaza timpul"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Afişaj"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Obiectele marcate"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Randarizează umbra norilor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Formatul stelelor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Rezoluţia &texturilor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Controale"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "Marca&je"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Vizualizare"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Vederi multiple"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Împarte vederea pe verticală"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Împarte &orizontal\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "împarte vederea pe orizontală"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Împarte &vertical\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Parcurge vederile ciclic"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "O singură vedere"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "O &singură vedere\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Şterge vederea"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Şterge"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Vederi vizibile"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Vederea activă vizibilă"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Sincronizează timpul"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Ajutor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Preferinţe pentru Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "Informaţii OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Adaugă marcaj"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizează marcajele..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Încarcăre "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Scripturi"
@@ -1677,11 +1651,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Marcaje"
 
@@ -1697,7 +1671,7 @@ msgstr "&Centrează selecţia\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Constelaţi"
 
@@ -1719,7 +1693,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Orbite"
 
@@ -1733,18 +1707,18 @@ msgstr "Orbite"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planete"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Planete pitici"
 
@@ -1757,16 +1731,16 @@ msgstr "Planete pitici"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Luni"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Loni minore"
 
@@ -1779,10 +1753,10 @@ msgstr "Loni minore"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroizi"
 
@@ -1795,10 +1769,10 @@ msgstr "Asteroizi"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Comete"
 
@@ -1815,11 +1789,11 @@ msgstr "Comete"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1837,7 +1811,7 @@ msgstr "10x Mai &repede\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Etichete"
 
@@ -1847,9 +1821,9 @@ msgstr "Etichete"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaxi"
 
@@ -1857,8 +1831,8 @@ msgstr "Galaxi"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "globularii"
 
@@ -1878,9 +1852,9 @@ msgstr "Rroiuri deschise"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nebuloase"
 
@@ -1892,48 +1866,48 @@ msgid "Locations"
 msgstr "Locaţii"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Rroiuri deschise"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Nori"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Luminile din timpul noapţi"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Cozile cometelor"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosfere"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Umbrele inelelor"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Umbrele eclipselor"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Umbrele norilor"
 
@@ -2006,237 +1980,237 @@ msgstr "Magnitudinea limită automată pentru 45 de grade: %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudinea limită: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Nume"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Mag. aparentă"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Mag. abs."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Tip"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Randarizează stelele"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Stele"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrează stelele"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Cu planete"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Randarizează stelele"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Baricentru"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Tip spectral invalid în baza de date stelară, steaua #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Reimprospătează"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Marchează"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Număr maxim de stele afişate în listă"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Marchează"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Marcaje activate"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Nimic"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Carou"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Triunghi"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Pătrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Cerc"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Săgeată stânga"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Săgeată dreapta"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Săgeată sus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Săgeată jos"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Selectează &obiect..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Mărime:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Selectează &obiect..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Nume"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Obiecte"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Marchează"
@@ -2351,8 +2325,8 @@ msgstr "Încărcarea imaginei din fişier "
 msgid "Behind %1"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2519,86 +2493,91 @@ msgstr "Dimensiune: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "&Formatul stelelor"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Format local"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Numele fusului orar"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Decalaj GMT"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Stea"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Distanţă: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Magnitudinea abs. (aparentă): "
 
@@ -2611,21 +2590,21 @@ msgid "&Select"
 msgstr "&Selectează"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Anulează"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "M&ergi la"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Urmareşte"
 
@@ -2639,12 +2618,12 @@ msgid "Visible"
 msgstr "Vederea activă vizibilă"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Demarchează"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Mod de randarizare"
@@ -2658,12 +2637,12 @@ msgid "Disk"
 msgstr "Disc"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Marchează"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 #, fuzzy
 msgid "&Reference Marks"
 msgstr "Puncte di&fuze"
@@ -2712,13 +2691,13 @@ msgid "Show &Terminator"
 msgstr "Randarizează terminatorul"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "Suprafeţe &alternative"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normal"
 
@@ -2730,7 +2709,7 @@ msgstr "Normal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Planete pitici"
@@ -2742,15 +2721,15 @@ msgstr "Planete pitici"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Loni minore"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Obiecte"
@@ -2761,7 +2740,7 @@ msgid "Set Time"
 msgstr "Seteaza timpul"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Fusu orar: "
 
@@ -2826,7 +2805,7 @@ msgid "Set Seconds"
 msgstr "Seteaza timpul"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Calendarul Iulian: "
 
@@ -2840,98 +2819,98 @@ msgstr "Calendarul Iulian: "
 msgid "Set time"
 msgstr "Seteaza timpul"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Baricentru"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Tip spectral invalid în baza de date stelară, steaua #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planetă"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Planetă pitică"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Lună"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Loni minore"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroid"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Cometă"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Nave spaţiale"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "Plaja dimensiunilor pentru puncte: "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Calculează"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Mergi la suprafaţa"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Eroare necunoscută la deschiderea scriptului"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteroizi"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "Puncte di&fuze"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Altele"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planete"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Obiecte"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3064,7 +3043,7 @@ msgstr "Rezoluţie: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organizează marcajele"
 
@@ -3171,7 +3150,7 @@ msgstr "Randarizează orbitele"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Zone de aterizare"
@@ -3179,7 +3158,7 @@ msgstr "Zone de aterizare"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Traiectori parţiale"
@@ -3187,14 +3166,14 @@ msgstr "Traiectori parţiale"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Caroiaje"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 #, fuzzy
 msgid "Equatorial"
 msgstr "Randarizează grila planetară"
@@ -3202,35 +3181,35 @@ msgstr "Randarizează grila planetară"
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ecliptică"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galactic"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Orizontal"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagrame"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Limite"
 
@@ -3432,41 +3411,41 @@ msgstr "Afişaj"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Extensii suportate: "
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Extensii suportate: "
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3716,13 +3695,13 @@ msgstr "&Despre Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3807,7 +3786,7 @@ msgid "Create in >>"
 msgstr "Crează in >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Dosar nou..."
 
@@ -3888,7 +3867,7 @@ msgid "Go to Object"
 msgstr "Mergi la obiect"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Mergi la"
 
@@ -3905,7 +3884,7 @@ msgid "Lat."
 msgstr "Lat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Distanţă"
 
@@ -3954,175 +3933,179 @@ msgstr "Mărime minimă a numelor reperelor"
 msgid "Size:"
 msgstr "Mărime:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Redenumeşte..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Redenumeşte marcaj sau dosar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Nume nou"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Setează timpul simulaţiei"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Format: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Sincronizează cu ora curentă"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Navigator al sistemului solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Mergi la"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Obiectele sistemului solar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Navigator stelar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Cel/cea mai apropiat(ă)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Luminozitate"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Cu planete"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Reactualizează"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Criteriu de cautare a stelelor"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Număr maxim de stele afişate în listă"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Tur de iniţiere..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Selectaţi destinaţia:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Obţiuni de vizualizare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Încet"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Setări"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Afişaj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 #, fuzzy
 msgid "Ecliptic Line"
 msgstr ", linia "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Orbite/Etichete"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Nume latine"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Text informativ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Concis"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Complet"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "418"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Ian"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Iun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mai"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Iul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Noi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Oct"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Sep"
 
@@ -4138,184 +4121,189 @@ msgstr "Dată"
 msgid "Start"
 msgstr "Stea"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Mod fereastră"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Invizibile"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "&Orbită sincronă"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Afişează axele corpului"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Afişează axele reper"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Afişează direcţia Soarelui"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Afişează vectorul viteză"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Randarizează grila planetară"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Randarizează terminatorul"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Sateliţi"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Obiecte în orbită"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Eroare la încarcarea fontului; textul nu va fi vizibil.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Eroare: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Captură video"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Controalele folosite de Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Se încarcă: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Încarcăre "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "ro"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Eroare la citirea fişierului de configurare."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Încarcare URL-ul"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versiune: "
 
@@ -4351,17 +4339,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Eroare la citirea fişierului cu imagine PNG "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Eroare la deschiderea fişierului script."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Eroare necunoscută la deschiderea scriptului"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4373,7 +4365,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4384,9 +4376,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Eroare la deschiderea scriptului '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Eroare la deschiderea scriptului"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4394,8 +4386,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Iniţializarea corutinei scriptului a eşuat"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Eroare la deschiderea scriptului '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4411,6 +4403,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Eroare la deschiderea "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Calea de ranbarizare: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Efectul Bloom activat"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Efectul Bloom dezactivat"
+
+#~ msgid "Exposure"
+#~ msgstr "Expunere"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Captură video"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Eroare la deschiderea scriptului '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6049,9 +6061,6 @@ msgstr "Eroare la deschiderea "
 #~ msgid "GLSL version: "
 #~ msgstr "Versiune GLSL: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Eroare la deschiderea scriptului"
-
 #~ msgid "Error loading script"
 #~ msgstr "Eroare la încărcarea scriptului"
 
@@ -6590,9 +6599,6 @@ msgstr "Eroare la deschiderea "
 #, fuzzy
 #~ msgid "Surface Temp: "
 #~ msgstr "Temperatura la suprafaţă: "
-
-#~ msgid "Radius: "
-#~ msgstr "Raza: "
 
 #~ msgid "Rsun"
 #~ msgstr "R-soare"

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,32 +2,34 @@
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # AlexL <loginov.alex.valer@gmail.com>, 2019
 # Hleb Valoshka <375gnu@gmail.com>, 2021
 # Askaniy Anpilogov, 2022
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Askaniy Anpilogov, 2022\n"
 "Language-Team: Russian (https://www.transifex.com/celestia/teams/93131/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "STD"
 
@@ -43,45 +45,47 @@ msgstr "{}:{} Ожидалась секция «Configuration».\n"
 msgid "{}: Bad configuration file.\n"
 msgstr "{}: Ошибка с конфигурационным файлом.\n"
 
+#.
 #. // Put AbsMag = avgAbsMag for Add-ons without AbsMag entry
 #. for (int i = 0; i < nDSOs; ++i)
 #. {
 #. if(DSOs[i]->getAbsoluteMagnitude() == DSO_DEFAULT_ABS_MAGNITUDE)
 #. DSOs[i]->setAbsoluteMagnitude((float)avgAbsMag);
 #. }
+#.
 #: ../src/celengine/dsodb.cpp:377
 msgid "Loaded {} deep space objects\n"
 msgstr "Загружено {} объектов глубокого космоса\n"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Галактика (тип: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Шаровое скопление (радиус ядра: %4.2f', плотность: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 msgid "Loading image from file {}\n"
 msgstr "Загрузка изображения из файла {}\n"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Загрузка 3D модели: %s\n"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
+#, fuzzy
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 "   У 3D модели вершин: %u, примитивов: %u, материалов: %u (%u уникальных)\n"
 
-#: ../src/celengine/meshmanager.cpp:553
-#, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Ошибка при загрузке модели '%s'\n"
 
 #: ../src/celengine/nebula.cpp:39
@@ -96,108 +100,103 @@ msgstr "Рассеянное скопление"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Ошибка в файле .ssc (строка {}): {}\n"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr "Недопустимое значение GeomAlbedo: {}\n"
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr "Недопустимое значение Reflectivity: {}\n"
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr "Недопустимое значение BondAlbedo: {}\n"
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "родитель '%s' объекта '%s' не найден.\n"
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "предупреждение о дубликате определения %s %s\n"
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "ошибка с альтернативной поверхностью"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "ошибка с местоположением"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Неверный заголовок для перекрёстного индекса\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Неверная версия для перекрёстного индекса\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 msgid "Loading cross index failed\n"
 msgstr "Не удалось загрузить перекрёстный индекс\n"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 msgid "Loading cross index failed at record {}\n"
 msgstr "Не удалось загрузить перекрёстный индекс при записи {}\n"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Неверный спектральный тип звезды №{}\n"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 msgid "{} stars in binary database\n"
 msgstr "Звёзд в бинарном каталоге: {}\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 msgid "Total star count: {}\n"
 msgstr "Общее количество звёзд: {}\n"
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Ошибка в файле .stc (строка {}): {}\n"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ошибка у звезды: неверный спектральный тип.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ошибка у звезды: отсутствие спектрального типа.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 msgid "Barycenter {} does not exist.\n"
 msgstr "Барицентр {} не существует.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ошибка у звезды: отсутствие прямого восхождения.\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Ошибка у звезды: отсутствие склонения.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Ошибка у звезды: отсутствие расстояния.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ошибка у звезды: отсутствие звёздной величины.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Ошибка у звезды: абсолютная (не видимая) звёздная величина должна быть "
 "указана для звезды вблизи источника\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr "Уровень %i, %.5f св. л., узлов: %i, звёзд: %i\n"
 
 #: ../src/celengine/texture.cpp:928
 msgid "Creating tiled texture. Width={}, max={}\n"
@@ -227,510 +226,492 @@ msgstr "Неподдерживаемый порядок байтов {}, ожи�
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Неподдерживаемое количество цифр {}, ожидается {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr "Путь {} не существует или не является директорией\n"
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 msgid "Error reading favorites file {}.\n"
 msgstr "Ошибка чтения файла избранного {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
-msgstr "Не удалось проверить существование директории для файла избранного {}\n"
+msgstr ""
+"Не удалось проверить существование директории для файла избранного {}\n"
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr "Не удалось создать директорию для файла избранного {}\n"
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Неверный тип файла"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Предел звёздной величины: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Метки включены"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Метки отключены"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Перейти к поверхности"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Альт-азимутальный режим включён"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Альт-азимутальный режим отключён"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Звёзды как размытые точки"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Звёзды как точки"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Звёзды как диски"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Хвосты комет включены"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Хвосты комет отключены"
 
-#: ../src/celestia/celestiacore.cpp:1188
-msgid "Render path: OpenGL 2.1"
-msgstr "Рендеринг: OpenGL 2.1"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 msgid "Anti-aliasing enabled"
 msgstr "Режим сглаживания включён"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 msgid "Anti-aliasing disabled"
 msgstr "Режим сглаживания отключён"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Автонастройка звёздной величины включена"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Автонастройка звёздной величины отключена"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Время и сценарий приостановлены"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Ход времени приостановлен"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Ход времени возобновлён"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr "Цвет звёзд: чёрнотельный D65"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr "Цвет звёзд: устаревший"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Световое запаздывание:  %.4f л"
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Световое запаздывание:  %d мин  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Световое запаздывание:  %d ч  %d мин  %.1f с"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Световое запаздывание включено"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Световое запаздывание отключено"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Световое запаздывание не учитывается"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Использование карт нормалей."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Использование текстур пределов известного."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Наблюдение"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Время: вперёд"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Время: назад"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, c-format
 msgid "Time rate: %.6g"
 msgstr "Множитель времени: %.6g"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 msgid "Low res textures"
 msgstr "Текстуры низкого разрешения"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 msgid "Medium res textures"
 msgstr "Текстуры среднего разрешения"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr "Текстуры высокого разрешения"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Синх. вращение"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Блокировка фазы"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Следовать"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Предел звёздной величины:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr ""
 "Предел автонастройки звёздной величины для поля зрения 45 градусов:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Яркость подсветки:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Яркость галактик"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Расцветка включена"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Расцветка отключена"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Экспозиция"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Ошибка GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Экран слишком мал для разделения"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Добавлен экран"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr "Мпк"
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr "кпк"
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "св. л."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "а.е."
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 msgid "mi"
 msgstr "миль"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr "фут(ов)"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529
-#: ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/celestiacore.cpp:2534
-#: ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/celestiacore.cpp:2557
-#: ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 msgid "days"
 msgstr "дн."
 
-#: ../src/celestia/celestiacore.cpp:2562
-#: ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "hours"
 msgstr "ч."
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 msgid "minutes"
 msgstr "мин."
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 msgid "seconds"
 msgstr "сек."
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Период вращения: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr "Масса: %.6g фунт(ов)\n"
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr "Масса: %.6g кг\n"
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr "Масса: %.2f Mj\n"
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr "Масса: %.2f Me\n"
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 msgid "ly/s"
 msgstr "св. л./с"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 msgid "AU/s"
 msgstr "а.е./с"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr "миль/с"
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr "фут(ов)/с"
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 msgid "km/s"
 msgstr "км/с"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 msgid "m/s"
 msgstr "м/с"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr "Скорость: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr "Склонение: %+d%s %02d' %.1f\"\n"
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr "Прямое восх.: %dh %02dm %.1fs\n"
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Угловой размер: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Видимая звёздная величина: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Абсолютная звёздная величина: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr "%.6f%c %.6f%c %s"
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Расстояние: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Центр масс звёздной системы\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Абс. (вид.) зв. величина: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Светимость: %s солн.\n"
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Нейтронная звезда"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Чёрная дыра"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, c-format
 msgid "Class: %s\n"
 msgstr "Класс: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2860
-#, c-format
-msgid "Surface temp: %s K\n"
+#: ../src/celestia/celestiacore.cpp:2905
+#, fuzzy, c-format
+msgid "Surface temp: %s\n"
 msgstr "Температура поверхности: %s К\n"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Радиус: %s солн.  (%s миль)\n"
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Радиус: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Присутствует планетарная система\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Расстояние от центра: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, c-format
+msgid "Radius: %s\n"
+msgstr "Радиус: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Фазовый угол: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr "Плотность: %.2f x 1000 фунт/фут^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "Плотность: %.2f x 1000 кг/м^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2999
-#, c-format
-msgid "Temperature: %.0f K\n"
+#: ../src/celestia/celestiacore.cpp:3045
+#, fuzzy, c-format
+msgid "Temperature: %s\n"
 msgstr "Температура: %.0f К\n"
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Прямой ход времени"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "Обратный ход времени"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Ход времени остановлен"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, c-format
 msgid "%.6g x faster"
 msgstr "Ускорено в %.6g раз(а)"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, c-format
 msgid "%.6g x slower"
 msgstr "Замедлено в %.6g раз(а)"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Пауза)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
@@ -739,178 +720,177 @@ msgstr ""
 "FPS: %.1f, статистика звёзд: [ %zu : %zu : %zu ], статистика DSO: [ %zu : "
 "%zu : %zu ]\n"
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Перемещение (%s)\n"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, c-format
+#: ../src/celestia/celestiacore.cpp:3291
 msgid "Travelling\n"
 msgstr "Перемещение\n"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, c-format
 msgid "Track %s\n"
 msgstr "Следование %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, c-format
 msgid "Follow %s\n"
 msgstr "Наблюдение %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Синх. вращение %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Блокировка фазы %s -> %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, c-format
 msgid "Chase %s\n"
 msgstr "Сопровождение %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr "Поле зрения: %s (%.2fx)\n"
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, c-format
 msgid "Target name: %s"
 msgstr "Найти: %s"
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr "%dx%d при %.2f fps  %s"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Paused"
 msgstr "Пауза"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Recording"
 msgstr "Запись"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Пуск/Пауза    F12 Стоп"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Режим правки"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Пропускается каталог системы: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 msgid "Loading solar system catalog: {}\n"
 msgstr "Загружается каталог системы: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 msgid "Skipping {} catalog: {}\n"
 msgstr "Пропускается каталог {}: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 msgid "Loading {} catalog: {}\n"
 msgstr "Загружается каталог {}: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Ошибка чтения файла каталога {}: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Ошибка чтения файла конфигурации."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Ошибка инициализации SPICE библиотеки."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Ошибка чтения базы данных звёзд."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Ошибка открытия файла каталога объектов глубокого космоса {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Ошибка чтения базы данных объектов глубокого космоса {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Ошибка открытия каталога системы {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 msgid "Error opening asterisms file {}.\n"
 msgstr "Ошибка открытия файла астеризмов {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Ошибка открытия файла границ созвездий {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Ошибка инициализации рендеринга"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Ошибка загрузки шрифта; текст не будет отображаться.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 msgid "Error reading cross index {}\n"
 msgstr "Ошибка чтения перекрёстного индекса {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 msgid "Loaded cross index {}\n"
 msgstr "Загружен перекрёстный индекс {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Ошибка чтения файла названий звёзд\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 msgid "Error opening {}\n"
 msgstr "Ошибка открытия {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Ошибка чтения файла звёзд\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 msgid "Error opening star catalog {}\n"
 msgstr "Ошибка открытия каталога звёзд {}\n"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr "Недействительный URL"
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr "Не удалось сделать снимок экрана!\n"
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 msgid "Unsupported image type: {}!\n"
 msgstr "Неподдерживаемый формат изображения: {}!\n"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr "Celestia не удалось инициализировать OpenGL 2.1.\n"
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr "Используйте название, оканчивающееся на «.jpg» или «.png»."
 
@@ -969,38 +949,38 @@ msgstr "Количество интерполяторов: %s\n"
 msgid "Max anisotropy filtering: %s\n"
 msgstr "Макс. фильтрируемая анизотропия: %s\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr "Автоматически"
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr "Настраиваемо"
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr "Ошибка получения пути для лог-файла!"
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
-"Celestia is unable to run because the data directory was not found, probably"
-" due to improper installation."
+"Celestia is unable to run because the data directory was not found, probably "
+"due to improper installation."
 msgstr ""
 "Celestia не может быть запущена, поскольку директория данных не была "
 "найдена, возможно, из-за неправильной установки."
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Каталог"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 msgid "Info Browser"
 msgstr "Панель данных"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Солнечная система"
 
@@ -1010,20 +990,19 @@ msgstr "Солнечная система"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Звёзды"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr "Объекты глубокого космоса"
 
-#: ../src/celestia/qt/qtappwin.cpp:341
-#: ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Поиск затмений"
@@ -1032,434 +1011,430 @@ msgstr "Поиск затмений"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Время"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Вспомогательные элементы"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 msgid "Full screen"
 msgstr "Во весь экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 msgid "Error opening bookmarks file"
 msgstr "Ошибка при открытии файла закладок"
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 msgid "Error Saving Bookmarks"
 msgstr "Ошибка записи закладок"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 msgid "Save Image"
 msgstr "Сохранить изображение"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr "Изображения (*.png *.jpg)"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Запись экрана"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr "Видео (*.avi)"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 msgid "Matroska Video (*.mkv)"
 msgstr "Matroska Video (*.mkv)"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr "Разрешение:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr "%1 x %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Частота кадров:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr "Видеокодек:"
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr "Без сжатия"
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr "Сжатие по H.264"
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr "Битрейт:"
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr "Снимок экрана скопирован в буфер обмена"
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL скопирован"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 msgid "Pasting URL"
 msgstr "Вставить URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Open Script"
 msgstr "Открыть сценарий"
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Сценарии Celestia (*.celx *.cel)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 msgid "New bookmark"
 msgstr "Новая закладка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
-"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit "
-"<b>%1</b>.</p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt "
-"library: %5<br>NAIF kernels are %7<br>AVIF images are %8</p>Runtime Qt "
-"version: %6</p><p>Copyright (C) 2001-2021 by the Celestia Development "
-"Team.<br>Celestia is free software. You can redistribute it and/or modify it"
-" under the terms of the GNU General Public License as published by the Free "
-"Software Foundation; either version 2 of the License, or (at your option) "
-"any later version.</p><p>Main site: <a "
-"href=\"https://celestia.space/\">https://celestia.space/</a><br>Forum: <a "
-"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</a><br>GitHub"
-" project: <a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
+"<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kernels are %7<br>AVIF images are %8</p>Runtime Qt version: %6</"
+"p><p>Copyright (C) 2001-2021 by the Celestia Development Team.<br>Celestia "
+"is free software. You can redistribute it and/or modify it under the terms "
+"of the GNU General Public License as published by the Free Software "
+"Foundation; either version 2 of the License, or (at your option) any later "
+"version.</p><p>Main site: <a href=\"https://celestia.space/\">https://"
+"celestia.space/</a><br>Forum: <a href=\"https://celestia.space/forum/"
+"\">https://celestia.space/forum/</a><br>GitHub project: <a href=\"https://"
+"github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/"
+"Celestia</a></p></html>"
 msgstr ""
-"<html><h1>Celestia 1.7</h1><p>Снепшот для разработчиков, коммит "
-"<b>%1</b>.</p>Компиляция для %2-битного CPU<br>Using %3 %4<br>Built against "
-"Qt library: %5<br>NAIF kernels are %7<br>AVIF images are %8 <p>Runtime Qt "
-"version: %6<p>Copyright (C) 2001-2021 by the Celestia Development "
-"Team.<br>Celestia является свободным программным обеспечением. Вы можете "
-"распространять и/или изменять его в соответствии с условиями Стандартной "
-"общественной лицензии GNU, опубликованной Free Software Foundation; либо "
-"Version 2, либо любой (на ваше усмотрение) более поздней "
-"версии.</p><p>Домашняя страница: <a "
-"href=\"https://celestia.space/\">https://celestia.space/</a><br>Форум: <a "
-"href=\"https://celestia.space/forum/\">https://celestia.space/forum/</a><br>Проект"
-" на GitHub: <a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
+"<html><h1>Celestia 1.7</h1><p>Снепшот для разработчиков, коммит <b>%1</b>.</"
+"p>Компиляция для %2-битного CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kernels are %7<br>AVIF images are %8 <p>Runtime Qt version: "
+"%6<p>Copyright (C) 2001-2021 by the Celestia Development Team.<br>Celestia "
+"является свободным программным обеспечением. Вы можете распространять и/или "
+"изменять его в соответствии с условиями Стандартной общественной лицензии "
+"GNU, опубликованной Free Software Foundation; либо Version 2, либо любой (на "
+"ваше усмотрение) более поздней версии.</p><p>Домашняя страница: <a href="
+"\"https://celestia.space/\">https://celestia.space/</a><br>Форум: <a href="
+"\"https://celestia.space/forum/\">https://celestia.space/forum/</"
+"a><br>Проект на GitHub: <a href=\"https://github.com/CelestiaProject/Celestia"
+"\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 msgid "Unknown compiler"
 msgstr "Неизвестный компилятор"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr "поддерживаются"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr "не поддерживаются"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "О программе"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>%1 версия:</b> %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Вендор:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Видеокарта:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "<b>%1 Версия:</b> %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "<b>Макс. кол-во текстур:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>Макс. размер текстур:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "<b>Диапазон размеров точек:</b> %1 - %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "<b>Шаг изменения размеров точек:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "<b>Макс. размер кубической карты:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "<b>Количество интерполяторов:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr "<b>Макс. фильтруемая анизотропия:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Поддерживаемые расширения:</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 msgid "Renderer Info"
 msgstr "Информация о видеокарте"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 msgid "&Grab image"
 msgstr "Сохранить &изображение"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 msgid "Capture &video"
 msgstr "&Запись экрана"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr "Сохранить &видео...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr "&Копировать изображение"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Открыть сценарий..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr "&Настройки..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "В&ыход"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Навигация"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 msgid "Select Sun"
 msgstr "Выбрать Солнце"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 msgid "Center Selection"
 msgstr "Центрировать выбранное"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Goto Selection"
 msgstr "Перейти к выбранному"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Перейти к объекту..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr "Копировать URL / текст консоли"
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr "Вставить URL / текст консоли"
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "В&ремя"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 msgid "Set &time"
 msgstr "&Установить время"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 msgid "&Display"
 msgstr "&Отобразить"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 msgid "Dee&p Sky Objects"
 msgstr "&Объекты глубокого космоса"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 msgid "&Shadows"
 msgstr "&Тени"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Звёзды как…"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr "&Разрешение текстур"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 msgid "&FPS control"
 msgstr "Контроль &FPS"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Закладки"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Окно"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 msgid "&MultiView"
 msgstr "&Экраны"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 msgid "Split view vertically"
 msgstr "Разделить экран по вертикали"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 msgid "Split view horizontally"
 msgstr "Разделить экран по горизонтали"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 msgid "Cycle views"
 msgstr "Переключить экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 msgid "Single view"
 msgstr "Один экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 msgid "Delete view"
 msgstr "Удалить экран"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 msgid "Frames visible"
 msgstr "Показывать рамки"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 msgid "Active frame visible"
 msgstr "Выделить экран рамкой"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 msgid "Synchronize time"
 msgstr "Синхронизировать время"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Справка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 msgid "Celestia Manual"
 msgstr "Руководство пользователя"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "Информация OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 msgid "Add Bookmark..."
 msgstr "Добавить закладку..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr "Упорядочить закладки..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr "Пользовательский FPS"
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr "Значение FPS"
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
@@ -1468,7 +1443,7 @@ msgstr ""
 "Загрузка файлов данных: %1\n"
 "\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Сценарии"
@@ -1518,8 +1493,7 @@ msgid "System time at activation"
 msgstr "Системное время при активации"
 
 #. i18n: file: ../src/celestia/qt/newbookmarkfolder.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. newBookmarkFolderDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, newBookmarkFolderDialog)
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:24
 #. i18n: ectx: property (text), widget (QPushButton, newFolderButton)
 #: ../src/celestia/qt/qtbookmark.cpp:880 ../src/celestia/qt/rc.cpp:39
@@ -1578,11 +1552,11 @@ msgstr "М"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Метки"
 
@@ -1597,7 +1571,7 @@ msgstr "С"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Созвездия"
 
@@ -1616,7 +1590,7 @@ msgstr "О"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Орбиты"
 
@@ -1630,19 +1604,18 @@ msgstr "Орбиты"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581
-#: ../src/celestia/qt/rc.cpp:75 ../src/celestia/qt/rc.cpp:157
-#: ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Планеты"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Карликовые планеты"
 
@@ -1655,17 +1628,16 @@ msgstr "Карликовые планеты"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583
-#: ../src/celestia/qt/rc.cpp:81 ../src/celestia/qt/rc.cpp:163
-#: ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Спутники"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Малые спутники"
 
@@ -1678,11 +1650,10 @@ msgstr "Малые спутники"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742
-#: ../src/celestia/qt/rc.cpp:87 ../src/celestia/qt/rc.cpp:169
-#: ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Астероиды"
 
@@ -1695,11 +1666,10 @@ msgstr "Астероиды"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750
-#: ../src/celestia/qt/rc.cpp:90 ../src/celestia/qt/rc.cpp:172
-#: ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Кометы"
 
@@ -1716,12 +1686,11 @@ msgstr "Кометы"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746
-#: ../src/celestia/qt/rc.cpp:94 ../src/celestia/qt/rc.cpp:176
-#: ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 msgctxt "plural"
 msgid "Spacecraft"
 msgstr "Космич. аппараты"
@@ -1737,7 +1706,7 @@ msgstr "Н"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Названия"
 
@@ -1747,9 +1716,9 @@ msgstr "Названия"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Галактики"
 
@@ -1757,8 +1726,8 @@ msgstr "Галактики"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Шаровые скопления"
 
@@ -1777,9 +1746,9 @@ msgstr "Рассеянные скопления"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Туманности"
 
@@ -1791,48 +1760,48 @@ msgid "Locations"
 msgstr "Местоположения"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Рассеянные скопления"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Облака"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Свет ночной стороны"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Хвосты комет"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Атмосферы"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Тени на кольцах"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Тени затмений"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Тени облаков"
 
@@ -1899,223 +1868,223 @@ msgstr ""
 msgid "Magnitude limit: %L1"
 msgstr "Предел звёздной величины: %L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Название"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Расстояние (св. л.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Вид. вел."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Абс. вел."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Тип"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 msgid "Closest Stars"
 msgstr "Ближайшие звёзды"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 msgid "Brightest Stars"
 msgstr "Ярчайшие звёзды"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 msgid "Filter"
 msgstr "Фильтр"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "С планетами"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 msgid "Multiple Stars"
 msgstr "Системы звёзд"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 msgid "Barycenters"
 msgstr "Центры масс"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr "Спектральный тип"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Обновить"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 msgid "Mark Selected"
 msgstr "Установить метку"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 msgid "Mark stars selected in list view"
 msgstr "Установить метки на выбранные звёзды"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark Selected"
 msgstr "Снять метку"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr "Снять метки с выбранных звёзд"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 msgid "Clear Markers"
 msgstr "Очистить метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr "Удалить все установленные метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Нет"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Ромб"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Треугольник"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Квадрат"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Плюс"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Круг"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Стрелка влево"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Стрелка вправо"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Стрелка вверх"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Стрелка вниз"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr "Вид метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr "Размер метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr "Цвет метки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr "Название"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, qt-format
 msgid "%1 objects found"
 msgstr "Найдено объектов: %1"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr "Установить метку на выбранный объект глубокого космоса"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr "Снять метку с выбранного объекта глубокого космоса"
 
@@ -2220,8 +2189,9 @@ msgstr "Показать от поверхности %1"
 msgid "Behind %1"
 msgstr "Показать от %1"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+#, fuzzy
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia не удалось инициализировать OpenGL 2.1."
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2385,81 +2355,86 @@ msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr "После --dir ожидалась директория"
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr "После --conf ожидалось название конфигурационного файла"
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr "После --extrasdir ожидалась директория"
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr "После --url ожидался URL"
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr "После --log/-l ожидалось название файла"
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr "Недействительный параметр командной строки «%s»"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.1"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr "Чёрнотельный D65"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr "Устаревшие цвета"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 msgid "Local format"
 msgstr "Местное время"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 msgid "Time zone name"
 msgstr "Часовой пояс"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 msgid "UTC offset"
 msgstr "Смещение UTC"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, qt-format
 msgid "Start: %1"
 msgstr "От: %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr "До: %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
-msgstr "%.3f км"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
+msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
-msgstr "%.3f м"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
+msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Расстояние: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Абс. (вид.) величина: "
 
@@ -2472,21 +2447,21 @@ msgid "&Select"
 msgstr "В&ыбрать"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Центрировать"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Перейти"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Наблюдение"
 
@@ -2499,12 +2474,12 @@ msgid "Visible"
 msgstr "Показывать"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "Снять &метку"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 msgid "Select &Primary Body"
 msgstr "Выбрать центральное тело"
 
@@ -2517,12 +2492,12 @@ msgid "Disk"
 msgstr "Диск"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "Поставить &метку"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Элементы графики"
 
@@ -2563,13 +2538,13 @@ msgid "Show &Terminator"
 msgstr "Показывать линию терминатора"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Альтернативная поверхность"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Нормали"
 
@@ -2581,7 +2556,7 @@ msgstr "Нормали"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr "Карликовые планеты"
 
@@ -2592,14 +2567,14 @@ msgstr "Карликовые планеты"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591
-#: ../src/celestia/qt/rc.cpp:84 ../src/celestia/qt/rc.cpp:166
-#: ../src/celestia/qt/rc.cpp:233 ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr "Малые луны"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 msgid "Other objects"
 msgstr "Другие объекты"
 
@@ -2608,7 +2583,7 @@ msgid "Set Time"
 msgstr "Установить время"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Стандарт:"
 
@@ -2664,7 +2639,7 @@ msgid "Set Seconds"
 msgstr "Секунды"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Юлианская дата: "
 
@@ -2676,85 +2651,85 @@ msgstr "Дата в юлианском формате"
 msgid "Set time"
 msgstr "Применить"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Центр масс"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr "Звезда"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Планета"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr "Карликовая планета"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Спутник"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 msgid "Minor moon"
 msgstr "Малый спутник"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Астероид"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Комета"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Космич. аппарат"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 msgid "Reference point"
 msgstr "Ориентир"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 msgid "Component"
 msgstr "Компонент"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 msgid "Surface feature"
 msgstr "Деталь поверхности"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr "Астероиды и кометы"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 msgid "Reference points"
 msgstr "Ориентиры"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr "Компоненты"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 msgid "Surface features"
 msgstr "Детали поверхности"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 msgid "Planets and moons"
 msgstr "Планеты и спутники"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr "Группировать объекты по классу"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr "Установить метку на выбранные объекты"
 
@@ -2868,10 +2843,9 @@ msgid "Description:"
 msgstr "Описание:"
 
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
-#. i18n: ectx: property (windowTitle), widget (QDialog,
-#. organizeBookmarksDialog)
+#. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Упорядочить закладки"
 
@@ -2966,63 +2940,63 @@ msgstr "Показывать орбиты"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 msgid "Fading orbits"
 msgstr "Затухающие орбиты"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr "Детали траекторий"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Координатные сетки"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Экваториальная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Эклиптическая"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Галактическая"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Горизонтальная"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Фигуры"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Границы"
 
@@ -3203,39 +3177,39 @@ msgstr "Стандарт даты:"
 msgid "Not an XBEL version 1.0 file."
 msgstr "Не файл XBEL версии 1.0."
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr "Недопустимое значение hex «{}»\n"
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr "URL должен начинаться с «{}»!\n"
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr "URL должен содержать по крайней мере режим и время!\n"
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Неподдерживаемый режим URL «{}»!\n"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr "URL должен содержать только один объект\n"
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr "URL должен содержать 2 объекта\n"
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr "Недействительная версия URL «{}»!\n"
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 msgid "Unsupported URL version: {}\n"
 msgstr "Неподдерживаемая версия URL: {}\n"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr "Параметр URL должен быть представлен в виде ключ=значение\n"
 
@@ -3480,13 +3454,13 @@ msgstr "&О программе..."
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3572,7 +3546,7 @@ msgid "Create in >>"
 msgstr "Создать в >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Новая папка..."
 
@@ -3653,7 +3627,7 @@ msgid "Go to Object"
 msgstr "Перейти к объекту"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Перейти"
 
@@ -3670,7 +3644,7 @@ msgid "Lat."
 msgstr "Широта"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Расстояние"
 
@@ -3718,169 +3692,173 @@ msgstr "Минимальный размер местоположений"
 msgid "Size:"
 msgstr "Размер:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Переименовать..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Переименовать закладку или папку"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Новое название"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Установить внутреннее время"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Формат: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Установить текущее время"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Каталог Солнечной системы"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Перейти"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Объекты системы:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Каталог звёзд"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Ближайшие"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Ярчайшие"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "С планетами"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Обновить"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Критерии поиска"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Количество звёзд в списке"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Путеводитель"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Выберите объект:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Настройки"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Show:"
 msgstr "Показывать:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Rings"
 msgstr "Кольца"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 msgid "Display:"
 msgstr "Отображать:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Эклиптика"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 msgid "Body / Orbit / Label display"
 msgstr "Отображать тела/орбиты/названия"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Имена латиницей"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Информация"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Кратко"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Подробно"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "419"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "апр"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "фев"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "янв"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "июн"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "мар"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "мая"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "авг"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "дек"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "июл"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "ноя"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "окт"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "сен"
 
@@ -3896,7 +3874,7 @@ msgstr "Дата"
 msgid "Start"
 msgstr "Начало"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
@@ -3904,154 +3882,158 @@ msgstr ""
 "Файл лицензии отсутствует!\n"
 "См. http://www.gnu.org/copyleft/gpl.html"
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, fuzzy, c-format
+msgid "%d x %d"
+msgstr "%1 x %2"
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Оконный режим"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Невидимые"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "Син&х. вращение"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Информация"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Показывать оси объекта"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Показывать оси каркаса"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Показывать направление к Солнцу"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Показывать вектор движения"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Показывать планетографическую сетку"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Показывать линию терминатора"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "С&путники"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Объекты системы"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr ""
-"Не удаётся перейти в полноэкранный режим; продолжение работы в оконном "
-"режиме"
+"Не удаётся перейти в полноэкранный режим; продолжение работы в оконном режиме"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr "Не удалось зарегистрировать класс окна."
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr "Критическая ошибка"
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr "Не удалось получить подходящий формат пикселей для рендеринга OpenGL."
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr "Ваша система не поддерживает OpenGL 2.1!"
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr "Не удалось освободить контекст."
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr "Сохранить как - выбрать файл для снимка экрана"
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr "Не удалось сохранить файл изображения."
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr "Остановите текущую запись экрана перед тем, как начать новую."
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr "Сохранить как - выбрать файл для записи экрана"
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr "Указано неизвестное расширение файла видео."
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr "Указанное расширение файла не распознано."
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 msgid "Could not capture movie."
 msgstr "Не удалось сделать запись экрана."
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 msgid "Celestia Command Line Error"
 msgstr "Ошибка командной строки Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Загрузка: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 msgid "Loading data files..."
 msgstr "Загрузка файлов данных..."
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "ru"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 msgid "Configuration file missing!"
 msgstr "Файл конфигурации отсутствует!"
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
@@ -4059,21 +4041,21 @@ msgstr ""
 "Обнаружен старый файл избранного.\n"
 "Копировать в новое расположение?"
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr "Копировать избранное?"
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr "Не удалось создать окно приложения."
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Загрузка URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Версия: "
 
@@ -4105,16 +4087,20 @@ msgstr "Не удаётся открыть файл снимка экрана «
 msgid "Error writing PNG file '{}'\n"
 msgstr "Ошибка записи файла PNG «{}»\n"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Ошибка открытия файла сценария."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 msgid "Unknown error loading script"
 msgstr "Неизвестная ошибка при загрузке сценария"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4134,7 +4120,7 @@ msgstr ""
 "\n"
 "y = да, ESC = закрыть скрипт, любая другая клавиша = нет"
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4151,8 +4137,8 @@ msgstr ""
 "Вы доверяете скрипту и хотите продолжить?"
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
 msgstr "Ошибка открытия сценария '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:107
@@ -4161,8 +4147,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Ошибка инициализации сценария"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Ошибка открытия LuaHook '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4176,3 +4162,27 @@ msgstr "Неизвестная ошибка, возвращённая функц
 #: ../src/tools/xyzv2bin/bin2xyzv.cpp:18
 msgid "Error opening {} or .\n"
 msgstr "Ошибка открытия {} или .\n"
+
+#~ msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
+#~ msgstr "Уровень %i, %.5f св. л., узлов: %i, звёзд: %i\n"
+
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Рендеринг: OpenGL 2.1"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Расцветка включена"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Расцветка отключена"
+
+#~ msgid "Exposure"
+#~ msgstr "Экспозиция"
+
+#~ msgid "Video (*.avi)"
+#~ msgstr "Видео (*.avi)"
+
+#~ msgid "%.3f km"
+#~ msgstr "%.3f км"
+
+#~ msgid "%.3f m"
+#~ msgstr "%.3f м"

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 21:00+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Letný čas"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "Štandardný čas"
 
@@ -54,36 +54,35 @@ msgstr "Chyba pri čítaní konfiguračného súboru."
 msgid "Loaded {} deep space objects\n"
 msgstr " telesá hlbokého vesmíru"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaxia (Hubblov typ: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 "Guľová hviezdokopa (polomer jadra: %4.2f', Kingova koncentrácia: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Načítava sa obrázok zo súboru "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Načítava sa model: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Chyba pri čítaní modelu '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -99,115 +98,110 @@ msgstr "Otvorená hviezdokopa"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Chyba v .ssc súbore (riadok "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "upozornenie viacnásobná definícia "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "zlý alternatívny povrch"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "zlé umiestnenie"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Zlá hlavička v krížovom indexe\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Zlá verzia pre krížový index\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Načítanie krížového indexu sa nepodarilo pri zázname "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Načítanie krížového indexu sa nepodarilo pri zázname "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Zlý spektrálny typ v hviezdnom katalógu, hviezda #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " hviezdy v katalógu dvojhviezd\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Celkový počet hviezd: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Chyba v .stc súbore (riadok "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Neplatná hviezda: zlý spektrálny typ.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Neplatná hviezda: chýba spektrálny typ.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " neexistuje.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Neplatná hviezda: chýba rektascenzia\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Neplatná hviezda: chýba deklinácia.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Neplatná hviezda: chýba vzdialenosť.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Neplatná hviezda: chýba jasnosť.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Neplatná hviezda: je potrebné špecifikovať absolútnu (nie zdanlivú) jasnosť "
 "hviezdy krátko po jej vzniku\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -242,721 +236,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Podporované rozšírenia:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Chyba pri čítaní súboru s obľúbenými položkami."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Neplatný typ súboru"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Medzná hviezdna veľkosť-jasnosť: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Značky zapnuté"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Značky vypnuté"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Prejsť na povrch"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-Azimut režim zapnutý"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-Azimut režim vypnutý"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Tvar hviezd: neostré body"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Tvar hviezd: body"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Zobrazenie hviezd: kotúče v mierke"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Chvosty komét zapnuté"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Chvosty komét vypnuté"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Spôsob vykresľovania: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Značky zapnuté"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Značky vypnuté"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Automatická hviezdna jasnosť zapnutá"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Automatická hviezdna jasnosť vypnutá"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Čas a skript sú pozastavené"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Čas je pozastavený"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Pokračovať"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Hviezdny katalóg..."
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Hviezdny katalóg..."
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Čas putovania svetla: %.4f rokov "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Čas putovania svetla:  %d min.  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Čas putovania svetla:  %d hod.  %d min.  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Počíta sa so spomalením cesty svetla"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Spomalenie cesty svetla vypnuté"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Nepočíta sa so spomalením cesty svetla"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Používajú sa normálne povrchové textúry."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Používajú sa textúry podľa dostupných vedomostí."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Nasledovať"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Čas: Dopredu"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Čas: Dozadu"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Rýchlosť času"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Textúry"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Textúry"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Textúry"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Synchronizovať obežnú dráhu"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Zamknúť"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Prenasledovať"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Medzná hviezdna veľkosť-jasnosť: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Medzná hviezdna veľkosť pri 45 stupňoch:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Úroveň rozptýleného svetla:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Zosilnenie svetla"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Presvetlenie zapnuté"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Presvetlenie vypnuté"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Expozícia"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Chyba GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Pohľad je príliš malý na rozdelenie"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Pohľad pridaný"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "ly"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "AU"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " dní"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " hodín"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minút"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " sekúnd"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " ly/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Rýchlosť: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Zdanlivý priemer: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Zdanlivá hviezdna jasnosť: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolútna hviezdna jasnosť: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Barycentrum (ťažisko) hviezdneho systému\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs. (zdan.) jasnosť: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Svietivosť: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Neutrónová hviezda"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Čierna diera"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Trieda: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Povrchová teplota: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Existujú planetárni súputníci\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Vzdialenosť od stredu: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Polomer: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fázový uhol: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Teplota: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  Miestny čas"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Skutočný čas"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Skutočný čas"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Čas zastavený"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " rýchlejšie"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " pomalšie"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Pozastavený)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Cestovanie "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Cestovanie "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Sleduje sa "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Nasleduje sa "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synchr. obeh nad "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Prenasleduje sa "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Názov cieľa: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr " Pozastavené"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  Nahrávanie"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Spustiť/Pozastaviť    F12 Ukončiť"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Režim zmien"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Načítava sa katalóg slnečnej sústavy: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Načítava sa katalóg slnečnej sústavy: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Načítava sa katalóg slnečnej sústavy: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Načítava sa katalóg slnečnej sústavy: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Chyba pri čítaní súboru s obľúbenými položkami."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Chyba pri čítaní konfiguračného súboru."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Inicializácia knižnice SPICE sa nepodarila."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Nedá sa čítať databáza hviezd."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Chyba pri otváraní katalógu deepsky objektov."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Nedá sa čítať databáza hviezd."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Chyba pri otváraní katalógu Slnečnej sústavy.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Chyba pri otváraní súboru asterizmov."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Chyba pri otváraní súboru hraníc súhvezdí."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Inicializácia vykresľovania neúspešná"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Chyba pri načítaní fontu; text nebude viditeľný.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Chyba pri načítaní krížového indexu "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Krížový index načítaný "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Chyba pri načítaní súboru s názvami hviezd\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Chyba pri otváraní "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Chyba pri čítaní súboru hviezd\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Chyba pri otváraní hviezdneho katalógu "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Podporované rozšírenia:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1015,37 +993,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Hviezdny katalóg..."
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "&Informácie"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Slnečná sústava"
 
@@ -1055,20 +1033,20 @@ msgstr "Slnečná sústava"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Hviezdy"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " telesá hlbokého vesmíru"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1078,123 +1056,119 @@ msgstr "Vyhľadávač zatmení..."
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Čas"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Sprievodca"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Celá obrazovka"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Nahrať video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Chyba pri otváraní súboru asterizmov."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "Záložky"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Uložiť ako:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " nie je súbor typu PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Nahrať video"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Nahrať video"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Nahrať video"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Rozlíšenie: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Snímok za sekundu:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL skopírované"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Načítava sa URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Otvoriť skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Vytvoriť nový priečinok záložiek v tomto menu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1211,351 +1185,351 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Neznáma chyba pri otváraní skriptu"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Podporované rozšírenia:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Podporované rozšírenia:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "O Celestii"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 1.1 bez rozšírení</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>OpenGL 1.1 bez rozšírení</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 bez rozšírení</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Verzia GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Max. počet simultánnych textúr: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Max. veľkosť textúry: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Rozsah veľkostí bodov: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Rozsah veľkostí bodov: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Maximálna veľkosť priestorovej mapy: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "Podporované rozšírenia:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Vykresľovací systém: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "Súbor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Snímok obrazovky"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Snímok obrazovky...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Nahrať video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Nahrať video...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopírovať URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Otvoriť skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Nastavenia Celestie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Ukončiť"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Vyhladzovanie\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigácia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "Vybrať"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Vycentrovať na výber\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Výber: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Prejsť k objektu..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 #, fuzzy
 msgid "&Time"
 msgstr "Čas"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Nastaviť čas..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Zobrazenie"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Objekty"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Tiene prstencov"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Tvar &hviezd"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Rozlíšenie &textúr"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Ovládanie"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 #, fuzzy
 msgid "&Bookmarks"
 msgstr "Záložky"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "Pohľad"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Pohľady"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Rozdeliť pohľad zvislo"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Rozdeliť vodorovne\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Rozdeliť pohľad vodorovne"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Rozdeliť zvislo\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Prepnúť na ďalší pohľad"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Jediný pohľad"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "Jediný pohľad\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Zrušiť pohľad"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Vymazať"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Ohraničenia pohľadov zobrazené"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktívny pohľad zvýraznený"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Synchronizovať čas"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "Pomoc"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "Informácie o OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Pridať záložku"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organizovať záložky"
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Načítava sa "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Skripty"
@@ -1678,11 +1652,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Značky"
 
@@ -1698,7 +1672,7 @@ msgstr "&Vycentrovať na výber\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Súhvezdia"
 
@@ -1720,7 +1694,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Obežné dráhy"
 
@@ -1734,18 +1708,18 @@ msgstr "Obežné dráhy"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planéty"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Trpasličie planéty"
 
@@ -1758,16 +1732,16 @@ msgstr "Trpasličie planéty"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Mesiace"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Malé mesiace"
 
@@ -1780,10 +1754,10 @@ msgstr "Malé mesiace"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroidy"
 
@@ -1796,10 +1770,10 @@ msgstr "Asteroidy"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Kométy"
 
@@ -1816,11 +1790,11 @@ msgstr "Kométy"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1838,7 +1812,7 @@ msgstr "10x Rýchlejšie\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Názvy"
 
@@ -1848,9 +1822,9 @@ msgstr "Názvy"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaxie"
 
@@ -1858,8 +1832,8 @@ msgstr "Galaxie"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Guľové hviezdokopy"
 
@@ -1879,9 +1853,9 @@ msgstr "Otvorené hviezdokopy"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Hmloviny"
 
@@ -1893,48 +1867,48 @@ msgid "Locations"
 msgstr "Lokality"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Otvorené hviezdokopy"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Oblaky"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Svetlá na nočnej strane"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Chvosty komét"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosféry"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Tiene prstencov"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Tiene zatmení"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Tiene oblakov"
 
@@ -2007,237 +1981,237 @@ msgstr "Medzná hviezdna veľkosť pri 45 stupňoch:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Medzná hviezdna veľkosť-jasnosť: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Názov"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Vzdialenosť (ly-svet.roky)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Zdan. jasnosť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Abs. jasnosť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Hviezdy"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Najjasnejšie"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrovať hviezdy"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "S planétami"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Hviezdy"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Barycentrum (ťažisko)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Zlý spektrálny typ v hviezdnom katalógu, hviezda #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Obnoviť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Označiť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maximum hviezd v zozname"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Označiť"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Značky"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Žiadny"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Kosoštvorec"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Trojuholník"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Štvorec"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Kruh"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Šípka doľava"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Šípka doprava"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Šípka hore"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Šípka dole"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Vybrať"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Veľkosť:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Vybrať"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Pomenovať útvary"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objekty"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Označiť"
@@ -2352,8 +2326,8 @@ msgstr "Od:"
 msgid "Behind %1"
 msgstr "Trvanie: %1"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2522,86 +2496,91 @@ msgstr "Veľkosť: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Tvar &hviezd"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Miestny formát"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Názov časového pásma"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Posun voči svetovému času"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Začiatok"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Abs. (zdan.) jasnosť: "
 
@@ -2614,21 +2593,21 @@ msgid "&Select"
 msgstr "Vybrať"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centrovať"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Prejsť na"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Nasledovať"
 
@@ -2642,12 +2621,12 @@ msgid "Visible"
 msgstr "Aktívny pohľad zvýraznený"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Zrušiť označenie"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Zvoliť režim zobrazenia"
@@ -2661,12 +2640,12 @@ msgid "Disk"
 msgstr "Kotúč/disk"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Označiť"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Referenčné značky"
 
@@ -2714,13 +2693,13 @@ msgid "Show &Terminator"
 msgstr "Zobraziť terminátor"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Alternatívne povrchy"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normálne"
 
@@ -2732,7 +2711,7 @@ msgstr "Normálne"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Trpasličie planéty"
@@ -2744,15 +2723,15 @@ msgstr "Trpasličie planéty"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Malé mesiace"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Objekty"
@@ -2763,7 +2742,7 @@ msgid "Set Time"
 msgstr "Nastaviť čas..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Časové pásmo: "
 
@@ -2828,7 +2807,7 @@ msgid "Set Seconds"
 msgstr " sekúnd"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Juliánsky dátum: "
 
@@ -2842,98 +2821,98 @@ msgstr "Juliánsky dátum: "
 msgid "Set time"
 msgstr "Nastaviť čas..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Barycentrum (ťažisko)"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Zlý spektrálny typ v hviezdnom katalógu, hviezda #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planéta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Trpasličia planéta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Mesiac"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Malé mesiace"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroid"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Kométa"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Kozmická loď"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Referenčné značky"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Vypočítať"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Prejsť na povrch"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Neznáma chyba pri otváraní skriptu"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteroidy"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Referenčné značky"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Iné útvary"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planéty"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objekty"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3066,7 +3045,7 @@ msgstr "Rozlíšenie: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organizovať záložky"
 
@@ -3173,7 +3152,7 @@ msgstr "Zobraziť dráhy"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Miesta pristátí"
@@ -3181,7 +3160,7 @@ msgstr "Miesta pristátí"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Čiastočné trajektórie"
@@ -3189,49 +3168,49 @@ msgstr "Čiastočné trajektórie"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Súradnicové siete"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Rovníková"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ekliptická"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galaktická"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horizontálna"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagramy"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Hranice súhvezdí"
 
@@ -3433,41 +3412,41 @@ msgstr "Zobrazenie"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Podporované rozšírenia:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Podporované rozšírenia:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3718,13 +3697,13 @@ msgstr "&O Celestii"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3810,7 +3789,7 @@ msgid "Create in >>"
 msgstr "Vytvoriť v >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Nový priečinok..."
 
@@ -3891,7 +3870,7 @@ msgid "Go to Object"
 msgstr "Prejsť k objektu"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 #, fuzzy
 msgid "Go To"
 msgstr "Prejsť"
@@ -3909,7 +3888,7 @@ msgid "Lat."
 msgstr "Zem. šírka"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Vzdialenosť"
 
@@ -3958,174 +3937,178 @@ msgstr "Minimálna veľkosť útvaru s názvom"
 msgid "Size:"
 msgstr "Veľkosť:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Premenovať..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Premenovať záložku alebo priečinok"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Nový názov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Nastaviť čas simulácie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Formát:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Nastaviť na aktuálny čas"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Katalóg Slnečnej sústavy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "Prejsť"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Objekty Slnečnej sústavy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Hviezdny katalóg"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Najbližšie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Najjasnejšie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "S planétami"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Obnoviť"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Kritériá vyhľadávania hviezd"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Maximum hviezd v zozname"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Sprievodca"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Vybrať cieľ:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Možnosti zobrazenia"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Zobraziť"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Zobrazenie"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Čiara ekliptiky"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Dráhy / Názvy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Latinské názvy"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Informačný text"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Stručný"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Podrobný"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "41b"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jún"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Máj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Júl"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Sep"
 
@@ -4141,184 +4124,189 @@ msgstr "Dátum"
 msgid "Start"
 msgstr "Začiatok"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Režim v okne"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Neviditeľné objekty"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "S&ynchronizovať obežnú dráhu"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Informácie"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Zobraziť osi telesa"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Zobraziť osi pohľadu"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Zobraziť smer k slnku"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Zobraziť vektor rýchlosti"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Zobraziť planetografickú súradnicovú sieť"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Zobraziť terminátor"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satelity"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Obiehajúce telesá"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Chyba pri načítaní fontu; text nebude viditeľný.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Chyba: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Nahrať video"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Ovládanie Celestie"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Načítava sa: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Načítava sa "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "sk"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Chyba pri čítaní konfiguračného súboru."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Načítava sa URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Verzia: "
 
@@ -4354,17 +4342,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Chyba pri čítaní súboru typu PNG "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Chyba pri otváraní skriptového súboru."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Neznáma chyba pri otváraní skriptu"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4376,7 +4368,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4387,9 +4379,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Chyba pri otváraní skriptu '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Chyba pri otváraní skriptu"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4397,8 +4389,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Chyba pri inicializácii skriptu podprogramu"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Chyba pri otváraní skriptu '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4414,6 +4406,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Chyba pri otváraní "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Spôsob vykresľovania: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Presvetlenie zapnuté"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Presvetlenie vypnuté"
+
+#~ msgid "Exposure"
+#~ msgstr "Expozícia"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Nahrať video"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Chyba pri otváraní skriptu '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6793,9 +6805,6 @@ msgstr "Chyba pri otváraní "
 #~ msgid "GLSL version: "
 #~ msgstr "Verzia GLSL: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Chyba pri otváraní skriptu"
-
 #~ msgid "Error loading script"
 #~ msgstr "Chyba pri čítaní skriptu"
 
@@ -7333,9 +7342,6 @@ msgstr "Chyba pri otváraní "
 #, fuzzy
 #~ msgid "Surface Temp: "
 #~ msgstr "Povrchová teplota: "
-
-#~ msgid "Radius: "
-#~ msgstr "Polomer: "
 
 #~ msgid "Rsun"
 #~ msgstr "Polomerov Slnka"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 21:01+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Sommartid"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "Standardtid"
 
@@ -54,35 +54,34 @@ msgstr "Fel vid läsning av konfigurationsfil."
 msgid "Loaded {} deep space objects\n"
 msgstr " rymdobjekt"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galax (Hubble-typ: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr ""
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Läser bild från fil "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Läser modell: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Fel vid inläsning av modell '"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,115 +97,110 @@ msgstr "Öppen stjärnhop"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Fel i .ssc-fil (rad "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "varning för dubbla definitioner av "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "felaktig alternativ yta"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "felaktig plats"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Felaktigt huvud för korsindex\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Felaktig version för korsindex\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Läsning av korsindex misslyckades på post "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Läsning av korsindex misslyckades på post "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Felaktig spektraltyp i stjärndatabas, stjärna #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " stjärnor i binärdatabasen\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Totalt antal stjärnor: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Fel i .stc-fil (rad "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Ogiltig stjärna: felaktig spektraltyp.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Ogiltig stjärna: saknar spektraltyp.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " finns ej.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Ogiltig stjärna: saknar rektascension\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Ogiltig stjärna: saknar deklination.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Ogiltig stjärna: saknar avstånd.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Ogiltig stjärna: saknar magnitud.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Felaktig stjärna: absolut (inte apparent) magnitud måste anges för en "
 "stjärna nära ursprung\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -241,721 +235,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Utökningar som stöds:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Fel vid läsning av favoritfil."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Ogiltig filtyp"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Magnitudgräns: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Markörer aktiverade"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Markörer inaktiverade"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Gå till yta"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Alt-azimutläge aktiverat"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Alt-azimutläge inaktiverat"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Visa stjärnor som: suddiga punkter"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Visa stjärnor som: punkter"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Visa stjärnor som: skalenliga skivor"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Kometsvansar aktiverade"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Kometsvansar inaktiverade"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Renderingsläge: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "Alt-azimutläge aktiverat"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "Alt-azimutläge inaktiverat"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Automagnitud aktiverad"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Automagnitud inaktiverad"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Tid och skript är pausade"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Tiden är pausad"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Återuppta"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "Totalt antal stjärnor: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "Totalt antal stjärnor: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Ljusets restid:  %.4f år "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Ljusets restid:  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Ljusets restid:  %d h  %d min  %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Fördröjning för ljusets resa inberäknad"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Fördröjning för ljusets resa avstängd"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Fördröjning för ljusets resa ignoreras"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Använder normala yttexturer."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Använder yttexturer utanför kunskapsgräns."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Följ"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Tid: Framåt"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Tid: Bakåt"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Tidsfrekvens"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Texturer"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Texturer"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Texturer"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Synkronisera omloppsbana"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Lås"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Jaga"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Magnitudgräns: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Automagnitudgräns på 45 grader:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Nivå för omgivande ljus: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Ljusförstärkning"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Överstrålning aktiverad"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Överstrålning inaktiverad"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Exponering"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL-fel: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Vy för liten för att delas upp"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Lade till vy"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "lå"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "au"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " dagar"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " timmar"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " minuter"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " sekunder"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " lå/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Hastighet: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Apparent diameter: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Apparent magnitud: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Absolut magnitud: "
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Avstånd: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Stjärnsystemets masscentrum\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Abs (ungefärlig) mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Ljusstyrka: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Neutronstjärna"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Svart hål"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klass: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Yttemperatur: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Radie: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Radie: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Följeslagare till stjärnan finns\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Avstånd från centrum: "
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Radie: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Fasvinkel: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Temperatur: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Realtid"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Realtid"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Tid stoppad"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " snabbare"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " långsammare"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Pausad)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Reser "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Reser "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Spåra "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Följ "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synkronisera omloppsbana "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Jaga"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Målnamn: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "  Pausad"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  Spelar in"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Paus     F12 Stopp"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Redigeringsläge"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Läser solsystemskatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Läser solsystemskatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Läser solsystemskatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Läser solsystemskatalog: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Fel vid läsning av favoritfil."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Fel vid läsning av konfigurationsfil."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Initiering av SPICE-biblioteket misslyckades."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Kan inte läsa stjärndatabas."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Fel vid öppning av deep-sky-katalog "
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Kan inte läsa stjärndatabas."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Fel vid öppning av solsystemskatalog.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Fel vid öppning av asterismfil."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Fel vid öppning av filer för begränsning av stjärnbilder."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Misslyckades med att initiera renderare"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Fel vid läsning av typsnitt; text kommer inte att vara synlig.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Fel vid läsning av korsindex "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Läste in korsindex "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Fel vid läsning av stjärnnamnsfil\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Fel vid öppning av "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Fel vid läsning av stjärnfil\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Fel vid öppning av stjärnkatalog "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Utökningar som stöds:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1014,37 +992,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Himlabläddrare"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "Himlabläddrare"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Solsystemet"
 
@@ -1054,20 +1032,20 @@ msgstr "Solsystemet"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Stjärnor"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " rymdobjekt"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1077,123 +1055,119 @@ msgstr "Förmörkelsefinnare"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Tid"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Turnéguide"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "Helskärm"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Fånga &film...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Fel vid öppning av asterismfil."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Lägg till bokmärke..."
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Spara som:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " är inte en PNG-fil.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Fånga video"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Fånga video"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Fånga video"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Upplösning: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Bildfrekvens:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Kopierad URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Läser url"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "Ö&ppna skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Skapa en ny bokmärkesmapp i denna meny"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1210,348 +1184,348 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Okänt fel vid öppning av skript"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Utökningar som stöds:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Utökningar som stöds:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Om Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0-skuggspråk</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Ej utökad OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Ej utökad OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL-version: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Max samtidiga texturer: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Max texturstorlek: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Intervall för punktstorlek: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Intervall för punktstorlek: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Max kubmappstorlek: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Ej utökad OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Uppritare: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Arkiv"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Fånga bild"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Fånga &bild...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Fånga video"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Fånga &film...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Kopiera URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Ö&ppna skript..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Inställningar för Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Avsluta"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Kantutjämning\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigering"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "&Välj"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Centrera valt objekt\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Val: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Gå till objekt..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Tid"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Ställ tid..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Visa"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Markerade objekt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Visa molnskuggor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Stjärnutseende"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "&Texturens upplösning"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Kontroller"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Bokmärken"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Visa"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Vyer"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Dela vy vertikalt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Dela vy &horisontellt\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Dela vy horisontellt"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Dela vy &vertikalt\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Växla vy"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Enkel vy"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Enkel vy\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Ta bort vy"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Ta bort"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Synliga ramar"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Aktiva ramar synliga"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Synkronisera tid"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Hjälp"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Inställningar för Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "OpenGL-Info"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Lägg till bokmärke"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Organisera bokmärken..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Läser "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Skript"
@@ -1674,11 +1648,11 @@ msgstr " m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Markörer"
 
@@ -1694,7 +1668,7 @@ msgstr "&Centrera valt objekt\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Stjärnbilder"
 
@@ -1716,7 +1690,7 @@ msgstr "OK"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Omloppsbanor"
 
@@ -1730,18 +1704,18 @@ msgstr "Omloppsbanor"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Planeter"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Dvärgplaneter"
 
@@ -1754,16 +1728,16 @@ msgstr "Dvärgplaneter"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Månar"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Mindre månar"
 
@@ -1776,10 +1750,10 @@ msgstr "Mindre månar"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroider"
 
@@ -1792,10 +1766,10 @@ msgstr "Asteroider"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Kometer"
 
@@ -1812,11 +1786,11 @@ msgstr "Kometer"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1834,7 +1808,7 @@ msgstr "10x &snabbare\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Etiketter"
 
@@ -1844,9 +1818,9 @@ msgstr "Etiketter"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaxer"
 
@@ -1854,8 +1828,8 @@ msgstr "Galaxer"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Klotformiga stjärnhopar"
 
@@ -1875,9 +1849,9 @@ msgstr "Öppna stjärnhopar"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Nebulosor"
 
@@ -1889,48 +1863,48 @@ msgid "Locations"
 msgstr "Platser"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Öppna stjärnhopar"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Moln"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Ljus på nattsidan"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Kometsvansar"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosfärer"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Ringskuggor"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Förmörkelseskuggor"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Molnskuggor"
 
@@ -2003,237 +1977,237 @@ msgstr "Automagnitudgräns på 45 grader:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Magnitudgräns: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Namn"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "App. mag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Abs. mag"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Typ"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Visa stjärnor"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Stjärnor"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Filtrera stjärnor"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Med planeter"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Visa stjärnor"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Masscentrum "
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Felaktig spektraltyp i stjärndatabas, stjärna #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Uppdatera"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Markera"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Maximalt antal stjärnor visade i lista"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Markera"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Markörer"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Diamant"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Triangel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Kvadrat"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Plus"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Cirkel"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Vänsterpil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Högerpil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Uppåtpil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Nedåtpil"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "Välj &objekt..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Storlek:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "Välj &objekt..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Etikettfunktioner"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Objekt"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Markera"
@@ -2348,8 +2322,8 @@ msgstr "Läser bild från fil "
 msgid "Behind %1"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2518,86 +2492,91 @@ msgstr "Storlek: %1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Stjärnutseende"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Lokalt format"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Namn på tidszon"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Avvikelse från UTC"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Start"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Avstånd: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Abs (ungefärlig) mag: "
 
@@ -2610,21 +2589,21 @@ msgid "&Select"
 msgstr "&Välj"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Centrera"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Gå till"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Följ"
 
@@ -2638,12 +2617,12 @@ msgid "Visible"
 msgstr "Aktiva ramar synliga"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Avmarkera"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Välj visningsläge"
@@ -2657,12 +2636,12 @@ msgid "Disk"
 msgstr "Disk"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Markera"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Referensvektorer"
 
@@ -2710,13 +2689,13 @@ msgid "Show &Terminator"
 msgstr "Visa terminator"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Alternativa ytor"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normal"
 
@@ -2728,7 +2707,7 @@ msgstr "Normal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Dvärgplaneter"
@@ -2740,15 +2719,15 @@ msgstr "Dvärgplaneter"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Mindre månar"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Objekt"
@@ -2759,7 +2738,7 @@ msgid "Set Time"
 msgstr "Ställ tid..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Tidszon: "
 
@@ -2824,7 +2803,7 @@ msgid "Set Seconds"
 msgstr " sekunder"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Julianskt datum: "
 
@@ -2838,98 +2817,98 @@ msgstr "Julianskt datum: "
 msgid "Set time"
 msgstr "Ställ tid..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 #, fuzzy
 msgid "Barycenter"
 msgstr "Masscentrum "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Felaktig spektraltyp i stjärndatabas, stjärna #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Planet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Dvärgplanet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Måne"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Mindre månar"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroid"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Komet"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Rymdfarkost"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Referensvektorer"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Beräkna"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Gå till yta"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Okänt fel vid öppning av skript"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Asteroider"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Referensvektorer"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Övriga funktioner"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Planeter"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Objekt"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3062,7 +3041,7 @@ msgstr "Upplösning: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Organisera bokmärken"
 
@@ -3169,7 +3148,7 @@ msgstr "Visa omloppsbanor"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Landningsplatser"
@@ -3177,7 +3156,7 @@ msgstr "Landningsplatser"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Partiella banor"
@@ -3185,14 +3164,14 @@ msgstr "Partiella banor"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Rutnät"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 #, fuzzy
 msgid "Equatorial"
 msgstr "Visa himlarutnät"
@@ -3200,35 +3179,35 @@ msgstr "Visa himlarutnät"
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ekliptika"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galaktisk"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Horisontell"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Diagram"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Gränser"
 
@@ -3430,41 +3409,41 @@ msgstr "Visa"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Utökningar som stöds:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Utökningar som stöds:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3713,13 +3692,13 @@ msgstr "&Om Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "OK"
 
@@ -3805,7 +3784,7 @@ msgid "Create in >>"
 msgstr "Skapa i >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Ny mapp..."
 
@@ -3886,7 +3865,7 @@ msgid "Go to Object"
 msgstr "Gå till objekt"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Gå till"
 
@@ -3903,7 +3882,7 @@ msgid "Lat."
 msgstr "Lat."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Avstånd"
 
@@ -3952,174 +3931,178 @@ msgstr "Minsta objektsstorlek för visning av etiketter"
 msgid "Size:"
 msgstr "Storlek:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Byt namn..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Byt namn på bokmärke eller mapp"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Nytt namn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Ställ in simuleringstid"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Format: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Ställ in till aktuell tid"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Bläddra i stjärnsystemet"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Gå till"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Stjärnsystemobjekt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Stjärnbläddrare"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Närmaste"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Ljusstarkast"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "Med planeter"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "Uppdate&ra"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Kriteria för stjärnsökning"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Maximalt antal stjärnor visade i lista"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Turnéguide"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Välj ditt mål:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Visningsalternativ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Visa"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Kingston"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Visa"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Ekliptika"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Omloppsbanor / Etiketter"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Latinska namn"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Informationstext"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Fåordig"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Informativ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "41d"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Apr"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Feb"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Jan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Jun"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Maj"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Aug"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Dec"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Jul"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Nov"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Okt"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Sep"
 
@@ -4135,184 +4118,189 @@ msgstr "Datum"
 msgid "Start"
 msgstr "Start"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Fönsterläge"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Osynliga"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "S&ynkronisera omloppsbana"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Info"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Visa kroppsaxlar"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Visa ramaxlar"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Visa solriktning"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Visa hastighetsvektor"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Visa planetografiskt rutnät"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Visa terminator"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Satelliter"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Himlakroppar i omloppsbana"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Fel vid läsning av typsnitt; text kommer inte att vara synlig.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Fel: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Fånga video"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Kontrollera Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Läser: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Läser "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "sv"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Fel vid läsning av konfigurationsfil."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Läser url"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Version: "
 
@@ -4348,17 +4336,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Fel vid läsning av PNG-bildfil "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Fel vid öppning av skriptfil."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Okänt fel vid öppning av skript"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4370,7 +4362,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4381,9 +4373,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "Fel vid öppning av skript '%s'"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Fel vid öppning av skript"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4391,8 +4383,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Initiering av skriptets medrutin misslyckades"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "Fel vid öppning av skript '%s'"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4408,6 +4400,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Fel vid öppning av "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Renderingsläge: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Överstrålning aktiverad"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Överstrålning inaktiverad"
+
+#~ msgid "Exposure"
+#~ msgstr "Exponering"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Fånga video"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "Fel vid öppning av skript '%s'"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6787,9 +6799,6 @@ msgstr "Fel vid öppning av "
 #~ msgid "GLSL version: "
 #~ msgstr "GLSL-version: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Fel vid öppning av skript"
-
 #~ msgid "Error loading script"
 #~ msgstr "Fel vid läsning av skript"
 
@@ -7326,9 +7335,6 @@ msgstr "Fel vid öppning av "
 #, fuzzy
 #~ msgid "Surface Temp: "
 #~ msgstr "Yttemperatur: "
-
-#~ msgid "Radius: "
-#~ msgstr "Radie: "
 
 #~ msgid "Rsun"
 #~ msgstr "Rsol"

--- a/po/tr.po
+++ b/po/tr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2021-12-20 00:20+0200\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: Turkish (https://www.transifex.com/celestia/teams/93131/tr/)\n"
@@ -21,11 +21,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "DST (Yaz saati uy.)"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "Yaz saati"
 
@@ -53,34 +53,34 @@ msgstr "{}: Hatalı yapılandırma dosyası.\n"
 msgid "Loaded {} deep space objects\n"
 msgstr "{} derin uzay cismi yüklendi\n"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Galaksi (Hubble türü: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Küresel (merkezi yarıçap: %4.2f', King konsantrasyonu %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 msgid "Loading image from file {}\n"
 msgstr "Dosyadan resim yükleniyor {}\n"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Model yükleniyor: %s\n"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
+#, fuzzy
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr "Model istatistikleri: %u köşe, %u ilkel, %u materyal (%u özgün)\n"
 
-#: ../src/celengine/meshmanager.cpp:553
-#, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Model yüklenirken hata '%s'\n"
 
 #: ../src/celengine/nebula.cpp:39
@@ -95,109 +95,104 @@ msgstr "Açık küme"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr ".ssc dosyasında hata (satır {}): {}\n"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr "Yanlış GeomAlbedo değeri: {}\n"
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr "Yanlış Yansıma değeri: {}\n"
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr "Yanlış BondAlbedo değeri: {}\n"
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "ana cisim '%s'nın '%s' bulunamadı.\n"
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "%s çift tanımlama uyarısı %s\n"
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "kötü alternatif yüzey"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "kötü konum"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Çapraz dizin için kötü başlık\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Çapraz dizin için kötü sürüm\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Çapraz dizin yüklemesi kayıt %u noktasında başarısız oldu\n"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 msgid "Loading cross index failed at record {}\n"
 msgstr "Çapraz dizin yüklemesi kayıt {} noktasında başarısız oldu\n"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Yıldız veritabanında kötü tayf türü, yıldız #{}\n"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 msgid "{} stars in binary database\n"
 msgstr "İkili veritabanında {} yıldız var\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 msgid "Total star count: {}\n"
 msgstr "Toplam yıldız sayısı: {}\n"
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 msgid "Error in .stc file (line {}): {}\n"
 msgstr ".stc dosyasında hata (satır {}): {}\n"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Geçersiz yıldız: kötü tayf türü.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Geçersiz yıldız: tayf türü yok.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 msgid "Barycenter {} does not exist.\n"
 msgstr "Kütle merkezi {} mevcut değil.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Geçersiz yıldız: sağ yükseliş yok\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Geçersiz yıldız: sapma yok.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Geçersiz yıldız: mesafe yok.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Geçersiz yıldız: kadir yok.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Geçersiz yıldız: mutlak (görünür değil) kadir orijin yakınındaki yıldız için "
 "belirtilmelidir\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr "Seviye %i, %.5f ıy, %i düğüm, %i  yıldız\n"
 
 #: ../src/celengine/texture.cpp:928
 msgid "Creating tiled texture. Width={}, max={}\n"
@@ -227,506 +222,491 @@ msgstr "Desteklenmeyen bayt sırası {}, beklenen {}.\n"
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Desteklenmeyen rakam sayısı {}, beklenen {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr "{} yolu mevcut değil veya bir dizin değil\n"
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 msgid "Error reading favorites file {}.\n"
 msgstr "Sık kullanılanlar dosyasını okurken hata. {}\n"
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr "Sık kullanılanlar dosyası {} için dizin varlığını kontrol edemedi\n"
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr "Sık kullanılanlar dosyası {} için bir dizin oluşturulamadı\n"
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Geçersiz dosya türü"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Kadir sınırı: %2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "İşaretleyiciler etkin"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "İşaretleyiciler devre dışı"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Yüzeye git"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "İrtifa-azimut modu etkin"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "İrtifa-azimut modu devre dışı"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Yıldız stili: bulanık noktalar"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Yıldız stili: noktalar"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Yıldız stili: ölçekli diskler"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Kuyruklu yıldızların kuyrukları etkin"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Kuyruklu yıldızların kuyrukları devre dışı"
 
-#: ../src/celestia/celestiacore.cpp:1188
-msgid "Render path: OpenGL 2.1"
-msgstr "Render yolu: OpenGL 2.1"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 msgid "Anti-aliasing enabled"
 msgstr "Kenar yumuşatma (anti-aliasing) etkin"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 msgid "Anti-aliasing disabled"
 msgstr "Kenar yumuşatma (anti-aliasing) devre dışı"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Oto-kadir etkin"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Oto-kadir devre dışı"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "İptal"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Zaman ve senaryo duraklatıldı"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Süre durduruldu"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Devam"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr "Yıldız rengi: Siyah cisim D65"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr "Yıldız rengi: Arttırılmış"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Işık hızında seyahat süresi: %.4f yıl"
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Işık hızında seyahat süresi:  %d dak  %.1f sn "
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Işık hızında seyahat süresi:  %d saat  %d dak  %.1f sn"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "Işık hızı gecikmesi ekli"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Işık hızı gecikmesi kapalı"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Işık hızı gecikmesi göz ardı ediliyor"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Normal yüzey dokuları kullanılıyor."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Sınırlı bilgi yüzey dokularını kullanılıyor."
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "İzle"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Zaman: İleri"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Zaman: Geri"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, c-format
 msgid "Time rate: %.6g"
 msgstr "Zaman oranı: %.6g"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 msgid "Low res textures"
 msgstr "Düşük çözünürlüklü dokular"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 msgid "Medium res textures"
 msgstr "Orta çözünürlüklü dokular"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr "Yüksek çözünürlüklü dokular"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Yörünge Senkronizasyonu"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Kilitli"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Takip"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Kadir sınırı:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "45 derecede oto kadir sınırı:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Çevre ışık seviyesi:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Işık kazanımı"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Parlama etkin"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Parlama devre dışı"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Pozlama"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL hatası:"
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Görünüm ayırmak için çok küçük"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Eklenen görünüm"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr "Mpc"
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr "kpc"
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "ly (ışık yılı)"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "ab"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr "m"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 msgid "days"
 msgstr "gün"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "hours"
 msgstr "saat"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 msgid "minutes"
 msgstr "dakika"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 msgid "seconds"
 msgstr "saniye"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Dönüş periyodu: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, fuzzy, c-format
 msgid "Mass: %.6g lb\n"
 msgstr "Kütle: %.6g kg\n"
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr "Kütle: %.6g kg\n"
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr "Kütle: %.2f Mj\n"
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr "Kütle: %.2f Me\n"
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 msgid "ly/s"
 msgstr "ıy/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 msgid "AU/s"
 msgstr "AB/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 msgid "km/s"
 msgstr "km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 msgid "m/s"
 msgstr "m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr "Hız: %s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr "Sap: %+d%s %02d' %.1f\"\n"
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr "RA: %dh %02dm %.1fs\n"
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Görünür çap: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Görünür kadir: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Mutlak kadir %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr "%.6f%c %.6f%c %s"
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Mesafe: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Yıldız sistemi kütle merkezi\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Mtlk (grnr) kad: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Parlaklık: %s x Güneş\n"
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Nötron yıldızı"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Kara delik"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, c-format
 msgid "Class: %s\n"
 msgstr "Sınıf: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2860
-#, c-format
-msgid "Surface temp: %s K\n"
+#: ../src/celestia/celestiacore.cpp:2905
+#, fuzzy, c-format
+msgid "Surface temp: %s\n"
 msgstr "Yüzey sıcaklığı: %s K\n"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Yarıçap: %s Rgüneş  (%s)\n"
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Yarıçap: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Gezegensel refakatçiler mevcut\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Merkezden uzaklık %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, c-format
+msgid "Radius: %s\n"
+msgstr "Yarıçap: %s\n"
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Faz açısı: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, fuzzy, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr "Yoğunluk: %.2f x 1000 kg/m^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "Yoğunluk: %.2f x 1000 kg/m^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2999
-#, c-format
-msgid "Temperature: %.0f K\n"
+#: ../src/celestia/celestiacore.cpp:3045
+#, fuzzy, c-format
+msgid "Temperature: %s\n"
 msgstr "Sıcaklık: %.0f K\n"
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr " LT"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Gerçek zaman"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Gerçek zaman"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Zaman durdu"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, c-format
 msgid "%.6g x faster"
 msgstr "%.6g x daha hızlı"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, c-format
 msgid "%.6g x slower"
 msgstr "%.6g x daha yavaş"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr "(duraklatıldı)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
@@ -735,181 +715,180 @@ msgstr ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS: %.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Seyahat ediliyor (%s)\n"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, c-format
+#: ../src/celestia/celestiacore.cpp:3291
 msgid "Travelling\n"
 msgstr "Seyahat ediliyor\n"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, c-format
 msgid "Track %s\n"
 msgstr "%s İzle\n"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, c-format
 msgid "Follow %s\n"
 msgstr "%s Takip Et\n"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "%s Yörüngesiyle Senkronize Et\n"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Kilitle %s -> %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, c-format
 msgid "Chase %s\n"
 msgstr "%s Peşinden Git\n"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr "FOV: %s (%.2fx)\n"
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, c-format
 msgid "Target name: %s"
 msgstr "Hedef adı: %s"
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Paused"
 msgstr "Durduruldu"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Recording"
 msgstr "Kaydediyor"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Başlat/Duraklat    F12 Durdur"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Düzenleme Modu"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Güneş sistemi kataloğu atlanıyor: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Güneş sistemi kataloğu yükleniyor: %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 msgid "Skipping {} catalog: {}\n"
 msgstr "{} kataloğu atlanıyor: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 msgid "Loading {} catalog: {}\n"
 msgstr "{} kataloğu yükleniyor: {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Sık kullanılanlar dosyasını okurken hata. {}\n"
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Yapılandırma dosyası okunurken hata oluştu."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "SPICE kütüphanesinin başlatılması başarısız oldu."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Yıldız veritabanı okunamıyor"
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "{} derin uzay katalog dosyası açılırken hata.\n"
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "{} Derin Uzay Cisimleri veritabanı okunamıyor.\n"
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 msgid "Error opening solar system catalog {}.\n"
 msgstr "{} güneş sistemi katalogu açılırken hata.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 msgid "Error opening asterisms file {}.\n"
 msgstr "{} yıldız kümeleri dosyası açılırken hata.\n"
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "{} takımyıldız sınırları dosyası açılırken hata.\n"
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Renderer başlatması başarısız oldu."
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Font yükleme hatası; metinler görünmeyecek.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 msgid "Error reading cross index {}\n"
 msgstr "{} çapraz dizini okunurken hata\n"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 msgid "Loaded cross index {}\n"
 msgstr "{} çapraz dizini yüklendi.\n"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Yıldız isimleri dosyası okunurken hata\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 msgid "Error opening {}\n"
 msgstr "{} açılırken hata\n"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Dosyadan yıldızlar okunurken hata\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 msgid "Error opening star catalog {}\n"
 msgstr "{} yıldız kataloğu açılırken hata\n"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr "Geçersiz URL"
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr "Bir kare yakalanamadı!\n"
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Desteklenmeyen URL modu \"%s\"!\n"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr "Celestia, OpenGL 2.1'i başlatamadı.\n"
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr "Lütfen '.jpg' veya '.png' ile biten bir ad kullanın."
 
@@ -968,19 +947,19 @@ msgstr "İnterpolatör sayısı: %s\n"
 msgid "Max anisotropy filtering: %s\n"
 msgstr "Maks. anizotropi filtreleme: %s\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr "Oto"
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr "Özel"
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
@@ -988,18 +967,18 @@ msgstr ""
 "Celestia, veri dizini bulunamadığından, muhtemelen yanlış kurulumdan dolayı "
 "çalıştırılamıyor."
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Gök Tarayıcı"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 msgid "Info Browser"
 msgstr "Bilgi Tarayıcısı"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Güneş Sistemi"
 
@@ -1009,19 +988,19 @@ msgstr "Güneş Sistemi"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Yıldızlar"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr "Derin Uzay Cisimleri"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "Olay Bulucu"
@@ -1030,110 +1009,107 @@ msgstr "Olay Bulucu"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Zaman"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Rehberler"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 msgid "Full screen"
 msgstr "Tam ekran"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 msgid "Error opening bookmarks file"
 msgstr "Yer imleri dosyası açılırken hata"
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 msgid "Error Saving Bookmarks"
 msgstr "Yer İmleri Kaydedilirken Hata"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 msgid "Save Image"
 msgstr "Resmi Kaydet"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr "Resimler (*.png *.jpg)"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Video Çek"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr "Video (*.avi)"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Video (*.avi)"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr "Çözünürlük:"
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr "%1 x %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "Kare hızı:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr "Ekran alıntısı panoya yakalandı"
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "URL kopyalandı"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 msgid "Pasting URL"
 msgstr "URL yapıştırılıyor"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Open Script"
 msgstr "Betiği Aç"
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Celestia Betikleri (*.celx *.cel)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 msgid "New bookmark"
 msgstr "Yeni yer imi"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, fuzzy, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1166,302 +1142,302 @@ msgstr ""
 "CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></"
 "p></html>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 msgid "Unknown compiler"
 msgstr "Bilinmeyen derleyici"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr "destekleniyor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr "desteklenmiyor"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Celestia Hakkında"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>%1 sürüm:</b> %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>Satıcı:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>Renderer:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "<b>%1 Sürüm:</b> %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "<b>Maksimum eşzamanlı dokular:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>Maksimum doku boyutu:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "<b>Nokta boyutu uzaklığı:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "<b>Nokta boyutu ayrıntı düzeyi:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "<b>Maks. küp haritası boyutu:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "<b>Periapsis argümanı:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr "<b>Maks anizotropi filtreleme:</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>Desteklenen eklentiler:</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 msgid "Renderer Info"
 msgstr "Renderer Bilgisi"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Dosya"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 msgid "&Grab image"
 msgstr "Resmi &al"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 msgid "Capture &video"
 msgstr "&Video çek"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr "Shift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr "Resmi &kopyala"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "Betik &Aç..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr "&Tercihler..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "&Çıkış"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Navigasyon"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 msgid "Select Sun"
 msgstr "Güneşi Seç"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 msgid "Center Selection"
 msgstr "Merkez Seçim"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Goto Selection"
 msgstr "Seçime Git"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Cisme Git..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr "URL / konsol metnini kopyala"
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr "URL / konsol metnini yapıştır"
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Zaman"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 msgid "Set &time"
 msgstr "&Zaman seç"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 msgid "&Display"
 msgstr "&Görünüm"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 msgid "Dee&p Sky Objects"
 msgstr "&Derin Uzay Cisimleri"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 msgid "&Shadows"
 msgstr "&Gölgeler"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "&Yıldız Stili"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr "Doku &Çözünürlüğü"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 msgid "&FPS control"
 msgstr "&FPS kontrolü"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Yerimleri"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Görüntü"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 msgid "&MultiView"
 msgstr "&Çoklu Görünüm"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 msgid "Split view vertically"
 msgstr "Görüntüyü dikey ayır"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 msgid "Split view horizontally"
 msgstr "Görüntüyü yatay ayır"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 msgid "Cycle views"
 msgstr "Görüntüler arası geçiş yap"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr "Sekme"
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 msgid "Single view"
 msgstr "Tek görüntü"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 msgid "Delete view"
 msgstr "Görüntüyü sil"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Sil"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 msgid "Frames visible"
 msgstr "Görünür kareler"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 msgid "Active frame visible"
 msgstr "Görünür aktif kareler"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 msgid "Synchronize time"
 msgstr "Zamanı senkronize et"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Yardım"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 msgid "Celestia Manual"
 msgstr "Celestia El Kitabı"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "OpenGL Bilgisi"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 msgid "Add Bookmark..."
 msgstr "Yer İmi Ekle..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr "Yer İmlerini Organize Et..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr "Özel FPS ayarla"
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr "FPS değeri"
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
@@ -1470,7 +1446,7 @@ msgstr ""
 "Veri dosyaları yükleniyor: %1\n"
 "\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Betikler"
@@ -1579,11 +1555,11 @@ msgstr "İ"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "İşaretleyiciler"
 
@@ -1598,7 +1574,7 @@ msgstr "T"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Takımyıldızlar"
 
@@ -1617,7 +1593,7 @@ msgstr "O"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Yörüngeler"
 
@@ -1631,18 +1607,18 @@ msgstr "Yörüngeler"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Gezegenler"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Cüce gezegenler"
 
@@ -1655,16 +1631,16 @@ msgstr "Cüce gezegenler"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Uydular"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Küçük Uydular"
 
@@ -1677,10 +1653,10 @@ msgstr "Küçük Uydular"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Asteroitler"
 
@@ -1693,10 +1669,10 @@ msgstr "Asteroitler"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Kuyruklu yıldızlar"
 
@@ -1713,11 +1689,11 @@ msgstr "Kuyruklu yıldızlar"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 msgctxt "plural"
 msgid "Spacecraft"
 msgstr "Uzay aracı"
@@ -1733,7 +1709,7 @@ msgstr "L"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Etiketler"
 
@@ -1743,9 +1719,9 @@ msgstr "Etiketler"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Galaksiler"
 
@@ -1753,8 +1729,8 @@ msgstr "Galaksiler"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Küresel kümeler"
 
@@ -1773,9 +1749,9 @@ msgstr "Açık kümeler"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Bulutsular"
 
@@ -1787,48 +1763,48 @@ msgid "Locations"
 msgstr "Konumlar"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Açık Kümeler"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Bulutlar"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Gece Işıkları"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Kuyruklu yıldız kuyrukları"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Atmosferler"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Halka Gölgeleri"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Tutulma Gölgeleri"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Bulut Gölgeleri"
 
@@ -1894,223 +1870,223 @@ msgstr "45 derecede oto kadir sınırı: %L1"
 msgid "Magnitude limit: %L1"
 msgstr "Kadir sınırı: %L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "İsim"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Mesafe (ıy)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Grnr. kad"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Mtlk. kad"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Türü"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 msgid "Closest Stars"
 msgstr "En Yakın Yıldızlar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 msgid "Brightest Stars"
 msgstr "En Parlak Yıldızlar"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 msgid "Filter"
 msgstr "Filtre"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "Gezegenlerle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 msgid "Multiple Stars"
 msgstr "Çoklu Yıldızlar"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 msgid "Barycenters"
 msgstr "Kütle Merkezleri"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr "Tayf Türü"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Yenile"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 msgid "Mark Selected"
 msgstr "Seçimi İşaretle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 msgid "Mark stars selected in list view"
 msgstr "Liste görünümünde seçili yıldızları işaretle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark Selected"
 msgstr "Seçililerin İşaretini Kaldır"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr "Liste görünümünde seçili yıldızların işaretini kaldır"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 msgid "Clear Markers"
 msgstr "İşaretleri Temizle"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr "Varolan tüm işaretleri kaldır"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Hiçbiri"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Elmas"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Üçgen"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Kare"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Artı"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Daire"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Sol Ok"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Sağ Ok"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Yukarı Ok"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Aşağı Ok"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr "İşaretçi sembolünü seç"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr "İşaretçi boyutunu seç"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr "İşaretçi rengini seçmek için tıkla"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr "Etiket"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, qt-format
 msgid "%1 objects found"
 msgstr "%1 cisim bulundu"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr "Liste görünümünde seçili D.U.C.ni işaretle"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr "Liste görünümünde seçili D.U.C.nin işaretini kaldır"
 
@@ -2215,8 +2191,9 @@ msgstr "%1 yüzeyinden"
 msgid "Behind %1"
 msgstr "%1 arkasından"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+#, fuzzy
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia, OpenGL 2.1'i başlatamadı."
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2382,81 +2359,86 @@ msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr "--dir'den sonra dizin bekleniyor"
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr "--conf'dan sonra yapılandırma dosyası adı bekleniyor"
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr "--extrasdir'den sonra dizin bekleniyor"
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr "--url'den sonra URL bekleniyor"
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr "--log/-l'den sonra dosya adı bekleniyor"
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr "Geçersiz komut satırı seçeneği '%s'"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.1"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr "Siyah cisim D65"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr "Klasik renkler"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 msgid "Local format"
 msgstr "Yerel format"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 msgid "Time zone name"
 msgstr "Zaman dilimi adı"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 msgid "UTC offset"
 msgstr "UTC kayması"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, qt-format
 msgid "Start: %1"
 msgstr "Başlangıç: %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr "Bitiş: %1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
-msgstr "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
+msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
-msgstr "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
+msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Mesafe:"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Mtlk (grnr) kad:"
 
@@ -2469,21 +2451,21 @@ msgid "&Select"
 msgstr "&Seçin"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "&Merkez"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Git"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&İzle"
 
@@ -2496,12 +2478,12 @@ msgid "Visible"
 msgstr "Görünür"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "İşareti &kaldır"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Birincil Gövdeyi Seçin"
@@ -2515,12 +2497,12 @@ msgid "Disk"
 msgstr "Disk"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&İşaretle"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Referans İşaretleri"
 
@@ -2561,13 +2543,13 @@ msgid "Show &Terminator"
 msgstr "&Sonlandırıcıyı Göster"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "Yüzeyleri &Değiştir"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Normal"
 
@@ -2579,7 +2561,7 @@ msgstr "Normal"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr "Cüce gezegenler"
 
@@ -2590,14 +2572,14 @@ msgstr "Cüce gezegenler"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr "Küçük uydular"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 msgid "Other objects"
 msgstr "Diğer cisimler"
 
@@ -2606,7 +2588,7 @@ msgid "Set Time"
 msgstr "Zaman Ayarla"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Saat Dilimi :"
 
@@ -2662,7 +2644,7 @@ msgid "Set Seconds"
 msgstr "Saniye Seç"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Jülyen Tarihi:"
 
@@ -2674,85 +2656,85 @@ msgstr "Jülyen Tarihi Seç"
 msgid "Set time"
 msgstr "Zaman seç"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Kütle merkezi"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr "Yıldız"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Gezegen"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr "Cüce gezegen"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Ay"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 msgid "Minor moon"
 msgstr "Küçük uydu"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Asteroit"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Kuyruklu yıldız"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Uzay aracı"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 msgid "Reference point"
 msgstr "Referans noktası"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 msgid "Component"
 msgstr "Bileşen"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 msgid "Surface feature"
 msgstr "Yüzey özelliği"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr "Asteroidler & kuyrukluyıldızlar"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 msgid "Reference points"
 msgstr "Referans noktaları"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr "Bileşenler"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 msgid "Surface features"
 msgstr "Yüzey özellikleri"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 msgid "Planets and moons"
 msgstr "Gezegenler ve uydular"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr "Cisimleri sınıflarına göre gruplandır"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr "Liste görünümünde seçili cisimleri işaretle"
 
@@ -2868,7 +2850,7 @@ msgstr "Açıklama:"
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Yer İmlerini Organize Et"
 
@@ -2963,63 +2945,63 @@ msgstr "Yörüngeleri göster"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 msgid "Fading orbits"
 msgstr "Solan yörüngeler"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr "Kısmi yörüngeler"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Izgaralar"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Ekvatoral"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Ekliptik"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Galaktik"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Yatay"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Şemalar"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Sınırlar"
 
@@ -3200,40 +3182,40 @@ msgstr "Tarih gösterme formatı:"
 msgid "Not an XBEL version 1.0 file."
 msgstr "XBEL sürüm 1.0 dosyası değil."
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 #, fuzzy
 msgid "Incorrect hex value \"{}\"\n"
 msgstr "Yanlış onaltılık değer \"%s\"\n"
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr "URL \"{}\" ile başlamalıdır!\n"
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr "URL'nin en az bir moda ve zamana sahip olmalıdır!\n"
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Desteklenmeyen URL modu \"{}\"!\n"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr "URL yalnızca bir gövde içermelidir\n"
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr "URL iki gövde içermelidir\n"
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr "Geçersiz URL sürümü \"{}\"!\n"
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 msgid "Unsupported URL version: {}\n"
 msgstr "Geçersiz URL sürümü: {}\n"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr "URL parametresi, anahtar=değer gibi görünmelidir\n"
 
@@ -3478,13 +3460,13 @@ msgstr "&Celestia Hakkında"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "TAMAM"
 
@@ -3569,7 +3551,7 @@ msgid "Create in >>"
 msgstr "Şurada oluştur >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Yeni Dizin..."
 
@@ -3650,7 +3632,7 @@ msgid "Go to Object"
 msgstr "Cisme Git"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Git"
 
@@ -3667,7 +3649,7 @@ msgid "Lat."
 msgstr "En."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Mesafe"
 
@@ -3715,169 +3697,173 @@ msgstr "Minimum Etiketli Özellik Boyutu"
 msgid "Size:"
 msgstr "Boyut:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Yeniden adlandır..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Yer İmi veya Klasörü Yeniden Adlandır"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Yeni İsim"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Simülasyon Zamanı Ayarla"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Biçim:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Şu Anki Zamana Ayarla"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Güneş Sistemi Tarayıcısı"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Git"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Güneş Sistemi Cisimleri"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Yıldız Tarayıcısı"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "En Yakın"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "En Parlak"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "Gezegenlerle"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Tazele"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Yıldız Arama Kriteri"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Listede Gösterilecek Maksimum Yıldız"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Tur Rehberi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Gideceğiniz yeri seçin:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Ayarları Görüntüle"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Show:"
 msgstr "Göster:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Rings"
 msgstr "Halkalar"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 msgid "Display:"
 msgstr "Görüntü:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Ekliptik çizgisi"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 msgid "Body / Orbit / Label display"
 msgstr "Cisim / Yörünge / Etiket görünümü"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Latince İsimler"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Bilgi Metni"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Özlü"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Ayrıntılı"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "WinLangID"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Nisan"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Şubat"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Ocak"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Haziran"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Mart"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Mayıs"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Ağustos"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Aralık"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Temmuz"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Kasım"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Ekim "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Eylül"
 
@@ -3893,7 +3879,7 @@ msgstr "Tarih"
 msgid "Start"
 msgstr "Başlat"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
@@ -3901,153 +3887,158 @@ msgstr ""
 "Lisans dosyası bulunmuyor!\n"
 "http://www.gnu.org/copyleft/gpl.html adresine bakın"
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, fuzzy, c-format
+msgid "%d x %d"
+msgstr "%1 x %2"
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Pencere Modu"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Görünmezler"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "Yörüngeyi Eş&zamanla"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Bilgi"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Cisim Eksenlerini Göster"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Kare Eksenlerini Göster"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Güneş Yönünü Göster"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Hız Vektörünü Göster"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Gezegensel Izgarayı Göster"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Bitiriciyi Göster"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Uydular"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Yörüngedeki Cisimler"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr ""
 "Tam ekran modundan düzgün şekilde çıkılamadı. Celestia şimdi kapanacak."
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 msgid "Error"
 msgstr "Kritik Hata"
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr "Pencere sınıfı kaydedilemedi."
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr "Kritik Hata"
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr "OpenGL işleme için uygun piksel biçimi alınamadı."
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr "Sisteminiz OpenGL 2.1 desteklemiyor!"
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr "Cihaz içeriği serbest bırakılamadı."
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr "Farklı Kaydet - Görüntü Yakalanacak Dosyayı Belirtin"
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr "Resim dosyası kaydedilemedi."
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr "Başka bir filme başlamadan önce mevcut film çekimini durdurun."
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr "Farklı Kaydet - Film Yakalama için Çıktı Dosyasını Belirtin"
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr "Belirtilen dosya uzantısı tanınmadı."
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 msgid "Could not capture movie."
 msgstr "Film Kaydedilemedi."
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 msgid "Celestia Command Line Error"
 msgstr "Celestia Komut Satırı Hatası"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Yükleniyor:"
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 msgid "Loading data files..."
 msgstr "Veri dosyaları yükleniyor.."
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "DİL"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 msgid "Configuration file missing!"
 msgstr "Yapılandırma dosyası eksik!"
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
@@ -4055,21 +4046,21 @@ msgstr ""
 "Eski sık kullanılanlar dosyası algılandı.\n"
 "Yeni konuma kopyalansın mı?"
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr "Sık kullanılanları kopyala?"
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr "Uygulama penceresi oluşturulamadı."
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "URL yükleniyor"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Sürüm:"
 
@@ -4102,16 +4093,20 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "PNG dosyasını okurken hata %s\n"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Betik dosyası açılırken hata."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 msgid "Unknown error loading script"
 msgstr "Komut dosyası yüklenirken bilinmeyen hata"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4131,7 +4126,7 @@ msgstr ""
 "\n"
 "y = evet, ESC = betiği iptal et, başka tuşlar = hayır"
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4148,8 +4143,8 @@ msgstr ""
 "istiyor musunuz?"
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
 msgstr "'%s' betiği açılırken hata"
 
 #: ../src/celscript/lua/luascript.cpp:107
@@ -4158,8 +4153,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Betik eşyordam başlatması başarısız oldu"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "'%s' LuaHook açılırken hata"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4174,6 +4169,30 @@ msgstr "GetTimeZoneInformation() tarafından döndürülen bilinmeyen değer\n"
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "%s açarken hata veya .\n"
+
+#~ msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
+#~ msgstr "Seviye %i, %.5f ıy, %i düğüm, %i  yıldız\n"
+
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Render yolu: OpenGL 2.1"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Parlama etkin"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Parlama devre dışı"
+
+#~ msgid "Exposure"
+#~ msgstr "Pozlama"
+
+#~ msgid "Video (*.avi)"
+#~ msgstr "Video (*.avi)"
+
+#~ msgid "%.3f km"
+#~ msgstr "%.3f km"
+
+#~ msgid "%.3f m"
+#~ msgstr "%.3f m"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 21:02+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "Лтн"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "Стд"
 
@@ -55,35 +55,34 @@ msgstr "Помилка під час читання файла налаштув�
 msgid "Loaded {} deep space objects\n"
 msgstr " віддалені об’єкти"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "Галактика (тип за Хабблом: %s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "Кулясте скупчення (радіус ядра: %4.2f', концентрація за Кінгом: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Завантаження зображення з файла "
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "Завантаження моделі: "
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "Помилка під час завантаження моделі «"
 
 #: ../src/celengine/nebula.cpp:39
@@ -99,115 +98,110 @@ msgstr "Розсіяне скупчення"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr "Помилка у файлі .ssc (рядок "
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "попередження про подвійне визначення "
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "помилкова альтернативна поверхня"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "помилкове розташування"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "Помилковий заголовок для покажчика\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "Помилкова версія для покажчика\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "Помилка під час завантаження покажчика на запису "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "Помилка під час завантаження покажчика на запису "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "Неправильний спектральний тип у базі даних зірок, зірка №"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " зірок у двійковій базі даних\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "Загальна кількість зірок: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr "Помилка у файлі .stc (рядок "
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "Некоректний запис: помилковий спектральний тип.\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "Некоректний запис: не вказано спектрального типу.\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " не існує.\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "Некоректний запис: не вказано пряме сходження\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "Некоректний запис: не вказано схилення.\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "Некоректний запис: не вказана відстань.\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "Некоректний запис: не вказано зоряної величини.\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr ""
 "Некоректний запис: слід задати абсолютну (а не видиму) величину для зірки "
 "поряд з початком координат\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -242,721 +236,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "Підтримувані додатки:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "Помилка під час читання файла обраного."
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "Некоректний тип файла"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "Межа величини: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "Позначки увімкнено"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "Позначки вимкнено"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "Перейти до поверхні"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "Режим «висота-азимут» увімкнено"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "Режим «висота-азимут» вимкнено"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "Стиль зірок: розпливчаті крапки"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "Стиль зірок: крапки"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "Стиль зірок: масштабовані диски"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "Хвости комет увімкнено"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "Хвости комет вимкнено"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "Шлях відтворення: OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "&Особливий"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "&Звичайний"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "Автозбільшення увімкнено"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "Автозбільшення вимкнено"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "Час та скрипт призупинено"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "Час зупинено"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "Поновити"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "   Колір зірок особливий"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "   Колір зірок особливий"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "Світлове запізнювання:  %.4f р "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "Світлове запізнювання:  %d хв  %.1f сек"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "Світлове запізнювання:  %d год  %d хв  %.1f сек"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "З врахуванням світлового запізнювання"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "Без врахування світлового запізнювання"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "Світлове запізнювання ігнорується"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "Використання нормальних текстур поверхонь."
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "Використання межі знань текстур поверхонь"
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "Стеження"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "Час: вперед"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "Час: назад"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "Швидкість"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "Текстури"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "Текстури"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "Текстури"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "Синхронна орбіта"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "Заблокувати"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "Гонитва"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "Межа величини: %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "Межа автозбільшення на 45 градусів:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "Рівень розсіювання світла:  %.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "Підсилення світла"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Блимання увімкнено"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Блимання вимкнено"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "Експозиція"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "Помилка GL: "
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "Зображення дуже мале для поділу"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "Доданий перегляд"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "св. р."
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "а. о."
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr " м/с"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr " м/с"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " днів"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " годин"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " хвилин"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " секунд"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "Період обертання: "
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " св. р./с"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr " а. о./с"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr " км/с"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr " м/с"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "Швидкість: "
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "Видимий діаметр: "
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "Видима зоряна величина: "
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "Абсолютна величина:"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Відстань: "
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "Центр тяжіння зоряної системи \n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "Абс. (вид.) величина: %.2f (%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "Світність: "
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "Нейтронна зірка"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "Чорна дірка"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Клас: "
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "Темп. поверхні: "
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "Має планетарну систему\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Відстань від центру:"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "Радіус: "
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "Фазовий кут: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "Температура: "
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  НТ"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "Реальний час"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-Реальний час"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "Час зупинений"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " раз швидше"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " раз повільніше"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (Призупинено)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "Кд/с: "
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "Подорож "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "Подорож "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Траєкторія "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Стеження "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Синхронна орбіта "
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Гонитва "
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "Назва цілі: "
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr "  Призупинено"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  Запис"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Пуск/Пауза    F12 Зупинка"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "Режим редагування"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "Завантаження каталогу зоряної системи: "
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "Завантаження каталогу зоряної системи: "
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "Завантаження каталогу зоряної системи: "
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "Завантаження каталогу зоряної системи: "
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "Помилка під час читання файла обраного."
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "Помилка під час читання файла налаштувань."
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Помилка під час ініціалізації бібліотеки SPICE."
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "Не вдалося прочитати базу даних зірок."
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Помилка під час відкриття каталогу віддалених об’єктів."
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Не вдалося прочитати базу даних зірок."
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Помилка під час відкриття каталогу сонячної системи.\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Помилка під час відкриття файла астероїдів."
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Помилка під час відкриття файла меж сузір’їв."
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "Помилка ініціалізації відображення"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "Помилка під час завантаження шрифту; текст не буде видимим.\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "Помилка під час читання покажчика "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "Завантажено покажчик "
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "Помилка під час читання назв у файлі зірок\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "Помилка відкриття"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "Помилка під час читання файла зірок\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "Помилка під час відкриття каталогу зірок "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "Підтримувані додатки:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1015,37 +993,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "Переглядач неба"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "&Інформація"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "Сонячна система"
 
@@ -1055,20 +1033,20 @@ msgstr "Сонячна система"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "Зірки"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr " віддалені об’єкти"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1078,123 +1056,119 @@ msgstr "Пошук затемнень"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Час"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "Путівник"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "На повний екран"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "Захопити &відео...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "Помилка під час відкриття файла астероїдів."
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "&Закладки"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "Зберегти як:"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " не є файлом PNG.\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "Захоплення відео"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "Захоплення відео"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "Захоплення відео"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "Роздільна здатність: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 #, fuzzy
 msgid "Frame rate:"
 msgstr "Частота кадрів:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "Копійована адреса"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "Завантаження адреси"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "&Відкрити скрипт..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "Створити теку закладок у цьому меню"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1211,349 +1185,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "Невідома помилка під час відкриття скрипту"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "Підтримувані додатки:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "Підтримувані додатки:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "Про Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 1.1 без додатків</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>OpenGL 1.1 без додатків</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>OpenGL 1.1 без додатків</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "Версія GLSL: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "Максимальна кількість текстур одночасно: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "Максимальний розмір текстури: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "Діапазон розмірів точки: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "Діапазон розмірів точки: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "Макс. розмір кубічної карти: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "Підтримувані додатки:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "Відеокарта: "
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "Захопити зображення"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "Захопити &зображення...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "Захоплення відео"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "Захопити &відео...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "Копіювати адресу"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "&Відкрити скрипт..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Налаштування Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "Ви&йти"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "Згладжування\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "&Навігація"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "В&ибрати"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "&Розташувати по центру\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "Вибор: "
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "Перейти до об'єкта..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "&Час"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "Встановити час..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "Показ"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "Об'єкти"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "Тіні від кілець"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "Стиль &зірок"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "Р&оздільна здатність"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "&Засоби керування"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "&Закладки"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "&Перегляд"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "Мультиперегляд"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "Розділити перегляд вертикально"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "Розділити &горизонтально\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "Розділити перегляд горизонтально"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "Розділити &вертикально\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "Циклічний перегляд"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "Єдина область"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "&Єдине вікно\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "Вилучити вікно"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "Вилучити"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "Видимі роздільники"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "Видимі роздільники активного"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "Синхронізувати час"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "&Довідка"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "Інформація щодо OpenGL"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "&Додати закладку"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "&Упорядкувати закладки..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "Завантаження"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "Скрипти"
@@ -1676,11 +1650,11 @@ msgstr " м/с"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "Позначки"
 
@@ -1696,7 +1670,7 @@ msgstr "&Розташувати по центру\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "Сузір'я"
 
@@ -1718,7 +1692,7 @@ msgstr "Гаразд"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "Орбіти"
 
@@ -1732,18 +1706,18 @@ msgstr "Орбіти"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "Планети"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "Карликові планети"
 
@@ -1756,16 +1730,16 @@ msgstr "Карликові планети"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "Місяці"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "Малі планети"
 
@@ -1778,10 +1752,10 @@ msgstr "Малі планети"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "Астероїди"
 
@@ -1794,10 +1768,10 @@ msgstr "Астероїди"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "Комети"
 
@@ -1814,11 +1788,11 @@ msgstr "Комети"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1836,7 +1810,7 @@ msgstr "При&скорення у 10 разів\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "Мітки"
 
@@ -1846,9 +1820,9 @@ msgstr "Мітки"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "Галактики"
 
@@ -1856,8 +1830,8 @@ msgstr "Галактики"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "Сферичні скупчення"
 
@@ -1877,9 +1851,9 @@ msgstr "Розсіяні скупчення"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "Туманності"
 
@@ -1891,48 +1865,48 @@ msgid "Locations"
 msgstr "Місця"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "Розсіяні скупчення"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "Хмари"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "Вогні нічного боку"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "Хвости комет"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "Атмосфери"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "Тіні від кілець"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "Тіні затемнення"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "Тіні хмар"
 
@@ -2005,237 +1979,237 @@ msgstr "Межа автозбільшення на 45 градусів:  %.2f"
 msgid "Magnitude limit: %L1"
 msgstr "Межа величини: %.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "Назва"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "Відстань (у св.р.)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "Вид. величина"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "Абс. величина"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "Тип"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "Зірки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "Найяскравіша"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "Фільтрування зірок"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "З планетами"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "Зірки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "Баріцентр"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "Неправильний спектральний тип у базі даних зірок, зірка №"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "Оновлення"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "&Позначити"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "Максимальна кількість зірок у списку"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "&Позначити"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "Позначки"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "Немає"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "Ромб"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "Трикутник"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "Квадрат"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "Плюс"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "Коло"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "Стрілка ліворуч"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "Стрілка праворуч"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "Стрілка вгору"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "Стрілка вниз"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "В&ибрати"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "Розмір:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "В&ибрати"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "Назва об'єктiв"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "Об'єкти"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "&Позначити"
@@ -2350,8 +2324,8 @@ msgstr "Від:"
 msgid "Behind %1"
 msgstr "Тривалість: %1"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2520,87 +2494,92 @@ msgstr "Розмір: %1 Мб"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 #, fuzzy
 msgid "Blackbody D65"
 msgstr "   Колір зірок особливий"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "Стиль &зірок"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "Місцевий формат"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "Часовий пояс"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "Відступ від UTC"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "Початок"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "Абс. (вид.) величина: "
 
@@ -2613,21 +2592,21 @@ msgid "&Select"
 msgstr "В&ибрати"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "По &центру"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "&Перейти"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "&Спостерігати"
 
@@ -2641,12 +2620,12 @@ msgid "Visible"
 msgstr "Видимі роздільники активного"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "&Зняти позначку"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "Виберіть режим дисплею"
@@ -2660,12 +2639,12 @@ msgid "Disk"
 msgstr "Диск"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "&Позначити"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "&Базові позначки"
 
@@ -2713,13 +2692,13 @@ msgid "Show &Terminator"
 msgstr "Показувати термінатор"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "&Альтернативні поверхні"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "Звичайні"
 
@@ -2731,7 +2710,7 @@ msgstr "Звичайні"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "Карликові планети"
@@ -2743,15 +2722,15 @@ msgstr "Карликові планети"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "Малі планети"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "Об'єкти"
@@ -2762,7 +2741,7 @@ msgid "Set Time"
 msgstr "Встановити час..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "Часовий пояс:"
 
@@ -2827,7 +2806,7 @@ msgid "Set Seconds"
 msgstr " секунд"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "Дата за юліанським календарем: "
 
@@ -2841,97 +2820,97 @@ msgstr "Дата за юліанським календарем: "
 msgid "Set time"
 msgstr "Встановити час..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "Баріцентр"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "Неправильний спектральний тип у базі даних зірок, зірка №"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "Планета"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "Карликова планета"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "Місяць"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "Малі планети"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "Астероїд"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "Комета"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "Космічні кораблі"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "&Базові позначки"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "Підрахувати"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "Перейти до поверхні"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "Невідома помилка під час відкриття скрипту"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "Астероїди"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "&Базові позначки"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "Інші особливості"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "Планети"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "Об'єкти"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3064,7 +3043,7 @@ msgstr "Роздільна здатність: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "Впорядкувати закладку"
 
@@ -3171,7 +3150,7 @@ msgstr "Показувати орбіти"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "Місця посадок"
@@ -3179,7 +3158,7 @@ msgstr "Місця посадок"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "Часткові траєкторії"
@@ -3187,49 +3166,49 @@ msgstr "Часткові траєкторії"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "Сітки"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "Екваторіальна"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "Екліптика"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "Галактика"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "Горизонтальна"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "Діаграми"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "Межі"
 
@@ -3431,41 +3410,41 @@ msgstr "Показ"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "Підтримувані додатки:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "Підтримувані додатки:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3711,13 +3690,13 @@ msgstr "&Про Celestia"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "Гаразд"
 
@@ -3806,7 +3785,7 @@ msgid "Create in >>"
 msgstr "Створити у >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "Створити теку..."
 
@@ -3887,7 +3866,7 @@ msgid "Go to Object"
 msgstr "Перейти до об'єкту"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "Перейти до"
 
@@ -3904,7 +3883,7 @@ msgid "Lat."
 msgstr "Шир."
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "Відстань"
 
@@ -3952,174 +3931,178 @@ msgstr "Мінімальний розмір об’єкта для познач�
 msgid "Size:"
 msgstr "Розмір:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "Перейменувати..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "Перейменувати закладку або теку"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "Нова назва"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "Встановити час імітації"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "Формат: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "Встановити поточний час системи"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "Переглядач зоряної системи"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "&Перейти до"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "Об'єкти зоряної системи"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "Переглядач зірок"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "Найближчі"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "Найяскравіша"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "З планетами"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "&Оновити"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "Критерій пошуку зірки"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "Максимальна кількість зірок у списку"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "Путівник"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "Оберіть призначення:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "Перегляд параметрів"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "Показувати"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "Кінгстон"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "Показ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "Лінія екліптики"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "Орбіти / Мітки"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "Назви латиною"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "Інформаційний текст"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "Коротко"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "Докладно"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "422"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "Кві"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "Лют"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "Січ"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "Чер"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "Бер"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "Тра"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "Сер"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "Гру"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "Лип"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "Лис"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "Жов"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "Вер"
 
@@ -4135,184 +4118,189 @@ msgstr "Дата"
 msgid "Start"
 msgstr "Початок"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "Віконний режим"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "Невидимі об’єкти"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "Син&хронна орбіта"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "&Інформація"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "Показувати осі тіла"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "Показувати осі вікна"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "Показувати напрямок на сонце"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "Показувати вектор швидкості"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "Показувати планетографічну сітку"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "Показувати термінатор"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "&Супутники"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "Тіла, що обертаються"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "Помилка під час завантаження шрифту; текст не буде видимим.\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "Помилка: "
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "Захоплення відео"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Засоби керування Celestia"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "Завантаження: "
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "Завантаження"
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "uk"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "Помилка під час читання файла налаштувань."
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "Завантаження адреси"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Версія: "
 
@@ -4348,17 +4336,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "Помилка під час читання файла зображення PNG "
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "Помилка під час відкриття файла скрипту."
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "Невідома помилка під час відкриття скрипту"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4370,7 +4362,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4381,11 +4373,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr ""
-"Помилка під час відкриття скрипту:\n"
-"«%s»"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "Помилка відкриття скрипту"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4393,8 +4383,8 @@ msgid "Script coroutine initialization failed"
 msgstr "Помилка під час ініціалізації підпрограми скрипту"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr ""
 "Помилка під час відкриття скрипту:\n"
 "«%s»"
@@ -4412,6 +4402,28 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "Помилка відкриття"
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "Шлях відтворення: OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Блимання увімкнено"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Блимання вимкнено"
+
+#~ msgid "Exposure"
+#~ msgstr "Експозиція"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "Захоплення відео"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr ""
+#~ "Помилка під час відкриття скрипту:\n"
+#~ "«%s»"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6793,9 +6805,6 @@ msgstr "Помилка відкриття"
 #~ msgid "GLSL version: "
 #~ msgstr "Версія GLSL: "
 
-#~ msgid "Error opening script"
-#~ msgstr "Помилка відкриття скрипту"
-
 #~ msgid "Error loading script"
 #~ msgstr "Помилка завантаження скрипту"
 
@@ -7333,9 +7342,6 @@ msgstr "Помилка відкриття"
 
 #~ msgid "Surface Temp: "
 #~ msgstr "Темп. поверхні:"
-
-#~ msgid "Radius: "
-#~ msgstr "Радіус: "
 
 #~ msgid "Rsun"
 #~ msgstr "R_сонця"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Levin Li <lilinfeng.app@outlook.com>, 2021\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/celestia/"
@@ -24,11 +24,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "夏令时"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "标准时间"
 
@@ -60,35 +60,35 @@ msgstr "%s：损坏的配置文件。\n"
 msgid "Loaded {} deep space objects\n"
 msgstr "已加载 %i 个深空天体\n"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "星系（哈勃分类：%s）"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "球状星团（核心半径：%4.2f'，King 模型聚度参数：%4.2f）"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "正在从 %s 文件加载图像\n"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "正在加载模型：%s\n"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
+#, fuzzy
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr "模型统计：%u 顶点，%u 原语，%u 材质（%u 唯一）\n"
 
-#: ../src/celengine/meshmanager.cpp:553
-#, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "加载模型 %s 时出错\n"
 
 #: ../src/celengine/nebula.cpp:39
@@ -104,113 +104,108 @@ msgstr "疏散星团"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr ".ssc 文件出错（行 %d）："
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr "错误的 GeomAlbedo 值：{}\n"
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr "错误的 Reflectivity 值：{}\n"
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr "错误的 BondAlbedo 值：{}\n"
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr "找不到“%s”的父级天体“%s”。\n"
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "警告：重复定义 %s %s\n"
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "可替换表面错误"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "地理位置错误"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "跨索引文件头错误\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "跨索引文件文本错误\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "加载跨索引文件失败 - 数据点 %u 错误\n"
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "加载跨索引文件失败 - 数据点 %u 错误\n"
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "恒星数据库中的恒星光谱型错误，恒星编号 #%u\n"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr "%d 个恒星在双星系统数据库中\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "总计恒星数：%d\n"
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr ".stc 文件出错（行 %i）：%s\n"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "无效恒星数据：恒星光谱型错误。\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "无效恒星数据：缺少恒星光谱类型。\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr "质心 %s 不存在。\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "无效恒星数据：缺少赤经\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "无效恒星数据：缺少赤纬。\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "无效恒星数据：缺少距离。\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "无效恒星数据：缺少星等。\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr "无效恒星数据：必须输入接近原始的恒星的绝对星等（非视星等）\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr "等级 %i，%.5f ly，%i 节点，%i 恒星\n"
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -247,507 +242,492 @@ msgstr "不支持的字节顺序 %i，缺少 %i。\n"
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "不支持的数字 %i，缺少 %i。\n"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 #, fuzzy
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr "路径 %s 不存在或者不是一个目录"
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 msgid "Error reading favorites file {}.\n"
 msgstr "读取收藏文件失败 {}。\n"
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr "无法确认收藏文件目录存在 {}\n"
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr "创建收藏文件目录失败 {}\n"
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "无效文件格式"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "极限星等：%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "标记已开启"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "标记已关闭"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "着陆"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "经纬仪模式已开启"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "经纬仪模式已关闭"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "星点渲染：模糊点"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "星点渲染：点"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "星点渲染：缩放点"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "彗尾渲染已开启"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "彗尾渲染已关闭"
 
-#: ../src/celestia/celestiacore.cpp:1188
-msgid "Render path: OpenGL 2.1"
-msgstr "渲染路径：OpenGL 2.1"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 msgid "Anti-aliasing enabled"
 msgstr "抗锯齿已开启"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 msgid "Anti-aliasing disabled"
 msgstr "抗锯齿已关闭"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "星等自动调节已开启"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "星等自动调节已关闭"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "取消"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "时间和脚本运行已暂停"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "时间已暂停"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "恢复"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 msgid "Star color: Blackbody D65"
 msgstr "恒星着色：黑体 D65"
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 msgid "Star color: Enhanced"
 msgstr "恒星着色：增强色"
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "光传播时间：%.4f yr"
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "光传播时间：%d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "光传播时间：%d h %d min %.1f s"
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "包含光传播时间延迟"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "关闭光传播时间延迟"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "忽略光传播时间延迟"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "调用一般表面纹理。"
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "调用知识界限表面纹理。"
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "跟随"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "时间：前进"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "时间：后退"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, c-format
 msgid "Time rate: %.6g"
 msgstr "时间步长：%.6g"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 msgid "Low res textures"
 msgstr "低分辨率纹理"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 msgid "Medium res textures"
 msgstr "中分辨率纹理"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 msgid "High res textures"
 msgstr "高分辨率纹理"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "同步轨道"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "锁定"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "追逐"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "极限星等：%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "45° 视野区内星等自动调节：%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "环境光等级：%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "增光"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "Bloom 已开启"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "Bloom 已关闭"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "曝光"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL 错误："
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "视窗太小不能再分割"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "已增加视窗"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr "Mpc"
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr "kpc"
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "ly"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "AU"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr "m"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 msgid "days"
 msgstr "天"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "hours"
 msgstr "小时"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 msgid "minutes"
 msgstr "分钟"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 msgid "seconds"
 msgstr "秒"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "自转周期：%s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, fuzzy, c-format
 msgid "Mass: %.6g lb\n"
 msgstr "质量：%.6g kg\n"
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr "质量：%.6g kg\n"
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr "质量：%.2f Mj\n"
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr "质量：%.2f Me\n"
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 msgid "ly/s"
 msgstr "ly/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 msgid "AU/s"
 msgstr "AU/s"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 msgid "km/s"
 msgstr "km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 msgid "m/s"
 msgstr "m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr "速度：%s %s\n"
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr "Dec: %+d%s %02d' %.1f\"\n"
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr "RA: %dh %02dm %.1fs\n"
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "视直径：%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "视星等：%.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "绝对星等：%.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, fuzzy, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr "%.6f%c %.6f%c %f km"
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, c-format
 msgid "Distance: %s\n"
 msgstr "距离：%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "星系质心\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "绝对星等（视星等）：%.2f（%.2f）\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "光度: %s Lsun\n"
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "中子星"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "黑洞"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, c-format
 msgid "Class: %s\n"
 msgstr "类别：%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2860
-#, c-format
-msgid "Surface temp: %s K\n"
+#: ../src/celestia/celestiacore.cpp:2905
+#, fuzzy, c-format
+msgid "Surface temp: %s\n"
 msgstr "表面温度：%s K\n"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "半径：%s Rsun（%s km）\n"
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "半径：%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "拥有行星\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "到中心的距离：%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, c-format
+msgid "Radius: %s\n"
+msgstr "半径：%s\n"
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "相位角：%.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, fuzzy, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr "密度：%.2f× 1000 kg/m^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr "密度：%.2f× 1000 kg/m^3\n"
 
-#: ../src/celestia/celestiacore.cpp:2999
-#, c-format
-msgid "Temperature: %.0f K\n"
+#: ../src/celestia/celestiacore.cpp:3045
+#, fuzzy, c-format
+msgid "Temperature: %s\n"
 msgstr "温度：%.0f K\n"
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr " 本地时间"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "实时"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-实时"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "时间已停止"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, c-format
 msgid "%.6g x faster"
 msgstr "加快 %.6g 倍"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, c-format
 msgid "%.6g x slower"
 msgstr "减慢至 1/%.6g"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr "（已暂停）"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
@@ -756,193 +736,192 @@ msgstr ""
 "FPS：%.1f，可见恒星统计：[ %zu : %zu : %zu ]，可见深空天体统计：[ %zu : "
 "%zu : %zu ]\n"
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, c-format
 msgid "FPS: %.1f\n"
 msgstr "FPS：%.1f\n"
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "正在飞行（%s）\n"
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, c-format
+#: ../src/celestia/celestiacore.cpp:3291
 msgid "Travelling\n"
 msgstr "正在飞行\n"
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, c-format
 msgid "Track %s\n"
 msgstr "跟踪 %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, c-format
 msgid "Follow %s\n"
 msgstr "跟随 %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "同步轨道 %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "锁定 %s -> %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, c-format
 msgid "Chase %s\n"
 msgstr "追逐 %s\n"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr "FOV：%s（%.2f×）\n"
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, c-format
 msgid "Target name: %s"
 msgstr "目标名称：%s"
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, fuzzy, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr "%d×%d 于 %f FPS  %s"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Paused"
 msgstr "已暂停"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 msgid "Recording"
 msgstr "正在录像"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 开始/暂停    F12 停止"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "编辑模式"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "跳过太阳系目录：%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "正在加载太阳系目录：%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "跳过 %s 目录：%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "正在加载 %s 目录：%s\n"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "读取收藏文件失败 {}。\n"
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "读取配置文件时出错。"
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "Spice 库初始化失败。"
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "无法读取星体数据库。"
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "读取深空天体目录文件 %s 时出错。\n"
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "深空天体数据库 %s 无法读取。\n"
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "打开太阳系目录文件 %s 时出错。\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "打开星群文件 %s 时出错。\n"
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "打开星座边界文件 %s 时出错。\n"
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "渲染器初始化失败"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "读取字体时出错，文字将无法显示。\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "读取跨索引文件 %s 时出错\n"
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "已加载跨索引文件 %s\n"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "读取恒星名称文件时出错\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "打开 %s 时出错\n"
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "读取恒星文件时出错\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "读取恒星目录文件 %s 时出错\n"
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr "无效 URL"
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr "无法捕获当前帧\n"
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "不支持的 URL 模式“%s”！\n"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr "Celestia 无法初始化 OpenGL 2.1。\n"
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr "请使用以“.jpg”或“.png”结尾的名称。"
 
@@ -1001,36 +980,36 @@ msgstr "插入器数量：%s\n"
 msgid "Max anisotropy filtering: %s\n"
 msgstr "最大各项异性过滤：%s\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr "自动"
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr "自定义"
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr "Celestia 无法运行，因为找不到数据目录，可能是安装不当。"
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "天体浏览器"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 msgid "Info Browser"
 msgstr "信息浏览器"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "太阳系"
 
@@ -1040,19 +1019,19 @@ msgstr "太阳系"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "恒星"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 msgid "Deep Sky Objects"
 msgstr "深空天体"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 msgid "Event Finder"
 msgstr "事件查找器"
@@ -1061,110 +1040,107 @@ msgstr "事件查找器"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "时间"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "向导"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 msgid "Full screen"
 msgstr "全屏"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 msgid "Shift+F11"
 msgstr "Shift+F11"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 msgid "Error opening bookmarks file"
 msgstr "打开书签时出错"
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 msgid "Error Saving Bookmarks"
 msgstr "保存书签时出错"
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 msgid "Save Image"
 msgstr "保存图像"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 msgid "Images (*.png *.jpg)"
 msgstr "图像（*.png *.jpg）"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "屏幕录制"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-msgid "Video (*.avi)"
-msgstr "视频（*.avi）"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "视频（*.avi）"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 msgid "Resolution:"
 msgstr "分辨率："
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr "%1 × %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "帧率："
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr "截取屏幕快照到剪贴板"
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "已复制 URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 msgid "Pasting URL"
 msgstr "加载 URL"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 msgid "Open Script"
 msgstr "打开脚本"
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr "Celestia 脚本（*.celx *.cel）"
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 msgid "New bookmark"
 msgstr "新建书签"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, fuzzy, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1192,302 +1168,302 @@ msgstr ""
 "a><br>GitHub project: <a href=\"https://github.com/CelestiaProject/Celestia"
 "\">https://github.com/CelestiaProject/Celestia</a></p></html>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 msgid "Unknown compiler"
 msgstr "未知编译器"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 msgid "supported"
 msgstr "支持"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 msgid "not supported"
 msgstr "不支持"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "关于 Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>%1 版本：</b>%2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>厂商：</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>渲染器：</b>%1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "<b>%1 版本：</b>%2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "<b>最大同步纹理</b> %1："
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "<b>最大纹理尺寸：</b>%1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "<b>点大小范围：</b> %1 - %2"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "<b>点大小粒度：</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "<b>最大立方体贴图尺寸：</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "<b>插值数：</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr "<b>最大各向异性过滤：</b> %1"
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>支持的扩展：</b><br>\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 msgid "Renderer Info"
 msgstr "渲染器信息"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "文件(&F)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 msgid "&Grab image"
 msgstr "捕捉图像(&G)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 msgid "F10"
 msgstr "F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 msgid "Capture &video"
 msgstr "屏幕录制(&V)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 msgid "Shift+F10"
 msgstr "Shift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 msgid "&Copy image"
 msgstr "复制图像"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 msgid "Ctrl+Shift+C"
 msgstr "Ctrl+Shift+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "打开脚本(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 msgid "&Preferences..."
 msgstr "偏好(&P)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "退出(&X)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 msgid "Ctrl+Q"
 msgstr "Ctrl+Q"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "导航(&N)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 msgid "Select Sun"
 msgstr "选择太阳"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 msgid "Center Selection"
 msgstr "置中所选天体"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 msgid "Goto Selection"
 msgstr "转到所选天体"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "转到天体..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr "复制 URL/控制台文本"
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr "粘贴 URL/控制台文本"
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "时间(&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 msgid "Set &time"
 msgstr "设置时间(&T)"
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 msgid "&Display"
 msgstr "显示(&D)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 msgid "Dee&p Sky Objects"
 msgstr "深空天体(&P)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 msgid "&Shadows"
 msgstr "阴影"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "恒星样式(&Y)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 msgid "Texture &Resolution"
 msgstr "纹理分辨率(&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 msgid "&FPS control"
 msgstr "FPS 控制(&F)"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "书签(&B)"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "视窗(&V)"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 msgid "&MultiView"
 msgstr "多重视窗(&M)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 msgid "Split view vertically"
 msgstr "垂直分割视窗"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 msgid "Split view horizontally"
 msgstr "水平分割视窗"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 msgid "Ctrl+U"
 msgstr "Ctrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 msgid "Cycle views"
 msgstr "切换视窗"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr "Tab"
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 msgid "Single view"
 msgstr "单视窗"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 msgid "Ctrl+D"
 msgstr "Ctrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 msgid "Delete view"
 msgstr "删除视窗"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "删除"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 msgid "Frames visible"
 msgstr "显示视窗框架"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 msgid "Active frame visible"
 msgstr "激活视窗框架显示"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 msgid "Synchronize time"
 msgstr "同步时间"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "帮助(&H)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 msgid "Celestia Manual"
 msgstr "Celestia 手册"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 msgid "OpenGL Info"
 msgstr "OpenGL 信息"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 msgid "Add Bookmark..."
 msgstr "添加书签..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 msgid "Organize Bookmarks..."
 msgstr "管理书签..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr "设置自定义 FPS"
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr "FPS 值"
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, qt-format
 msgid ""
 "Loading data files: %1\n"
@@ -1496,7 +1472,7 @@ msgstr ""
 "正在加载数据文件：%1\n"
 "\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "脚本"
@@ -1605,11 +1581,11 @@ msgstr "M"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "标记"
 
@@ -1624,7 +1600,7 @@ msgstr "C"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "星座"
 
@@ -1643,7 +1619,7 @@ msgstr "O"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "轨道"
 
@@ -1657,18 +1633,18 @@ msgstr "轨道"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "行星"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "矮行星"
 
@@ -1681,16 +1657,16 @@ msgstr "矮行星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "卫星"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "子卫星"
 
@@ -1703,10 +1679,10 @@ msgstr "子卫星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "小行星"
 
@@ -1719,10 +1695,10 @@ msgstr "小行星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "彗星"
 
@@ -1739,11 +1715,11 @@ msgstr "彗星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 msgctxt "plural"
 msgid "Spacecraft"
 msgstr "航天器"
@@ -1759,7 +1735,7 @@ msgstr "L"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "标签"
 
@@ -1769,9 +1745,9 @@ msgstr "标签"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "星系"
 
@@ -1779,8 +1755,8 @@ msgstr "星系"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "球状星团"
 
@@ -1799,9 +1775,9 @@ msgstr "疏散星团"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "星云"
 
@@ -1813,48 +1789,48 @@ msgid "Locations"
 msgstr "位置"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "疏散星团"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "云层"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "夜视光"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "彗尾"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "大气层"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "光环投影"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "日食投影"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "云层投影"
 
@@ -1920,223 +1896,223 @@ msgstr "45° 视野区内星等自动调节：%L1"
 msgid "Magnitude limit: %L1"
 msgstr "极限星等：%L1"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "名称"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "距离（ly）"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "视星等"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "绝对星等"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "类型"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 msgid "Closest Stars"
 msgstr "最近的恒星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 msgid "Brightest Stars"
 msgstr "最亮的恒星"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 msgid "Filter"
 msgstr "过滤器"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "拥有行星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 msgid "Multiple Stars"
 msgstr "多重恒星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 msgid "Barycenters"
 msgstr "质心"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 msgid "Spectral Type"
 msgstr "光谱型"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "刷新"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 msgid "Mark Selected"
 msgstr "标记所选天体"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 msgid "Mark stars selected in list view"
 msgstr "标记在列表视图中所选的恒星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 msgid "Unmark Selected"
 msgstr "取消标记所选天体"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr "取消标记在列表视图中选择的恒星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 msgid "Clear Markers"
 msgstr "清除标记"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr "移除所有现有标记"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "无"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "菱形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "三角形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "正方形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "+"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "圆形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "左箭头"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "右箭头"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "上箭头"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "下箭头"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 msgid "Select marker symbol"
 msgstr "选择标记样式"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 msgid "Select marker size"
 msgstr "选择标记大小"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 msgid "Click to select marker color"
 msgstr "单击以选择标记颜色"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 msgid "Label"
 msgstr "标签"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, qt-format
 msgid "%1 objects found"
 msgstr "%1 个天体被找到"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr "标记在列表视图中所选的深空天体"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 msgid "Unmark DSOs selected in list view"
 msgstr "取消标记在列表视图中所选的深空天体"
 
@@ -2241,8 +2217,9 @@ msgstr "从 %1 的表面"
 msgid "Behind %1"
 msgstr "在 %1 后"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+#, fuzzy
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia 无法初始化 OpenGL 2.1。"
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2408,81 +2385,86 @@ msgstr "<b>L：</b> %L1%2 %L3' %L4\""
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B：</b> %L1%2 %L3' %L4\""
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr "--dir 后面应该包含目录"
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr "--conf 后面应该包含配置文件名称"
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr "-extrasdir 后面应该包含目录"
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr "--url 后面应该包含 URL"
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr "--log/-l 后面应该包含文件名"
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr "无效的命令行参数‘%s’"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.1"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr "黑体 D65"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 msgid "Classic colors"
 msgstr "传统着色"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 msgid "Local format"
 msgstr "本地格式"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 msgid "Time zone name"
 msgstr "时区名称"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 msgid "UTC offset"
 msgstr "与 UTC 的差异"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, qt-format
 msgid "Start: %1"
 msgstr "开始：%1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr "结束：%1"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
-msgstr "%.3f 千米"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
+msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
-msgstr "%.3f 米"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
+msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "距离："
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "绝对星等（视星等）："
 
@@ -2495,21 +2477,21 @@ msgid "&Select"
 msgstr "选择(&S)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "置中(&C)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "转到(&G)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "跟随(&F)"
 
@@ -2522,12 +2504,12 @@ msgid "Visible"
 msgstr "可见"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "取消标记(&U)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "选择主体"
@@ -2541,12 +2523,12 @@ msgid "Disk"
 msgstr "盘"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "标记(&M)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "参考标记(&R)"
 
@@ -2587,13 +2569,13 @@ msgid "Show &Terminator"
 msgstr "显示晨昏线(&T)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "替换表面(&A)"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "一般"
 
@@ -2605,7 +2587,7 @@ msgstr "一般"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 msgid "Dwarf planets"
 msgstr "矮行星"
 
@@ -2616,14 +2598,14 @@ msgstr "矮行星"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 msgid "Minor moons"
 msgstr "子卫星"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 msgid "Other objects"
 msgstr "其他天体"
 
@@ -2632,7 +2614,7 @@ msgid "Set Time"
 msgstr "设置时间"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "时区："
 
@@ -2688,7 +2670,7 @@ msgid "Set Seconds"
 msgstr "设置秒钟"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "儒略日："
 
@@ -2700,85 +2682,85 @@ msgstr "设置儒略日"
 msgid "Set time"
 msgstr "设置时间"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "质心 "
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 msgid "Star"
 msgstr "恒星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "行星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 msgid "Dwarf planet"
 msgstr "矮行星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "月球"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 msgid "Minor moon"
 msgstr "子卫星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "小行星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "彗星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "航天器"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 msgid "Reference point"
 msgstr "参考点"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 msgid "Component"
 msgstr "成分"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 msgid "Surface feature"
 msgstr "表面特征"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 msgid "Unknown"
 msgstr "未知"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 msgid "Asteroids & comets"
 msgstr "小行星&彗星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 msgid "Reference points"
 msgstr "参考点"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr "成分"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 msgid "Surface features"
 msgstr "表面特征"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 msgid "Planets and moons"
 msgstr "行星和卫星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 msgid "Group objects by class"
 msgstr "按类别对天体分组"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr "标记在列表中所选的天体"
 
@@ -2894,7 +2876,7 @@ msgstr "描述："
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "管理书签"
 
@@ -2989,63 +2971,63 @@ msgstr "显示轨道"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 msgid "Fading orbits"
 msgstr "渐变轨道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 msgid "Partial trajectories"
 msgstr "部分轨道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "网格"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "赤道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "黄道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "银道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "地平线"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "星座线"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "星座边界"
 
@@ -3226,44 +3208,44 @@ msgstr "日期显示格式："
 msgid "Not an XBEL version 1.0 file."
 msgstr "XBEL 1.0 版本文件不存在"
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 #, fuzzy
 msgid "Incorrect hex value \"{}\"\n"
 msgstr "无效的十六进制数值 “%s”\n"
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 #, fuzzy
 msgid "URL must start with \"{}\"!\n"
 msgstr "URL 开头必须为“%s”！\n"
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr "URL 需要至少包含模式和时间！\n"
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "不支持的 URL 模式“%s”！\n"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr "URL 必须只包含一个物体\n"
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr "URL 必须包含两个物体\n"
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 #, fuzzy
 msgid "Invalid URL version \"{}\"!\n"
 msgstr "无效的 URL 版本“%s”！\n"
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "不支持的 URL 版本：%i\n"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr "URL 参数必须为 key=value\n"
 
@@ -3508,13 +3490,13 @@ msgstr "关于 Celestia(&A)"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 msgid "OK"
 msgstr "确定"
 
@@ -3599,7 +3581,7 @@ msgid "Create in >>"
 msgstr "建立于 >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "新建文件夹..."
 
@@ -3680,7 +3662,7 @@ msgid "Go to Object"
 msgstr "转到天体"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "转到"
 
@@ -3697,7 +3679,7 @@ msgid "Lat."
 msgstr "纬度"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "距离"
 
@@ -3745,169 +3727,173 @@ msgstr "最小标签大小"
 msgid "Size:"
 msgstr "大小："
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "重命名..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "重新命名书签或文件夹"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "新名称"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "设置模拟时间"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "格式："
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "设置为当前时间"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "类太阳系浏览器"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "转到(&G)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "类太阳系天体"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "恒星浏览器"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "按最近距离"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "按最大亮度"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 msgid "With planets"
 msgstr "拥有行星"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "刷新(&R)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "恒星查找标准"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "列表中可显示最多恒星数"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "向导"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "选择目标："
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "显示设置"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 msgid "Show:"
 msgstr "显示："
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 msgid "Rings"
 msgstr "星环"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 msgid "Display:"
 msgstr "显示："
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "黄道线"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 msgid "Body / Orbit / Label display"
 msgstr "天体/轨道/标签显示"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "拉丁名"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "文字信息"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "简单"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "详细"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "804"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "4"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "2"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "1"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "6"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "3"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "5"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "8"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "12"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "7"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "11"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "10"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "9"
 
@@ -3923,7 +3909,7 @@ msgstr "日期"
 msgid "Start"
 msgstr "开始"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
@@ -3931,152 +3917,157 @@ msgstr ""
 "找不到许可证文件！\n"
 "查看 http://www.gnu.org/copyleft/gpl.html"
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, fuzzy, c-format
+msgid "%d x %d"
+msgstr "%1 × %2"
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "窗口模式"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "不可见"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "同步轨道(&Y)"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "信息(&I)"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "显示赤道轴"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "显示黄道轴"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "显示太阳方向"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "显示速度矢量"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "显示经纬网格"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "显示明暗边界线"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "卫星(&S)"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "环绕的天体"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "无法切换到全屏模式；当前正处于窗口模式"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 msgid "Error"
 msgstr "错误"
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr "无法注册 window class"
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr "致命错误"
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr "无法获取 OpenGL 渲染可使用的正确像素格式。"
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr "您的系统不支持 OpenGL 2.1！"
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr "释放设备上下文失败。"
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr "另存为 - 指定文件保存截图"
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr "无法保存图片文件。"
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr "在开始录制新的视频前请停止当前视频录制。"
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr "另存为 - 指定文件保存视频"
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr "无法识别指定的文件扩展名。"
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 msgid "Could not capture movie."
 msgstr "无法录制视频。"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 msgid "Celestia Command Line Error"
 msgstr "Celestia 命令行错误"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "正在加载："
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 msgid "Loading data files..."
 msgstr "加载数据文件..."
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "zh_CN"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 msgid "Configuration file missing!"
 msgstr "找不到配置文件！"
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
@@ -4084,21 +4075,21 @@ msgstr ""
 "找到旧的收藏文件。.\n"
 "复制到新位置？"
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr "复制收藏文件？"
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr "无法创建应用程序窗口。"
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "加载 URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "版本："
 
@@ -4134,16 +4125,20 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "读取 PNG 图像文件 %s 时出错。\n"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "打开脚本文件时出错。"
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 msgid "Unknown error loading script"
 msgstr "加载脚本时出现未知错误"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4162,7 +4157,7 @@ msgstr ""
 "\n"
 "Y - 是，Esc - 取消，其他任意键 - 否"
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4178,8 +4173,8 @@ msgstr ""
 "是否信任该脚本并允许该行为？"
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
+#, fuzzy
+msgid "Error opening script {}"
 msgstr "打开脚本文件 %s 时出错"
 
 #: ../src/celscript/lua/luascript.cpp:107
@@ -4188,8 +4183,8 @@ msgid "Script coroutine initialization failed"
 msgstr "脚本子函数初始化失败"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "打开 LuaHook %s 时出错"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4204,6 +4199,30 @@ msgstr "GetTimeZoneInformation() 函数返回了一个未知数值\n"
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "错误打开 %s 或 。\n"
+
+#~ msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
+#~ msgstr "等级 %i，%.5f ly，%i 节点，%i 恒星\n"
+
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "渲染路径：OpenGL 2.1"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "Bloom 已开启"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "Bloom 已关闭"
+
+#~ msgid "Exposure"
+#~ msgstr "曝光"
+
+#~ msgid "Video (*.avi)"
+#~ msgstr "视频（*.avi）"
+
+#~ msgid "%.3f km"
+#~ msgstr "%.3f 千米"
+
+#~ msgid "%.3f m"
+#~ msgstr "%.3f 米"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestia.space\n"
-"POT-Creation-Date: 2021-12-19 21:13+0200\n"
+"POT-Creation-Date: 2022-08-02 19:45+0300\n"
 "PO-Revision-Date: 2018-05-28 21:03+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "DST"
 msgstr "日光節約時間"
 
-#: ../src/celengine/astro.cpp:707
+#: ../src/celengine/astro.cpp:708
 msgid "STD"
 msgstr "標準時間"
 
@@ -54,35 +54,34 @@ msgstr "讀取設定檔時發生錯誤。"
 msgid "Loaded {} deep space objects\n"
 msgstr "深太空天體"
 
-#: ../src/celengine/galaxy.cpp:210
+#: ../src/celengine/galaxy.cpp:416
 #, c-format
 msgid "Galaxy (Hubble type: %s)"
 msgstr "星系 (哈伯分類:%s)"
 
-#: ../src/celengine/globular.cpp:240
+#: ../src/celengine/globular.cpp:515
 #, c-format, qt-format
 msgid "Globular (core radius: %4.2f', King concentration: %4.2f)"
 msgstr "球狀星團 (核半徑: %4.2f', King 聚度: %4.2f)"
 
-#: ../src/celengine/image.cpp:291
+#: ../src/celengine/image.cpp:290
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "從檔案讀取影像"
 
-#: ../src/celengine/meshmanager.cpp:461
-#, fuzzy, c-format
-msgid "Loading model: %s\n"
+#: ../src/celengine/meshmanager.cpp:422
+#, fuzzy
+msgid "Loading model: {}\n"
 msgstr "載入模式:"
 
-#: ../src/celengine/meshmanager.cpp:543
-#, c-format
+#: ../src/celengine/meshmanager.cpp:494
 msgid ""
-"   Model statistics: %u vertices, %u primitives, %u materials (%u unique)\n"
+"   Model statistics: {} vertices, {} primitives, {} materials ({} unique)\n"
 msgstr ""
 
-#: ../src/celengine/meshmanager.cpp:553
-#, fuzzy, c-format
-msgid "Error loading model '%s'\n"
+#: ../src/celengine/meshmanager.cpp:504
+#, fuzzy
+msgid "Error loading model '{}'\n"
 msgstr "載入模式錯誤"
 
 #: ../src/celengine/nebula.cpp:39
@@ -98,113 +97,108 @@ msgstr "疏散星團"
 msgid "Error in .ssc file (line {}): {}\n"
 msgstr ".ssc 檔案發生錯誤 (行號:"
 
-#: ../src/celengine/solarsys.cpp:830
+#: ../src/celengine/solarsys.cpp:827
 msgid "Incorrect GeomAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:839
+#: ../src/celengine/solarsys.cpp:836
 msgid "Incorrect Reflectivity value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:847
+#: ../src/celengine/solarsys.cpp:844
 msgid "Incorrect BondAlbedo value: {}\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1250 ../src/celengine/solarsys.cpp:1311
+#: ../src/celengine/solarsys.cpp:1247 ../src/celengine/solarsys.cpp:1308
 #, c-format
 msgid "parent body '%s' of '%s' not found.\n"
 msgstr ""
 
-#: ../src/celengine/solarsys.cpp:1260
+#: ../src/celengine/solarsys.cpp:1257
 #, fuzzy, c-format
 msgid "warning duplicate definition of %s %s\n"
 msgstr "雙重定義警告-"
 
-#: ../src/celengine/solarsys.cpp:1291
+#: ../src/celengine/solarsys.cpp:1288
 msgid "bad alternate surface"
 msgstr "錯誤的替代表面"
 
-#: ../src/celengine/solarsys.cpp:1306
+#: ../src/celengine/solarsys.cpp:1303
 msgid "bad location"
 msgstr "錯誤的位置"
 
-#: ../src/celengine/stardb.cpp:584
+#: ../src/celengine/stardb.cpp:583
 msgid "Bad header for cross index\n"
 msgstr "錯誤的跨索引標頭\n"
 
-#: ../src/celengine/stardb.cpp:596
+#: ../src/celengine/stardb.cpp:595
 msgid "Bad version for cross index\n"
 msgstr "錯誤的跨索引版本\n"
 
-#: ../src/celengine/stardb.cpp:610
+#: ../src/celengine/stardb.cpp:609
 #, fuzzy
 msgid "Loading cross index failed\n"
 msgstr "載入跨索引失敗，於紀錄 "
 
-#: ../src/celengine/stardb.cpp:617
+#: ../src/celengine/stardb.cpp:616
 #, fuzzy
 msgid "Loading cross index failed at record {}\n"
 msgstr "載入跨索引失敗，於紀錄 "
 
-#: ../src/celengine/stardb.cpp:695
+#: ../src/celengine/stardb.cpp:694
 #, fuzzy
 msgid "Bad spectral type in star database, star #{}\n"
 msgstr "恆星資料庫內的光譜類型錯誤，恆星 #"
 
-#: ../src/celengine/stardb.cpp:710
+#: ../src/celengine/stardb.cpp:709
 #, fuzzy
 msgid "{} stars in binary database\n"
 msgstr " 個恆星在雙星資料庫裡\n"
 
-#: ../src/celengine/stardb.cpp:734
+#: ../src/celengine/stardb.cpp:733
 #, fuzzy
 msgid "Total star count: {}\n"
 msgstr "全部恆星數: "
 
-#: ../src/celengine/stardb.cpp:768
+#: ../src/celengine/stardb.cpp:767
 #, fuzzy
 msgid "Error in .stc file (line {}): {}\n"
 msgstr " .stc檔案內有錯誤 (行號:"
 
-#: ../src/celengine/stardb.cpp:798
+#: ../src/celengine/stardb.cpp:797
 msgid "Invalid star: bad spectral type.\n"
 msgstr "無效的恆星內容:錯誤的光譜型。\n"
 
-#: ../src/celengine/stardb.cpp:807
+#: ../src/celengine/stardb.cpp:806
 msgid "Invalid star: missing spectral type.\n"
 msgstr "無效的恆星內容:遺漏光譜型。\n"
 
-#: ../src/celengine/stardb.cpp:994
+#: ../src/celengine/stardb.cpp:993
 #, fuzzy
 msgid "Barycenter {} does not exist.\n"
 msgstr " 不存在。\n"
 
-#: ../src/celengine/stardb.cpp:1050
+#: ../src/celengine/stardb.cpp:1049
 msgid "Invalid star: missing right ascension\n"
 msgstr "無效的恆星內容:遺漏赤經\n"
 
-#: ../src/celengine/stardb.cpp:1063
+#: ../src/celengine/stardb.cpp:1062
 msgid "Invalid star: missing declination.\n"
 msgstr "無效的恆星內容:遺漏赤緯。\n"
 
-#: ../src/celengine/stardb.cpp:1076
+#: ../src/celengine/stardb.cpp:1075
 msgid "Invalid star: missing distance.\n"
 msgstr "無效的恆星內容:遺漏距離。\n"
 
-#: ../src/celengine/stardb.cpp:1110
+#: ../src/celengine/stardb.cpp:1109
 msgid "Invalid star: missing magnitude.\n"
 msgstr "無效的恆星內容:遺漏星等。\n"
 
-#: ../src/celengine/stardb.cpp:1127
+#: ../src/celengine/stardb.cpp:1126
 msgid ""
 "Invalid star: absolute (not apparent) magnitude must be specified for star "
 "near origin\n"
 msgstr "無效的恆星內容:靠近原點恆星的絕對星等(非視星等)一定要輸入\n"
-
-#: ../src/celengine/stardb.cpp:1432
-#, c-format
-msgid "Level %i, %.5f ly, %i nodes, %i  stars\n"
-msgstr ""
 
 #: ../src/celengine/texture.cpp:928
 #, fuzzy
@@ -239,721 +233,705 @@ msgstr ""
 msgid "Unsupported digits number {}, expected {}.\n"
 msgstr "支援的延伸功能:"
 
-#: ../src/celestia/celestiacore.cpp:102 ../src/celestia/scriptmenu.cpp:87
+#: ../src/celestia/celestiacore.cpp:147 ../src/celestia/scriptmenu.cpp:87
 #: ../src/celscript/lua/luascript.cpp:173
 msgid "Path {} doesn't exist or isn't a directory\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:203
+#: ../src/celestia/celestiacore.cpp:282
 #, fuzzy
 msgid "Error reading favorites file {}.\n"
 msgstr "讀取我的最愛檔案時發生錯誤。"
 
-#: ../src/celestia/celestiacore.cpp:224
+#: ../src/celestia/celestiacore.cpp:303
 msgid "Failed to check directory existance for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:232
+#: ../src/celestia/celestiacore.cpp:311
 msgid "Failed to create a directory for favorites file {}\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:352
+#: ../src/celestia/celestiacore.cpp:431
 msgid "Invalid filetype"
 msgstr "無效的檔案型態"
 
-#: ../src/celestia/celestiacore.cpp:690 ../src/celestia/celestiacore.cpp:1420
-#: ../src/celestia/celestiacore.cpp:1437
+#: ../src/celestia/celestiacore.cpp:769 ../src/celestia/celestiacore.cpp:1485
+#: ../src/celestia/celestiacore.cpp:1502
 #, c-format
 msgid "Magnitude limit: %.2f"
 msgstr "極限星等:%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1067
+#: ../src/celestia/celestiacore.cpp:1146
 msgid "Markers enabled"
 msgstr "標記已開啟"
 
-#: ../src/celestia/celestiacore.cpp:1070
+#: ../src/celestia/celestiacore.cpp:1149
 msgid "Markers disabled"
 msgstr "標記已關閉"
 
 #. Ctrl+G
-#: ../src/celestia/celestiacore.cpp:1080
+#: ../src/celestia/celestiacore.cpp:1159
 msgid "Goto surface"
 msgstr "前往表面"
 
-#: ../src/celestia/celestiacore.cpp:1091
+#: ../src/celestia/celestiacore.cpp:1170
 msgid "Alt-azimuth mode enabled"
 msgstr "經緯儀模式啟動"
 
-#: ../src/celestia/celestiacore.cpp:1094
+#: ../src/celestia/celestiacore.cpp:1173
 msgid "Alt-azimuth mode disabled"
 msgstr "經緯儀模式關閉"
 
-#: ../src/celestia/celestiacore.cpp:1150
+#: ../src/celestia/celestiacore.cpp:1229
 msgid "Star style: fuzzy points"
 msgstr "恆星樣式:模糊的點"
 
-#: ../src/celestia/celestiacore.cpp:1153
+#: ../src/celestia/celestiacore.cpp:1232
 msgid "Star style: points"
 msgstr "恆星樣式:點"
 
-#: ../src/celestia/celestiacore.cpp:1156
+#: ../src/celestia/celestiacore.cpp:1235
 msgid "Star style: scaled discs"
 msgstr "恆星樣式:按比例的盤面"
 
-#: ../src/celestia/celestiacore.cpp:1169
+#: ../src/celestia/celestiacore.cpp:1248
 msgid "Comet tails enabled"
 msgstr "彗尾已開啟動"
 
-#: ../src/celestia/celestiacore.cpp:1172
+#: ../src/celestia/celestiacore.cpp:1251
 msgid "Comet tails disabled"
 msgstr "彗尾已關閉"
 
-#: ../src/celestia/celestiacore.cpp:1188
-#, fuzzy
-msgid "Render path: OpenGL 2.1"
-msgstr "成像路徑:OpenGL 2.0"
-
-#: ../src/celestia/celestiacore.cpp:1207
+#: ../src/celestia/celestiacore.cpp:1264
 #, fuzzy
 msgid "Anti-aliasing enabled"
 msgstr "經緯儀模式啟動"
 
-#: ../src/celestia/celestiacore.cpp:1212
+#: ../src/celestia/celestiacore.cpp:1269
 #, fuzzy
 msgid "Anti-aliasing disabled"
 msgstr "經緯儀模式關閉"
 
-#: ../src/celestia/celestiacore.cpp:1221
+#: ../src/celestia/celestiacore.cpp:1278
 msgid "Auto-magnitude enabled"
 msgstr "自動調整星等已開啟"
 
-#: ../src/celestia/celestiacore.cpp:1226
+#: ../src/celestia/celestiacore.cpp:1283
 msgid "Auto-magnitude disabled"
 msgstr "自動調整星等已關閉"
 
-#: ../src/celestia/celestiacore.cpp:1248
+#: ../src/celestia/celestiacore.cpp:1305
 #: ../src/celestia/win32/res/resource_strings.cpp:93
 #: ../src/celestia/win32/res/resource_strings.cpp:98
 #: ../src/celestia/win32/res/resource_strings.cpp:105
 #: ../src/celestia/win32/res/resource_strings.cpp:118
 #: ../src/celestia/win32/res/resource_strings.cpp:127
 #: ../src/celestia/win32/res/resource_strings.cpp:147
-#: ../src/celestia/win32/res/resource_strings.cpp:155
-#: ../src/celestia/win32/res/resource_strings.cpp:161
-#: ../src/celestia/win32/res/resource_strings.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:235
+#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:171
+#: ../src/celestia/win32/res/resource_strings.cpp:237
 msgid "Cancel"
 msgstr "取消"
 
-#: ../src/celestia/celestiacore.cpp:1280
+#: ../src/celestia/celestiacore.cpp:1345
 msgid "Time and script are paused"
 msgstr "時間與腳本已暫停"
 
-#: ../src/celestia/celestiacore.cpp:1282
+#: ../src/celestia/celestiacore.cpp:1347
 msgid "Time is paused"
 msgstr "時間已暫停"
 
-#: ../src/celestia/celestiacore.cpp:1286
+#: ../src/celestia/celestiacore.cpp:1351
 msgid "Resume"
 msgstr "回復"
 
-#: ../src/celestia/celestiacore.cpp:1320
+#: ../src/celestia/celestiacore.cpp:1385
 #, fuzzy
 msgid "Star color: Blackbody D65"
 msgstr "全部恆星數: "
 
-#: ../src/celestia/celestiacore.cpp:1326
+#: ../src/celestia/celestiacore.cpp:1391
 #, fuzzy
 msgid "Star color: Enhanced"
 msgstr "全部恆星數: "
 
 #. Light travel time in years, if >= 1day
-#: ../src/celestia/celestiacore.cpp:1363
+#: ../src/celestia/celestiacore.cpp:1428
 #, fuzzy, c-format
 msgid "Light travel time:  %.4f yr"
 msgstr "光旅行時間:%.4f 年 "
 
-#: ../src/celestia/celestiacore.cpp:1372
+#: ../src/celestia/celestiacore.cpp:1437
 #, c-format
 msgid "Light travel time:  %d min  %.1f s"
 msgstr "光旅行時間:%d 分 %.1f 秒 "
 
-#: ../src/celestia/celestiacore.cpp:1377
+#: ../src/celestia/celestiacore.cpp:1442
 #, c-format
 msgid "Light travel time:  %d h  %d min  %.1f s"
 msgstr "光旅行時間:%d 小時 %d 分 %.1f 秒 "
 
-#: ../src/celestia/celestiacore.cpp:1395
+#: ../src/celestia/celestiacore.cpp:1460
 msgid "Light travel delay included"
 msgstr "包括光旅行延遲"
 
-#: ../src/celestia/celestiacore.cpp:1400
+#: ../src/celestia/celestiacore.cpp:1465
 msgid "Light travel delay switched off"
 msgstr "關閉光旅行延遲"
 
-#: ../src/celestia/celestiacore.cpp:1406
+#: ../src/celestia/celestiacore.cpp:1471
 msgid "Light travel delay ignored"
 msgstr "忽略光旅行延遲"
 
-#: ../src/celestia/celestiacore.cpp:1449
+#: ../src/celestia/celestiacore.cpp:1514
 msgid "Using normal surface textures."
 msgstr "使用一般表面紋理"
 
-#: ../src/celestia/celestiacore.cpp:1454
+#: ../src/celestia/celestiacore.cpp:1519
 msgid "Using limit of knowledge surface textures."
 msgstr "使用知識的界限表面紋理。"
 
-#: ../src/celestia/celestiacore.cpp:1521
+#: ../src/celestia/celestiacore.cpp:1586
 msgid "Follow"
 msgstr "跟隨天體"
 
-#: ../src/celestia/celestiacore.cpp:1546
+#: ../src/celestia/celestiacore.cpp:1611
 msgid "Time: Forward"
 msgstr "時間:前進"
 
-#: ../src/celestia/celestiacore.cpp:1548
+#: ../src/celestia/celestiacore.cpp:1613
 msgid "Time: Backward"
 msgstr "時間:後退"
 
-#: ../src/celestia/celestiacore.cpp:1560 ../src/celestia/celestiacore.cpp:1575
+#: ../src/celestia/celestiacore.cpp:1625 ../src/celestia/celestiacore.cpp:1640
 #, fuzzy, c-format
 msgid "Time rate: %.6g"
 msgstr "時間速率"
 
-#: ../src/celestia/celestiacore.cpp:1615
+#: ../src/celestia/celestiacore.cpp:1680
 #, fuzzy
 msgid "Low res textures"
 msgstr "紋理"
 
-#: ../src/celestia/celestiacore.cpp:1618
+#: ../src/celestia/celestiacore.cpp:1683
 #, fuzzy
 msgid "Medium res textures"
 msgstr "紋理"
 
-#: ../src/celestia/celestiacore.cpp:1621
+#: ../src/celestia/celestiacore.cpp:1686
 #, fuzzy
 msgid "High res textures"
 msgstr "紋理"
 
-#: ../src/celestia/celestiacore.cpp:1668
+#: ../src/celestia/celestiacore.cpp:1733
 msgid "Sync Orbit"
 msgstr "同步軌道"
 
-#: ../src/celestia/celestiacore.cpp:1674
+#: ../src/celestia/celestiacore.cpp:1739
 msgid "Lock"
 msgstr "鎖定"
 
-#: ../src/celestia/celestiacore.cpp:1680
+#: ../src/celestia/celestiacore.cpp:1745
 msgid "Chase"
 msgstr "追逐"
 
-#: ../src/celestia/celestiacore.cpp:1693 ../src/celestia/celestiacore.cpp:1724
+#: ../src/celestia/celestiacore.cpp:1758 ../src/celestia/celestiacore.cpp:1789
 #, fuzzy, c-format
 msgid "Magnitude limit:  %.2f"
 msgstr "極限星等:%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1704 ../src/celestia/celestiacore.cpp:1735
+#: ../src/celestia/celestiacore.cpp:1769 ../src/celestia/celestiacore.cpp:1800
 #, c-format
 msgid "Auto magnitude limit at 45 degrees:  %.2f"
 msgstr "45 度時自動調整星等限制:%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1754 ../src/celestia/celestiacore.cpp:1769
+#: ../src/celestia/celestiacore.cpp:1819 ../src/celestia/celestiacore.cpp:1834
 #, c-format
 msgid "Ambient light level:  %.2f"
 msgstr "環境光線等級:%.2f"
 
-#: ../src/celestia/celestiacore.cpp:1780 ../src/celestia/celestiacore.cpp:1791
+#: ../src/celestia/celestiacore.cpp:1845 ../src/celestia/celestiacore.cpp:1856
 #, c-format
 msgid "Light gain"
 msgstr "增光"
 
-#: ../src/celestia/celestiacore.cpp:1812
-msgid "Bloom enabled"
-msgstr "彗尾已啟動"
-
-#: ../src/celestia/celestiacore.cpp:1814
-msgid "Bloom disabled"
-msgstr "彗尾已關閉"
-
-#: ../src/celestia/celestiacore.cpp:1820 ../src/celestia/celestiacore.cpp:1828
-#, c-format
-msgid "Exposure"
-msgstr "曝光"
-
-#: ../src/celestia/celestiacore.cpp:2150
+#: ../src/celestia/celestiacore.cpp:2189
 msgid "GL error: "
 msgstr "GL 錯誤:"
 
-#: ../src/celestia/celestiacore.cpp:2299
+#: ../src/celestia/celestiacore.cpp:2348
 msgid "View too small to be split"
 msgstr "檢視過小無法分離"
 
-#: ../src/celestia/celestiacore.cpp:2319
+#: ../src/celestia/celestiacore.cpp:2368
 msgid "Added view"
 msgstr "已新增檢視"
 
-#: ../src/celestia/celestiacore.cpp:2495
+#: ../src/celestia/celestiacore.cpp:2541
 msgid "Mpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2500
+#: ../src/celestia/celestiacore.cpp:2546
 msgid "kpc"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2505
-#: ../src/celestia/qt/qtselectionpopup.cpp:108
+#: ../src/celestia/celestiacore.cpp:2551
 msgid "ly"
 msgstr "光年"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:194
 #. i18n: ectx: property (text), widget (QRadioButton, auButton)
-#: ../src/celestia/celestiacore.cpp:2509
-#: ../src/celestia/qt/qtselectionpopup.cpp:110 ../src/celestia/qt/rc.cpp:36
+#: ../src/celestia/celestiacore.cpp:2555 ../src/celestia/qt/rc.cpp:36
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "au"
 msgstr "天文單位"
 
-#: ../src/celestia/celestiacore.cpp:2516
+#: ../src/celestia/celestiacore.cpp:2562
 #, fuzzy
 msgid "mi"
 msgstr "m/s"
 
-#: ../src/celestia/celestiacore.cpp:2521
+#: ../src/celestia/celestiacore.cpp:2567
 msgid "ft"
 msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/celestiacore.cpp:2529 ../src/celestia/qt/qtinfopanel.cpp:124
+#: ../src/celestia/celestiacore.cpp:2575 ../src/celestia/qt/qtinfopanel.cpp:124
 #: ../src/celestia/qt/qtinfopanel.cpp:251 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:123
 msgid "km"
 msgstr "公里"
 
-#: ../src/celestia/celestiacore.cpp:2534 ../src/celestia/qt/qtinfopanel.cpp:128
+#: ../src/celestia/celestiacore.cpp:2580 ../src/celestia/qt/qtinfopanel.cpp:128
 #, fuzzy
 msgid "m"
 msgstr "m/s"
 
-#: ../src/celestia/celestiacore.cpp:2557 ../src/celestia/qt/qtinfopanel.cpp:180
+#: ../src/celestia/celestiacore.cpp:2603 ../src/celestia/qt/qtinfopanel.cpp:180
 #: ../src/celestia/qt/qtinfopanel.cpp:213
 #: ../src/celestia/qt/qtinfopanel.cpp:263
 #, fuzzy
 msgid "days"
 msgstr " 日"
 
-#: ../src/celestia/celestiacore.cpp:2562 ../src/celestia/qt/qtinfopanel.cpp:176
+#: ../src/celestia/celestiacore.cpp:2608 ../src/celestia/qt/qtinfopanel.cpp:176
 #: ../src/celestia/qt/qtinfopanel.cpp:209
 #, fuzzy
 msgid "hours"
 msgstr " 時"
 
-#: ../src/celestia/celestiacore.cpp:2567
+#: ../src/celestia/celestiacore.cpp:2613
 #, fuzzy
 msgid "minutes"
 msgstr " 分"
 
-#: ../src/celestia/celestiacore.cpp:2572
+#: ../src/celestia/celestiacore.cpp:2618
 #, fuzzy
 msgid "seconds"
 msgstr " 秒"
 
-#: ../src/celestia/celestiacore.cpp:2575
-#, fuzzy, c-format
-msgid "Rotation period: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2621
+#, fuzzy
+msgid "Rotation period: {} {}\n"
 msgstr "自轉週期:"
 
-#: ../src/celestia/celestiacore.cpp:2583
+#: ../src/celestia/celestiacore.cpp:2629
 #, c-format
 msgid "Mass: %.6g lb\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2585
+#: ../src/celestia/celestiacore.cpp:2631
 #, c-format
 msgid "Mass: %.6g kg\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2588
+#: ../src/celestia/celestiacore.cpp:2634
 #, c-format
 msgid "Mass: %.2f Mj\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2590
+#: ../src/celestia/celestiacore.cpp:2636
 #, c-format
 msgid "Mass: %.2f Me\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2601
+#: ../src/celestia/celestiacore.cpp:2647
 #, fuzzy
 msgid "ly/s"
 msgstr " ly/s"
 
-#: ../src/celestia/celestiacore.cpp:2606
+#: ../src/celestia/celestiacore.cpp:2652
 #, fuzzy
 msgid "AU/s"
 msgstr "天文單位"
 
-#: ../src/celestia/celestiacore.cpp:2618
+#: ../src/celestia/celestiacore.cpp:2664
 msgid "mi/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2623
+#: ../src/celestia/celestiacore.cpp:2669
 msgid "ft/s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2631
+#: ../src/celestia/celestiacore.cpp:2677
 #, fuzzy
 msgid "km/s"
 msgstr "km/s"
 
-#: ../src/celestia/celestiacore.cpp:2636
+#: ../src/celestia/celestiacore.cpp:2682
 #, fuzzy
 msgid "m/s"
 msgstr "m/s"
 
-#: ../src/celestia/celestiacore.cpp:2639
-#, fuzzy, c-format
-msgid "Speed: %s %s\n"
+#: ../src/celestia/celestiacore.cpp:2685
+#, fuzzy
+msgid "Speed: {} {}\n"
 msgstr ""
 "\n"
 "速度:"
 
-#: ../src/celestia/celestiacore.cpp:2673
+#: ../src/celestia/celestiacore.cpp:2717
 #, c-format, qt-format
 msgid "Dec: %+d%s %02d' %.1f\"\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2685
+#: ../src/celestia/celestiacore.cpp:2729
 #, c-format, qt-format
 msgid "RA: %dh %02dm %.1fs\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2701
+#: ../src/celestia/celestiacore.cpp:2745
 #, fuzzy, c-format
 msgid "Apparent diameter: %s\n"
 msgstr "視直徑:"
 
-#: ../src/celestia/celestiacore.cpp:2714
+#: ../src/celestia/celestiacore.cpp:2758
 #, fuzzy, c-format
 msgid "Apparent magnitude: %.1f\n"
 msgstr "視星等:"
 
-#: ../src/celestia/celestiacore.cpp:2718
+#: ../src/celestia/celestiacore.cpp:2762
 #, fuzzy, c-format
 msgid "Absolute magnitude: %.1f\n"
 msgstr "絕對星等:"
 
-#: ../src/celestia/celestiacore.cpp:2799
+#: ../src/celestia/celestiacore.cpp:2843
 #, c-format
 msgid "%.6f%c %.6f%c %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2826 ../src/celestia/celestiacore.cpp:2898
-#: ../src/celestia/celestiacore.cpp:2928 ../src/celestia/celestiacore.cpp:3009
+#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2943
+#: ../src/celestia/celestiacore.cpp:2974 ../src/celestia/celestiacore.cpp:3055
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "距離:"
 
-#: ../src/celestia/celestiacore.cpp:2830
+#: ../src/celestia/celestiacore.cpp:2875
 msgid "Star system barycenter\n"
 msgstr "恆星系統質心\n"
 
-#: ../src/celestia/celestiacore.cpp:2834
+#: ../src/celestia/celestiacore.cpp:2879
 #, c-format
 msgid "Abs (app) mag: %.2f (%.2f)\n"
 msgstr "絕對星等(視星等):%.2f(%.2f)\n"
 
-#: ../src/celestia/celestiacore.cpp:2839
-#, fuzzy, c-format
-msgid "Luminosity: %sx Sun\n"
+#: ../src/celestia/celestiacore.cpp:2884
+#, fuzzy
+msgid "Luminosity: {}x Sun\n"
 msgstr "光度:"
 
-#: ../src/celestia/celestiacore.cpp:2845
+#: ../src/celestia/celestiacore.cpp:2890
 msgid "Neutron star"
 msgstr "中子星"
 
-#: ../src/celestia/celestiacore.cpp:2848
+#: ../src/celestia/celestiacore.cpp:2893
 msgid "Black hole"
 msgstr "黑洞"
 
-#: ../src/celestia/celestiacore.cpp:2853
+#: ../src/celestia/celestiacore.cpp:2898
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "類別:"
 
-#: ../src/celestia/celestiacore.cpp:2860
+#: ../src/celestia/celestiacore.cpp:2905
 #, fuzzy, c-format
-msgid "Surface temp: %s K\n"
+msgid "Surface temp: %s\n"
 msgstr "表面溫度:"
 
-#: ../src/celestia/celestiacore.cpp:2865
-#, fuzzy, c-format
-msgid "Radius: %s Rsun  (%s)\n"
+#: ../src/celestia/celestiacore.cpp:2910
+#, fuzzy
+msgid "Radius: {} Rsun  ({})\n"
 msgstr "半徑:"
 
-#: ../src/celestia/celestiacore.cpp:2871 ../src/celestia/celestiacore.cpp:2906
-#: ../src/celestia/celestiacore.cpp:2935
-#, fuzzy, c-format
-msgid "Radius: %s\n"
+#: ../src/celestia/celestiacore.cpp:2916
+#, fuzzy
+msgid "Radius: {}\n"
 msgstr "半徑:"
 
-#: ../src/celestia/celestiacore.cpp:2887
+#: ../src/celestia/celestiacore.cpp:2932
 msgid "Planetary companions present\n"
 msgstr "呈現行星的伴星\n"
 
-#: ../src/celestia/celestiacore.cpp:2903
+#: ../src/celestia/celestiacore.cpp:2948
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "與中心距離:"
 
-#: ../src/celestia/celestiacore.cpp:2976
+#: ../src/celestia/celestiacore.cpp:2951 ../src/celestia/celestiacore.cpp:2981
+#, fuzzy, c-format
+msgid "Radius: %s\n"
+msgstr "半徑:"
+
+#: ../src/celestia/celestiacore.cpp:3022
 #, c-format
 msgid "Phase angle: %.1f%s\n"
 msgstr "相位角: %.1f%s\n"
 
-#: ../src/celestia/celestiacore.cpp:2992
+#: ../src/celestia/celestiacore.cpp:3038
 #, c-format
 msgid "Density: %.2f x 1000 lb/ft^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2994
+#: ../src/celestia/celestiacore.cpp:3040
 #, c-format
 msgid "Density: %.2f x 1000 kg/m^3\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2999
+#: ../src/celestia/celestiacore.cpp:3045
 #, fuzzy, c-format
-msgid "Temperature: %.0f K\n"
+msgid "Temperature: %s\n"
 msgstr "溫度:"
 
-#: ../src/celestia/celestiacore.cpp:3160
+#: ../src/celestia/celestiacore.cpp:3206
 msgid "  LT"
 msgstr "  本地時間"
 
-#: ../src/celestia/celestiacore.cpp:3169
+#: ../src/celestia/celestiacore.cpp:3215
 #: ../src/celestia/qt/qttimetoolbar.cpp:39
 #: ../src/celestia/qt/qttimetoolbar.cpp:54
 msgid "Real time"
 msgstr "即時"
 
-#: ../src/celestia/celestiacore.cpp:3171
+#: ../src/celestia/celestiacore.cpp:3217
 msgid "-Real time"
 msgstr "-即時"
 
-#: ../src/celestia/celestiacore.cpp:3175
+#: ../src/celestia/celestiacore.cpp:3221
 msgid "Time stopped"
 msgstr "時間已停止"
 
-#: ../src/celestia/celestiacore.cpp:3179
+#: ../src/celestia/celestiacore.cpp:3225
 #, fuzzy, c-format
 msgid "%.6g x faster"
 msgstr " 增快"
 
-#: ../src/celestia/celestiacore.cpp:3183
+#: ../src/celestia/celestiacore.cpp:3229
 #, fuzzy, c-format
 msgid "%.6g x slower"
 msgstr " 減慢"
 
-#: ../src/celestia/celestiacore.cpp:3189
+#: ../src/celestia/celestiacore.cpp:3235
 msgid " (Paused)"
 msgstr " (已暫停)"
 
-#: ../src/celestia/celestiacore.cpp:3208
+#: ../src/celestia/celestiacore.cpp:3254
 #, c-format
 msgid ""
 "FPS: %.1f, vis. stars stats: [ %zu : %zu : %zu ], vis. DSOs stats: [ %zu : "
 "%zu : %zu ]\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3217
+#: ../src/celestia/celestiacore.cpp:3263
 #, fuzzy, c-format
 msgid "FPS: %.1f\n"
 msgstr "每秒影格速率:"
 
-#: ../src/celestia/celestiacore.cpp:3242
-#, fuzzy, c-format
-msgid "Travelling (%s)\n"
+#: ../src/celestia/celestiacore.cpp:3288
+#, fuzzy
+msgid "Travelling ({})\n"
 msgstr "旅行中 "
 
-#: ../src/celestia/celestiacore.cpp:3245
-#, fuzzy, c-format
+#: ../src/celestia/celestiacore.cpp:3291
+#, fuzzy
 msgid "Travelling\n"
 msgstr "旅行中 "
 
-#: ../src/celestia/celestiacore.cpp:3254
+#: ../src/celestia/celestiacore.cpp:3300
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "追蹤 "
 
-#: ../src/celestia/celestiacore.cpp:3270
+#: ../src/celestia/celestiacore.cpp:3316
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "跟隨 "
 
-#: ../src/celestia/celestiacore.cpp:3274
+#: ../src/celestia/celestiacore.cpp:3320
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "同步軌道"
 
-#: ../src/celestia/celestiacore.cpp:3278
+#: ../src/celestia/celestiacore.cpp:3324
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3284
+#: ../src/celestia/celestiacore.cpp:3330
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "追逐"
 
-#: ../src/celestia/celestiacore.cpp:3298
+#: ../src/celestia/celestiacore.cpp:3344
 #, c-format
 msgid "FOV: %s (%.2fx)\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3481
+#: ../src/celestia/celestiacore.cpp:3529
 #, fuzzy, c-format
 msgid "Target name: %s"
 msgstr "目標名稱:"
 
-#: ../src/celestia/celestiacore.cpp:3568
+#: ../src/celestia/celestiacore.cpp:3605
 #, c-format
 msgid "%dx%d at %.2f fps  %s"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Paused"
 msgstr " 已暫停"
 
-#: ../src/celestia/celestiacore.cpp:3571
+#: ../src/celestia/celestiacore.cpp:3608
 #, fuzzy
 msgid "Recording"
 msgstr "  錄影中"
 
-#: ../src/celestia/celestiacore.cpp:3592
+#: ../src/celestia/celestiacore.cpp:3629
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 開始/暫停   F12 停止"
 
-#: ../src/celestia/celestiacore.cpp:3603 ../src/celestia/celestiacore.cpp:3608
+#: ../src/celestia/celestiacore.cpp:3640 ../src/celestia/celestiacore.cpp:3645
 msgid "Edit Mode"
 msgstr "編輯模式"
 
-#: ../src/celestia/celestiacore.cpp:3641
+#: ../src/celestia/celestiacore.cpp:3678
 #, fuzzy
 msgid "Skipping solar system catalog: {}\n"
 msgstr "載入太陽系目錄:"
 
-#: ../src/celestia/celestiacore.cpp:3644
+#: ../src/celestia/celestiacore.cpp:3681
 #, fuzzy
 msgid "Loading solar system catalog: {}\n"
 msgstr "載入太陽系目錄:"
 
-#: ../src/celestia/celestiacore.cpp:3687
+#: ../src/celestia/celestiacore.cpp:3724
 #, fuzzy
 msgid "Skipping {} catalog: {}\n"
 msgstr "載入太陽系目錄:"
 
-#: ../src/celestia/celestiacore.cpp:3690
+#: ../src/celestia/celestiacore.cpp:3727
 #, fuzzy
 msgid "Loading {} catalog: {}\n"
 msgstr "載入太陽系目錄:"
 
-#: ../src/celestia/celestiacore.cpp:3698
+#: ../src/celestia/celestiacore.cpp:3735
 #, fuzzy
 msgid "Error reading {} catalog file: {}\n"
 msgstr "讀取我的最愛檔案時發生錯誤。"
 
-#: ../src/celestia/celestiacore.cpp:3726
+#: ../src/celestia/celestiacore.cpp:3767
 msgid "Error reading configuration file."
 msgstr "讀取設定檔時發生錯誤。"
 
-#: ../src/celestia/celestiacore.cpp:3737
+#: ../src/celestia/celestiacore.cpp:3781
 msgid "Initialization of SPICE library failed."
 msgstr "初始化 SPICE 函式庫時失敗。"
 
-#: ../src/celestia/celestiacore.cpp:3780
+#: ../src/celestia/celestiacore.cpp:3824
 msgid "Cannot read star database."
 msgstr "無法讀取星體資料庫。"
 
-#: ../src/celestia/celestiacore.cpp:3801
+#: ../src/celestia/celestiacore.cpp:3845
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "開啟深空目錄時發生錯誤 "
 
-#: ../src/celestia/celestiacore.cpp:3805
+#: ../src/celestia/celestiacore.cpp:3849
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "無法讀取星體資料庫。"
 
-#: ../src/celestia/celestiacore.cpp:3854
+#: ../src/celestia/celestiacore.cpp:3898
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "開啟太陽系目錄時發生錯誤。\n"
 
-#: ../src/celestia/celestiacore.cpp:3894
+#: ../src/celestia/celestiacore.cpp:3938
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "開啟星群檔時發生錯誤。"
 
-#: ../src/celestia/celestiacore.cpp:3910
+#: ../src/celestia/celestiacore.cpp:3954
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "開啟星座邊界檔時發生錯誤。"
 
-#: ../src/celestia/celestiacore.cpp:4045
+#: ../src/celestia/celestiacore.cpp:4088
 msgid "Failed to initialize renderer"
 msgstr "初始化成像器失敗。"
 
-#: ../src/celestia/celestiacore.cpp:4061
+#: ../src/celestia/celestiacore.cpp:4104
 msgid "Error loading font; text will not be visible.\n"
 msgstr "載入字型時發生錯誤；將無法看到文字。\n"
 
-#: ../src/celestia/celestiacore.cpp:4109
+#: ../src/celestia/celestiacore.cpp:4140
 #, fuzzy
 msgid "Error reading cross index {}\n"
 msgstr "讀取跨索引時發生錯誤 "
 
-#: ../src/celestia/celestiacore.cpp:4111
+#: ../src/celestia/celestiacore.cpp:4142
 #, fuzzy
 msgid "Loaded cross index {}\n"
 msgstr "已載入跨索引"
 
-#: ../src/celestia/celestiacore.cpp:4128
+#: ../src/celestia/celestiacore.cpp:4159
 msgid "Error reading star names file\n"
 msgstr "讀取星體名稱檔時發生錯誤\n"
 
-#: ../src/celestia/celestiacore.cpp:4132 ../src/celestia/celestiacore.cpp:4146
+#: ../src/celestia/celestiacore.cpp:4163 ../src/celestia/celestiacore.cpp:4177
 #, fuzzy
 msgid "Error opening {}\n"
 msgstr "發生錯誤於開啟 "
 
-#: ../src/celestia/celestiacore.cpp:4154
+#: ../src/celestia/celestiacore.cpp:4185
 msgid "Error reading stars file\n"
 msgstr "讀取星體檔時發生錯誤\n"
 
-#: ../src/celestia/celestiacore.cpp:4180
+#: ../src/celestia/celestiacore.cpp:4211
 #, fuzzy
 msgid "Error opening star catalog {}\n"
 msgstr "開啟星體目錄時發生錯誤 "
 
-#: ../src/celestia/celestiacore.cpp:4542
+#: ../src/celestia/celestiacore.cpp:4571
 msgid "Invalid URL"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4767
+#: ../src/celestia/celestiacore.cpp:4800
 msgid "Unable to capture a frame!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:4779
+#: ../src/celestia/celestiacore.cpp:4811
 #, fuzzy
 msgid "Unsupported image type: {}!\n"
 msgstr "支援的延伸功能:"
 
-#: ../src/celestia/glut/glutmain.cpp:530
+#: ../src/celestia/glut/glutmain.cpp:524
 msgid "Celestia was unable to initialize OpenGL 2.1.\n"
 msgstr ""
 
-#: ../src/celestia/gtk/actions.cpp:1095 ../src/celestia/win32/winmain.cpp:2663
+#: ../src/celestia/gtk/actions.cpp:1100 ../src/celestia/win32/winmain.cpp:2719
 msgid "Please use a name ending in '.jpg' or '.png'."
 msgstr ""
 
@@ -1012,37 +990,37 @@ msgstr ""
 msgid "Max anisotropy filtering: %s\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:169
+#: ../src/celestia/qt/qtappwin.cpp:167
 msgid "Auto"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:175
+#: ../src/celestia/qt/qtappwin.cpp:173
 msgid "Custom"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:214
+#: ../src/celestia/qt/qtappwin.cpp:212
 msgid "Error getting path for log filename!"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:231
+#: ../src/celestia/qt/qtappwin.cpp:229
 msgid ""
 "Celestia is unable to run because the data directory was not found, probably "
 "due to improper installation."
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:297
+#: ../src/celestia/qt/qtappwin.cpp:294
 msgid "Celestial Browser"
 msgstr "天球瀏覽"
 
 #. Info browser for a selected object
-#: ../src/celestia/qt/qtappwin.cpp:303
+#: ../src/celestia/qt/qtappwin.cpp:300
 #, fuzzy
 msgid "Info Browser"
 msgstr "天球瀏覽"
 
 #. Set up the browser tabs
-#: ../src/celestia/qt/qtappwin.cpp:332
-#: ../src/celestia/win32/res/resource_strings.cpp:172
+#: ../src/celestia/qt/qtappwin.cpp:329
+#: ../src/celestia/win32/res/resource_strings.cpp:174
 msgid "Solar System"
 msgstr "太陽系"
 
@@ -1052,20 +1030,20 @@ msgstr "太陽系"
 #. i18n: ectx: property (text), widget (QCheckBox, starOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:499
 #. i18n: ectx: property (text), widget (QCheckBox, starLabelsCheck)
-#: ../src/celestia/qt/qtappwin.cpp:333
+#: ../src/celestia/qt/qtappwin.cpp:330
 #: ../src/celestia/qt/qtcelestiaactions.cpp:84
 #: ../src/celestia/qt/qtcelestiaactions.cpp:111 ../src/celestia/qt/rc.cpp:72
 #: ../src/celestia/qt/rc.cpp:154 ../src/celestia/qt/rc.cpp:221
-#: ../src/celestia/win32/res/resource_strings.cpp:212
+#: ../src/celestia/win32/res/resource_strings.cpp:214
 msgid "Stars"
 msgstr "星體"
 
-#: ../src/celestia/qt/qtappwin.cpp:334
+#: ../src/celestia/qt/qtappwin.cpp:331
 #, fuzzy
 msgid "Deep Sky Objects"
 msgstr "深太空天體"
 
-#: ../src/celestia/qt/qtappwin.cpp:341 ../src/celestia/qt/qteventfinder.cpp:335
+#: ../src/celestia/qt/qtappwin.cpp:338 ../src/celestia/qt/qteventfinder.cpp:335
 #: ../src/celestia/qt/qteventfinder.cpp:345
 #, fuzzy
 msgid "Event Finder"
@@ -1075,122 +1053,118 @@ msgstr "食相尋找器"
 #. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1034
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
-#: ../src/celestia/qt/qtappwin.cpp:350 ../src/celestia/qt/rc.cpp:351
+#: ../src/celestia/qt/qtappwin.cpp:347 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "時間"
 
 #. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
-#: ../src/celestia/qt/qtappwin.cpp:357 ../src/celestia/qt/rc.cpp:139
+#: ../src/celestia/qt/qtappwin.cpp:354 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
 msgstr "遊歷指導"
 
-#: ../src/celestia/qt/qtappwin.cpp:407
+#: ../src/celestia/qt/qtappwin.cpp:404
 #, fuzzy
 msgid "Full screen"
 msgstr "全螢幕"
 
-#: ../src/celestia/qt/qtappwin.cpp:409
+#: ../src/celestia/qt/qtappwin.cpp:406
 #, fuzzy
 msgid "Shift+F11"
 msgstr "抓取影片(&M)...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:564
+#: ../src/celestia/qt/qtappwin.cpp:560
 #, fuzzy
 msgid "Error opening bookmarks file"
 msgstr "開啟星群檔時發生錯誤。"
 
-#: ../src/celestia/qt/qtappwin.cpp:583
+#: ../src/celestia/qt/qtappwin.cpp:579
 #, fuzzy
 msgid "Error Saving Bookmarks"
 msgstr "新增書籤(&A)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:620
+#: ../src/celestia/qt/qtappwin.cpp:616
 #, fuzzy
 msgid "Save Image"
 msgstr "另存新檔"
 
-#: ../src/celestia/qt/qtappwin.cpp:622
+#: ../src/celestia/qt/qtappwin.cpp:618
 #, fuzzy
 msgid "Images (*.png *.jpg)"
 msgstr " 並不是一個PNG檔案。\n"
 
-#: ../src/celestia/qt/qtappwin.cpp:647 ../src/celestia/qt/qtappwin.cpp:652
-#: ../src/celestia/qt/qtappwin.cpp:665
+#: ../src/celestia/qt/qtappwin.cpp:642 ../src/celestia/qt/qtappwin.cpp:652
 msgid "Capture Video"
 msgstr "抓取影像"
 
-#: ../src/celestia/qt/qtappwin.cpp:649
-#, fuzzy
-msgid "Video (*.avi)"
-msgstr "抓取影像"
-
-#: ../src/celestia/qt/qtappwin.cpp:654
+#: ../src/celestia/qt/qtappwin.cpp:644
 #, fuzzy
 msgid "Matroska Video (*.mkv)"
 msgstr "抓取影像"
 
-#: ../src/celestia/qt/qtappwin.cpp:670
+#: ../src/celestia/qt/qtappwin.cpp:657
 #, fuzzy
 msgid "Resolution:"
 msgstr "解析度: "
 
-#: ../src/celestia/qt/qtappwin.cpp:673
+#: ../src/celestia/qt/qtappwin.cpp:660
 #, qt-format
 msgid "%1 x %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/qt/qtappwin.cpp:663
 #: ../src/celestia/win32/res/resource_strings.cpp:152
 msgid "Frame rate:"
 msgstr "影像速率:"
 
-#: ../src/celestia/qt/qtappwin.cpp:683
+#: ../src/celestia/qt/qtappwin.cpp:669
 msgid "Video codec:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:685
+#: ../src/celestia/qt/qtappwin.cpp:671
 msgid "Lossless"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:686
+#: ../src/celestia/qt/qtappwin.cpp:672
 msgid "Lossy (H.264)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:690
+#: ../src/celestia/qt/qtappwin.cpp:676
+#: ../src/celestia/win32/res/resource_strings.cpp:154
 msgid "Bitrate:"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:763
+#: ../src/celestia/qt/qtappwin.cpp:734
 msgid "Captured screen shot to clipboard"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:774 ../src/celestia/win32/winmain.cpp:3818
+#: ../src/celestia/qt/qtappwin.cpp:745 ../src/celestia/sdl/sdlmain.cpp:517
+#: ../src/celestia/win32/winmain.cpp:3873
 msgid "Copied URL"
 msgstr "已複製網址"
 
-#: ../src/celestia/qt/qtappwin.cpp:784
+#: ../src/celestia/qt/qtappwin.cpp:755 ../src/celestia/sdl/sdlmain.cpp:529
 #, fuzzy
 msgid "Pasting URL"
 msgstr "載入網址中"
 
-#: ../src/celestia/qt/qtappwin.cpp:908
+#: ../src/celestia/qt/qtappwin.cpp:879
 #, fuzzy
 msgid "Open Script"
 msgstr "開啟腳本(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:910
+#: ../src/celestia/qt/qtappwin.cpp:881
 msgid "Celestia Scripts (*.celx *.cel)"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1027
+#: ../src/celestia/qt/qtappwin.cpp:1034
 #, fuzzy
 msgid "New bookmark"
 msgstr "在本選單中建立新的書籤資料夾"
 
-#: ../src/celestia/qt/qtappwin.cpp:1082
+#: ../src/celestia/qt/qtappwin.cpp:1089
 #, qt-format
 msgid ""
 "<html><h1>Celestia 1.7</h1><p>Development snapshot, commit <b>%1</b>.</"
@@ -1207,349 +1181,349 @@ msgid ""
 "Celestia</a></p></html>"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1118
+#: ../src/celestia/qt/qtappwin.cpp:1125
 #, fuzzy
 msgid "Unknown compiler"
 msgstr "開啟腳本時發生未知的錯誤"
 
-#: ../src/celestia/qt/qtappwin.cpp:1122 ../src/celestia/qt/qtappwin.cpp:1127
+#: ../src/celestia/qt/qtappwin.cpp:1129 ../src/celestia/qt/qtappwin.cpp:1134
 #, fuzzy
 msgid "supported"
 msgstr "支援的延伸功能:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1124 ../src/celestia/qt/qtappwin.cpp:1129
+#: ../src/celestia/qt/qtappwin.cpp:1131 ../src/celestia/qt/qtappwin.cpp:1136
 #, fuzzy
 msgid "not supported"
 msgstr "支援的延伸功能:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1132 ../src/celestia/qt/qtappwin.cpp:1526
+#: ../src/celestia/qt/qtappwin.cpp:1139 ../src/celestia/qt/qtappwin.cpp:1533
 #: ../src/celestia/win32/res/resource_strings.cpp:70
 msgid "About Celestia"
 msgstr "關於 Celestia"
 
-#: ../src/celestia/qt/qtappwin.cpp:1151
+#: ../src/celestia/qt/qtappwin.cpp:1158
 #, fuzzy, qt-format
 msgid "<b>%1 version:</b> %2"
 msgstr "<b>OpenGL 2.0 Shading 語言</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1157
+#: ../src/celestia/qt/qtappwin.cpp:1164
 #, fuzzy, qt-format
 msgid "<b>Vendor:</b> %1"
 msgstr "<b>未延伸 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1163
+#: ../src/celestia/qt/qtappwin.cpp:1170
 #, fuzzy, qt-format
 msgid "<b>Renderer:</b> %1"
 msgstr "<b>未延伸 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1170
+#: ../src/celestia/qt/qtappwin.cpp:1177
 #, fuzzy, qt-format
 msgid "<b>%1 Version:</b> %2"
 msgstr "GLSL 版本:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1177
+#: ../src/celestia/qt/qtappwin.cpp:1184
 #, fuzzy, qt-format
 msgid "<b>Max simultaneous textures:</b> %1"
 msgstr "最大同時紋理:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1183
+#: ../src/celestia/qt/qtappwin.cpp:1190
 #, fuzzy, qt-format
 msgid "<b>Maximum texture size:</b> %1"
 msgstr "最大紋理尺寸:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1189
+#: ../src/celestia/qt/qtappwin.cpp:1196
 #, fuzzy, qt-format
 msgid "<b>Point size range:</b> %1 - %2"
 msgstr "點尺寸範圍:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1195
+#: ../src/celestia/qt/qtappwin.cpp:1202
 #, fuzzy, qt-format
 msgid "<b>Point size granularity:</b> %1"
 msgstr "點尺寸範圍:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1201
+#: ../src/celestia/qt/qtappwin.cpp:1208
 #, fuzzy, qt-format
 msgid "<b>Max cube map size:</b> %1"
 msgstr "最大立方體地圖尺寸:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1207
+#: ../src/celestia/qt/qtappwin.cpp:1214
 #, fuzzy, qt-format
 msgid "<b>Number of interpolators:</b> %1"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtappwin.cpp:1213
+#: ../src/celestia/qt/qtappwin.cpp:1220
 #, qt-format
 msgid "<b>Max anisotropy filtering:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1223
+#: ../src/celestia/qt/qtappwin.cpp:1230
 #, fuzzy
 msgid "<b>Supported extensions:</b><br>\n"
 msgstr "<b>未延伸 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtappwin.cpp:1237
+#: ../src/celestia/qt/qtappwin.cpp:1244
 #, fuzzy
 msgid "Renderer Info"
 msgstr "成像器:"
 
 #. ***** File menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1261
+#: ../src/celestia/qt/qtappwin.cpp:1268
 #: ../src/celestia/win32/res/resource_strings.cpp:1
 msgid "&File"
 msgstr "檔案(&F)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1264
+#: ../src/celestia/qt/qtappwin.cpp:1271
 #, fuzzy
 msgid "&Grab image"
 msgstr "抓取圖像"
 
-#: ../src/celestia/qt/qtappwin.cpp:1265
+#: ../src/celestia/qt/qtappwin.cpp:1272
 #, fuzzy
 msgid "F10"
 msgstr "抓取圖像(&I)...\tF10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1270
+#: ../src/celestia/qt/qtappwin.cpp:1277
 #, fuzzy
 msgid "Capture &video"
 msgstr "抓取影像"
 
-#: ../src/celestia/qt/qtappwin.cpp:1274
+#: ../src/celestia/qt/qtappwin.cpp:1281
 #, fuzzy
 msgid "Shift+F10"
 msgstr "抓取影片(&M)...\tShift+F10"
 
-#: ../src/celestia/qt/qtappwin.cpp:1278
+#: ../src/celestia/qt/qtappwin.cpp:1285
 #, fuzzy
 msgid "&Copy image"
 msgstr "複製網址"
 
-#: ../src/celestia/qt/qtappwin.cpp:1279
+#: ../src/celestia/qt/qtappwin.cpp:1286
 #, fuzzy
 msgid "Ctrl+Shift+C"
 msgstr "Alt+C"
 
-#: ../src/celestia/qt/qtappwin.cpp:1285
+#: ../src/celestia/qt/qtappwin.cpp:1292
 #: ../src/celestia/win32/res/resource_strings.cpp:2
 msgid "&Open Script..."
 msgstr "開啟腳本(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1296
+#: ../src/celestia/qt/qtappwin.cpp:1303
 #, fuzzy
 msgid "&Preferences..."
 msgstr "Celestia 偏好設定"
 
-#: ../src/celestia/qt/qtappwin.cpp:1300
+#: ../src/celestia/qt/qtappwin.cpp:1307
 #: ../src/celestia/win32/res/resource_strings.cpp:7
 msgid "E&xit"
 msgstr "離開(&X)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1301
+#: ../src/celestia/qt/qtappwin.cpp:1308
 #, fuzzy
 msgid "Ctrl+Q"
 msgstr "反鋸齒\tCtrl+X"
 
 #. ***** Navigation menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1306
+#: ../src/celestia/qt/qtappwin.cpp:1313
 #: ../src/celestia/win32/res/resource_strings.cpp:8
 msgid "&Navigation"
 msgstr "導覽(&N)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1308
+#: ../src/celestia/qt/qtappwin.cpp:1315
 #, fuzzy
 msgid "Select Sun"
 msgstr "選取(&S)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1312
+#: ../src/celestia/qt/qtappwin.cpp:1319
 #, fuzzy
 msgid "Center Selection"
 msgstr "選取星體置中(&C)\tC"
 
-#: ../src/celestia/qt/qtappwin.cpp:1316
+#: ../src/celestia/qt/qtappwin.cpp:1323
 #, fuzzy
 msgid "Goto Selection"
 msgstr ""
 "\n"
 "選擇區:"
 
-#: ../src/celestia/qt/qtappwin.cpp:1320
+#: ../src/celestia/qt/qtappwin.cpp:1327
 #: ../src/celestia/win32/res/resource_strings.cpp:12
 msgid "Goto Object..."
 msgstr "前往星體..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1324
+#: ../src/celestia/qt/qtappwin.cpp:1331
 msgid "Copy URL / console text"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1329
+#: ../src/celestia/qt/qtappwin.cpp:1336
 msgid "Paste URL / console text"
 msgstr ""
 
 #. ***** Time menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1335
+#: ../src/celestia/qt/qtappwin.cpp:1342
 #: ../src/celestia/win32/res/resource_strings.cpp:21
 msgid "&Time"
 msgstr "時間(&T)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1337
+#: ../src/celestia/qt/qtappwin.cpp:1344
 #, fuzzy
 msgid "Set &time"
 msgstr "設定時間..."
 
 #. ***** Display menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1345
+#: ../src/celestia/qt/qtappwin.cpp:1352
 #, fuzzy
 msgid "&Display"
 msgstr "顯示"
 
-#: ../src/celestia/qt/qtappwin.cpp:1351
+#: ../src/celestia/qt/qtappwin.cpp:1358
 #, fuzzy
 msgid "Dee&p Sky Objects"
 msgstr "已標記星體"
 
-#: ../src/celestia/qt/qtappwin.cpp:1357
+#: ../src/celestia/qt/qtappwin.cpp:1364
 #, fuzzy
 msgid "&Shadows"
 msgstr "顯示雲影"
 
-#: ../src/celestia/qt/qtappwin.cpp:1368
+#: ../src/celestia/qt/qtappwin.cpp:1375
 #: ../src/celestia/win32/res/resource_strings.cpp:37
 msgid "Star St&yle"
 msgstr "恆星樣式(&Y)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1375
+#: ../src/celestia/qt/qtappwin.cpp:1382
 #, fuzzy
 msgid "Texture &Resolution"
 msgstr "紋理解析度"
 
-#: ../src/celestia/qt/qtappwin.cpp:1380
+#: ../src/celestia/qt/qtappwin.cpp:1387
 #, fuzzy
 msgid "&FPS control"
 msgstr "控制(&C)"
 
 #. ***** Bookmark menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1397
+#: ../src/celestia/qt/qtappwin.cpp:1404
 #: ../src/celestia/win32/res/resource_strings.cpp:60
 msgid "&Bookmarks"
 msgstr "書籤(&B)"
 
 #. ***** View menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1400
+#: ../src/celestia/qt/qtappwin.cpp:1407
 #: ../src/celestia/win32/res/resource_strings.cpp:53
 msgid "&View"
 msgstr "檢視(&V)"
 
 #. ***** MultiView menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1403
+#: ../src/celestia/qt/qtappwin.cpp:1410
 #, fuzzy
 msgid "&MultiView"
 msgstr "多重檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1406
+#: ../src/celestia/qt/qtappwin.cpp:1413
 #, fuzzy
 msgid "Split view vertically"
 msgstr "垂直分割檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1407
+#: ../src/celestia/qt/qtappwin.cpp:1414
 #, fuzzy
 msgid "Ctrl+R"
 msgstr "水平分離(&H)\tCtrl+R"
 
-#: ../src/celestia/qt/qtappwin.cpp:1412
+#: ../src/celestia/qt/qtappwin.cpp:1419
 #, fuzzy
 msgid "Split view horizontally"
 msgstr "水平分割檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1413
+#: ../src/celestia/qt/qtappwin.cpp:1420
 #, fuzzy
 msgid "Ctrl+U"
 msgstr "垂直分離(&V)\tCtrl+U"
 
-#: ../src/celestia/qt/qtappwin.cpp:1418
+#: ../src/celestia/qt/qtappwin.cpp:1425
 #, fuzzy
 msgid "Cycle views"
 msgstr "循環檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1419
+#: ../src/celestia/qt/qtappwin.cpp:1426
 msgid "Tab"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1424
+#: ../src/celestia/qt/qtappwin.cpp:1431
 #, fuzzy
 msgid "Single view"
 msgstr "單一檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1425
+#: ../src/celestia/qt/qtappwin.cpp:1432
 #, fuzzy
 msgid "Ctrl+D"
 msgstr "單一檢視(&S)\tCtrl+D"
 
-#: ../src/celestia/qt/qtappwin.cpp:1430
+#: ../src/celestia/qt/qtappwin.cpp:1437
 #, fuzzy
 msgid "Delete view"
 msgstr "刪除檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1431
-#: ../src/celestia/win32/res/resource_strings.cpp:158
+#: ../src/celestia/qt/qtappwin.cpp:1438
+#: ../src/celestia/win32/res/resource_strings.cpp:160
 msgid "Delete"
 msgstr "刪除"
 
-#: ../src/celestia/qt/qtappwin.cpp:1437
+#: ../src/celestia/qt/qtappwin.cpp:1444
 #, fuzzy
 msgid "Frames visible"
 msgstr "影格檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1458
+#: ../src/celestia/qt/qtappwin.cpp:1465
 #, fuzzy
 msgid "Active frame visible"
 msgstr "作用中影格檢視"
 
-#: ../src/celestia/qt/qtappwin.cpp:1474
+#: ../src/celestia/qt/qtappwin.cpp:1481
 #, fuzzy
 msgid "Synchronize time"
 msgstr "同步時間"
 
 #. ***** Help Menu *****
-#: ../src/celestia/qt/qtappwin.cpp:1515
+#: ../src/celestia/qt/qtappwin.cpp:1522
 #: ../src/celestia/win32/res/resource_strings.cpp:63
 msgid "&Help"
 msgstr "說明(&H)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1517
+#: ../src/celestia/qt/qtappwin.cpp:1524
 #, fuzzy
 msgid "Celestia Manual"
 msgstr "Celestia 偏好設定"
 
-#: ../src/celestia/qt/qtappwin.cpp:1522
+#: ../src/celestia/qt/qtappwin.cpp:1529
 #, fuzzy
 msgid "OpenGL Info"
 msgstr "OpenGL 資訊"
 
-#: ../src/celestia/qt/qtappwin.cpp:1542
+#: ../src/celestia/qt/qtappwin.cpp:1549
 #, fuzzy
 msgid "Add Bookmark..."
 msgstr "加入書籤(&A)"
 
-#: ../src/celestia/qt/qtappwin.cpp:1546
+#: ../src/celestia/qt/qtappwin.cpp:1553
 #, fuzzy
 msgid "Organize Bookmarks..."
 msgstr "組織書籤(&O)..."
 
-#: ../src/celestia/qt/qtappwin.cpp:1584
+#: ../src/celestia/qt/qtappwin.cpp:1591
 msgid "Set custom FPS"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1585
+#: ../src/celestia/qt/qtappwin.cpp:1592
 msgid "FPS value"
 msgstr ""
 
-#: ../src/celestia/qt/qtappwin.cpp:1606
+#: ../src/celestia/qt/qtappwin.cpp:1613
 #, fuzzy, qt-format
 msgid ""
 "Loading data files: %1\n"
 "\n"
 msgstr "載入中 "
 
-#: ../src/celestia/qt/qtappwin.cpp:1617
+#: ../src/celestia/qt/qtappwin.cpp:1624
 #: ../src/celestia/win32/res/resource_strings.cpp:3
 msgid "Scripts"
 msgstr "腳本"
@@ -1672,11 +1646,11 @@ msgstr "m/s"
 #. i18n: ectx: property (text), widget (QCheckBox, markersCheck)
 #. Controls for marking selected objects
 #: ../src/celestia/qt/qtcelestiaactions.cpp:53
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:561
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:481
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:774
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:562
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:482
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:775
 #: ../src/celestia/qt/rc.cpp:209
-#: ../src/celestia/win32/res/resource_strings.cpp:204
+#: ../src/celestia/win32/res/resource_strings.cpp:206
 msgid "Markers"
 msgstr "標記"
 
@@ -1692,7 +1666,7 @@ msgstr "選取星體置中(&C)\tC"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:58
 #: ../src/celestia/qt/qtcelestiaactions.cpp:124 ../src/celestia/qt/rc.cpp:194
 #: ../src/celestia/qt/rc.cpp:258
-#: ../src/celestia/win32/res/resource_strings.cpp:224
+#: ../src/celestia/win32/res/resource_strings.cpp:226
 msgid "Constellations"
 msgstr "星座"
 
@@ -1714,7 +1688,7 @@ msgstr "確定"
 #. i18n: file: ../src/celestia/qt/preferences.ui:236
 #. i18n: ectx: property (title), widget (QGroupBox, orbitsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:68 ../src/celestia/qt/rc.cpp:142
-#: ../src/celestia/win32/res/resource_strings.cpp:201
+#: ../src/celestia/win32/res/resource_strings.cpp:203
 msgid "Orbits"
 msgstr "軌道"
 
@@ -1728,18 +1702,18 @@ msgstr "軌道"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:85
 #: ../src/celestia/qt/qtcelestiaactions.cpp:112
 #: ../src/celestia/qt/qtselectionpopup.cpp:388
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:581 ../src/celestia/qt/rc.cpp:75
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:582 ../src/celestia/qt/rc.cpp:75
 #: ../src/celestia/qt/rc.cpp:157 ../src/celestia/qt/rc.cpp:224
-#: ../src/celestia/win32/res/resource_strings.cpp:213
-#: ../src/celestia/win32/winmain.cpp:1468
-#: ../src/celestia/win32/winmain.cpp:1506
-#: ../src/celestia/win32/winmain.cpp:1626
+#: ../src/celestia/win32/res/resource_strings.cpp:215
+#: ../src/celestia/win32/winmain.cpp:1534
+#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1692
 msgid "Planets"
 msgstr "行星"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:86
 #: ../src/celestia/qt/qtcelestiaactions.cpp:113
-#: ../src/celestia/win32/res/resource_strings.cpp:214
+#: ../src/celestia/win32/res/resource_strings.cpp:216
 msgid "Dwarf Planets"
 msgstr "矮行星"
 
@@ -1752,16 +1726,16 @@ msgstr "矮行星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:87
 #: ../src/celestia/qt/qtcelestiaactions.cpp:114
 #: ../src/celestia/qt/qtselectionpopup.cpp:394
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:583 ../src/celestia/qt/rc.cpp:81
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:584 ../src/celestia/qt/rc.cpp:81
 #: ../src/celestia/qt/rc.cpp:163 ../src/celestia/qt/rc.cpp:230
-#: ../src/celestia/win32/res/resource_strings.cpp:215
-#: ../src/celestia/win32/winmain.cpp:1464
+#: ../src/celestia/win32/res/resource_strings.cpp:217
+#: ../src/celestia/win32/winmain.cpp:1530
 msgid "Moons"
 msgstr "衛星"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:88
 #: ../src/celestia/qt/qtcelestiaactions.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:216
+#: ../src/celestia/win32/res/resource_strings.cpp:218
 msgid "Minor Moons"
 msgstr "小行星衛星 (二重小行星)"
 
@@ -1774,10 +1748,10 @@ msgstr "小行星衛星 (二重小行星)"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:89
 #: ../src/celestia/qt/qtcelestiaactions.cpp:116
 #: ../src/celestia/qt/qtselectionpopup.cpp:400
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:742 ../src/celestia/qt/rc.cpp:87
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:743 ../src/celestia/qt/rc.cpp:87
 #: ../src/celestia/qt/rc.cpp:169 ../src/celestia/qt/rc.cpp:236
-#: ../src/celestia/win32/res/resource_strings.cpp:217
-#: ../src/celestia/win32/winmain.cpp:1458
+#: ../src/celestia/win32/res/resource_strings.cpp:219
+#: ../src/celestia/win32/winmain.cpp:1524
 msgid "Asteroids"
 msgstr "小行星"
 
@@ -1790,10 +1764,10 @@ msgstr "小行星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:90
 #: ../src/celestia/qt/qtcelestiaactions.cpp:117
 #: ../src/celestia/qt/qtselectionpopup.cpp:403
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:750 ../src/celestia/qt/rc.cpp:90
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:751 ../src/celestia/qt/rc.cpp:90
 #: ../src/celestia/qt/rc.cpp:172 ../src/celestia/qt/rc.cpp:239
-#: ../src/celestia/win32/res/resource_strings.cpp:218
-#: ../src/celestia/win32/winmain.cpp:1460
+#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/winmain.cpp:1526
 msgid "Comets"
 msgstr "彗星"
 
@@ -1810,11 +1784,11 @@ msgstr "彗星"
 #: ../src/celestia/qt/qtcelestiaactions.cpp:91
 #: ../src/celestia/qt/qtcelestiaactions.cpp:118
 #: ../src/celestia/qt/qtselectionpopup.cpp:406
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:585
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:746 ../src/celestia/qt/rc.cpp:94
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:586
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:747 ../src/celestia/qt/rc.cpp:94
 #: ../src/celestia/qt/rc.cpp:176 ../src/celestia/qt/rc.cpp:243
-#: ../src/celestia/win32/res/resource_strings.cpp:219
-#: ../src/celestia/win32/winmain.cpp:1473
+#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/win32/winmain.cpp:1539
 #, fuzzy
 msgctxt "plural"
 msgid "Spacecraft"
@@ -1832,7 +1806,7 @@ msgstr "10x 快轉(&F)\tL"
 #. i18n: ectx: property (title), widget (QGroupBox, labelsGroupBox)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:108 ../src/celestia/qt/rc.cpp:215
 #: ../src/celestia/qt/rc.cpp:218
-#: ../src/celestia/win32/res/resource_strings.cpp:227
+#: ../src/celestia/win32/res/resource_strings.cpp:229
 msgid "Labels"
 msgstr "標籤"
 
@@ -1842,9 +1816,9 @@ msgstr "標籤"
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:119
 #: ../src/celestia/qt/qtcelestiaactions.cpp:143
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:443 ../src/celestia/qt/rc.cpp:97
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:444 ../src/celestia/qt/rc.cpp:97
 #: ../src/celestia/qt/rc.cpp:246
-#: ../src/celestia/win32/res/resource_strings.cpp:220
+#: ../src/celestia/win32/res/resource_strings.cpp:222
 msgid "Galaxies"
 msgstr "星系"
 
@@ -1852,8 +1826,8 @@ msgstr "星系"
 #. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:120
 #: ../src/celestia/qt/qtcelestiaactions.cpp:145
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:439
-#: ../src/celestia/win32/res/resource_strings.cpp:221
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:440
+#: ../src/celestia/win32/res/resource_strings.cpp:223
 msgid "Globulars"
 msgstr "球狀星團"
 
@@ -1873,9 +1847,9 @@ msgstr "疏散星團"
 #. i18n: ectx: property (text), widget (QCheckBox, nebulaLabelsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtcelestiaactions.cpp:147
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:447 ../src/celestia/qt/rc.cpp:100
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:448 ../src/celestia/qt/rc.cpp:100
 #: ../src/celestia/qt/rc.cpp:249
-#: ../src/celestia/win32/res/resource_strings.cpp:223
+#: ../src/celestia/win32/res/resource_strings.cpp:225
 msgid "Nebulae"
 msgstr "星雲"
 
@@ -1887,48 +1861,48 @@ msgid "Locations"
 msgstr "位置"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:146
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:451
-#: ../src/celestia/win32/res/resource_strings.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:452
+#: ../src/celestia/win32/res/resource_strings.cpp:224
 msgid "Open Clusters"
 msgstr "疏散星團"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:155
 #. i18n: ectx: property (text), widget (QCheckBox, cloudsCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:154 ../src/celestia/qt/rc.cpp:115
-#: ../src/celestia/win32/res/resource_strings.cpp:193
+#: ../src/celestia/win32/res/resource_strings.cpp:195
 msgid "Clouds"
 msgstr "雲層"
 
 #. cloudsAction->setShortcut(QString("I"));
 #: ../src/celestia/qt/qtcelestiaactions.cpp:156
-#: ../src/celestia/win32/res/resource_strings.cpp:197
+#: ../src/celestia/win32/res/resource_strings.cpp:199
 msgid "Night Side Lights"
 msgstr "夜視光"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:158
-#: ../src/celestia/win32/res/resource_strings.cpp:198
+#: ../src/celestia/win32/res/resource_strings.cpp:200
 msgid "Comet Tails"
 msgstr "彗尾"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:148
 #. i18n: ectx: property (text), widget (QCheckBox, atmospheresCheck)
 #: ../src/celestia/qt/qtcelestiaactions.cpp:159 ../src/celestia/qt/rc.cpp:112
-#: ../src/celestia/win32/res/resource_strings.cpp:192
+#: ../src/celestia/win32/res/resource_strings.cpp:194
 msgid "Atmospheres"
 msgstr "大氣壓"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:166
-#: ../src/celestia/win32/res/resource_strings.cpp:195
+#: ../src/celestia/win32/res/resource_strings.cpp:197
 msgid "Ring Shadows"
 msgstr "環狀陰影"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:167
-#: ../src/celestia/win32/res/resource_strings.cpp:196
+#: ../src/celestia/win32/res/resource_strings.cpp:198
 msgid "Eclipse Shadows"
 msgstr "日月食陰影"
 
 #: ../src/celestia/qt/qtcelestiaactions.cpp:169
-#: ../src/celestia/win32/res/resource_strings.cpp:194
+#: ../src/celestia/win32/res/resource_strings.cpp:196
 msgid "Cloud Shadows"
 msgstr "雲層陰影"
 
@@ -2001,237 +1975,237 @@ msgstr "45 度時自動調整星等限制:%.2f"
 msgid "Magnitude limit: %L1"
 msgstr "極限星等:%.2f"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:221
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:192
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:654
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:222
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:193
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:655
 #: ../src/celestia/win32/res/resource_strings.cpp:91
 #: ../src/celestia/win32/winstarbrowser.cpp:61
 msgid "Name"
 msgstr "名稱"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:223
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:194
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:224
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:195
 #: ../src/celestia/win32/winstarbrowser.cpp:62
 msgid "Distance (ly)"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:225
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:196
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:226
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:197
 #: ../src/celestia/win32/winstarbrowser.cpp:63
 msgid "App. mag"
 msgstr "視星等"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:227
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:228
 #: ../src/celestia/win32/winstarbrowser.cpp:64
 msgid "Abs. mag"
 msgstr "絕對星等"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:229
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:198
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:467
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:656
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:230
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:199
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:468
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:657
 #: ../src/celestia/win32/winstarbrowser.cpp:65
 msgid "Type"
 msgstr "類型"
 
 #. Buttons to select filtering criterion for stars
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:517
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:518
 #, fuzzy
 msgid "Closest Stars"
 msgstr "顯示恆星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:521
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:522
 #, fuzzy
 msgid "Brightest Stars"
 msgstr "星體"
 
 #. Additional filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:531
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:464
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:758
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:532
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:465
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:759
 #, fuzzy
 msgid "Filter"
 msgstr "過濾恆星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:534
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:535
 msgid "With Planets"
 msgstr "包含行星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:538
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:539
 #, fuzzy
 msgid "Multiple Stars"
 msgstr "顯示恆星"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:541
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:542
 #, fuzzy
 msgid "Barycenters"
 msgstr "質心"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:547
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:548
 #, fuzzy
 msgid "Spectral Type"
 msgstr "恆星資料庫內的光譜類型錯誤，恆星 #"
 
 #. End filtering controls
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:556
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:476
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:765
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:557
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:477
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:766
 msgid "Refresh"
 msgstr "重新整理"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:564
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:484
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:777
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:565
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:778
 #, fuzzy
 msgid "Mark Selected"
 msgstr "標示(&M)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:566
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:567
 #, fuzzy
 msgid "Mark stars selected in list view"
 msgstr "列表中顯示的最多恆星數"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:569
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:489
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:782
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
 #, fuzzy
 msgid "Unmark Selected"
 msgstr "標示(&M)"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:570
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:783
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:571
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:784
 msgid "Unmark stars selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:574
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:494
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:787
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:575
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:495
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:788
 #, fuzzy
 msgid "Clear Markers"
 msgstr "標記"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:576
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:496
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:789
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:577
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:497
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:790
 msgid "Remove all existing markers"
 msgstr ""
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:583
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:503
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:796
-#: ../src/celestia/win32/res/resource_strings.cpp:230
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/win32/res/resource_strings.cpp:232
 msgid "None"
 msgstr "無"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:584
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:504
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
 #: ../src/celestia/qt/qtselectionpopup.cpp:244
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:797
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
 msgid "Diamond"
 msgstr "鑽石"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:585
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:505
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
 #: ../src/celestia/qt/qtselectionpopup.cpp:245
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:798
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
 msgid "Triangle"
 msgstr "三角形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:586
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:506
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
 #: ../src/celestia/qt/qtselectionpopup.cpp:246
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:799
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
 msgid "Square"
 msgstr "方形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:587
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:507
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
 #: ../src/celestia/qt/qtselectionpopup.cpp:248
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:800
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
 msgid "Plus"
 msgstr "加號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:588
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:508
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
 #: ../src/celestia/qt/qtselectionpopup.cpp:249
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:801
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
 msgid "X"
 msgstr "X"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:589
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:509
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
 #: ../src/celestia/qt/qtselectionpopup.cpp:254
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:802
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
 msgid "Circle"
 msgstr "圓形"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:590
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:510
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
 #: ../src/celestia/qt/qtselectionpopup.cpp:250
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:803
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
 msgid "Left Arrow"
 msgstr "左箭號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:591
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:511
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
 #: ../src/celestia/qt/qtselectionpopup.cpp:251
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:804
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
 msgid "Right Arrow"
 msgstr "右箭號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:592
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:512
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
 #: ../src/celestia/qt/qtselectionpopup.cpp:252
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:805
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
 msgid "Up Arrow"
 msgstr "上箭號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:593
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:513
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:594
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:514
 #: ../src/celestia/qt/qtselectionpopup.cpp:253
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:806
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:807
 msgid "Down Arrow"
 msgstr "下箭號"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:595
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:515
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:808
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:596
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:516
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:809
 #, fuzzy
 msgid "Select marker symbol"
 msgstr "選取星體(&O)..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:608
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:528
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:821
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:609
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:529
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:822
 #, fuzzy
 msgid "Select marker size"
 msgstr "大小:"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:612
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:532
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:825
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:613
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:533
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:826
 #, fuzzy
 msgid "Click to select marker color"
 msgstr "選取星體(&O)..."
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:615
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:535
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:828
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:616
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:536
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:829
 #, fuzzy
 msgid "Label"
 msgstr "標記特徵"
 
-#: ../src/celestia/qt/qtcelestialbrowser.cpp:679
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:587
+#: ../src/celestia/qt/qtcelestialbrowser.cpp:680
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:588
 #, fuzzy, qt-format
 msgid "%1 objects found"
 msgstr "天體"
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:485
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:486
 msgid "Mark DSOs selected in list view"
 msgstr ""
 
-#: ../src/celestia/qt/qtdeepskybrowser.cpp:490
+#: ../src/celestia/qt/qtdeepskybrowser.cpp:491
 #, fuzzy
 msgid "Unmark DSOs selected in list view"
 msgstr "標示(&M)"
@@ -2346,8 +2320,8 @@ msgstr "從檔案讀取影像"
 msgid "Behind %1"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtglwidget.cpp:122
-msgid "Celestia was unable to initialize OpenGL 2.1."
+#: ../src/celestia/qt/qtglwidget.cpp:99
+msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:81
@@ -2516,86 +2490,91 @@ msgstr "大小:%1 MB"
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtmain.cpp:162 ../src/celestia/win32/winmain.cpp:3023
+#: ../src/celestia/qt/qtmain.cpp:161 ../src/celestia/win32/winmain.cpp:3081
 msgid "Directory expected after --dir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:172 ../src/celestia/win32/winmain.cpp:3036
+#: ../src/celestia/qt/qtmain.cpp:171 ../src/celestia/win32/winmain.cpp:3094
 msgid "Configuration file name expected after --conf"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:183 ../src/celestia/win32/winmain.cpp:3050
+#: ../src/celestia/qt/qtmain.cpp:182 ../src/celestia/win32/winmain.cpp:3108
 msgid "Directory expected after --extrasdir"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:193 ../src/celestia/win32/winmain.cpp:3063
+#: ../src/celestia/qt/qtmain.cpp:192 ../src/celestia/win32/winmain.cpp:3121
 msgid "URL expected after --url"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:207
+#: ../src/celestia/qt/qtmain.cpp:206
 msgid "A filename expected after --log/-l"
 msgstr ""
 
-#: ../src/celestia/qt/qtmain.cpp:215 ../src/celestia/win32/winmain.cpp:3078
+#: ../src/celestia/qt/qtmain.cpp:214 ../src/celestia/win32/winmain.cpp:3136
 #, c-format
 msgid "Invalid command line option '%s'"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:174
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:178
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:165
 #, fuzzy
 msgid "OpenGL 2.1"
 msgstr "OpenGL 2.0"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:217
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:203
 msgid "Blackbody D65"
 msgstr ""
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:218
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:204
 #, fuzzy
 msgid "Classic colors"
 msgstr "恆星樣式(&Y)"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:224
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:210
 #, fuzzy
 msgid "Local format"
 msgstr "本地格式"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:226
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:212
 #, fuzzy
 msgid "Time zone name"
 msgstr "時區名稱"
 
-#: ../src/celestia/qt/qtpreferencesdialog.cpp:227
+#: ../src/celestia/qt/qtpreferencesdialog.cpp:213
 #, fuzzy
 msgid "UTC offset"
 msgstr "與世界協調時間的差異"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:77
+#: ../src/celestia/qt/qtselectionpopup.cpp:78
 #, fuzzy, qt-format
 msgid "Start: %1"
 msgstr "開始"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:86
+#: ../src/celestia/qt/qtselectionpopup.cpp:87
 #, qt-format
 msgid "End: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:112
-#, c-format
-msgid "%.3f km"
+#: ../src/celestia/qt/qtselectionpopup.cpp:109
+msgid "{:.3f} ly"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:114
-#, c-format
-msgid "%.3f m"
+#: ../src/celestia/qt/qtselectionpopup.cpp:111
+msgid "{:.3f} au"
 msgstr ""
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:116
+#: ../src/celestia/qt/qtselectionpopup.cpp:113
+msgid "{:.3f} km"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:115
+msgid "{:.3f} m"
+msgstr ""
+
+#: ../src/celestia/qt/qtselectionpopup.cpp:117
 msgid "Distance: "
 msgstr "距離:"
 
-#: ../src/celestia/qt/qtselectionpopup.cpp:121
+#: ../src/celestia/qt/qtselectionpopup.cpp:122
 msgid "Abs (app) mag: "
 msgstr "絕對星等(視星等):"
 
@@ -2608,21 +2587,21 @@ msgid "&Select"
 msgstr "選取(&S)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:139
-#: ../src/celestia/win32/res/resource_strings.cpp:173
-#: ../src/celestia/win32/res/resource_strings.cpp:180
+#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:182
 msgid "&Center"
 msgstr "置中(&C)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:143
-#: ../src/celestia/win32/winmain.cpp:1564
-#: ../src/celestia/win32/winmain.cpp:1614
-#: ../src/celestia/win32/winmain.cpp:1637
+#: ../src/celestia/win32/winmain.cpp:1630
+#: ../src/celestia/win32/winmain.cpp:1680
+#: ../src/celestia/win32/winmain.cpp:1703
 msgid "&Goto"
 msgstr "前往(&G)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:147
-#: ../src/celestia/win32/winmain.cpp:1565
-#: ../src/celestia/win32/winmain.cpp:1638
+#: ../src/celestia/win32/winmain.cpp:1631
+#: ../src/celestia/win32/winmain.cpp:1704
 msgid "&Follow"
 msgstr "跟隨(&F)"
 
@@ -2636,12 +2615,12 @@ msgid "Visible"
 msgstr "作用中影格檢視"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:177
-#: ../src/celestia/win32/winmain.cpp:1651
+#: ../src/celestia/win32/winmain.cpp:1717
 msgid "&Unmark"
 msgstr "取消標示(&U)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:195
-#: ../src/celestia/win32/winmain.cpp:1584
+#: ../src/celestia/win32/winmain.cpp:1650
 #, fuzzy
 msgid "Select &Primary Body"
 msgstr "選擇顯示模式"
@@ -2655,12 +2634,12 @@ msgid "Disk"
 msgstr "碟形"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:258
-#: ../src/celestia/win32/winmain.cpp:1653
+#: ../src/celestia/win32/winmain.cpp:1719
 msgid "&Mark"
 msgstr "標示(&M)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:275
-#: ../src/celestia/win32/winmain.cpp:1569
+#: ../src/celestia/win32/winmain.cpp:1635
 msgid "&Reference Marks"
 msgstr "參考標記(&R)"
 
@@ -2708,13 +2687,13 @@ msgid "Show &Terminator"
 msgstr "顯示晝夜界線"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:344
-#: ../src/celestia/win32/winmain.cpp:1601
+#: ../src/celestia/win32/winmain.cpp:1667
 msgid "&Alternate Surfaces"
 msgstr "替代表面(&A)"
 
 #. TRANSLATORS: normal texture in an alternative surface menu
 #: ../src/celestia/qt/qtselectionpopup.cpp:345
-#: ../src/celestia/win32/winmain.cpp:1538
+#: ../src/celestia/win32/winmain.cpp:1604
 msgid "Normal"
 msgstr "一般"
 
@@ -2726,7 +2705,7 @@ msgstr "一般"
 #. i18n: ectx: property (text), widget (QCheckBox, dwarfPlanetLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:391 ../src/celestia/qt/rc.cpp:78
 #: ../src/celestia/qt/rc.cpp:160 ../src/celestia/qt/rc.cpp:227
-#: ../src/celestia/win32/winmain.cpp:1470
+#: ../src/celestia/win32/winmain.cpp:1536
 #, fuzzy
 msgid "Dwarf planets"
 msgstr "矮行星"
@@ -2738,15 +2717,15 @@ msgstr "矮行星"
 #. i18n: file: ../src/celestia/qt/preferences.ui:527
 #. i18n: ectx: property (text), widget (QCheckBox, minorMoonLabelsCheck)
 #: ../src/celestia/qt/qtselectionpopup.cpp:397
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:591 ../src/celestia/qt/rc.cpp:84
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:592 ../src/celestia/qt/rc.cpp:84
 #: ../src/celestia/qt/rc.cpp:166 ../src/celestia/qt/rc.cpp:233
-#: ../src/celestia/win32/winmain.cpp:1466
+#: ../src/celestia/win32/winmain.cpp:1532
 #, fuzzy
 msgid "Minor moons"
 msgstr "小行星衛星 (二重小行星)"
 
 #: ../src/celestia/qt/qtselectionpopup.cpp:409
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:597
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:598
 #, fuzzy
 msgid "Other objects"
 msgstr "天體"
@@ -2757,7 +2736,7 @@ msgid "Set Time"
 msgstr "設定時間..."
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:55
-#: ../src/celestia/win32/res/resource_strings.cpp:164
+#: ../src/celestia/win32/res/resource_strings.cpp:166
 msgid "Time Zone: "
 msgstr "時區: "
 
@@ -2822,7 +2801,7 @@ msgid "Set Seconds"
 msgstr " 秒"
 
 #: ../src/celestia/qt/qtsettimedialog.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:166
+#: ../src/celestia/win32/res/resource_strings.cpp:168
 msgid "Julian Date: "
 msgstr "儒略日: "
 
@@ -2836,97 +2815,97 @@ msgstr "儒略日: "
 msgid "Set time"
 msgstr "設定時間..."
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:540
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:541
 msgid "Barycenter"
 msgstr "質心"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:542
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:543
 #, fuzzy
 msgid "Star"
 msgstr "恆星資料庫內的光譜類型錯誤，恆星 #"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:550
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:551
 #: ../src/celestia/win32/wineclipses.cpp:58
 msgid "Planet"
 msgstr "行星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:552
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:553
 #, fuzzy
 msgid "Dwarf planet"
 msgstr "矮行星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:554
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:555
 msgid "Moon"
 msgstr "月球"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:556
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:557
 #, fuzzy
 msgid "Minor moon"
 msgstr "小行星衛星 (二重小行星)"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:558
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:559
 msgid "Asteroid"
 msgstr "小行星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:560
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:561
 msgid "Comet"
 msgstr "彗星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:562
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:563
 msgid "Spacecraft"
 msgstr "太空船"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:564
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:565
 #, fuzzy
 msgid "Reference point"
 msgstr "參考標記(&R)"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:566
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:567
 #, fuzzy
 msgid "Component"
 msgstr "計算"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:568
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:569
 #, fuzzy
 msgid "Surface feature"
 msgstr "前往表面"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:572
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:573
 #, fuzzy
 msgid "Unknown"
 msgstr "開啟腳本時發生未知的錯誤"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:587
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:588
 #, fuzzy
 msgid "Asteroids & comets"
 msgstr "小行星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:589
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:590
 #, fuzzy
 msgid "Reference points"
 msgstr "參考標記(&R)"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:593
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:594
 msgid "Components"
 msgstr ""
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:595
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:596
 #, fuzzy
 msgid "Surface features"
 msgstr "其他特徵"
 
 #. Buttons to select filtering criterion for objects
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:738
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:739
 #, fuzzy
 msgid "Planets and moons"
 msgstr "行星"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:769
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:770
 #, fuzzy
 msgid "Group objects by class"
 msgstr "天體"
 
-#: ../src/celestia/qt/qtsolarsystembrowser.cpp:779
+#: ../src/celestia/qt/qtsolarsystembrowser.cpp:780
 msgid "Mark bodies selected in list view"
 msgstr ""
 
@@ -3059,7 +3038,7 @@ msgstr "解析度: "
 #. i18n: file: ../src/celestia/qt/organizebookmarks.ui:13
 #. i18n: ectx: property (windowTitle), widget (QDialog, organizeBookmarksDialog)
 #: ../src/celestia/qt/rc.cpp:51
-#: ../src/celestia/win32/res/resource_strings.cpp:153
+#: ../src/celestia/win32/res/resource_strings.cpp:155
 msgid "Organize Bookmarks"
 msgstr "組織書籤"
 
@@ -3166,7 +3145,7 @@ msgstr "顯示軌道"
 #. i18n: file: ../src/celestia/qt/preferences.ui:249
 #. i18n: ectx: property (text), widget (QCheckBox, fadingOrbitsCheck)
 #: ../src/celestia/qt/rc.cpp:148
-#: ../src/celestia/win32/res/resource_strings.cpp:202
+#: ../src/celestia/win32/res/resource_strings.cpp:204
 #, fuzzy
 msgid "Fading orbits"
 msgstr "著陸點(Landing Sites)"
@@ -3174,7 +3153,7 @@ msgstr "著陸點(Landing Sites)"
 #. i18n: file: ../src/celestia/qt/preferences.ui:256
 #. i18n: ectx: property (text), widget (QCheckBox, partialTrajectoriesCheck)
 #: ../src/celestia/qt/rc.cpp:151
-#: ../src/celestia/win32/res/resource_strings.cpp:203
+#: ../src/celestia/win32/res/resource_strings.cpp:205
 #, fuzzy
 msgid "Partial trajectories"
 msgstr "部份軌道"
@@ -3182,49 +3161,49 @@ msgstr "部份軌道"
 #. i18n: file: ../src/celestia/qt/preferences.ui:355
 #. i18n: ectx: property (title), widget (QGroupBox, gridsGroupBox)
 #: ../src/celestia/qt/rc.cpp:179
-#: ../src/celestia/win32/res/resource_strings.cpp:206
+#: ../src/celestia/win32/res/resource_strings.cpp:208
 msgid "Grids"
 msgstr "格子"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:361
 #. i18n: ectx: property (text), widget (QCheckBox, equatorialGridCheck)
 #: ../src/celestia/qt/rc.cpp:182
-#: ../src/celestia/win32/res/resource_strings.cpp:207
+#: ../src/celestia/win32/res/resource_strings.cpp:209
 msgid "Equatorial"
 msgstr "赤道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:368
 #. i18n: ectx: property (text), widget (QCheckBox, eclipticGridCheck)
 #: ../src/celestia/qt/rc.cpp:185
-#: ../src/celestia/win32/res/resource_strings.cpp:210
+#: ../src/celestia/win32/res/resource_strings.cpp:212
 msgid "Ecliptic"
 msgstr "黃道"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:375
 #. i18n: ectx: property (text), widget (QCheckBox, galacticGridCheck)
 #: ../src/celestia/qt/rc.cpp:188
-#: ../src/celestia/win32/res/resource_strings.cpp:209
+#: ../src/celestia/win32/res/resource_strings.cpp:211
 msgid "Galactic"
 msgstr "銀河"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:382
 #. i18n: ectx: property (text), widget (QCheckBox, horizontalGridCheck)
 #: ../src/celestia/qt/rc.cpp:191
-#: ../src/celestia/win32/res/resource_strings.cpp:208
+#: ../src/celestia/win32/res/resource_strings.cpp:210
 msgid "Horizontal"
 msgstr "水平分割檢視"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:411
 #. i18n: ectx: property (text), widget (QCheckBox, diagramsCheck)
 #: ../src/celestia/qt/rc.cpp:197
-#: ../src/celestia/win32/res/resource_strings.cpp:225
+#: ../src/celestia/win32/res/resource_strings.cpp:227
 msgid "Diagrams"
 msgstr "圖形"
 
 #. i18n: file: ../src/celestia/qt/preferences.ui:418
 #. i18n: ectx: property (text), widget (QCheckBox, boundariesCheck)
 #: ../src/celestia/qt/rc.cpp:200
-#: ../src/celestia/win32/res/resource_strings.cpp:226
+#: ../src/celestia/win32/res/resource_strings.cpp:228
 msgid "Boundaries"
 msgstr "邊界"
 
@@ -3426,41 +3405,41 @@ msgstr "顯示"
 msgid "Not an XBEL version 1.0 file."
 msgstr ""
 
-#: ../src/celestia/url.cpp:314
+#: ../src/celestia/url.cpp:312
 msgid "Incorrect hex value \"{}\"\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:397
+#: ../src/celestia/url.cpp:395
 msgid "URL must start with \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:413
+#: ../src/celestia/url.cpp:411
 msgid "URL must have at least mode and time!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:424
+#: ../src/celestia/url.cpp:422
 #, fuzzy
 msgid "Unsupported URL mode \"{}\"!\n"
 msgstr "支援的延伸功能:"
 
-#: ../src/celestia/url.cpp:442
+#: ../src/celestia/url.cpp:440
 msgid "URL must contain only one body\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:454
+#: ../src/celestia/url.cpp:452
 msgid "URL must contain 2 bodies\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:495
+#: ../src/celestia/url.cpp:493
 msgid "Invalid URL version \"{}\"!\n"
 msgstr ""
 
-#: ../src/celestia/url.cpp:502
+#: ../src/celestia/url.cpp:500
 #, fuzzy
 msgid "Unsupported URL version: {}\n"
 msgstr "支援的延伸功能:"
 
-#: ../src/celestia/url.cpp:534
+#: ../src/celestia/url.cpp:532
 msgid "URL parameter must look like key=value\n"
 msgstr ""
 
@@ -3710,13 +3689,13 @@ msgstr "關於 Celestia(&A)"
 #: ../src/celestia/win32/res/resource_strings.cpp:121
 #: ../src/celestia/win32/res/resource_strings.cpp:133
 #: ../src/celestia/win32/res/resource_strings.cpp:146
-#: ../src/celestia/win32/res/resource_strings.cpp:154
-#: ../src/celestia/win32/res/resource_strings.cpp:160
-#: ../src/celestia/win32/res/resource_strings.cpp:168
-#: ../src/celestia/win32/res/resource_strings.cpp:171
-#: ../src/celestia/win32/res/resource_strings.cpp:183
-#: ../src/celestia/win32/res/resource_strings.cpp:187
-#: ../src/celestia/win32/res/resource_strings.cpp:234
+#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:173
+#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:236
 #, fuzzy
 msgid "OK"
 msgstr "確定"
@@ -3803,7 +3782,7 @@ msgid "Create in >>"
 msgstr "建立於 >>"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:95
-#: ../src/celestia/win32/res/resource_strings.cpp:156
+#: ../src/celestia/win32/res/resource_strings.cpp:158
 msgid "New Folder..."
 msgstr "新資料夾..."
 
@@ -3885,7 +3864,7 @@ msgid "Go to Object"
 msgstr "前往星體"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:188
+#: ../src/celestia/win32/res/resource_strings.cpp:190
 msgid "Go To"
 msgstr "前往"
 
@@ -3902,7 +3881,7 @@ msgid "Lat."
 msgstr "緯度"
 
 #: ../src/celestia/win32/res/resource_strings.cpp:131
-#: ../src/celestia/win32/res/resource_strings.cpp:233
+#: ../src/celestia/win32/res/resource_strings.cpp:235
 msgid "Distance"
 msgstr "距離"
 
@@ -3951,174 +3930,178 @@ msgstr "最小已標記特徵的尺寸"
 msgid "Size:"
 msgstr "大小:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:157
+#: ../src/celestia/win32/res/resource_strings.cpp:153
+msgid "Codec:"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:159
 msgid "Rename..."
 msgstr "重新命名..."
 
-#: ../src/celestia/win32/res/resource_strings.cpp:159
+#: ../src/celestia/win32/res/resource_strings.cpp:161
 msgid "Rename Bookmark or Folder"
 msgstr "重新命名書籤或資料夾"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:162
+#: ../src/celestia/win32/res/resource_strings.cpp:164
 msgid "New Name"
 msgstr "新名稱"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:163
+#: ../src/celestia/win32/res/resource_strings.cpp:165
 msgid "Set Simulation Time"
 msgstr "設定模擬時間"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:165
+#: ../src/celestia/win32/res/resource_strings.cpp:167
 msgid "Format: "
 msgstr "格式: "
 
-#: ../src/celestia/win32/res/resource_strings.cpp:167
+#: ../src/celestia/win32/res/resource_strings.cpp:169
 msgid "Set To Current Time"
 msgstr "設為目前的時間"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:170
+#: ../src/celestia/win32/res/resource_strings.cpp:172
 msgid "Solar System Browser"
 msgstr "太陽系瀏覽器"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:174
-#: ../src/celestia/win32/res/resource_strings.cpp:181
+#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:183
 msgid "&Go To"
 msgstr "前往(&G)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:175
+#: ../src/celestia/win32/res/resource_strings.cpp:177
 msgid "Solar System Objects"
 msgstr "太陽系星體"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:176
+#: ../src/celestia/win32/res/resource_strings.cpp:178
 msgid "Star Browser"
 msgstr "恆星瀏覽器"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:177
+#: ../src/celestia/win32/res/resource_strings.cpp:179
 msgid "Nearest"
 msgstr "最接近"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:178
+#: ../src/celestia/win32/res/resource_strings.cpp:180
 msgid "Brightest"
 msgstr "最亮"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:179
+#: ../src/celestia/win32/res/resource_strings.cpp:181
 #, fuzzy
 msgid "With planets"
 msgstr "包含行星"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:182
+#: ../src/celestia/win32/res/resource_strings.cpp:184
 msgid "&Refresh"
 msgstr "刷新(&R)"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:184
+#: ../src/celestia/win32/res/resource_strings.cpp:186
 msgid "Star Search Criteria"
 msgstr "恆星搜尋條件"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:185
+#: ../src/celestia/win32/res/resource_strings.cpp:187
 msgid "Maximum Stars Displayed in List"
 msgstr "列表中顯示的最多恆星數"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:186
+#: ../src/celestia/win32/res/resource_strings.cpp:188
 msgid "Tour Guide"
 msgstr "遊歷指導"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:189
+#: ../src/celestia/win32/res/resource_strings.cpp:191
 msgid "Select your destination:"
 msgstr "選擇您的目標:"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:190
+#: ../src/celestia/win32/res/resource_strings.cpp:192
 msgid "View Options"
 msgstr "檢視選項"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:191
+#: ../src/celestia/win32/res/resource_strings.cpp:193
 #, fuzzy
 msgid "Show:"
 msgstr "顯示"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:199
+#: ../src/celestia/win32/res/resource_strings.cpp:201
 #, fuzzy
 msgid "Rings"
 msgstr "京斯頓"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:200
+#: ../src/celestia/win32/res/resource_strings.cpp:202
 #, fuzzy
 msgid "Display:"
 msgstr "顯示"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:205
+#: ../src/celestia/win32/res/resource_strings.cpp:207
 msgid "Ecliptic Line"
 msgstr "黃道"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:211
+#: ../src/celestia/win32/res/resource_strings.cpp:213
 #, fuzzy
 msgid "Body / Orbit / Label display"
 msgstr "軌道 / 標籤"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:228
+#: ../src/celestia/win32/res/resource_strings.cpp:230
 msgid "Latin Names"
 msgstr "拉丁文名"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:229
+#: ../src/celestia/win32/res/resource_strings.cpp:231
 msgid "Information Text"
 msgstr "資訊文字"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:231
+#: ../src/celestia/win32/res/resource_strings.cpp:233
 msgid "Terse"
 msgstr "精簡"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:232
+#: ../src/celestia/win32/res/resource_strings.cpp:234
 msgid "Verbose"
 msgstr "詳細"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:236
-#: ../src/celestia/win32/winmain.cpp:3261
+#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/winmain.cpp:3319
 msgid "WinLangID"
 msgstr "WinLangID"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Apr"
 msgstr "4"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Feb"
 msgstr "2"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jan"
 msgstr "1"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Jun"
 msgstr "6"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "Mar"
 msgstr "3"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:237
+#: ../src/celestia/win32/res/resource_strings.cpp:239
 msgid "May"
 msgstr "5"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Aug"
 msgstr "8"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Dec"
 msgstr "12"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Jul"
 msgstr "7"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Nov"
 msgstr "11"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Oct"
 msgstr "10"
 
-#: ../src/celestia/win32/res/resource_strings.cpp:238
+#: ../src/celestia/win32/res/resource_strings.cpp:240
 msgid "Sep"
 msgstr "9"
 
@@ -4134,184 +4117,189 @@ msgstr "日期"
 msgid "Start"
 msgstr "開始"
 
-#: ../src/celestia/win32/winmain.cpp:507
+#: ../src/celestia/win32/winmain.cpp:534
 msgid ""
 "License file missing!\n"
 "See http://www.gnu.org/copyleft/gpl.html"
 msgstr ""
 
+#: ../src/celestia/win32/winmain.cpp:700
+#, c-format
+msgid "%d x %d"
+msgstr ""
+
 #. Add windowed mode as the first item on the menu
-#: ../src/celestia/win32/winmain.cpp:1327
+#: ../src/celestia/win32/winmain.cpp:1393
 msgid "Windowed Mode"
 msgstr "視窗模式"
 
-#: ../src/celestia/win32/winmain.cpp:1462
+#: ../src/celestia/win32/winmain.cpp:1528
 msgid "Invisibles"
 msgstr "不可見"
 
-#: ../src/celestia/win32/winmain.cpp:1566
+#: ../src/celestia/win32/winmain.cpp:1632
 msgid "S&ync Orbit"
 msgstr "同步軌道(&Y)"
 
-#: ../src/celestia/win32/winmain.cpp:1567
-#: ../src/celestia/win32/winmain.cpp:1615
-#: ../src/celestia/win32/winmain.cpp:1639
+#: ../src/celestia/win32/winmain.cpp:1633
+#: ../src/celestia/win32/winmain.cpp:1681
+#: ../src/celestia/win32/winmain.cpp:1705
 msgid "&Info"
 msgstr "資訊(&I)"
 
-#: ../src/celestia/win32/winmain.cpp:1570
+#: ../src/celestia/win32/winmain.cpp:1636
 msgid "Show Body Axes"
 msgstr "顯示天體轉軸"
 
-#: ../src/celestia/win32/winmain.cpp:1571
+#: ../src/celestia/win32/winmain.cpp:1637
 msgid "Show Frame Axes"
 msgstr "顯示系統轉軸"
 
-#: ../src/celestia/win32/winmain.cpp:1572
+#: ../src/celestia/win32/winmain.cpp:1638
 msgid "Show Sun Direction"
 msgstr "顯示太陽方向"
 
-#: ../src/celestia/win32/winmain.cpp:1573
+#: ../src/celestia/win32/winmain.cpp:1639
 msgid "Show Velocity Vector"
 msgstr "顯示速度向量"
 
-#: ../src/celestia/win32/winmain.cpp:1574
+#: ../src/celestia/win32/winmain.cpp:1640
 msgid "Show Planetographic Grid"
 msgstr "顯示行星格線"
 
-#: ../src/celestia/win32/winmain.cpp:1575
+#: ../src/celestia/win32/winmain.cpp:1641
 msgid "Show Terminator"
 msgstr "顯示晝夜界線"
 
-#: ../src/celestia/win32/winmain.cpp:1591
+#: ../src/celestia/win32/winmain.cpp:1657
 msgid "&Satellites"
 msgstr "衛星(&S)"
 
-#: ../src/celestia/win32/winmain.cpp:1624
+#: ../src/celestia/win32/winmain.cpp:1690
 msgid "Orbiting Bodies"
 msgstr "繞行天體"
 
-#: ../src/celestia/win32/winmain.cpp:1743
+#: ../src/celestia/win32/winmain.cpp:1809
 #, fuzzy
 msgid "Unable to switch to full screen mode; running in window mode"
 msgstr "載入字型時發生錯誤；將無法看到文字。\n"
 
-#: ../src/celestia/win32/winmain.cpp:1744
-#: ../src/celestia/win32/winmain.cpp:2016
-#: ../src/celestia/win32/winmain.cpp:2664
-#: ../src/celestia/win32/winmain.cpp:2675
-#: ../src/celestia/win32/winmain.cpp:2692
-#: ../src/celestia/win32/winmain.cpp:2773
-#: ../src/celestia/win32/winmain.cpp:2794
+#: ../src/celestia/win32/winmain.cpp:1810
+#: ../src/celestia/win32/winmain.cpp:2082
+#: ../src/celestia/win32/winmain.cpp:2720
+#: ../src/celestia/win32/winmain.cpp:2731
+#: ../src/celestia/win32/winmain.cpp:2748
+#: ../src/celestia/win32/winmain.cpp:2829
+#: ../src/celestia/win32/winmain.cpp:2852
 #, fuzzy
 msgid "Error"
 msgstr "錯誤:"
 
-#: ../src/celestia/win32/winmain.cpp:1908
+#: ../src/celestia/win32/winmain.cpp:1974
 msgid "Failed to register the window class."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1909
-#: ../src/celestia/win32/winmain.cpp:1960
-#: ../src/celestia/win32/winmain.cpp:1984
-#: ../src/celestia/win32/winmain.cpp:2294
-#: ../src/celestia/win32/winmain.cpp:3302
-#: ../src/celestia/win32/winmain.cpp:3375
+#: ../src/celestia/win32/winmain.cpp:1975
+#: ../src/celestia/win32/winmain.cpp:2026
+#: ../src/celestia/win32/winmain.cpp:2050
+#: ../src/celestia/win32/winmain.cpp:2360
+#: ../src/celestia/win32/winmain.cpp:3363
+#: ../src/celestia/win32/winmain.cpp:3436
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1959
+#: ../src/celestia/win32/winmain.cpp:2025
 msgid "Could not get appropriate pixel format for OpenGL rendering."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:1983
+#: ../src/celestia/win32/winmain.cpp:2049
 msgid "Your system doesn't support OpenGL 2.1!"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2015
+#: ../src/celestia/win32/winmain.cpp:2081
 msgid "Releasing device context failed."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2630
+#: ../src/celestia/win32/winmain.cpp:2686
 msgid "Save As - Specify File to Capture Image"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2674
+#: ../src/celestia/win32/winmain.cpp:2730
 msgid "Could not save image file."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2691
+#: ../src/celestia/win32/winmain.cpp:2747
 msgid "Stop current movie capture before starting another one."
 msgstr ""
 
 #. Comment this out if you just want the standard "Save As" caption.
-#: ../src/celestia/win32/winmain.cpp:2717
+#: ../src/celestia/win32/winmain.cpp:2773
 msgid "Save As - Specify Output File for Capture Movie"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2772
+#: ../src/celestia/win32/winmain.cpp:2828
 msgid "Unknown file extension specified for movie capture."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2790
+#: ../src/celestia/win32/winmain.cpp:2848
 msgid "Specified file extension is not recognized."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:2792
+#: ../src/celestia/win32/winmain.cpp:2850
 #, fuzzy
 msgid "Could not capture movie."
 msgstr "抓取影像"
 
-#: ../src/celestia/win32/winmain.cpp:3024
-#: ../src/celestia/win32/winmain.cpp:3037
-#: ../src/celestia/win32/winmain.cpp:3051
-#: ../src/celestia/win32/winmain.cpp:3064
-#: ../src/celestia/win32/winmain.cpp:3080
+#: ../src/celestia/win32/winmain.cpp:3082
+#: ../src/celestia/win32/winmain.cpp:3095
+#: ../src/celestia/win32/winmain.cpp:3109
+#: ../src/celestia/win32/winmain.cpp:3122
+#: ../src/celestia/win32/winmain.cpp:3138
 #, fuzzy
 msgid "Celestia Command Line Error"
 msgstr "Celestia 控制"
 
-#: ../src/celestia/win32/winmain.cpp:3101
+#: ../src/celestia/win32/winmain.cpp:3159
 msgid "Loading: "
 msgstr "載入:"
 
-#: ../src/celestia/win32/winmain.cpp:3159
+#: ../src/celestia/win32/winmain.cpp:3218
 #, fuzzy
 msgid "Loading data files..."
 msgstr "載入中 "
 
-#: ../src/celestia/win32/winmain.cpp:3259 ../src/celutil/fsutils.cpp:44
-#: ../src/celutil/fsutils.cpp:47
+#: ../src/celestia/win32/winmain.cpp:3317 ../src/celutil/fsutils.cpp:42
+#: ../src/celutil/fsutils.cpp:45
 msgid "LANGUAGE"
 msgstr "zh_TW"
 
-#: ../src/celestia/win32/winmain.cpp:3301
+#: ../src/celestia/win32/winmain.cpp:3362
 #, fuzzy
 msgid "Configuration file missing!"
 msgstr "讀取設定檔時發生錯誤。"
 
-#: ../src/celestia/win32/winmain.cpp:3339
+#: ../src/celestia/win32/winmain.cpp:3400
 msgid ""
 "Old favorites file detected.\n"
 "Copy to the new location?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3340
+#: ../src/celestia/win32/winmain.cpp:3401
 msgid "Copy favorites?"
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3374
+#: ../src/celestia/win32/winmain.cpp:3435
 msgid "Failed to create the application window."
 msgstr ""
 
-#: ../src/celestia/win32/winmain.cpp:3916
+#: ../src/celestia/win32/winmain.cpp:3971
 msgid "Loading URL"
 msgstr "載入網址中"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:138
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "版本:"
 
@@ -4347,17 +4335,21 @@ msgstr ""
 msgid "Error writing PNG file '{}'\n"
 msgstr "讀取PNG影像檔發生錯誤"
 
-#: ../src/celscript/legacy/legacyscript.cpp:96
+#: ../src/celscript/legacy/legacyscript.cpp:94
 msgid "Error opening script file."
 msgstr "開啟腳本檔案時發生錯誤。"
 
-#: ../src/celscript/legacy/legacyscript.cpp:105
+#: ../src/celscript/legacy/legacyscript.cpp:103
 #: ../src/celscript/lua/luascript.cpp:99
 #, fuzzy
 msgid "Unknown error loading script"
 msgstr "開啟腳本時發生未知的錯誤"
 
-#: ../src/celscript/lua/celx.cpp:771
+#: ../src/celscript/lua/celx.cpp:728
+msgid "In line {}: {}"
+msgstr ""
+
+#: ../src/celscript/lua/celx.cpp:774
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4369,7 +4361,7 @@ msgid ""
 "y = yes, ESC = cancel script, any other key = no"
 msgstr ""
 
-#: ../src/celscript/lua/celx.cpp:782
+#: ../src/celscript/lua/celx.cpp:785
 msgid ""
 "WARNING:\n"
 "\n"
@@ -4380,9 +4372,9 @@ msgid ""
 msgstr ""
 
 #: ../src/celscript/lua/luascript.cpp:90
-#, c-format
-msgid "Error opening script '%s'"
-msgstr "開啟腳本 '%s' 時發生錯誤"
+#, fuzzy
+msgid "Error opening script {}"
+msgstr "開啟腳本錯誤"
 
 #: ../src/celscript/lua/luascript.cpp:107
 #: ../src/celscript/lua/luascript.cpp:242
@@ -4390,8 +4382,8 @@ msgid "Script coroutine initialization failed"
 msgstr "腳本的子函式初始化失敗"
 
 #: ../src/celscript/lua/luascript.cpp:214
-#, fuzzy, c-format
-msgid "Error opening LuaHook '%s'"
+#, fuzzy
+msgid "Error opening LuaHook {}"
 msgstr "開啟腳本 '%s' 時發生錯誤"
 
 #: ../src/celscript/lua/luascript.cpp:231
@@ -4407,6 +4399,26 @@ msgstr ""
 #, fuzzy
 msgid "Error opening {} or .\n"
 msgstr "發生錯誤於開啟 "
+
+#, fuzzy
+#~ msgid "Render path: OpenGL 2.1"
+#~ msgstr "成像路徑:OpenGL 2.0"
+
+#~ msgid "Bloom enabled"
+#~ msgstr "彗尾已啟動"
+
+#~ msgid "Bloom disabled"
+#~ msgstr "彗尾已關閉"
+
+#~ msgid "Exposure"
+#~ msgstr "曝光"
+
+#, fuzzy
+#~ msgid "Video (*.avi)"
+#~ msgstr "抓取影像"
+
+#~ msgid "Error opening script '%s'"
+#~ msgstr "開啟腳本 '%s' 時發生錯誤"
 
 #, fuzzy
 #~ msgid "Error opening %s.\n"
@@ -6786,9 +6798,6 @@ msgstr "發生錯誤於開啟 "
 #~ msgid "GLSL version: "
 #~ msgstr "GLSL 版本:"
 
-#~ msgid "Error opening script"
-#~ msgstr "開啟腳本錯誤"
-
 #~ msgid "Error loading script"
 #~ msgstr "載入腳本錯誤"
 
@@ -7321,9 +7330,6 @@ msgstr "發生錯誤於開啟 "
 #, fuzzy
 #~ msgid "Surface Temp: "
 #~ msgstr "表面溫度:"
-
-#~ msgid "Radius: "
-#~ msgstr "半徑:"
 
 #~ msgid "Rsun"
 #~ msgstr "太陽半徑"

--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -12,13 +12,13 @@
 
 #include <cmath>
 #include <Eigen/Geometry>
+#include <fmt/format.h>
 #include <celcompat/numbers.h>
 #include <celmath/intersect.h>
 #include "body.h"
 #include "planetgrid.h"
 #include "render.h"
 #include "vecgl.h"
-#include <fmt/printf.h>
 
 using namespace std;
 using namespace Eigen;
@@ -220,7 +220,7 @@ PlanetographicGrid::render(Renderer* renderer,
                 else
                     ns = northDirection == NorthNormal ? 'N' : 'S';
                 string buf;
-                buf = fmt::sprintf("%d%c", (int) fabs(latitude), ns);
+                buf = fmt::format("{}{}", static_cast<int>(fabs(latitude)), ns);
                 longLatLabel(buf, 0.0, latitude, viewRayOrigin, viewNormal, posd, q, semiAxes, offset, renderer);
                 longLatLabel(buf, 180.0, latitude, viewRayOrigin, viewNormal, posd, q, semiAxes, offset, renderer);
             }
@@ -276,7 +276,7 @@ PlanetographicGrid::render(Renderer* renderer,
             }
 
             string buf;
-            buf = fmt::sprintf("%d%c", (int) showLongitude, ew);
+            buf = fmt::format("{}{}", showLongitude, ew);
             longLatLabel(buf, longitude, 0.0, viewRayOrigin, viewNormal, posd, q, semiAxes, offset, renderer);
             if (longitude > 0.0f && longitude < 180.0f)
             {
@@ -297,7 +297,7 @@ PlanetographicGrid::render(Renderer* renderer,
                     break;
                 }
 
-                buf = fmt::sprintf("%d%c", showLongitude, ew);
+                buf = fmt::format("{}{}", showLongitude, ew);
                 longLatLabel(buf, -longitude, 0.0, viewRayOrigin, viewNormal, posd, q, semiAxes, offset, renderer);
             }
         }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -14,7 +14,7 @@
 
 #include <Eigen/Geometry>
 
-#include <fmt/printf.h>
+#include <fmt/format.h>
 
 #include "render.h"
 #include "boundaries.h"
@@ -5425,7 +5425,7 @@ bool Renderer::getInfo(map<string, string>& info) const
 #ifndef GL_ES
     GLfloat pointSizeGran = 0;
     glGetFloatv(GL_SMOOTH_POINT_SIZE_GRANULARITY, &pointSizeGran);
-    info["PointSizeGran"] = fmt::sprintf("%.2f", pointSizeGran);
+    info["PointSizeGran"] = fmt::format("{:.2f}", pointSizeGran);
 
     GLint maxVaryings = 0;
     glGetIntegerv(GL_MAX_VARYING_FLOATS, &maxVaryings);
@@ -5435,7 +5435,7 @@ bool Renderer::getInfo(map<string, string>& info) const
     {
         float maxAnisotropy = 0.0f;
         glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAnisotropy);
-        info["MaxAnisotropy"] = fmt::sprintf("%.2f", maxAnisotropy);
+        info["MaxAnisotropy"] = fmt::format("{:.2f}", maxAnisotropy);
     }
 #endif
 

--- a/src/celengine/selection.cpp
+++ b/src/celengine/selection.cpp
@@ -9,6 +9,7 @@
 // of the License, or (at your option) any later version.
 
 #include <cassert>
+#include <fmt/format.h>
 #include "astro.h"
 #include "selection.h"
 #include "frametree.h"
@@ -16,7 +17,6 @@
 #include <celengine/body.h>
 #include <celengine/location.h>
 #include <celengine/deepskyobj.h>
-#include <fmt/printf.h>
 
 using namespace Eigen;
 using namespace std;
@@ -115,10 +115,10 @@ string Selection::getName(bool i18n) const
     switch (type)
     {
     case Type_Star:
-        return fmt::sprintf("#%u", star()->getIndex());
+        return fmt::format("#{}", star()->getIndex());
 
     case Type_DeepSky:
-        return fmt::sprintf("#%u", deepsky()->getIndex());
+        return fmt::format("#{}", deepsky()->getIndex());
 
     case Type_Body:
         {
@@ -136,7 +136,7 @@ string Selection::getName(bool i18n) const
                 {
                     const Star* parentStar = system->getStar();
                     if (parentStar != nullptr)
-                        name = fmt::sprintf("#%u/%s", parentStar->getIndex(), name);
+                        name = fmt::format("#{}/{}", parentStar->getIndex(), name);
                     system = nullptr;
                 }
             }

--- a/src/celengine/star.cpp
+++ b/src/celengine/star.cpp
@@ -8,15 +8,14 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <celmath/mathlib.h>
-#include <celengine/selection.h>
 #include <cassert>
-#include <config.h>
+#include <fmt/format.h>
+#include <celephem/orbit.h>
+#include <celmath/mathlib.h>
 #include "astro.h"
+#include "selection.h"
 #include "star.h"
 #include "texmanager.h"
-#include "celephem/orbit.h"
-#include <fmt/printf.h>
 
 using namespace Eigen;
 using namespace std;
@@ -474,16 +473,16 @@ StarDetails::GetNormalStarDetails(StellarClass::SpectralClass specClass,
         {
             // Hot subdwarfs are prefixed with "sd", while cool subdwarfs use
             // luminosity class VI, per recommendations in arXiv:0805.2567v1
-            name = fmt::sprintf("sd%s%s",
-                                SpectralClassNames[specClass],
-                                SubclassNames[subclass]);
+            name = fmt::format("sd{}{}",
+                               SpectralClassNames[specClass],
+                               SubclassNames[subclass]);
         }
         else
         {
-            name = fmt::sprintf("%s%s%s",
-                                SpectralClassNames[specClass],
-                                SubclassNames[subclass],
-                                LumClassNames[lumClass]);
+            name = fmt::format("{}{}{}",
+                               SpectralClassNames[specClass],
+                               SubclassNames[subclass],
+                               LumClassNames[lumClass]);
         }
 
         // Use the same properties for an unknown subclass as for subclass 5
@@ -697,10 +696,9 @@ StarDetails::GetWhiteDwarfDetails(StellarClass::SpectralClass specClass,
     unsigned int index = subclass + (scIndex * StellarClass::SubclassCount);
     if (whiteDwarfDetails[index] == nullptr)
     {
-        string name;
-        name = fmt::sprintf("%s%s",
-                            WDSpectralClassNames[scIndex],
-                            SubclassNames[subclass]);
+        auto name = fmt::format("{}{}",
+                                WDSpectralClassNames[scIndex],
+                                SubclassNames[subclass]);
 
         float temp;
         float bmagCorrection;

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -8,12 +8,12 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <config.h>
 #include <cstring>
 #include <cmath>
 #include <cstdlib>
 #include <cassert>
 #include <algorithm>
+#include <fmt/format.h>
 #include <celmath/mathlib.h>
 #include <celutil/binaryread.h>
 #include <celutil/logger.h>
@@ -26,7 +26,6 @@
 #include "multitexture.h"
 #include "meshmanager.h"
 
-#include <fmt/printf.h>
 
 using namespace Eigen;
 using namespace std;
@@ -348,7 +347,7 @@ static string catalogNumberToString(AstroCatalog::IndexNumber catalogNumber)
 {
     if (catalogNumber <= StarDatabase::MAX_HIPPARCOS_NUMBER)
     {
-        return fmt::sprintf("HIP %d", catalogNumber);
+        return fmt::format("HIP {}", catalogNumber);
     }
     else
     {
@@ -357,7 +356,7 @@ static string catalogNumberToString(AstroCatalog::IndexNumber catalogNumber)
         AstroCatalog::IndexNumber tyc2 = catalogNumber / 10000;
         catalogNumber -= tyc2 * 10000;
         AstroCatalog::IndexNumber tyc1 = catalogNumber;
-        return fmt::sprintf("TYC %d-%d-%d", tyc1, tyc2, tyc3);
+        return fmt::format("TYC {}-{}-{}", tyc1, tyc2, tyc3);
     }
 }
 
@@ -397,7 +396,7 @@ string StarDatabase::getStarName(const Star& star, bool i18n) const
     /*
       // Get the HD catalog name
       if (star.getIndex() != AstroCatalog::InvalidIndex)
-      return fmt::sprintf("HD %d", star.getIndex(Star::HDCatalog));
+      return fmt::format("HD {}", star.getIndex(Star::HDCatalog));
       else
     */
     return catalogNumberToString(catalogNumber);
@@ -484,11 +483,11 @@ string StarDatabase::getStarNameList(const Star& star, const unsigned int maxNam
                        h     -= tyc2 * 10000;
                 AstroCatalog::IndexNumber tyc1   = h;
 
-                append(fmt::sprintf("TYC %u-%u-%u", tyc1, tyc2, tyc3));
+                append(fmt::format("TYC {}-{}-{}", tyc1, tyc2, tyc3));
             }
             else
             {
-                append(fmt::sprintf("HIP %u", hip));
+                append(fmt::format("HIP {}", hip));
             }
         }
     }
@@ -496,13 +495,13 @@ string StarDatabase::getStarNameList(const Star& star, const unsigned int maxNam
     AstroCatalog::IndexNumber hd   = crossIndex(StarDatabase::HenryDraper, hip);
     if (nameSet.size() < maxNames && hd != AstroCatalog::InvalidIndex)
     {
-        append(fmt::sprintf("HD %u", hd));
+        append(fmt::format("HD {}", hd));
     }
 
     AstroCatalog::IndexNumber sao   = crossIndex(StarDatabase::SAO, hip);
     if (nameSet.size() < maxNames && sao != AstroCatalog::InvalidIndex)
     {
-        append(fmt::sprintf("SAO %u", sao));
+        append(fmt::format("SAO {}", sao));
     }
 
     return starNames;
@@ -1428,8 +1427,8 @@ void StarDatabase::buildOctree()
     for (const auto& stat : stats)
     {
         level++;
-        clog << fmt::sprintf(
-                     _("Level %i, %.5f ly, %i nodes, %i  stars\n"),
+        clog << fmt::format(
+                     "Level {}, {:.5f} ly, {} nodes, {} stars\n",
                      level,
                      STAR_OCTREE_ROOT_SIZE / pow(2.0, (double) level),
                      stat.nodeCount,

--- a/src/celengine/stellarclass.cpp
+++ b/src/celengine/stellarclass.cpp
@@ -7,10 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <cstring>
-#include <fmt/printf.h>
 #include <cassert>
-#include <config.h>
 #include "stellarclass.h"
 
 using namespace std;

--- a/src/celengine/trajmanager.cpp
+++ b/src/celengine/trajmanager.cpp
@@ -7,10 +7,9 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <config.h>
 #include <fstream>
 #include <cassert>
-#include <fmt/printf.h>
+#include <fmt/format.h>
 #include <celephem/samporbit.h>
 #include <celutil/logger.h>
 #include <celutil/filetype.h>
@@ -21,7 +20,7 @@ using celestia::util::GetLogger;
 
 static TrajectoryManager* trajectoryManager = nullptr;
 
-constexpr const fs::path::value_type UniqueSuffixChar = '!';
+constexpr const char UniqueSuffixChar = '!';
 
 
 TrajectoryManager* GetTrajectoryManager()
@@ -37,13 +36,7 @@ fs::path TrajectoryInfo::resolve(const fs::path& baseDir)
     // Ensure that trajectories with different interpolation or precision get resolved to different objects by
     // adding a 'uniquifying' suffix to the filename that encodes the properties other than filename which can
     // distinguish two trajectories. This suffix is stripped before the file is actually loaded.
-    fs::path::string_type uniquifyingSuffix, format;
-#ifdef _WIN32
-    format = L"%c%u%u";
-#else
-    format = "%c%u%u";
-#endif
-    uniquifyingSuffix = fmt::sprintf(format, UniqueSuffixChar, (unsigned int) interpolation, (unsigned int) precision);
+    auto uniquifyingSuffix = fmt::format("{}{}{}", UniqueSuffixChar, (unsigned int) interpolation, (unsigned int) precision);
 
     if (!path.empty())
     {
@@ -59,7 +52,7 @@ fs::path TrajectoryInfo::resolve(const fs::path& baseDir)
 Orbit* TrajectoryInfo::load(const fs::path& filename)
 {
     // strip off the uniquifying suffix
-    string::size_type uniquifyingSuffixStart = filename.string().rfind(UniqueSuffixChar);
+    auto uniquifyingSuffixStart = filename.string().rfind(UniqueSuffixChar);
     fs::path strippedFilename = filename.string().substr(0, uniquifyingSuffixStart);
     ContentType filetype = DetermineFileType(strippedFilename);
 

--- a/src/celephem/scriptobject.cpp
+++ b/src/celephem/scriptobject.cpp
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <fmt/printf.h>
-
+#include <fmt/format.h>
 #include "scriptobject.h"
 
 using namespace std;
@@ -49,7 +48,7 @@ string
 GenerateScriptObjectName()
 {
     string buf;
-    buf = fmt::sprintf("%s%u", ScriptedObjectNamePrefix, ScriptedObjectNameIndex);
+    buf = fmt::format("{}{}", ScriptedObjectNamePrefix, ScriptedObjectNameIndex);
     ScriptedObjectNameIndex++;
 
     return buf;

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -1311,7 +1311,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
 #ifdef USE_MINIAUDIO
             resumeAudioIfNeeded();
 #endif
-    
+
             if (scriptState == ScriptPaused)
                 scriptState = ScriptRunning;
             sim->setPauseState(false);
@@ -2582,7 +2582,7 @@ static string DistanceLyToStr(double distance, int digits, CelestiaCore::Measure
         }
     }
 
-    return fmt::sprintf("%s %s", SigDigitNum(distance, digits), units);
+    return fmt::format("{} {}", SigDigitNum(distance, digits), units);
 }
 
 
@@ -2618,7 +2618,7 @@ static void displayRotationPeriod(Overlay& overlay, double days)
         p = _("seconds");
     }
 
-    overlay.printf(_("Rotation period: %s %s\n"), n, p);
+    overlay.print(_("Rotation period: {} {}\n"), n, p);
 }
 
 static void displayMass(Overlay& overlay, float mass, CelestiaCore::MeasurementSystem measurement)
@@ -2682,7 +2682,7 @@ static void displaySpeed(Overlay& overlay, float speed, CelestiaCore::Measuremen
             u = _("m/s");
         }
     }
-    overlay.printf(_("Speed: %s %s\n"), n, u);
+    overlay.print(_("Speed: {} {}\n"), n, u);
 }
 
 // Display a positive angle as degrees, minutes, and seconds. If the angle is less than one
@@ -2696,18 +2696,16 @@ static string angleToStr(double angle)
 
     if (degrees > 0)
     {
-        return fmt::sprintf("%d%s %02d' %.1f\"",
-                            degrees, UTF8_DEGREE_SIGN,
-                            abs(minutes), abs(seconds));
+        return fmt::format("{}" UTF8_DEGREE_SIGN "{:02d}' {:.1f}\"",
+                           degrees, abs(minutes), abs(seconds));
     }
 
     if (minutes > 0)
     {
-        return fmt::sprintf("%02d' %.1f\"",
-                            abs(minutes), abs(seconds));
+        return fmt::format("{:02d}' {:.1f}\"", abs(minutes), abs(seconds));
     }
 
-    return fmt::sprintf("%.2f\"", abs(seconds));
+    return fmt::format("{:.2f}\"", abs(seconds));
 }
 
 static void displayDeclination(Overlay& overlay, double angle)
@@ -2883,7 +2881,7 @@ static void displayStarInfo(Overlay& overlay,
                                 star.getApparentMagnitude(float(distance)));
 
         if (star.getLuminosity() > 1.0e-10f)
-            overlay.printf(_("Luminosity: %sx Sun\n"), SigDigitNum(star.getLuminosity(), 3));
+            overlay.print(_("Luminosity: {}x Sun\n"), SigDigitNum(star.getLuminosity(), 3));
 
         const char* star_class;
         switch (star.getSpectralType()[0])
@@ -2909,14 +2907,14 @@ static void displayStarInfo(Overlay& overlay,
 
             if (solarRadii > 0.01f)
             {
-                overlay.printf(_("Radius: %s Rsun  (%s)\n"),
-                             SigDigitNum(star.getRadius() / 696000.0f, 2),
-                             DistanceKmToStr(star.getRadius(), 3, measurement));
+                overlay.print(_("Radius: {} Rsun  ({})\n"),
+                              SigDigitNum(star.getRadius() / 696000.0f, 2),
+                              DistanceKmToStr(star.getRadius(), 3, measurement));
             }
             else
             {
-                overlay.printf(_("Radius: %s\n"),
-                             DistanceKmToStr(star.getRadius(), 3, measurement));
+                overlay.print(_("Radius: {}\n"),
+                              DistanceKmToStr(star.getRadius(), 3, measurement));
             }
 
             if (star.getRotationModel()->isPeriodic())
@@ -3200,7 +3198,7 @@ void CelestiaCore::renderOverlay()
         overlay->moveBy(width - safeAreaInsets.right - dateStrWidth, height - safeAreaInsets.top - fontHeight);
         overlay->beginText();
 
-        overlay->printf(dateStr.c_str());
+        *overlay << dateStr;
 
         if (lightTravelFlag && lt > 0.0)
         {
@@ -3287,10 +3285,10 @@ void CelestiaCore::renderOverlay()
         {
             double timeLeft = sim->getArrivalTime() - sim->getRealTime();
             if (timeLeft >= 1)
-                overlay->printf(_("Travelling (%s)\n"),
-                             FormattedNumber(timeLeft, 0, FormattedNumber::GroupThousands));
+                overlay->print(_("Travelling ({})\n"),
+                               FormattedNumber(timeLeft, 0, FormattedNumber::GroupThousands));
             else
-                overlay->printf(_("Travelling\n"));
+                overlay->print(_("Travelling\n"));
         }
         else
         {
@@ -3620,7 +3618,7 @@ void CelestiaCore::renderOverlay()
         auto min = (int) (sec / 60);
         sec -= min * 60.0f;
         overlay->beginText();
-        overlay->printf("%3d:%05.2f", min, sec);
+        overlay->print("{:3i}:{05.2f}", min, sec);
         overlay->endText();
         overlay->restorePos();
 

--- a/src/celestia/glut/glutmain.cpp
+++ b/src/celestia/glut/glutmain.cpp
@@ -27,7 +27,6 @@
 #include <Carbon/Carbon.h>
 #include <GLUT/glut.h>
 #endif
-#include <fmt/printf.h>
 #include <celutil/gettext.h>
 #include <celutil/logger.h>
 #include <celutil/tzutil.h>

--- a/src/celestia/helper.cpp
+++ b/src/celestia/helper.cpp
@@ -147,11 +147,11 @@ std::string Helper::getRenderInfo(const Renderer *r)
         string::size_type old = 0, pos = ext.find(' ');
         while (pos != string::npos)
         {
-            s += fmt::sprintf("    %s\n", ext.substr(old, pos - old));
+            s += fmt::format("    {}\n", ext.substr(old, pos - old));
             old = pos + 1;
             pos = ext.find(' ', old);
         }
-        s += fmt::sprintf("    %s\n", ext.substr(old));
+        s += fmt::format("    {}\n", ext.substr(old));
     }
 
     return s;

--- a/src/celestia/qt/qtselectionpopup.cpp
+++ b/src/celestia/qt/qtselectionpopup.cpp
@@ -18,7 +18,7 @@
 #include <celengine/planetgrid.h>
 #include <celutil/gettext.h>
 #include <celutil/greek.h>
-#include <fmt/printf.h>
+#include <fmt/format.h>
 #include "qtselectionpopup.h"
 #include "qtappwin.h"
 
@@ -106,23 +106,22 @@ SelectionPopup::SelectionPopup(const Selection& sel,
         setlocale(LC_NUMERIC, "");
 
         if (abs(distance) >= astro::AUtoLightYears(1000.0f))
-            buff = fmt::sprintf("%.3f %s", distance, _("ly"));
+            buff = fmt::format(_("{:.3f} ly"), distance);
         else if (abs(distance) >= astro::kilometersToLightYears(10000000.0))
-            buff = fmt::sprintf("%.3f %s", astro::lightYearsToAU(distance), _("au"));
+            buff = fmt::format(_("{:.3f} au"), astro::lightYearsToAU(distance));
         else if (abs(distance) > astro::kilometersToLightYears(1.0f))
-            buff = fmt::sprintf(_("%.3f km"), astro::lightYearsToKilometers(distance));
+            buff = fmt::format(_("{:.3f} km"), astro::lightYearsToKilometers(distance));
         else
-            buff = fmt::sprintf(_("%.3f m"), astro::lightYearsToKilometers(distance) * 1000.0f);
+            buff = fmt::format(_("{:.3f} m"), astro::lightYearsToKilometers(distance) * 1000.0f);
 
         addAction(italicTextItem(_("Distance: ") + QString::fromStdString(buff)));
 
-        buff = fmt::sprintf("%.2f (%.2f)",
-                            sel.star()->getAbsoluteMagnitude(),
-                            sel.star()->getApparentMagnitude((float) distance));
+        buff = fmt::format("{:.2f} ({:.2f})",
+                           sel.star()->getAbsoluteMagnitude(),
+                           sel.star()->getApparentMagnitude((float) distance));
         addAction(italicTextItem(_("Abs (app) mag: ") + QString::fromStdString(buff)));
 
-        buff = fmt::sprintf("%s", sel.star()->getSpectralType());
-        addAction(italicTextItem(_("Class: ") + QString::fromStdString(buff)));
+        addAction(italicTextItem(_("Class: ") + QString::fromStdString(sel.star()->getSpectralType())));
 
         setlocale(LC_NUMERIC, "C");
     }

--- a/src/celestia/url.cpp
+++ b/src/celestia/url.cpp
@@ -8,9 +8,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <iostream>
-#include <fmt/ostream.h>
-#include <fmt/printf.h>
+#include <fmt/format.h>
 #include <celcompat/charconv.h>
 #include <celutil/bigfix.h>
 #include <celutil/gettext.h>
@@ -360,7 +358,7 @@ Url::encodeString(std::string_view str)
         }
 
         if (encode)
-            enc << fmt::sprintf("%%%02x", ch);
+            enc << fmt::format("%{:02x}", ch);
         else
             enc << _ch;
     }
@@ -652,12 +650,12 @@ void Url::evalName()
 {
     std::string name;
     if (!m_state.m_refBodyName.empty())
-        name += fmt::sprintf(" %s", getBodyShortName(m_state.m_refBodyName));
+        name += fmt::format(" {}", getBodyShortName(m_state.m_refBodyName));
     if (!m_state.m_targetBodyName.empty())
-        name += fmt::sprintf(" %s", getBodyShortName(m_state.m_targetBodyName));
+        name += fmt::format(" {}", getBodyShortName(m_state.m_targetBodyName));
     if (!m_state.m_trackedBodyName.empty())
-        name += fmt::sprintf(" -> %s", getBodyShortName(m_state.m_trackedBodyName));
+        name += fmt::format(" -> {}", getBodyShortName(m_state.m_trackedBodyName));
     if (!m_state.m_selectedBodyName.empty())
-        name += fmt::sprintf(" [%s]", getBodyShortName(m_state.m_selectedBodyName));
+        name += fmt::format(" [{}]", getBodyShortName(m_state.m_selectedBodyName));
     m_name = std::move(name);
 }

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -725,7 +725,7 @@ void Celx_DoError(lua_State* l, const char* errorMsg)
     {
         if (lua_getinfo(l, "l", &debug))
         {
-            string buf = fmt::sprintf("In line %i: %s", debug.currentline, errorMsg);
+            string buf = fmt::format(_("In line {}: {}"), debug.currentline, errorMsg);
             lua_pushstring(l, buf.c_str());
             lua_error(l);
         }

--- a/src/celscript/lua/celx_category.cpp
+++ b/src/celscript/lua/celx_category.cpp
@@ -1,13 +1,11 @@
 #include <string>
-
-#include <fmt/printf.h>
-
+#include <fmt/format.h>
+#include <celengine/category.h>
+#include <celengine/selection.h>
 #include "celx.h"
 #include "celx_internal.h"
 #include "celx_category.h"
 #include "celx_object.h"
-#include <celengine/category.h>
-#include <celengine/selection.h>
 
 static int category_tostring(lua_State *l)
 {
@@ -19,7 +17,7 @@ static int category_tostring(lua_State *l)
         celx.doError("Category object is null!");
         return 0;
     }
-    std::string s = fmt::sprintf("[UserCategory:%s]", c->name());
+    std::string s = fmt::format("[UserCategory:{}]", c->name());
     return celx.push(s.c_str());
 }
 

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -10,13 +10,7 @@
 // of the License, or (at your option) any later version.
 
 #include <optional>
-#include <celutil/gettext.h>
-#include <celutil/logger.h>
-#include "celttf/truetypefont.h"
-#include <fmt/printf.h>
-#include <celengine/category.h>
-#include <celengine/texture.h>
-#include <celcompat/filesystem.h>
+#include <fmt/format.h>
 #include "celx.h"
 #include "celx_internal.h"
 #include "celx_celestia.h"
@@ -33,6 +27,13 @@
 #include <celestia/celestiacore.h>
 #include <celestia/view.h>
 #include <celscript/common/scriptmaps.h>
+#include <celutil/gettext.h>
+#include <celutil/logger.h>
+#include <celttf/truetypefont.h>
+#include <celengine/category.h>
+#include <celengine/texture.h>
+#include <celcompat/filesystem.h>
+
 
 using namespace std;
 using namespace Eigen;
@@ -2023,10 +2024,10 @@ static int celestia_takescreenshot(lua_State* l)
     luastate->screenshotCount++;
     bool success = false;
     string filenamestem;
-    filenamestem = fmt::sprintf("screenshot-%s%06i", fileid, luastate->screenshotCount);
+    filenamestem = fmt::format("screenshot-{}{:06i}", fileid, luastate->screenshotCount);
 
     fs::path path = appCore->getConfig()->scriptScreenshotDirectory;
-    fs::path filepath = path / fmt::sprintf("%s.%s", filenamestem, filetype);
+    fs::path filepath = path / fmt::format("{}.{}", filenamestem, filetype);
     success = appCore->saveScreenShot(filepath);
     lua_pushboolean(l, success);
 

--- a/src/celscript/lua/celx_misc.cpp
+++ b/src/celscript/lua/celx_misc.cpp
@@ -331,7 +331,7 @@ static int image_tostring(lua_State* l)
 {
     CelxLua celx(l);
     auto image = *celx.getThis<Image*>();
-    std::string s = fmt::sprintf("[Image:%dx%d]", image->getWidth(), image->getHeight());
+    std::string s = fmt::format("[Image:{}x{}]", image->getWidth(), image->getHeight());
     return celx.push(s.c_str());
 }
 
@@ -386,7 +386,7 @@ static int texture_tostring(lua_State* l)
     CelxLua celx(l);
 
     auto tex = *celx.getThis<Texture*>();
-    std::string s = fmt::sprintf("[Texture:%dx%d]", tex->getWidth(), tex->getHeight());
+    std::string s = fmt::format("[Texture:{}x{}]", tex->getWidth(), tex->getHeight());
     return celx.push(s.c_str());
 }
 

--- a/src/celscript/lua/luascript.cpp
+++ b/src/celscript/lua/luascript.cpp
@@ -87,7 +87,7 @@ unique_ptr<IScript> LuaScriptPlugin::loadScript(const fs::path &path)
     ifstream scriptfile(path);
     if (!scriptfile.good())
     {
-        appCore()->fatalError(fmt::sprintf(_("Error opening script '%s'"), path));
+        appCore()->fatalError(fmt::format(_("Error opening script {}"), path));
         return nullptr;
     }
 
@@ -211,7 +211,7 @@ bool CreateLuaEnvironment(CelestiaCore *appCore, const CelestiaConfig *config, P
     {
         ifstream scriptfile(config->luaHook);
         if (!scriptfile.good())
-            appCore->fatalError(fmt::sprintf(_("Error opening LuaHook '%s'"), config->luaHook));
+            appCore->fatalError(fmt::format(_("Error opening LuaHook {}"), config->luaHook));
 
         if (progressNotifier != nullptr)
             progressNotifier->update(config->luaHook.string());

--- a/src/celutil/formatnum.h
+++ b/src/celutil/formatnum.h
@@ -7,11 +7,9 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef CELUTIL_FORMATNUM_H_
-#define CELUTIL_FORMATNUM_H_
+#pragma once
 
-#include <iostream>
-
+#include <fmt/ostream.h>
 
 class FormattedNumber
 {
@@ -35,6 +33,6 @@ private:
     unsigned int flags;
 };
 
-
-#endif // CELUTIL_FORMATNUM_H_
-
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<FormattedNumber> : ostream_formatter {};
+#endif

--- a/src/celutil/fsutils.cpp
+++ b/src/celutil/fsutils.cpp
@@ -10,9 +10,10 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <config.h>
+#include <config.h> // HAVE_WORDEXP
 #include <fstream>
-#include <fmt/printf.h>
+#include <iostream>
+#include <fmt/format.h>
 #include "gettext.h"
 #ifdef _WIN32
 #include <shlobj.h>
@@ -36,15 +37,12 @@ namespace celestia::util
 
 fs::path LocaleFilename(const fs::path &p)
 {
-    fs::path::string_type format, lang;
-#ifdef _WIN32
-    format = L"%s_%s%s";
-    lang = CurrentCPToWide(_("LANGUAGE"));
-#else
-    format = "%s_%s%s";
-    lang = _("LANGUAGE");
-#endif
-    fs::path locPath = p.parent_path() / fmt::sprintf(format, p.stem().native(), lang, p.extension().native());
+    const char *orig = N_("LANGUAGE");
+    const char *lang = _(orig);
+    if (lang == orig)
+        return p;
+
+    fs::path locPath = p.parent_path() / p.stem().concat("_").concat(lang).replace_extension(p.extension());
 
     std::error_code ec;
     if (fs::exists(locPath, ec))


### PR DESCRIPTION
Closes: #1391

A bit messy PR but the 1st part is partially implemented when I work on compatibility with fmt 9, because `template <> struct fmt::formatter<FormattedNumber> : ostream_formatter {};` doesn't work with `printf("%s")`.

The 2nd part will remove printf completely, but I want to find a way to avoid introducing too many new  strings for translators.