### PR TITLE
WIP: Common line renderer and vertex object cleanup

### DIFF
--- a/shaders/orbit_frag.glsl
+++ b/shaders/orbit_frag.glsl
@@ -1,0 +1,6 @@
+varying vec4 v_color;
+
+void main(void)
+{
+    gl_FragColor = v_color;
+}

--- a/shaders/orbit_vert.glsl
+++ b/shaders/orbit_vert.glsl
@@ -1,0 +1,11 @@
+attribute vec4 in_Position;
+attribute vec4 in_Color;
+varying vec4 v_color;
+
+void main(void)
+{
+    float alphaFactor = in_Position.w;
+    vec4 pos = vec4(in_Position.xyz, 1.0);
+    v_color = vec4(in_Color.rgb, in_Color.a * alphaFactor);
+    set_vp(pos);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CELESTIA_LIBS
   celimage
   celmath
   celmodel
+  celrender
   celttf
   celutil
 )

--- a/src/celengine/asterismrenderer.cpp
+++ b/src/celengine/asterismrenderer.cpp
@@ -1,6 +1,6 @@
 // asterismrenderer.cpp
 //
-// Copyright (C) 2018-2019, the Celestia Development Team
+// Copyright (C) 2018-present, the Celestia Development Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -8,17 +8,18 @@
 // of the License, or (at your option) any later version.
 
 #include <cassert>
+#include <celutil/color.h>
 #include "asterismrenderer.h"
 #include "render.h"
 #include "vecgl.h"
 
-using namespace std;
+using celestia::engine::LineRenderer;
 
-AsterismRenderer::AsterismRenderer(const AsterismList *asterisms) :
-    m_asterisms(asterisms)
+AsterismRenderer::AsterismRenderer(const Renderer &renderer, const AsterismList *asterisms) :
+    m_renderer(renderer),
+    m_asterisms(asterisms),
+    m_lineRenderer(LineRenderer(renderer))
 {
-    m_shadprop.texUsage = ShaderProperties::VertexColors;
-    m_shadprop.lightModel = ShaderProperties::UnlitModel;
 }
 
 bool AsterismRenderer::sameAsterisms(const AsterismList *asterisms) const
@@ -28,56 +29,19 @@ bool AsterismRenderer::sameAsterisms(const AsterismList *asterisms) const
 
 /*! Draw visible asterisms.
  */
-void AsterismRenderer::render(const Renderer &renderer, const Color &defaultColor, const Matrices &mvp)
+void AsterismRenderer::render(const Color &defaultColor, const Matrices &mvp)
 {
-    using AttributesType = celgl::VertexObject::AttributesType;
-
-    ShaderProperties props = m_shadprop;
-    bool lineAsTriangles = renderer.shouldDrawLineAsTriangles();
-    if (lineAsTriangles)
-        props.texUsage |= ShaderProperties::LineAsTriangles;
-
-    auto *prog = renderer.getShaderManager().getShader(props);
-    if (prog == nullptr)
-        return;
-
-    m_vo.bind(lineAsTriangles ? AttributesType::Default : AttributesType::Alternative1);
-    if (!m_vo.initialized())
+    if (!m_initialized)
     {
-        std::vector<LineEnds> data;
-        if (!prepare(data))
-        {
-            m_vo.unbind();
-            return;
-        }
-
-        // Attributes for lines drawn as triangles
-        m_vo.allocate(data.size() * sizeof(LineEnds), data.data());
-        m_vo.setVertices(3, GL_FLOAT, false, sizeof(LineEnds), offsetof(LineEnds, point1));
-        m_vo.setVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex, 3, GL_FLOAT, false, sizeof(LineEnds), offsetof(LineEnds, point2));
-        m_vo.setVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex, 1, GL_FLOAT, false, sizeof(LineEnds), offsetof(LineEnds, scale));
-
-        // Attributes for lines drawn as lines
-        m_vo.setVertices(3, GL_FLOAT, false, sizeof(LineEnds) * 3, offsetof(LineEnds, point1), AttributesType::Alternative1);
+        if (!prepare()) return;
+        m_initialized = true;
     }
 
-    prog->use();
-    prog->setMVPMatrices(*mvp.projection, *mvp.modelview);
-    glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, defaultColor);
-    if (lineAsTriangles)
-    {
-        prog->lineWidthX = renderer.getLineWidthX();
-        prog->lineWidthY = renderer.getLineWidthY();
-        m_vo.draw(GL_TRIANGLES, m_totalLineCount * 6);
-    }
-    else
-    {
-        m_vo.draw(GL_LINES, m_totalLineCount * 2);
-    }
+    m_lineRenderer.render(mvp, defaultColor, m_totalLineCount * 2);
 
     assert(m_asterisms->size() == m_lineCount.size());
 
-    ptrdiff_t offset = 0;
+    int offset = 0;
     float opacity = defaultColor.alpha();
     for (size_t size = m_asterisms->size(), i = 0; i < size; i++)
     {
@@ -89,18 +53,12 @@ void AsterismRenderer::render(const Renderer &renderer, const Color &defaultColo
         }
 
         Color color = {ast->getOverrideColor(), opacity};
-        glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, color);
-        if (lineAsTriangles)
-            m_vo.draw(GL_TRIANGLES, m_lineCount[i] * 6, offset * 6);
-        else
-            m_vo.draw(GL_LINES, m_lineCount[i] * 2, offset * 2);
+        m_lineRenderer.render(mvp, color, m_lineCount[i] * 2, offset * 2);
         offset += m_lineCount[i];
     }
-
-    m_vo.unbind();
 }
 
-bool AsterismRenderer::prepare(std::vector<LineEnds> &data)
+bool AsterismRenderer::prepare()
 {
     // calculate required vertices number
     GLsizei vtx_num = 0;
@@ -109,9 +67,9 @@ bool AsterismRenderer::prepare(std::vector<LineEnds> &data)
         GLsizei ast_vtx_num = 0;
         for (int k = 0; k < ast->getChainCount(); k++)
         {
-            // as we use GL_TRIANGLES we should six times the number of
-            // vertices as we don't need closed figures we have only one
-            // copy of the 1st and last vertexes
+            // as we use GL_LINES we should double the number of vertices.
+            // as we don't need closed figures we have only one copy of
+            // the 1st and last vertexes
             GLsizei s = ast->getChain(k).size();
             if (s > 1)
                 ast_vtx_num += s - 1;
@@ -126,31 +84,15 @@ bool AsterismRenderer::prepare(std::vector<LineEnds> &data)
 
     m_totalLineCount = vtx_num;
 
-    // we reserve 6 times the space so we can allow to
-    // draw a line segment with two triangles
-    data.reserve(m_totalLineCount * 6);
     for (const auto ast : *m_asterisms)
     {
         for (int k = 0; k < ast->getChainCount(); k++)
         {
             const auto& chain = ast->getChain(k);
-
-            // skip empty (without starts or only with one star) chains
-            if (chain.size() <= 1)
-                continue;
-
             for (unsigned i = 1; i < chain.size(); i++)
-            {
-                Eigen::Vector3f prev = chain[i - 1];
-                Eigen::Vector3f cur = chain[i];
-                data.emplace_back(prev, cur, -0.5);
-                data.emplace_back(prev ,cur, 0.5);
-                data.emplace_back(cur, prev, -0.5);
-                data.emplace_back(cur, prev, -0.5);
-                data.emplace_back(cur, prev, 0.5);
-                data.emplace_back(prev, cur, -0.5);
-            }
+                m_lineRenderer.addSegment(chain[i - 1], chain[i]);
         }
     }
+
     return true;
 }

--- a/src/celengine/asterismrenderer.h
+++ b/src/celengine/asterismrenderer.h
@@ -1,6 +1,6 @@
 // asterismrenderer.h
 //
-// Copyright (C) 2018-2019, the Celestia Development Team
+// Copyright (C) 2018-present, the Celestia Development Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -11,18 +11,16 @@
 
 #include <vector>
 #include <celengine/asterism.h>
-#include <celutil/color.h>
-#include "shadermanager.h"
-#include "vertexobject.h"
+#include <celrender/linerenderer.h>
 
+class Color;
 class Renderer;
 struct Matrices;
-struct LineEnds;
 
 class AsterismRenderer
 {
- public:
-    AsterismRenderer(const AsterismList *asterisms);
+public:
+    AsterismRenderer(const Renderer &renderer, const AsterismList *asterisms);
     ~AsterismRenderer() = default;
     AsterismRenderer() = delete;
     AsterismRenderer(const AsterismRenderer&) = delete;
@@ -30,16 +28,16 @@ class AsterismRenderer
     AsterismRenderer& operator=(const AsterismRenderer&) = delete;
     AsterismRenderer& operator=(AsterismRenderer&&) = delete;
 
-    void render(const Renderer &renderer, const Color &color, const Matrices &mvp);
+    void render(const Color &color, const Matrices &mvp);
     bool sameAsterisms(const AsterismList *asterisms) const;
 
- private:
-    bool prepare(std::vector<LineEnds> &data);
+private:
+    bool prepare();
 
-    celgl::VertexObject     m_vo        { GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW };
-    ShaderProperties        m_shadprop;
-    std::vector<GLsizei>    m_lineCount;
-
-    const AsterismList     *m_asterisms { nullptr };
-    GLsizei                 m_totalLineCount  { 0 };
+    celestia::engine::LineRenderer  m_lineRenderer;
+    std::vector<int>                m_lineCount;
+    const Renderer                 &m_renderer; 
+    const AsterismList             *m_asterisms       { nullptr };
+    int                             m_totalLineCount  { 0 };
+    bool                            m_initialized     { false };
 };

--- a/src/celengine/axisarrow.cpp
+++ b/src/celengine/axisarrow.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <celcompat/numbers.h>
 #include <celmath/mathlib.h>
+#include <celrender/linerenderer.h>
 #include "axisarrow.h"
 #include "body.h"
 #include "frame.h"
@@ -27,6 +28,7 @@ using namespace std;
 using namespace celestia;
 using namespace celmath;
 using namespace celgl;
+using celestia::engine::LineRenderer;
 
 // draw a simple circle or annulus
 #define DRAW_ANNULUS 0
@@ -146,121 +148,17 @@ static size_t initArrow(VertexObject &vo)
     vo.setBufferData(head.data(), offset, s);
     offset += s;
 
-    vo.setVertices(3, GL_FLOAT, GL_FALSE, 0, 0);
+    vo.setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex, 3, GL_FLOAT, GL_FALSE, 0, 0);
 
     return count;
 }
 
-static void initLetters(VertexObject &vo, VertexObject::AttributesType attributes)
-{
-    vo.bind(attributes);
-    if (vo.initialized())
-        return;
-
-    GLfloat lettersVtx[] =
-    {
-        // X
-        0,    0,    0,    1,    0,    1,    -0.5f,
-        0,    0,    0,    1,    0,    1,    0.5f,
-        1,    0,    1,    0,    0,    0,    -0.5f,
-        1,    0,    1,    0,    0,    0,    -0.5f,
-        1,    0,    1,    0,    0,    0,    0.5f,
-        0,    0,    0,    1,    0,    1,    -0.5f,
-
-        1,    0,    0,    0,    0,    1,    -0.5f,
-        1,    0,    0,    0,    0,    1,    0.5f,
-        0,    0,    1,    1,    0,    0,    -0.5f,
-        0,    0,    1,    1,    0,    0,    -0.5f,
-        0,    0,    1,    1,    0,    0,    0.5f,
-        1,    0,    0,    0,    0,    1,    -0.5f,
-        // Y
-        0,    0,    1,    0.5f, 0,    0.5f, -0.5f,
-        0,    0,    1,    0.5f, 0,    0.5f, 0.5f,
-        0.5f, 0,    0.5f, 0,    0,    1,    -0.5f,
-        0.5f, 0,    0.5f, 0,    0,    1,    -0.5f,
-        0.5f, 0,    0.5f, 0,    0,    1,    0.5f,
-        0,    0,    1,    0.5f, 0,    0.5f, -0.5f,
-
-        1,    0,    1,    0.5f, 0,    0.5f, -0.5f,
-        1,    0,    1,    0.5f, 0,    0.5f, 0.5f,
-        0.5f, 0,    0.5f, 1,    0,    1,    -0.5f,
-        0.5f, 0,    0.5f, 1,    0,    1,    -0.5f,
-        0.5f, 0,    0.5f, 1,    0,    1,    0.5f,
-        1,    0,    1,    0.5f, 0,    0.5f, -0.5f,
-
-        0.5f, 0,    0,    0.5f, 0,    0.5f, -0.5f,
-        0.5f, 0,    0,    0.5f, 0,    0.5f, 0.5f,
-        0.5f, 0,    0.5f, 0.5f, 0,    0,    -0.5f,
-        0.5f, 0,    0.5f, 0.5f, 0,    0,    -0.5f,
-        0.5f, 0,    0.5f, 0.5f, 0,    0,    0.5f,
-        0.5f, 0,    0,    0.5f, 0,    0.5f, -0.5f,
-        // Z
-        0,    0,    1,    1,    0,    1,    -0.5f,
-        0,    0,    1,    1,    0,    1,    0.5f,
-        1,    0,    1,    0,    0,    1,    -0.5f,
-        1,    0,    1,    0,    0,    1,    -0.5f,
-        1,    0,    1,    0,    0,    1,    0.5f,
-        0,    0,    1,    1,    0,    1,    -0.5f,
-
-        1,    0,    1,    0,    0,    0,    -0.5f,
-        1,    0,    1,    0,    0,    0,    0.5f,
-        0,    0,    0,    1,    0,    1,    -0.5f,
-        0,    0,    0,    1,    0,    1,    -0.5f,
-        0,    0,    0,    1,    0,    1,    0.5f,
-        1,    0,    1,    0,    0,    0,    -0.5f,
-
-        0,    0,    0,    1,    0,    0,    -0.5f,
-        0,    0,    0,    1,    0,    0,    0.5f,
-        1,    0,    0,    0,    0,    0,    -0.5f,
-        1,    0,    0,    0,    0,    0,    -0.5f,
-        1,    0,    0,    0,    0,    0,    0.5f,
-        0,    0,    0,    1,    0,    0,    -0.5f,
-    };
-
-    vo.allocate(sizeof(lettersVtx));
-
-    vo.setBufferData(lettersVtx, 0, sizeof(lettersVtx));
-    vo.setVertices(3, GL_FLOAT, GL_FALSE, sizeof(float) * 7, 0);
-    vo.setVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex, 3, GL_FLOAT, GL_FALSE, sizeof(float) * 7, sizeof(float) * 3);
-    vo.setVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex, 1, GL_FLOAT, GL_FALSE, sizeof(float) * 7, sizeof(float) * 6);
-
-    vo.setVertices(3, GL_FLOAT, GL_FALSE, sizeof(float) * 7 * 3, 0, celgl::VertexObject::AttributesType::Alternative1);
-}
 
 static void RenderArrow(VertexObject& vo)
 {
     auto count = initArrow(vo);
     vo.draw(GL_TRIANGLES, count);
     vo.unbind();
-}
-
-// Draw letter x in xz plane
-static void RenderX(VertexObject& vo, bool lineAsTriangles)
-{
-    if (lineAsTriangles)
-        vo.draw(GL_TRIANGLES, 12);
-    else
-        vo.draw(GL_LINES, 4);
-}
-
-
-// Draw letter y in xz plane
-static void RenderY(VertexObject& vo, bool lineAsTriangles)
-{
-    if (lineAsTriangles)
-        vo.draw(GL_TRIANGLES, 18, 12);
-    else
-        vo.draw(GL_LINES, 6, 4);
-}
-
-
-// Draw letter z in xz plane
-static void RenderZ(VertexObject& vo, bool lineAsTriangles)
-{
-    if (lineAsTriangles)
-        vo.draw(GL_TRIANGLES, 18, 30);
-    else
-        vo.draw(GL_LINES, 6, 10);
 }
 
 
@@ -334,7 +232,7 @@ ArrowReferenceMark::render(Renderer* renderer,
     prog->setMVPMatrices(*m.projection, mv);
 
     glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex,
-		     color.red(), color.green(), color.blue(), opacity);
+                     color.red(), color.green(), color.blue(), opacity);
 
     auto &vo = renderer->getVertexObject(VOType::AxisArrow, GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW);
     RenderArrow(vo);
@@ -447,34 +345,37 @@ AxesReferenceMark::render(Renderer* renderer,
     prog->setMVPMatrices(projection, zModelView);
     RenderArrow(arrowVo);
 
-    bool lineAsTriangles = renderer->shouldDrawLineAsTriangles();
-    if (lineAsTriangles)
-    {
-        ShaderProperties letterProp = shadprop;
-        letterProp.texUsage |= ShaderProperties::LineAsTriangles;
-        prog = renderer->getShaderManager().getShader(letterProp);
-        if (prog == nullptr)
-            return;
+    LineRenderer lr(*renderer);
+    // X
+    lr.addVertex(0.0f, 0.0f, 0.0f);
+    lr.addVertex(1.0f, 0.0f, 1.0f);
+    lr.addVertex(1.0f, 0.0f, 0.0f);
+    lr.addVertex(0.0f, 0.0f, 1.0f);
+    // Y
+    lr.addVertex(0.0f, 0.0f, 1.0f);
+    lr.addVertex(0.5f, 0.0f, 0.5f);
+    lr.addVertex(1.0f, 0.0f, 1.0f);
+    lr.addVertex(0.5f, 0.0f, 0.5f);
+    lr.addVertex(0.5f, 0.0f, 0.0f);
+    lr.addVertex(0.5f, 0.0f, 0.5f);
+    // Z
+    lr.addVertex(0.0f, 0.0f, 1.0f);
+    lr.addVertex(1.0f, 0.0f, 1.0f);
+    lr.addVertex(1.0f, 0.0f, 1.0f);
+    lr.addVertex(0.0f, 0.0f, 0.0f);
+    lr.addVertex(0.0f, 0.0f, 0.0f);
+    lr.addVertex(1.0f, 0.0f, 0.0f);
 
-        prog->use();
-        prog->lineWidthX = renderer->getLineWidthX();
-        prog->lineWidthY = renderer->getLineWidthY();
-    }
-
-    auto &letterVo = renderer->getVertexObject(VOType::AxisLetter, GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW);
-    initLetters(letterVo, lineAsTriangles ? VertexObject::AttributesType::Default : VertexObject::AttributesType::Alternative1);
-
-    glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex, 1.0f, 0.0f, 0.0f, opacity);
-    prog->setMVPMatrices(projection, xModelView * labelTransformMatrix);
-    RenderX(letterVo, lineAsTriangles);
-    glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex, 0.0f, 1.0f, 0.0f, opacity);
-    prog->setMVPMatrices(projection, yModelView * labelTransformMatrix);
-    RenderY(letterVo, lineAsTriangles);
-    glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex, 0.0f, 0.0f, 1.0f, opacity);
-    prog->setMVPMatrices(projection, zModelView * labelTransformMatrix);
-    RenderZ(letterVo, lineAsTriangles);
-
-    letterVo.unbind();
+    Eigen::Matrix4f mv;
+    // X
+    mv = xModelView * labelTransformMatrix;
+    lr.render({&projection, &mv}, {1.0f, 0.0f, 0.0f, opacity}, 4, 0);
+    // Y
+    mv = yModelView * labelTransformMatrix;
+    lr.render({&projection, &mv}, {0.0f, 1.0f, 0.0f, opacity}, 6, 4);
+    // Z
+    mv = zModelView * labelTransformMatrix;
+    lr.render({&projection, &mv}, {0.0f, 0.0f, 1.0f, opacity}, 6, 10);
 
     renderer->enableBlending();
     renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE);

--- a/src/celengine/boundariesrenderer.cpp
+++ b/src/celengine/boundariesrenderer.cpp
@@ -1,6 +1,6 @@
 // boundariesrenderer.cpp
 //
-// Copyright (C) 2018-2019, the Celestia Development Team
+// Copyright (C) 2018-present, the Celestia Development Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,14 +15,13 @@
 #include "render.h"
 #include "vecgl.h"
 
-using namespace Eigen;
-using namespace std;
+using celestia::engine::LineRenderer;
 
-BoundariesRenderer::BoundariesRenderer(const ConstellationBoundaries *boundaries) :
-    m_boundaries(boundaries)
+BoundariesRenderer::BoundariesRenderer(const Renderer &renderer, const ConstellationBoundaries *boundaries) :
+    m_renderer(renderer),
+    m_boundaries(boundaries),
+    m_lineRenderer(LineRenderer(renderer))
 {
-    m_shadprop.texUsage = ShaderProperties::VertexColors;
-    m_shadprop.lightModel = ShaderProperties::UnlitModel;
 }
 
 bool BoundariesRenderer::sameBoundaries(const ConstellationBoundaries *boundaries) const
@@ -30,83 +29,33 @@ bool BoundariesRenderer::sameBoundaries(const ConstellationBoundaries *boundarie
     return m_boundaries == boundaries;
 }
 
-void BoundariesRenderer::render(const Renderer &renderer, const Color &color, const Matrices &mvp)
+void BoundariesRenderer::render(const Color &color, const Matrices &mvp)
 {
-    using AttributesType = celgl::VertexObject::AttributesType;
-
-    ShaderProperties props = m_shadprop;
-    bool lineAsTriangles = renderer.shouldDrawLineAsTriangles();
-    if (lineAsTriangles)
-        props.texUsage |= ShaderProperties::LineAsTriangles;
-
-    auto *prog = renderer.getShaderManager().getShader(props);
-    if (prog == nullptr)
-        return;
-
-    m_vo.bind(lineAsTriangles ? AttributesType::Default : AttributesType::Alternative1);
-    if (!m_vo.initialized())
+    if (!m_initialized)
     {
-        std::vector<LineEnds> data;
-        if (!prepare(data))
-        {
-            m_vo.unbind();
-            return;
-        }
-        m_vo.allocate(data.size() * sizeof(LineEnds), data.data());
-        // Attributes for lines drawn as triangles
-        m_vo.setVertices(3, GL_FLOAT, false, sizeof(LineEnds), offsetof(LineEnds, point1));
-        m_vo.setVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex, 3, GL_FLOAT, false, sizeof(LineEnds), offsetof(LineEnds, point2));
-        m_vo.setVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex, 1, GL_FLOAT, false, sizeof(LineEnds), offsetof(LineEnds, scale));
-
-        // Attributes for lines drawn as lines
-        m_vo.setVertices(3, GL_FLOAT, false, sizeof(LineEnds) * 3, offsetof(LineEnds, point1), AttributesType::Alternative1);
+        if (!prepare()) return;
+        m_initialized = true;
     }
 
-    prog->use();
-    prog->setMVPMatrices(*mvp.projection, *mvp.modelview);
-    glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, color);
-    if (lineAsTriangles)
-    {
-        prog->lineWidthX = renderer.getLineWidthX();
-        prog->lineWidthY = renderer.getLineWidthY();
-        m_vo.draw(GL_TRIANGLES, m_lineCount * 6, 0);
-    }
-    else
-    {
-        m_vo.draw(GL_LINES, m_lineCount * 2, 0);
-    }
-
-    m_vo.unbind();
+    m_lineRenderer.render(mvp, color, m_lineCount * 2);
 }
 
 
-bool BoundariesRenderer::prepare(std::vector<LineEnds> &data)
+bool BoundariesRenderer::prepare()
 {
     auto chains = m_boundaries->getChains();
-    auto lineCount = accumulate(chains.begin(), chains.end(), 0,
-                                [](int a, ConstellationBoundaries::Chain* b) { return a + b->size() - 1; });
+    auto lineCount = std::accumulate(chains.begin(), chains.end(), 0,
+                                     [](int a, ConstellationBoundaries::Chain* b) { return a + b->size() - 1; });
 
     if (lineCount == 0)
         return false;
 
     m_lineCount = lineCount;
 
-    // we reserve 6 times the space so we can allow to
-    // draw a line segment with two triangles
-    data.reserve(m_lineCount * 6);
     for (const auto chain : chains)
     {
         for (unsigned i = 1; i < chain->size(); i++)
-        {
-            Eigen::Vector3f prev = (*chain)[i - 1];
-            Eigen::Vector3f cur = (*chain)[i];
-            data.emplace_back(prev, cur, -0.5);
-            data.emplace_back(prev ,cur, 0.5);
-            data.emplace_back(cur, prev, -0.5);
-            data.emplace_back(cur, prev, -0.5);
-            data.emplace_back(cur, prev, 0.5);
-            data.emplace_back(prev, cur, -0.5);
-        }
+            m_lineRenderer.addSegment((*chain)[i - 1], (*chain)[i]);
     }
 
     return true;

--- a/src/celengine/boundariesrenderer.h
+++ b/src/celengine/boundariesrenderer.h
@@ -1,6 +1,6 @@
 // boundariesrenderer.h
 //
-// Copyright (C) 2018-2019, the Celestia Development Team
+// Copyright (C) 2018-present, the Celestia Development Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -9,19 +9,17 @@
 
 #pragma once
 
-#include "shadermanager.h"
-#include "vertexobject.h"
+#include <celrender/linerenderer.h>
 
 class Color;
 class ConstellationBoundaries;
 class Renderer;
 struct Matrices;
-struct LineEnds;
 
 class BoundariesRenderer
 {
- public:
-    BoundariesRenderer(const ConstellationBoundaries*);
+public:
+    BoundariesRenderer(const Renderer &renderer, const ConstellationBoundaries*);
     ~BoundariesRenderer() = default;
     BoundariesRenderer() = delete;
     BoundariesRenderer(const BoundariesRenderer&) = delete;
@@ -29,14 +27,15 @@ class BoundariesRenderer
     BoundariesRenderer& operator=(const BoundariesRenderer&) = delete;
     BoundariesRenderer& operator=(BoundariesRenderer&&) = delete;
 
-    void render(const Renderer &renderer, const Color &color, const Matrices &mvp);
+    void render(const Color &color, const Matrices &mvp);
     bool sameBoundaries(const ConstellationBoundaries*) const;
 
- private:
-    bool prepare(std::vector<LineEnds> &data);
+private:
+    bool prepare();
 
-    celgl::VertexObject            m_vo         { GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW };
-    ShaderProperties               m_shadprop;
-    const ConstellationBoundaries *m_boundaries { nullptr };
-    GLsizei                        m_lineCount  { 0 };
+    celestia::engine::LineRenderer  m_lineRenderer;
+    const Renderer                 &m_renderer;
+    const ConstellationBoundaries  *m_boundaries      { nullptr };
+    int                             m_lineCount       { 0 };
+    bool                            m_initialized     { false };
 };

--- a/src/celengine/curveplot.h
+++ b/src/celengine/curveplot.h
@@ -34,6 +34,10 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <celutil/color.h>
+
+class Color;
+class Renderer;
 
 class CurvePlotSample
 {
@@ -48,25 +52,19 @@ public:
 class CurvePlot
 {
  public:
-    CurvePlot();
+    CurvePlot(const Renderer &renderer);
 
     double duration() const { return m_duration; }
     void setDuration(double duration);
 
     double startTime() const
     {
-        if (m_samples.empty())
-            return 0.0;
-        else
-            return m_samples.front().t;
+        return m_samples.empty() ? 0.0 : m_samples.front().t;
     }
 
     double endTime() const
     {
-        if (m_samples.empty())
-            return 0.0;
-        else
-            return m_samples.back().t;
+        return m_samples.empty() ? 0.0 : m_samples.back().t;
     }
 
     void render(const Eigen::Affine3d& modelview,
@@ -74,8 +72,7 @@ class CurvePlot
                 double farZ,
                 const Eigen::Vector3d viewFrustumPlaneNormals[],
                 double subdivisionThreshold,
-                const Eigen::Vector4f& color,
-                bool lineAsTriangles) const;
+                const Eigen::Vector4f& color) const;
     void render(const Eigen::Affine3d& modelview,
                 double nearZ,
                 double farZ,
@@ -83,8 +80,7 @@ class CurvePlot
                 double subdivisionThreshold,
                 double startTime,
                 double endTime,
-                const Eigen::Vector4f& color,
-                bool lineAsTriangles) const;
+                const Eigen::Vector4f& color) const;
     void renderFaded(const Eigen::Affine3d& modelview,
                      double nearZ,
                      double farZ,
@@ -94,8 +90,7 @@ class CurvePlot
                      double endTime,
                      const Eigen::Vector4f& color,
                      double fadeStartTime,
-                     double fadeEndTime,
-                     bool lineAsTriangles) const;
+                     double fadeEndTime) const;
 
     unsigned int lastUsed() const { return m_lastUsed; }
     void setLastUsed(unsigned int lastUsed) { m_lastUsed = lastUsed; }
@@ -106,13 +101,12 @@ class CurvePlot
 
     bool empty() const { return m_samples.empty(); }
 
-    unsigned int sampleCount() const { return m_samples.size(); }
+    unsigned int sampleCount() const { return static_cast<unsigned int>(m_samples.size()); }
 
  private:
-    std::deque<CurvePlotSample> m_samples;
-
-    double m_duration{ 0.0 };
-
-    unsigned int m_lastUsed{ 0 };
+    std::deque<CurvePlotSample>     m_samples;
+    const Renderer                 &m_renderer;
+    double                          m_duration      { 0.0 };
+    unsigned int                    m_lastUsed      { 0   };
 };
 

--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -12,6 +12,7 @@
 #include <celcompat/numbers.h>
 #include <celmath/frustum.h>
 #include <celmath/mathlib.h>
+#include <celrender/linerenderer.h>
 #include "marker.h"
 #include "render.h"
 #include "vecgl.h"
@@ -23,10 +24,11 @@ using namespace celgl;
 using namespace celmath;
 using namespace celestia;
 using namespace Eigen;
+using celestia::engine::LineRenderer;
 
-constexpr const int SquareOffset = 0;
-constexpr const int SquareCount  = 4;
-static GLfloat Square[SquareCount * 2] =
+constexpr int FilledSquareOffset = 0;
+constexpr int FilledSquareCount  = 4;
+static GLfloat FilledSquare[FilledSquareCount * 2] =
 {
     -1.0f, -1.0f,
      1.0f, -1.0f,
@@ -34,17 +36,8 @@ static GLfloat Square[SquareCount * 2] =
     -1.0f,  1.0f
 };
 
-constexpr const int TriangleOffset = SquareOffset + SquareCount;
-constexpr const int TriangleCount  = 3;
-static GLfloat Triangle[TriangleCount * 2] =
-{
-    0.0f,  1.0f,
-    1.0f, -1.0f,
-   -1.0f, -1.0f
-};
-
-constexpr const int RightArrowOffset = TriangleOffset + TriangleCount;
-constexpr const int RightArrowCount  = 9;
+constexpr int RightArrowOffset = FilledSquareOffset + FilledSquareCount;
+constexpr int RightArrowCount  = 9;
 static GLfloat RightArrow[RightArrowCount * 2] =
 {
     -3*1.0f,  1.0f/3.0f,
@@ -58,8 +51,8 @@ static GLfloat RightArrow[RightArrowCount * 2] =
     -1.0f,         0.0f
 };
 
-constexpr const int LeftArrowOffset = RightArrowOffset + RightArrowCount;
-constexpr const int LeftArrowCount  = 9;
+constexpr int LeftArrowOffset = RightArrowOffset + RightArrowCount;
+constexpr int LeftArrowCount  = 9;
 static GLfloat LeftArrow[LeftArrowCount * 2] =
 {
      3*1.0f,    -1.0f/3,
@@ -73,8 +66,8 @@ static GLfloat LeftArrow[LeftArrowCount * 2] =
      1.0f,         0.0f
 };
 
-constexpr const int UpArrowOffset = LeftArrowOffset + LeftArrowCount;
-constexpr const int UpArrowCount  = 9;
+constexpr int UpArrowOffset = LeftArrowOffset + LeftArrowCount;
+constexpr int UpArrowCount  = 9;
 static GLfloat UpArrow[UpArrowCount * 2] =
 {
     -1.0f/3,    -3*1.0f,
@@ -88,8 +81,8 @@ static GLfloat UpArrow[UpArrowCount * 2] =
      0.0f,        -1.0f
 };
 
-constexpr const int DownArrowOffset = UpArrowOffset + UpArrowCount;
-constexpr const int DownArrowCount  = 9;
+constexpr int DownArrowOffset = UpArrowOffset + UpArrowCount;
+constexpr int DownArrowCount  = 9;
 static GLfloat DownArrow[DownArrowCount * 2] =
 {
      1.0f/3,     3*1.0f,
@@ -103,8 +96,8 @@ static GLfloat DownArrow[DownArrowCount * 2] =
      0.0f,         1.0f
 };
 
-constexpr const int SelPointerOffset = DownArrowOffset + DownArrowCount;
-constexpr const int SelPointerCount  = 3;
+constexpr int SelPointerOffset = DownArrowOffset + DownArrowCount;
+constexpr int SelPointerCount  = 3;
 static GLfloat SelPointer[SelPointerCount * 2] =
 {
     0.0f,       0.0f,
@@ -112,8 +105,8 @@ static GLfloat SelPointer[SelPointerCount * 2] =
    -20.0f,     -6.0f
 };
 
-constexpr const int CrosshairOffset = SelPointerOffset + SelPointerCount;
-constexpr const int CrosshairCount  = 3;
+constexpr int CrosshairOffset = SelPointerOffset + SelPointerCount;
+constexpr int CrosshairCount  = 3;
 static GLfloat Crosshair[CrosshairCount * 2] =
 {
     0.0f,       0.0f,
@@ -121,28 +114,69 @@ static GLfloat Crosshair[CrosshairCount * 2] =
     1.0f,       1.0f
 };
 
-constexpr const int StaticVtxCount = CrosshairOffset + CrosshairCount;
 
-constexpr const int SmallCircleOffset = StaticVtxCount;
-constexpr const int SmallCircleCount  = 10;
-constexpr const int LargeCircleOffset = SmallCircleOffset + SmallCircleCount;
-constexpr const int LargeCircleCount  = 60;
+// Markers drawn with lines
+constexpr int SquareCount = 8;
+constexpr int SquareOffset = 0;
+static GLfloat Square[SquareCount * 2] =
+{
+    -1.0f, -1.0f,  1.0f, -1.0f,
+     1.0f, -1.0f,  1.0f,  1.0f,
+     1.0f,  1.0f, -1.0f,  1.0f,
+    -1.0f,  1.0f, -1.0f, -1.0f
+};
 
-static int DiamondLineOffset = 0;
-static int DiamondLineCount = 0;
-static int PlusLineOffset = 0;
-static int PlusLineCount = 0;
-static int XLineOffset = 0;
-static int XLineCount = 0;
-static int TriangleLineOffset = 0;
-static int TriangleLineCount = 0;
-static int SquareLineOffset = 0;
-static int SquareLineCount = 0;
-static int SmallCircleLineOffset = 0;
-static int SmallCircleLineCount = 0;
-static int LargeCircleLineOffset = 0;
-static int LargeCircleLineCount = 0;
-static int EclipticLineCount = 0;
+constexpr int TriangleOffset = SquareOffset + SquareCount;
+constexpr int TriangleCount  = 6;
+static GLfloat Triangle[TriangleCount * 2] =
+{
+    0.0f,  1.0f,  1.0f, -1.0f,
+    1.0f, -1.0f, -1.0f, -1.0f,
+   -1.0f, -1.0f,  0.0f,  1.0f
+};
+
+constexpr int DiamondCount = 8;
+constexpr int DiamondOffset = TriangleOffset + TriangleCount;
+static GLfloat Diamond[DiamondCount * 2] =
+{
+     0.0f,  1.0f,  1.0f,  0.0f,
+     1.0f,  0.0f,  0.0f, -1.0f,
+     0.0f, -1.0f, -1.0f,  0.0f,
+    -1.0f,  0.0f,  0.0f,  1.0f
+
+};
+
+constexpr int PlusCount = 4;
+constexpr int PlusOffset = DiamondOffset + DiamondCount;
+static GLfloat Plus[PlusCount * 2] =
+{
+     0.0f,  1.0f,  0.0f, -1.0f,
+     1.0f,  0.0f, -1.0f,  0.0f
+};
+
+constexpr int XCount = 4;
+constexpr int XOffset = PlusOffset + PlusCount;
+static GLfloat X[XCount * 2] =
+{
+    -1.0f, -1.0f,  1.0f,  1.0f,
+     1.0f, -1.0f, -1.0f,  1.0f
+};
+
+constexpr int StaticVtxCount = CrosshairOffset + CrosshairCount;
+constexpr int SmallCircleOffset = StaticVtxCount;
+constexpr int SmallCircleCount  = 10;
+constexpr int LargeCircleOffset = SmallCircleOffset + SmallCircleCount;
+constexpr int LargeCircleCount  = 60;
+
+constexpr int _SmallCircleOffset = XOffset + XCount;
+constexpr int _SmallCircleCount = SmallCircleCount*2;
+constexpr int _LargeCircleOffset = _SmallCircleCount + _SmallCircleOffset;
+constexpr int _LargeCircleCount = LargeCircleCount*2;
+
+static GLfloat SmallCircle[SmallCircleCount*2];
+static GLfloat LargeCircle[LargeCircleCount*2];
+
+static bool CirclesInitilized = false;
 
 static void fillCircleValue(GLfloat* data, int size, float scale)
 {
@@ -163,80 +197,25 @@ static int bufferVertices(VertexObject& vo, GLfloat* data, int vertexCount, int&
     return vertexCount;
 }
 
-static int bufferLineVertices(VertexObject& vo, GLfloat* data, int vertexSize, int vertexCount, int& offset)
+static void initializeCircles()
 {
-    int dataSize = vertexCount * 3 * (2 * vertexSize + 1) * sizeof(GLfloat);
-    GLfloat* tranformed = new GLfloat[dataSize];
-    GLfloat* ptr = tranformed;
-    for (int i = 0; i < vertexCount; i += 2)
-    {
-        int index = i * vertexSize;
-        GLfloat* thisVert = &data[index];
-        GLfloat* nextVert = &data[index + vertexSize];
-#define STREAM_AND_ADVANCE(firstVertex, secondVertex, scale) do {\
-memcpy(ptr, firstVertex, vertexSize * sizeof(GLfloat));\
-memcpy(ptr + vertexSize, secondVertex, vertexSize * sizeof(GLfloat));\
-ptr[2 * vertexSize] = scale;\
-ptr += 2 * vertexSize + 1;\
-} while (0)
-        STREAM_AND_ADVANCE(thisVert, nextVert, -0.5);
-        STREAM_AND_ADVANCE(thisVert, nextVert,  0.5);
-        STREAM_AND_ADVANCE(nextVert, thisVert, -0.5);
-        STREAM_AND_ADVANCE(nextVert, thisVert, -0.5);
-        STREAM_AND_ADVANCE(nextVert, thisVert,  0.5);
-        STREAM_AND_ADVANCE(thisVert, nextVert, -0.5);
-#undef STREAM_AND_ADVANCE
-    }
-    vo.setBufferData(tranformed, offset, dataSize);
-    offset += dataSize;
-    delete[] tranformed;
-    return vertexCount * 3;
-}
+    if (CirclesInitilized)
+        return;
 
-static int bufferLineLoopVertices(VertexObject& vo, GLfloat* data, int vertexSize, int vertexCount, int& offset)
-{
-    int dataSize = vertexCount * 6 * (2 * vertexSize + 1) * sizeof(GLfloat);
-    GLfloat* tranformed = new GLfloat[dataSize];
-    GLfloat* ptr = tranformed;
-    for (int i = 0; i < vertexCount; i += 1)
-    {
-        int index = i * vertexSize;
-        int nextIndex = ((i + 1) % vertexCount) * vertexSize;
-        GLfloat* thisVert = &data[index];
-        GLfloat* nextVert = &data[nextIndex];
-#define STREAM_AND_ADVANCE(firstVertex, secondVertex, scale) do {\
-memcpy(ptr, firstVertex, vertexSize * sizeof(GLfloat));\
-memcpy(ptr + vertexSize, secondVertex, vertexSize * sizeof(GLfloat));\
-ptr[2 * vertexSize] = scale;\
-ptr += 2 * vertexSize + 1;\
-} while (0)
-        STREAM_AND_ADVANCE(thisVert, nextVert, -0.5);
-        STREAM_AND_ADVANCE(thisVert, nextVert,  0.5);
-        STREAM_AND_ADVANCE(nextVert, thisVert, -0.5);
-        STREAM_AND_ADVANCE(nextVert, thisVert, -0.5);
-        STREAM_AND_ADVANCE(nextVert, thisVert,  0.5);
-        STREAM_AND_ADVANCE(thisVert, nextVert, -0.5);
-#undef STREAM_AND_ADVANCE
-    }
-    vo.setBufferData(tranformed, offset, dataSize);
-    offset += dataSize;
-    delete[] tranformed;
-    return vertexCount * 6;
+    fillCircleValue(SmallCircle, SmallCircleCount, 1.0f);
+    fillCircleValue(LargeCircle, LargeCircleCount, 1.0f);
+    CirclesInitilized = true;
 }
 
 static void initVO(VertexObject& vo)
 {
-    GLfloat SmallCircle[SmallCircleCount * 2];
-    GLfloat LargeCircle[LargeCircleCount * 2];
-    fillCircleValue(SmallCircle, SmallCircleCount, 1.0f);
-    fillCircleValue(LargeCircle, LargeCircleCount, 1.0f);
+    initializeCircles();
 
     vo.allocate((LargeCircleOffset + LargeCircleCount) * sizeof(GLfloat) * 2);
 
     int offset = 0;
 #define VOSTREAM(a) bufferVertices(vo, a, a##Count, offset)
-    VOSTREAM(Square);
-    VOSTREAM(Triangle);
+    VOSTREAM(FilledSquare);
     VOSTREAM(RightArrow);
     VOSTREAM(LeftArrow);
     VOSTREAM(UpArrow);
@@ -247,96 +226,92 @@ static void initVO(VertexObject& vo)
     VOSTREAM(LargeCircle);
 #undef VOSTREAM
 
-    vo.setVertices(2, GL_FLOAT, false, 0, 0);
+    vo.setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex,
+                            2, GL_FLOAT, false, 0, 0);
 }
 
-static void initLineVO(VertexObject& vo)
+
+static void render_hollow_marker(const Renderer &renderer,
+                        celestia::MarkerRepresentation::Symbol symbol,
+                        float size,
+                        const Color &color,
+                        const Matrices &m)
 {
-    constexpr const int DiamondCount  = 4;
-    static GLfloat Diamond[DiamondCount * 2] =
+    static LineRenderer *lr = nullptr;
+
+    if (lr == nullptr)
     {
-         0.0f,  1.0f,
-         1.0f,  0.0f,
-         0.0f, -1.0f,
-        -1.0f,  0.0f
-    };
-    constexpr const int PlusCount  = 4;
-    GLfloat Plus[PlusCount * 2] =
-    {
-         0.0f,  1.0f,
-         0.0f, -1.0f,
-         1.0f,  0.0f,
-        -1.0f,  0.0f
-    };
-    constexpr const int XCount  = 4;
-    GLfloat X[XCount * 2] =
-    {
-        -1.0f, -1.0f,
-         1.0f,  1.0f,
-         1.0f, -1.0f,
-        -1.0f,  1.0f
-    };
+        lr = new LineRenderer(renderer, 1.0f, LineRenderer::LINES, LineRenderer::STATIC_STORAGE);
+        lr->setHints(LineRenderer::DISABLE_FISHEYE_TRANFORMATION);
 
-    GLfloat SmallCircle[SmallCircleCount * 2];
-    GLfloat LargeCircle[LargeCircleCount * 2];
-    fillCircleValue(SmallCircle, SmallCircleCount, 1.0f);
-    fillCircleValue(LargeCircle, LargeCircleCount, 1.0f);
+        for (int i = 0; i < SquareCount*2; i+=2)
+            lr->addVertex(Square[i], Square[i+1]);
 
-    int stride = sizeof(GLfloat) * 5;
-    int size = ((DiamondCount + SquareCount + TriangleCount + SmallCircleCount + LargeCircleCount) * 6 + (PlusCount + XCount) * 3) * stride;
+        for (int i = 0; i < TriangleCount*2; i+=2)
+            lr->addVertex(Triangle[i], Triangle[i+1]);
 
-    vo.allocate(size);
+        for (int i = 0; i < DiamondCount*2; i+=2)
+            lr->addVertex(Diamond[i], Diamond[i+1]);
 
-    int offset = 0;
-#define VOSTREAM_LINES(a) do { \
-a##LineOffset = offset / stride / 6;\
-a##LineCount = bufferLineVertices(vo, a, 2, a##Count, offset) / 6; \
-} while (0)
-#define VOSTREAM_LINE_LOOP(a) do { \
-a##LineOffset = offset / stride / 6;\
-a##LineCount = bufferLineLoopVertices(vo, a, 2, a##Count, offset) / 6; \
-} while (0)
-    VOSTREAM_LINE_LOOP(Diamond);
-    VOSTREAM_LINES(Plus);
-    VOSTREAM_LINES(X);
-    VOSTREAM_LINE_LOOP(Square);
-    VOSTREAM_LINE_LOOP(Triangle);
-    VOSTREAM_LINE_LOOP(SmallCircle);
-    VOSTREAM_LINE_LOOP(LargeCircle);
-#undef VOSTREAM_LINES
-#undef VOSTREAM_LINE_LOOP
+        for (int i = 0; i < PlusCount*2; i+=2)
+            lr->addVertex(Plus[i], Plus[i+1]);
 
-    vo.setVertices(2, GL_FLOAT, false, stride, 0);
-    vo.setVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex, 2, GL_FLOAT, false, stride, sizeof(GLfloat) * 2);
-    vo.setVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex, 1, GL_FLOAT, false, stride, sizeof(GLfloat) * 4);
+        for (int i = 0; i < XCount*2; i+=2)
+            lr->addVertex(X[i], X[i+1]);
 
-    vo.setVertices(2, GL_FLOAT, false, stride * 3, 0, VertexObject::AttributesType::Alternative1);
-}
+        initializeCircles();
+        for (int i = 0; i < SmallCircleCount; i++)
+        {
+            int j = i * 2;
+            lr->addVertex(SmallCircle[j], SmallCircle[j+1]);
+            int k = ((i + 1) % SmallCircleCount) * 2;
+            lr->addVertex(SmallCircle[k], SmallCircle[k+1]);
+        }
 
-static void initEclipticVO(VertexObject& vo)
-{
-    constexpr const int eclipticCount = 200;
-    GLfloat ecliptic[eclipticCount * 3];
-    float s, c;
-    float scale = 1000.0f;
-    for (int i = 0; i < eclipticCount; i++)
-    {
-        sincos((float) (2 * i) / (float) eclipticCount * celestia::numbers::pi_v<float>, s, c);
-        ecliptic[i * 3] = c * scale;
-        ecliptic[i * 3 + 1] = 0;
-        ecliptic[i * 3 + 2] = s * scale;
+        for (int i = 0; i < LargeCircleCount; i++)
+        {
+            int j = i * 2;
+            lr->addVertex(LargeCircle[j], LargeCircle[j+1]);
+            int k = ((i + 1) % LargeCircleCount) * 2;
+            lr->addVertex(LargeCircle[k], LargeCircle[k+1]);
+        }
+
     }
 
-    int stride = sizeof(GLfloat) * 7;
-    vo.allocate(eclipticCount * 6 * stride);
-    int offset = 0;
-    EclipticLineCount = bufferLineLoopVertices(vo, ecliptic, 3, eclipticCount, offset) / 6;
+    float s = size / 2.0f * renderer.getScaleFactor();
+    Eigen::Matrix4f mv = (*m.modelview) * vecgl::scale(Vector3f(s, s, 0));
 
-    vo.setVertices(3, GL_FLOAT, false, stride, 0);
-    vo.setVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex, 3, GL_FLOAT, false, stride, sizeof(GLfloat) * 3);
-    vo.setVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex, 1, GL_FLOAT, false, stride, sizeof(GLfloat) * 6);
+    switch (symbol)
+    {
+    case MarkerRepresentation::Square:
+        lr->render({m.projection, &mv}, color, SquareCount, SquareOffset);
+        break;
 
-    vo.setVertices(3, GL_FLOAT, false, stride * 3, 0, VertexObject::AttributesType::Alternative1);
+    case MarkerRepresentation::Triangle:
+        lr->render({m.projection, &mv}, color, TriangleCount, TriangleOffset);
+        break;
+
+    case MarkerRepresentation::Diamond:
+        lr->render({m.projection, &mv}, color, DiamondCount, DiamondOffset);
+        break;
+
+    case MarkerRepresentation::Plus:
+        lr->render({m.projection, &mv}, color, PlusCount, PlusOffset);
+        break;
+
+    case MarkerRepresentation::X:
+        lr->render({m.projection, &mv}, color, XCount, XOffset);
+        break;
+
+    case MarkerRepresentation::Circle:
+        if (size <= 40.0f) // TODO: this should be configurable
+            lr->render({m.projection, &mv}, color, _SmallCircleCount, _SmallCircleOffset);
+        else
+            lr->render({m.projection, &mv}, color, _LargeCircleCount, _LargeCircleOffset);
+        break;
+    default:
+        return;
+    }
 }
 
 void Renderer::renderMarker(celestia::MarkerRepresentation::Symbol symbol,
@@ -346,10 +321,6 @@ void Renderer::renderMarker(celestia::MarkerRepresentation::Symbol symbol,
 {
     assert(shaderManager != nullptr);
 
-    using namespace celestia;
-    using AttributesType = celgl::VertexObject::AttributesType;
-
-    bool solid = true;
     switch (symbol)
     {
     case MarkerRepresentation::Diamond:
@@ -358,76 +329,39 @@ void Renderer::renderMarker(celestia::MarkerRepresentation::Symbol symbol,
     case MarkerRepresentation::Square:
     case MarkerRepresentation::Triangle:
     case MarkerRepresentation::Circle:
-        solid = false;
+        render_hollow_marker(*this, symbol, size, color, m);
+        return;
     default:
         break;
     }
 
     ShaderProperties shadprop;
     shadprop.texUsage = ShaderProperties::VertexColors;
-
-    bool lineAsTriangles = false;
-    if (!solid)
-    {
-        lineAsTriangles = shouldDrawLineAsTriangles();
-        if (lineAsTriangles)
-            shadprop.texUsage |= ShaderProperties::LineAsTriangles;
-    }
     shadprop.lightModel = ShaderProperties::UnlitModel;
     shadprop.fishEyeOverride = ShaderProperties::FisheyeOverrideModeDisabled;
     auto* prog = shaderManager->getShader(shadprop);
     if (prog == nullptr)
         return;
 
-    auto &markerVO = getVertexObject(solid ? VOType::Marker : VOType::MarkerLine, GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW);
-    if (solid)
-        markerVO.bind();
-    else
-        markerVO.bind(lineAsTriangles ? AttributesType::Default : AttributesType::Alternative1);
+    auto &markerVO = getVertexObject(VOType::Marker, GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW);
+    markerVO.bind();
     if (!markerVO.initialized())
-        solid ? initVO(markerVO) : initLineVO(markerVO);
+        initVO(markerVO);
 
-    glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, color);
+#ifdef GL_ES
+    glVertexAttrib4fv(CelestiaGLProgram::ColorAttributeIndex, color.toVector4().data());
+#else
+    glVertexAttrib4Nubv(CelestiaGLProgram::ColorAttributeIndex, color.data());
+#endif
 
     prog->use();
     float s = size / 2.0f * getScaleFactor();
     prog->setMVPMatrices(*m.projection, (*m.modelview) * vecgl::scale(Vector3f(s, s, 0)));
-    if (lineAsTriangles)
-    {
-        prog->lineWidthX = getLineWidthX();
-        prog->lineWidthY = getLineWidthY();
-    }
 
-#define DRAW_LINE(type) do { \
-if (lineAsTriangles) \
-    markerVO.draw(GL_TRIANGLES, type##LineCount * 6, type##LineOffset * 6); \
-else \
-    markerVO.draw(GL_LINES, type##LineCount * 2, type##LineOffset * 2); \
-} while (0)
     switch (symbol)
     {
-    case MarkerRepresentation::Diamond:
-        DRAW_LINE(Diamond);
-        break;
-
-    case MarkerRepresentation::Plus:
-        DRAW_LINE(Plus);
-        break;
-
-    case MarkerRepresentation::X:
-        DRAW_LINE(X);
-        break;
-
-    case MarkerRepresentation::Square:
-        DRAW_LINE(Square);
-        break;
-
     case MarkerRepresentation::FilledSquare:
-        markerVO.draw(GL_TRIANGLE_FAN, SquareCount, SquareOffset);
-        break;
-
-    case MarkerRepresentation::Triangle:
-        DRAW_LINE(Triangle);
+        markerVO.draw(GL_TRIANGLE_FAN, FilledSquareCount, FilledSquareOffset);
         break;
 
     case MarkerRepresentation::RightArrow:
@@ -443,14 +377,7 @@ else \
         break;
 
     case MarkerRepresentation::DownArrow:
-        markerVO.draw(GL_TRIANGLES, UpArrowCount, DownArrowOffset);
-        break;
-
-    case MarkerRepresentation::Circle:
-        if (size <= 40.0f) // TODO: this should be configurable
-            DRAW_LINE(SmallCircle);
-        else
-            DRAW_LINE(LargeCircle);
+        markerVO.draw(GL_TRIANGLES, DownArrowCount, DownArrowOffset);
         break;
 
     case MarkerRepresentation::Disk:
@@ -463,7 +390,6 @@ else \
     default:
         break;
     }
-#undef DRAW_LINE
 
     markerVO.unbind();
 }
@@ -476,7 +402,7 @@ void Renderer::renderSelectionPointer(const Observer& observer,
                                       const Frustum& viewFrustum,
                                       const Selection& sel)
 {
-    constexpr const float cursorDistance = 20.0f;
+    constexpr float cursorDistance = 20.0f;
     if (sel.empty())
         return;
 
@@ -500,7 +426,7 @@ void Renderer::renderSelectionPointer(const Observer& observer,
     enableBlending();
     setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    float vfov = (float) observer.getFOV();
+    float vfov = observer.getFOV();
     float h = tan(vfov / 2);
     float w = h * getAspectRatio();
     float diag = sqrt(h * h + w * w);
@@ -547,41 +473,16 @@ void Renderer::renderEclipticLine()
     if ((renderFlags & ShowEcliptic) == 0)
         return;
 
-    using AttributesType = celgl::VertexObject::AttributesType;
-
-    ShaderProperties shadprop;
-    shadprop.texUsage = ShaderProperties::VertexColors;
-    shadprop.lightModel = ShaderProperties::UnlitModel;
-
-    bool lineAsTriangles = shouldDrawLineAsTriangles();
-    if (lineAsTriangles)
-        shadprop.texUsage |= ShaderProperties::LineAsTriangles;
-
-    auto* prog = shaderManager->getShader(shadprop);
-    if (prog == nullptr)
-        return;
-
-    auto &eclipticVO = getVertexObject(VOType::Ecliptic, GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW);
-    eclipticVO.bind(lineAsTriangles ? AttributesType::Default : AttributesType::Alternative1);
-    if (!eclipticVO.initialized())
-        initEclipticVO(eclipticVO);
-
-    glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, EclipticColor);
-
-    prog->use();
-    prog->setMVPMatrices(getProjectionMatrix(), getModelViewMatrix());
-    if (lineAsTriangles)
+    constexpr int eclipticCount = 200;
+    constexpr float scale = 1000.0f;
+    LineRenderer lr(*this, 1.0f, LineRenderer::LINE_LOOP);
+    for (int i = 0; i < eclipticCount; i++)
     {
-        prog->lineWidthX = getLineWidthX();
-        prog->lineWidthY = getLineWidthY();
-        eclipticVO.draw(GL_TRIANGLES, EclipticLineCount * 6);
+        float s, c;
+        sincos((float) (2 * i) / (float) eclipticCount * celestia::numbers::pi_v<float>, s, c);
+        lr.addVertex(c * scale, 0.0f, s * scale);
     }
-    else
-    {
-        eclipticVO.draw(GL_LINES, EclipticLineCount * 2);
-    }
-
-    eclipticVO.unbind();
+    lr.render({&getProjectionMatrix(), &getModelViewMatrix()}, EclipticColor, eclipticCount);
 }
 
 void Renderer::renderCrosshair(float selectionSizeInPixels,

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -219,9 +219,12 @@ void initGlobularData(celgl::VertexObject& vo,
     }
 
     vo.allocate(globularVtx.size() * sizeof(GlobularVtx), globularVtx.data());
-    vo.setVertices(3, GL_FLOAT, false, sizeof(GlobularVtx), 0);
-    vo.setTextureCoords(2, GL_FLOAT, false, sizeof(GlobularVtx), offsetof(GlobularVtx, starSize)); //HACK!!! used only for tidal
-    vo.setColors(4, GL_UNSIGNED_BYTE, true, sizeof(GlobularVtx), offsetof(GlobularVtx, color));
+    vo.setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex,
+                            3, GL_FLOAT, false, sizeof(GlobularVtx), 0);
+    vo.setVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex,
+                            2, GL_FLOAT, false, sizeof(GlobularVtx), offsetof(GlobularVtx, starSize)); //HACK!!! used only for tidal
+    vo.setVertexAttribArray(CelestiaGLProgram::ColorAttributeIndex,
+                            4, GL_UNSIGNED_BYTE, true, sizeof(GlobularVtx), offsetof(GlobularVtx, color));
     vo.setVertexAttribArray(sizeLoc, 1, GL_FLOAT, false, sizeof(GlobularVtx), offsetof(GlobularVtx, starSize));
     vo.setVertexAttribArray(etaLoc,  1, GL_FLOAT, false, sizeof(GlobularVtx), offsetof(GlobularVtx, eta));
 }

--- a/src/celengine/planetgrid.h
+++ b/src/celengine/planetgrid.h
@@ -2,7 +2,7 @@
 //
 // Longitude/latitude grids for ellipsoidal bodies.
 //
-// Copyright (C) 2008, the Celestia Development Team
+// Copyright (C) 2008-present, the Celestia Development Team
 // Initial version by Chris Laurel, claurel@gmail.com
 //
 // This program is free software; you can redistribute it and/or
@@ -10,13 +10,12 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_PLANETGRID_H_
-#define _CELENGINE_PLANETGRID_H_
+#pragma once
 
 #include <celengine/referencemark.h>
 
 class Body;
-struct LineStripEnd;
+class Renderer;
 
 class PlanetographicGrid : public ReferenceMark
 {
@@ -46,22 +45,29 @@ public:
         NorthReversed
     };
 
-    PlanetographicGrid(const Body& _body);
+    PlanetographicGrid(Renderer& _renderer, const Body& _body);
     ~PlanetographicGrid() = default;
 
-    void render(Renderer* renderer,
+    void render(const Eigen::Vector3f& pos,
+                float discSizeInPixels,
+                double tdb,
+                const Matrices& m) const/* override*/;
+    void render(Renderer *, /* FIXME */
                 const Eigen::Vector3f& pos,
                 float discSizeInPixels,
                 double tdb,
-                const Matrices& m) const override;
+                const Matrices& m) const override
+    {
+        render(pos, discSizeInPixels, tdb, m);
+    };
     float boundingSphereRadius() const override;
 
     void setIAULongLatConvention();
 
 private:
-    static void InitializeGeometry();
+    static void InitializeGeometry(const Renderer&);
 
-private:
+    Renderer& renderer;
     const Body& body;
 
     float minLongitudeStep{ 10.0f };
@@ -69,11 +75,4 @@ private:
 
     LongitudeConvention longitudeConvention{ Westward };
     NorthDirection northDirection{ NorthNormal };
-
-    static unsigned int circleSubdivisions;
-    static std::vector<LineStripEnd> xyCircle;
-    static std::vector<LineStripEnd> xzCircle;
 };
-
-#endif // _CELENGINE_PLANETGRID_H_
-

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -51,20 +51,6 @@ struct Matrices
     const Eigen::Matrix4f *modelview;
 };
 
-struct LineStripEnd
-{
-    LineStripEnd(Eigen::Vector3f point, float scale) : point(point), scale(scale) {};
-    Eigen::Vector3f point;
-    float scale;
-};
-
-struct LineEnds
-{
-    LineEnds(Eigen::Vector3f point1, Eigen::Vector3f point2, float scale) : point1(point1), point2(point2), scale(scale) {};
-    Eigen::Vector3f point1;
-    Eigen::Vector3f point2;
-    float scale;
-};
 
 struct LightSource
 {

--- a/src/celengine/skygrid.cpp
+++ b/src/celengine/skygrid.cpp
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <celcompat/numbers.h>
 #include <celmath/geomutil.h>
+#include <celmath/mathlib.h>
+#include <celrender/linerenderer.h>
 #include "render.h"
 #include "vecgl.h"
 #include "skygrid.h"
@@ -25,6 +27,7 @@ using namespace Eigen;
 using namespace std;
 using namespace celmath;
 using namespace celestia;
+using celestia::engine::LineRenderer;
 
 
 // #define DEBUG_LABEL_PLACEMENT
@@ -144,6 +147,12 @@ toStandardCoords(const Vector3d& v)
     return Vector3d(v.x(), -v.z(), v.y());
 }
 
+static Vector3d
+toCelestiaCoords(const Vector3d& v)
+{
+    return Vector3d(v.x(), v.z(), -v.y());
+}
+
 // Compute the difference between two angles in [-PI, PI]
 template<class T> static T
 angleDiff(T a, T b)
@@ -154,12 +163,6 @@ angleDiff(T a, T b)
         return (T) (2.0 * pi_v<T> - diff);
     else
         return diff;
-}
-
-template<class T> static T
-min4(T a, T b, T c, T d)
-{
-    return std::min(a, std::min(b, std::min(c, d)));
 }
 
 
@@ -195,69 +198,6 @@ static Renderer::LabelVerticalAlignment
 getCoordLabelVAlign(int planeIndex)
 {
     return planeIndex == 1 ? Renderer::VerticalAlignTop : Renderer::VerticalAlignBottom;
-}
-
-
-// Find the intersection of a circle and the plane with the specified normal and
-// containing the origin. The circle is defined parametrically by:
-// center + cos(t)*u + sin(t)*u
-// u and v are orthogonal vectors with magnitudes equal to the radius of the
-// circle.
-// Return true if there are two solutions.
-template<typename T> static bool planeCircleIntersection(const Matrix<T, 3, 1>& planeNormal,
-                                                         const Matrix<T, 3, 1>& center,
-                                                         const Matrix<T, 3, 1>& u,
-                                                         const Matrix<T, 3, 1>& v,
-                                                         Matrix<T, 3, 1>* sol0,
-                                                         Matrix<T, 3, 1>* sol1)
-{
-    // Any point p on the plane must satisfy p*N = 0. Thus the intersection points
-    // satisfy (center + cos(t)U + sin(t)V)*N = 0
-    // This simplifies to an equation of the form:
-    // a*cos(t)+b*sin(t)+c = 0, with a=N*U, b=N*V, and c=N*center
-    T a = u.dot(planeNormal);
-    T b = v.dot(planeNormal);
-    T c = center.dot(planeNormal);
-
-    // The solution is +-acos((-ac +- sqrt(a^2+b^2-c^2))/(a^2+b^2))
-    T s = a * a + b * b;
-    if (s == 0.0)
-    {
-        // No solution; plane containing circle is parallel to test plane
-        return false;
-    }
-
-    if (s - c * c <= 0)
-    {
-        // One or no solutions; no need to distinguish between these
-        // cases for our purposes.
-        return false;
-    }
-
-    // No need to actually call acos to get the solution, since we're just
-    // going to plug it into sin and cos anyhow.
-    T r = b * std::sqrt(s - c * c);
-    T cosTheta0 = (-a * c + r) / s;
-    T cosTheta1 = (-a * c - r) / s;
-    T sinTheta0 = std::sqrt(1 - cosTheta0 * cosTheta0);
-    T sinTheta1 = std::sqrt(1 - cosTheta1 * cosTheta1);
-
-    *sol0 = center + cosTheta0 * u + sinTheta0 * v;
-    *sol1 = center + cosTheta1 * u + sinTheta1 * v;
-
-    // Check that we've chosen a solution that produces a point on the
-    // plane. If not, we need to use the -acos solution.
-    if (std::abs(sol0->dot(planeNormal)) > 1.0e-8)
-    {
-        *sol0 = center + cosTheta0 * u - sinTheta0 * v;
-    }
-
-    if (std::abs(sol1->dot(planeNormal)) > 1.0e-8)
-    {
-        *sol1 = center + cosTheta1 * u - sinTheta1 * v;
-    }
-
-    return true;
 }
 
 
@@ -392,18 +332,6 @@ SkyGrid::render(Renderer& renderer,
                 int windowWidth,
                 int windowHeight)
 {
-    ShaderProperties shadprop;
-    shadprop.texUsage = ShaderProperties::VertexColors;
-    shadprop.lightModel = ShaderProperties::UnlitModel;
-
-    bool lineAsTriangles = renderer.shouldDrawLineAsTriangles();
-    if (lineAsTriangles)
-        shadprop.texUsage |= ShaderProperties::LineAsTriangles;
-
-    auto *prog = renderer.getShaderManager().getShader(shadprop);
-    if (prog == nullptr)
-        return;
-
     // 90 degree rotation about the x-axis used to transform coordinates
     // to Celestia's system.
     Quaterniond xrot90 = XRotation(-celestia::numbers::pi / 2.0);
@@ -480,10 +408,10 @@ SkyGrid::render(Renderer& renderer,
     // when computing intersection points with the parallels and meridians of the
     // grid. Coordinate labels will be drawn at the intersection points.
     Vector3d frustumNormal[4];
-    frustumNormal[0] = Vector3d( 0,  1, -h);
-    frustumNormal[1] = Vector3d( 0, -1, -h);
-    frustumNormal[2] = Vector3d( 1,  0, -w);
-    frustumNormal[3] = Vector3d(-1,  0, -w);
+    frustumNormal[0] = Vector3d( 0.0,  1.0, -h);
+    frustumNormal[1] = Vector3d( 0.0, -1.0, -h);
+    frustumNormal[2] = Vector3d( 1.0,  0.0, -w);
+    frustumNormal[3] = Vector3d(-1.0,  0.0, -w);
 
     for (int i = 0; i < 4; i++)
     {
@@ -544,51 +472,24 @@ SkyGrid::render(Renderer& renderer,
     int raIncrement  = meridianSpacing(idealMeridianSpacing);
     int decIncrement = parallelSpacing(idealParallelSpacing);
 
-    int startRa  = (int) std::ceil (totalLongitudeUnits * (minTheta / (celestia::numbers::pi * 2.0)) / (float) raIncrement) * raIncrement;
-    int endRa    = (int) std::floor(totalLongitudeUnits * (maxTheta / (celestia::numbers::pi * 2.0)) / (float) raIncrement) * raIncrement;
-    int startDec = (int) std::ceil (DEG_MIN_SEC_TOTAL  * (minDec / celestia::numbers::pi) / (float) decIncrement) * decIncrement;
-    int endDec   = (int) std::floor(DEG_MIN_SEC_TOTAL  * (maxDec / celestia::numbers::pi) / (float) decIncrement) * decIncrement;
+    int startRa  = (int) std::ceil (totalLongitudeUnits * (minTheta / (celestia::numbers::pi * 2.0)) / (double) raIncrement) * raIncrement;
+    int endRa    = (int) std::floor(totalLongitudeUnits * (maxTheta / (celestia::numbers::pi * 2.0)) / (double) raIncrement) * raIncrement;
+    int startDec = (int) std::ceil (DEG_MIN_SEC_TOTAL  * (minDec / celestia::numbers::pi) / (double) decIncrement) * decIncrement;
+    int endDec   = (int) std::floor(DEG_MIN_SEC_TOTAL  * (maxDec / celestia::numbers::pi) / (double) decIncrement) * decIncrement;
 
     // Get the orientation at single precision
     Quaterniond q = xrot90 * m_orientation * xrot90.conjugate();
     Quaternionf orientationf = q.cast<float>();
-
-    prog->use();
-    glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, m_lineColor);
 
     // Radius of sphere is arbitrary, with the constraint that it shouldn't
     // intersect the near or far plane of the view frustum.
     Matrix4f m = renderer.getModelViewMatrix() *
                  vecgl::rotate((xrot90 * m_orientation.conjugate() * xrot90.conjugate()).cast<float>()) *
                  vecgl::scale(1000.0f);
-    prog->setMVPMatrices(renderer.getProjectionMatrix(), m);
-    if (lineAsTriangles)
-    {
-        prog->lineWidthX = renderer.getLineWidthX();
-        prog->lineWidthY = renderer.getLineWidthY();
-    }
+    Matrices matrices = {&renderer.getProjectionMatrix(), &m};
 
     double arcStep = (maxTheta - minTheta) / (double) ARC_SUBDIVISIONS;
     double theta0 = minTheta;
-    static vector<LineStripEnd> buffer(2 * (ARC_SUBDIVISIONS + 2), { Vector3f::Identity(), 1.0f });
-    glEnableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
-    if (lineAsTriangles)
-    {
-        glEnableVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex);
-        glEnableVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex);
-
-        glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
-                              3, GL_FLOAT, GL_FALSE, sizeof(LineStripEnd), &buffer[0].point);
-        glVertexAttribPointer(CelestiaGLProgram::NextVCoordAttributeIndex,
-                              3, GL_FLOAT, GL_FALSE, sizeof(LineStripEnd), &buffer[2].point);
-        glVertexAttribPointer(CelestiaGLProgram::ScaleFactorAttributeIndex,
-                              1, GL_FLOAT, GL_FALSE, sizeof(LineStripEnd), &buffer[0].scale);
-    }
-    else
-    {
-        glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
-                              3, GL_FLOAT, GL_FALSE, sizeof(LineStripEnd) * 2, &buffer[0].point);
-    }
 
     for (int dec = startDec; dec <= endDec; dec += decIncrement)
     {
@@ -596,20 +497,16 @@ SkyGrid::render(Renderer& renderer,
         double cosPhi = cos(phi);
         double sinPhi = sin(phi);
 
+        LineRenderer lr(renderer, 1.0f, LineRenderer::LINE_STRIP);
         for (int j = 0; j <= ARC_SUBDIVISIONS + 1; j++)
         {
             double theta = theta0 + j * arcStep;
             auto x = (float) (cosPhi * std::cos(theta));
             auto y = (float) (cosPhi * std::sin(theta));
             auto z = (float) sinPhi;
-            Vector3f position = {x, z, -y};  // convert to Celestia coords
-            buffer[2 * j] = {position, -0.5f};
-            buffer[2 * j + 1] =  {position, 0.5f};
+            lr.addVertex(x, z, -y);  // convert to Celestia coords
         }
-        if (lineAsTriangles)
-            glDrawArrays(GL_TRIANGLE_STRIP, 0, 2 * (ARC_SUBDIVISIONS + 1));
-        else
-            glDrawArrays(GL_LINE_STRIP, 0, ARC_SUBDIVISIONS + 1);
+        lr.render(matrices, m_lineColor, ARC_SUBDIVISIONS + 1);
 
         // Place labels at the intersections of the view frustum planes
         // and the parallels.
@@ -620,16 +517,14 @@ SkyGrid::render(Renderer& renderer,
         {
             Vector3d isect0(Vector3d::Zero());
             Vector3d isect1(Vector3d::Zero());
-            Renderer::LabelAlignment hAlign = getCoordLabelHAlign(k);
-            Renderer::LabelVerticalAlignment vAlign = getCoordLabelVAlign(k);
 
             if (planeCircleIntersection(frustumNormal[k], center, axis0, axis1,
                                         &isect0, &isect1))
             {
                 string labelText = latitudeLabel(dec, decIncrement);
 
-                Vector3f p0((float) isect0.x(), (float) isect0.z(), (float) -isect0.y());
-                Vector3f p1((float) isect1.x(), (float) isect1.z(), (float) -isect1.y());
+                Vector3f p0(toCelestiaCoords(isect0).cast<float>());
+                Vector3f p1(toCelestiaCoords(isect1).cast<float>());
 
 #ifdef DEBUG_LABEL_PLACEMENT
                 glPointSize(5.0);
@@ -644,6 +539,8 @@ SkyGrid::render(Renderer& renderer,
                 Matrix3f m = observer.getOrientationf().toRotationMatrix();
                 p0 = orientationf.conjugate() * p0;
                 p1 = orientationf.conjugate() * p1;
+                Renderer::LabelAlignment hAlign = getCoordLabelHAlign(k);
+                Renderer::LabelVerticalAlignment vAlign = getCoordLabelVAlign(k);
 
                 if ((m * p0).z() < 0.0)
                 {
@@ -676,40 +573,34 @@ SkyGrid::render(Renderer& renderer,
         double cosTheta = cos(theta);
         double sinTheta = sin(theta);
 
+        LineRenderer lr(renderer, 1.0f, LineRenderer::LINE_STRIP);
         for (int j = 0; j <= ARC_SUBDIVISIONS + 1; j++)
         {
             double phi = phi0 + j * arcStep;
             auto x = (float) (cos(phi) * cosTheta);
             auto y = (float) (cos(phi) * sinTheta);
             auto z = (float) sin(phi);
-            Vector3f position = {x, z, -y};  // convert to Celestia coords
-            buffer[2 * j] = {position, -0.5f};
-            buffer[2 * j + 1] =  {position, 0.5f};
+            lr.addVertex(x, z, -y);  // convert to Celestia coords
         }
-        if (lineAsTriangles)
-            glDrawArrays(GL_TRIANGLE_STRIP, 0, 2 * (ARC_SUBDIVISIONS + 1));
-        else
-            glDrawArrays(GL_LINE_STRIP, 0, ARC_SUBDIVISIONS + 1);
+        lr.render(matrices, m_lineColor, ARC_SUBDIVISIONS + 1);
 
         // Place labels at the intersections of the view frustum planes
         // and the meridians.
-        Vector3d center(0.0, 0.0, 0.0);
+        Vector3d center(Vector3d::Zero());
         Vector3d axis0(cosTheta, sinTheta, 0.0);
-        Vector3d axis1(0.0, 0.0, 1.0);
+        Vector3d axis1(Vector3d::UnitZ());
         for (int k = 1; k < 4; k += 2)
         {
-            Vector3d isect0(0.0, 0.0, 0.0);
-            Vector3d isect1(0.0, 0.0, 0.0);
-            Renderer::LabelAlignment hAlign = getCoordLabelHAlign(k);
-            Renderer::LabelVerticalAlignment vAlign = getCoordLabelVAlign(k);
+            Vector3d isect0(Vector3d::Zero());
+            Vector3d isect1(Vector3d::Zero());
 
             if (planeCircleIntersection(frustumNormal[k], center, axis0, axis1,
                                         &isect0, &isect1))
             {
                 string labelText = longitudeLabel(ra, raIncrement);
 
-                Vector3f p0((float) isect0.x(), (float) isect0.z(), (float) -isect0.y());
-                Vector3f p1((float) isect1.x(), (float) isect1.z(), (float) -isect1.y());
+                Vector3f p0(toCelestiaCoords(isect0).cast<float>());
+                Vector3f p1(toCelestiaCoords(isect1).cast<float>());
 
 #ifdef DEBUG_LABEL_PLACEMENT
                 glPointSize(5.0);
@@ -724,6 +615,8 @@ SkyGrid::render(Renderer& renderer,
                 Matrix3f m = observer.getOrientationf().toRotationMatrix();
                 p0 = orientationf.conjugate() * p0;
                 p1 = orientationf.conjugate() * p1;
+                Renderer::LabelAlignment hAlign = getCoordLabelHAlign(k);
+                Renderer::LabelVerticalAlignment vAlign = getCoordLabelVAlign(k);
 
                 if ((m * p0).z() < 0.0 && axis0.dot(isect0) >= cosMaxMeridianAngle)
                 {
@@ -739,59 +632,14 @@ SkyGrid::render(Renderer& renderer,
     }
 
     // Draw crosses indicating the north and south poles
-    array<float, 112> lineAsTriangleVertices = {
-        -polarCrossSize, 1.0f, 0.0f,   polarCrossSize, 1.0f, 0.0f,   -0.5,
-        -polarCrossSize, 1.0f, 0.0f,   polarCrossSize, 1.0f, 0.0f,    0.5,
-
-        polarCrossSize, 1.0f, 0.0f,    -polarCrossSize, 1.0f, 0.0f,  -0.5,
-        polarCrossSize, 1.0f, 0.0f,    -polarCrossSize, 1.0f, 0.0f,   0.5,
-
-        0.0f, 1.0f, -polarCrossSize,   0.0f, 1.0f, polarCrossSize,   -0.5,
-        0.0f, 1.0f, -polarCrossSize,   0.0f, 1.0f, polarCrossSize,    0.5,
-
-        0.0f, 1.0f, polarCrossSize,    0.0f, 1.0f, -polarCrossSize,  -0.5,
-        0.0f, 1.0f, polarCrossSize,    0.0f, 1.0f, -polarCrossSize,   0.5,
-
-        -polarCrossSize, -1.0f, 0.0f,  polarCrossSize, -1.0f, 0.0f,  -0.5,
-        -polarCrossSize, -1.0f, 0.0f,  polarCrossSize, -1.0f, 0.0f,   0.5,
-
-        polarCrossSize, -1.0f, 0.0f,   -polarCrossSize, -1.0f, 0.0f, -0.5,
-        polarCrossSize, -1.0f, 0.0f,   -polarCrossSize, -1.0f, 0.0f,  0.5,
-
-        0.0f, -1.0f, -polarCrossSize,  0.0f, -1.0f, polarCrossSize,  -0.5,
-        0.0f, -1.0f, -polarCrossSize,  0.0f, -1.0f, polarCrossSize,   0.5,
-
-        0.0f, -1.0f, polarCrossSize,   0.0f, -1.0f, -polarCrossSize, -0.5,
-        0.0f, -1.0f, polarCrossSize,   0.0f, -1.0f, -polarCrossSize,  0.5,
-    };
-    constexpr array<short, 24> lineAsTriangleIndcies = {
-        0,  1,  2,   2,  3,  0,
-        4,  5,  6,   6,  7,  4,
-        8,  9,  10,  10, 11, 8,
-        12, 13, 14,  14, 15, 12
-    };
-
-    if (lineAsTriangles)
-    {
-        glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
-                              3, GL_FLOAT, GL_FALSE, sizeof(float) * 7, lineAsTriangleVertices.data());
-        glVertexAttribPointer(CelestiaGLProgram::NextVCoordAttributeIndex,
-                              3, GL_FLOAT, GL_FALSE, sizeof(float) * 7, lineAsTriangleVertices.data() + 3);
-        glVertexAttribPointer(CelestiaGLProgram::ScaleFactorAttributeIndex,
-                              1, GL_FLOAT, GL_FALSE, sizeof(float) * 7, lineAsTriangleVertices.data() + 6);
-        glDrawElements(GL_TRIANGLES, lineAsTriangleIndcies.size(), GL_UNSIGNED_SHORT, lineAsTriangleIndcies.data());
-    }
-    else
-    {
-        glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
-                              3, GL_FLOAT, GL_FALSE, sizeof(float) * 7 * 2, lineAsTriangleVertices.data());
-        glDrawArrays(GL_LINES, 0, 8);
-    }
-
-    glDisableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
-    if (lineAsTriangles)
-    {
-        glDisableVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex);
-        glDisableVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex);
-    }
+    LineRenderer lr(renderer);
+    lr.addVertex(-polarCrossSize,  1.0f,  0.0f);
+    lr.addVertex( polarCrossSize,  1.0f,  0.0f);
+    lr.addVertex( 0.0f,            1.0f, -polarCrossSize);
+    lr.addVertex( 0.0f,            1.0f,  polarCrossSize);
+    lr.addVertex(-polarCrossSize, -1.0f,  0.0f);
+    lr.addVertex( polarCrossSize, -1.0f,  0.0f);
+    lr.addVertex( 0.0f,           -1.0f, -polarCrossSize);
+    lr.addVertex( 0.0f,           -1.0f,  polarCrossSize);
+    lr.render(matrices, m_lineColor, 8);
 }

--- a/src/celengine/vecgl.h
+++ b/src/celengine/vecgl.h
@@ -1,39 +1,19 @@
 // vecgl.h
 //
-// Copyright (C) 2000-2009, the Celestia Development Team
+// Copyright (C) 2000-present, the Celestia Development Team
 // Original version by Chris Laurel <claurel@gmail.com>
 //
-// Overloaded versions of GL functions
+// Utility functions to perform matrix transformation
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_VECGL_H_
-#define _CELENGINE_VECGL_H_
+#pragma once
 
-#include <celutil/color.h>
-#include "glsupport.h"
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-
-
-/**** Helpers for OpenGL ****/
-
-inline void glVertexAttrib(GLuint index, const Color &color)
-{
-#ifdef GL_ES
-    glVertexAttrib4fv(index, color.toVector4().data());
-#else
-    glVertexAttrib4Nubv(index, color.data());
-#endif
-}
-
-inline void glVertexAttrib(GLuint index, const Eigen::Vector4f &v)
-{
-    glVertexAttrib4fv(index, v.data());
-}
 
 namespace celestia::vecgl
 {
@@ -151,5 +131,3 @@ translate(T x, T y, T z)
     return Eigen::Transform<T,3,Eigen::Affine>(Eigen::Translation<T,3>(Eigen::Matrix<T,3,1>(x,y,z))).matrix();
 }
 } // end namespace celestia::vecgl
-
-#endif // _CELENGINE_VECGL_H_

--- a/src/celengine/vertexobject.cpp
+++ b/src/celengine/vertexobject.cpp
@@ -9,6 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <cassert>
 #include "shadermanager.h"
 #include "vertexobject.h"
 
@@ -37,9 +38,8 @@ VertexObject::~VertexObject()
         glDeleteBuffers(1, &m_vboId);
 }
 
-void VertexObject::bind(AttributesType attributes) noexcept
+void VertexObject::bind() noexcept
 {
-    m_currentAttributes = attributes;
     if ((m_state & State::Initialize) != 0)
     {
         if (isVAOSupported())
@@ -66,10 +66,10 @@ void VertexObject::bind(AttributesType attributes) noexcept
     }
 }
 
-void VertexObject::bindWritable(AttributesType attributes) noexcept
+void VertexObject::bindWritable() noexcept
 {
     m_state |= State::Update;
-    bind(attributes);
+    bind();
 }
 
 void VertexObject::unbind() noexcept
@@ -86,33 +86,30 @@ void VertexObject::unbind() noexcept
         glBindBuffer(m_bufferType, 0);
     }
     m_state = State::NormalState;
-    m_currentAttributes = AttributesType::Invalid;
 }
 
-bool VertexObject::allocate(const void* data) noexcept
+void VertexObject::allocate(const void* data) noexcept
 {
     glBufferData(m_bufferType, m_bufferSize, data, m_streamType);
-    return glGetError() != GL_NO_ERROR;
 }
 
-bool VertexObject::allocate(GLsizeiptr bufferSize, const void* data) noexcept
+void VertexObject::allocate(GLsizeiptr bufferSize, const void* data) noexcept
 {
     m_bufferSize = bufferSize;
-    return allocate(data);
+    allocate(data);
 }
 
-bool VertexObject::allocate(GLenum bufferType, GLsizeiptr bufferSize, const void* data, GLenum streamType) noexcept
+void VertexObject::allocate(GLenum bufferType, GLsizeiptr bufferSize, const void* data, GLenum streamType) noexcept
 {
     m_bufferType = bufferType;
     m_bufferSize = bufferSize;
     m_streamType = streamType;
-    return allocate(data);
+    allocate(data);
 }
 
-bool VertexObject::setBufferData(const void* data, GLintptr offset, GLsizeiptr size) noexcept
+void VertexObject::setBufferData(const void* data, GLintptr offset, GLsizeiptr size) noexcept
 {
     glBufferSubData(m_bufferType, offset, size == 0 ? m_bufferSize : size, data);
-    return glGetError() == GL_NO_ERROR;
 }
 
 void VertexObject::draw(GLenum primitive, GLsizei count, GLint first) noexcept
@@ -125,63 +122,26 @@ void VertexObject::draw(GLenum primitive, GLsizei count, GLint first) noexcept
 
 void VertexObject::enableAttribArrays() noexcept
 {
-    glBindBuffer(m_bufferType, m_vboId);
-    for (const auto& t : m_attribParams[(unsigned int)m_currentAttributes])
+    for (const auto& t : m_attribParams)
     {
         auto  n = t.first;
         auto& p = t.second;
         glEnableVertexAttribArray(n);
-        glVertexAttribPointer(n, p.count, p.type, p.normalized, p.stride, (GLvoid*) (size_t) p.offset);
+        glVertexAttribPointer(n, p.count, p.type, p.normalized, p.stride, (GLvoid*) p.offset);
     }
 }
 
 void VertexObject::disableAttribArrays() noexcept
 {
-    if (m_currentAttributes == AttributesType::Invalid)
-        return;
-
-    for (const auto& t : m_attribParams[(unsigned int)m_currentAttributes])
+    for (const auto& t : m_attribParams)
         glDisableVertexAttribArray(t.first);
-
-    glBindBuffer(m_bufferType, 0);
 }
 
-void VertexObject::setVertices(GLint count, GLenum type, bool normalized, GLsizei stride, GLsizeiptr offset, AttributesType attributes) noexcept
+void VertexObject::setVertexAttribArray(GLint location, GLint count, GLenum type, bool normalized, GLsizei stride, GLsizeiptr offset)
 {
-    setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex, count, type, normalized, stride, offset, attributes);
-}
-
-void VertexObject::setNormals(GLint count, GLenum type, bool normalized, GLsizei stride, GLsizeiptr offset, AttributesType attributes) noexcept
-{
-    setVertexAttribArray(CelestiaGLProgram::NormalAttributeIndex, count, type, normalized, stride, offset, attributes);
-}
-
-void VertexObject::setColors(GLint count, GLenum type, bool normalized, GLsizei stride, GLsizeiptr offset, AttributesType attributes) noexcept
-{
-    setVertexAttribArray(CelestiaGLProgram::ColorAttributeIndex, count, type, normalized, stride, offset, attributes);
-}
-
-void VertexObject::setTextureCoords(GLint count, GLenum type, bool normalized, GLsizei stride, GLsizeiptr offset, AttributesType attributes) noexcept
-{
-    setVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex, count, type, normalized, stride, offset, attributes);
-}
-
-void VertexObject::setTangents(GLint count, GLenum type, bool normalized, GLsizei stride, GLsizeiptr offset, AttributesType attributes) noexcept
-{
-    setVertexAttribArray(CelestiaGLProgram::TangentAttributeIndex, count, type, normalized, stride, offset, attributes);
-}
-
-void VertexObject::setPointSizes(GLint count, GLenum type, bool normalized, GLsizei stride, GLsizeiptr offset, AttributesType attributes) noexcept
-{
-    setVertexAttribArray(CelestiaGLProgram::PointSizeAttributeIndex, count, type, normalized, offset, stride, attributes);
-}
-
-void VertexObject::setVertexAttribArray(GLint location, GLint count, GLenum type, bool normalized, GLsizei stride, GLsizeiptr offset, AttributesType attributes)
-{
-    if (location < 0)
-        return;
+    assert(location >= 0);
 
     PtrParams p = { offset, stride, count, type, normalized };
-    m_attribParams[(unsigned int)attributes][location] = p;
+    m_attribParams[location] = p;
 }
 } // namespace

--- a/src/celengine/vertexobject.h
+++ b/src/celengine/vertexobject.h
@@ -30,35 +30,24 @@ class VertexObject
     VertexObject(GLenum bufferType, GLsizeiptr bufferSize, GLenum streamType);
     ~VertexObject();
 
-    enum class AttributesType
-    {
-        Default      = 0,
-        Alternative1 = 1,
-        Count        = 2,
-        Invalid      = -1,
-    };
-
-    void bind(AttributesType attributes = AttributesType::Default) noexcept;
-    void bindWritable(AttributesType attributes = AttributesType::Default) noexcept;
+    void bind() noexcept;
+    void bindWritable() noexcept;
     void unbind() noexcept;
     void draw(GLenum primitive, GLsizei count, GLint first = 0) noexcept;
-    bool allocate(const void* data = nullptr) noexcept;
-    bool allocate(GLsizeiptr bufferSize, const void* data = nullptr) noexcept;
-    bool allocate(GLenum bufferType, GLsizeiptr bufferSize, const void* data, GLenum streamType) noexcept;
-    bool setBufferData(const void* data, GLintptr offset = 0, GLsizeiptr size = 0) noexcept;
-    void setVertices(GLint count, GLenum type, bool normalized = false, GLsizei stride = 0, GLsizeiptr offset = 0, AttributesType attributes = AttributesType::Default) noexcept;
-    void setNormals(GLint count, GLenum type, bool normalized = false, GLsizei stride = 0, GLsizeiptr offset = 0, AttributesType attributes = AttributesType::Default) noexcept;
-    void setColors(GLint count, GLenum type, bool normalized = false, GLsizei stride = 0, GLsizeiptr offset = 0, AttributesType attributes = AttributesType::Default) noexcept;
-    void setTextureCoords(GLint count, GLenum type, bool normalized = false, GLsizei stride = 0, GLsizeiptr offset = 0, AttributesType attributes = AttributesType::Default) noexcept;
-    void setTangents(GLint count, GLenum type, bool normalized = false, GLsizei stride = 0, GLsizeiptr offset = 0, AttributesType attributes = AttributesType::Default) noexcept;
-    void setPointSizes(GLint count, GLenum type, bool normalized = false, GLsizei stride = 0, GLsizeiptr offset = 0, AttributesType attributes = AttributesType::Default) noexcept;
-    void setVertexAttribArray(GLint location, GLint count, GLenum type, bool normalized = false, GLsizei stride = 0, GLsizeiptr offset = 0, AttributesType attributes = AttributesType::Default);
+    void allocate(const void* data = nullptr) noexcept;
+    void allocate(GLsizeiptr bufferSize, const void* data = nullptr) noexcept;
+    void allocate(GLenum bufferType, GLsizeiptr bufferSize, const void* data, GLenum streamType) noexcept;
+    void setBufferData(const void* data, GLintptr offset = 0, GLsizeiptr size = 0) noexcept;
+    void setVertexAttribArray(GLint location, GLint count, GLenum type, bool normalized = false, GLsizei stride = 0, GLsizeiptr offset = 0);
     inline bool initialized() const noexcept
     {
         return (m_state & State::Initialize) == 0;
     }
+    GLenum getBufferType() const noexcept              { return m_bufferType; }
     void setBufferType(GLenum bufferType) noexcept     { m_bufferType = bufferType; }
+    GLsizeiptr getBufferSize() const noexcept          { return m_bufferSize; }
     void setBufferSize(GLsizeiptr bufferSize) noexcept { m_bufferSize = bufferSize; }
+    GLenum getStreamType() const noexcept              { return m_streamType; }
     void setStreamType(GLenum streamType) noexcept     { m_streamType = streamType; }
 
  private:
@@ -92,13 +81,13 @@ class VertexObject
 
     GLuint     m_vboId{ 0 };
     GLuint     m_vaoId{ 0 };
-    uint16_t   m_state{ State::Initialize };
 
     GLsizeiptr m_bufferSize{ 0 };
     GLenum     m_bufferType{ 0 };
     GLenum     m_streamType{ 0 };
 
-    AttributesType m_currentAttributes { AttributesType::Invalid };
-    std::array<std::map<GLint, PtrParams>, (unsigned int)AttributesType::Count> m_attribParams;
+    uint16_t   m_state{ State::Initialize };
+
+    std::map<GLint, PtrParams> m_attribParams;
 };
 } // namespace

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -82,8 +82,10 @@ void PassthroughViewportEffect::initializeVO(celgl::VertexObject& vo)
          1.0f,  1.0f,  1.0f, 1.0f
     };
     vo.allocate(sizeof(quadVertices), quadVertices);
-    vo.setVertices(2, GL_FLOAT, false, 4 * sizeof(float), 0);
-    vo.setTextureCoords(2, GL_FLOAT, false, 4 * sizeof(float), 2 * sizeof(float));
+    vo.setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex,
+                            2, GL_FLOAT, false, 4 * sizeof(float), 0);
+    vo.setVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex,
+                            2, GL_FLOAT, false, 4 * sizeof(float), 2 * sizeof(float));
 }
 
 void PassthroughViewportEffect::draw(celgl::VertexObject& vo)
@@ -134,9 +136,12 @@ void WarpMeshViewportEffect::initializeVO(celgl::VertexObject& vo)
 {
     mesh->scopedDataForRendering([&vo](float *data, int size){
         vo.allocate(size, data);
-        vo.setVertices(2, GL_FLOAT, false, 5 * sizeof(float), 0);
-        vo.setTextureCoords(2, GL_FLOAT, false, 5 * sizeof(float), 2 * sizeof(float));
-        vo.setVertexAttribArray(CelestiaGLProgram::IntensityAttributeIndex, 1, GL_FLOAT, false, 5 * sizeof(float), 4 * sizeof(float));
+        vo.setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex,
+                                2, GL_FLOAT, false, 5 * sizeof(float), 0);
+        vo.setVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex,
+                                2, GL_FLOAT, false, 5 * sizeof(float), 2 * sizeof(float));
+        vo.setVertexAttribArray(CelestiaGLProgram::IntensityAttributeIndex,
+                                1, GL_FLOAT, false, 5 * sizeof(float), 4 * sizeof(float));
     });
 }
 

--- a/src/celestia/CMakeLists.txt
+++ b/src/celestia/CMakeLists.txt
@@ -60,6 +60,7 @@ set(CELESTIA_CORE_LIBS $<TARGET_OBJECTS:cel3ds>
                        $<TARGET_OBJECTS:celimage>
                        $<TARGET_OBJECTS:celmath>
                        $<TARGET_OBJECTS:celmodel>
+                       $<TARGET_OBJECTS:celrender>
                        $<TARGET_OBJECTS:celttf>
                        $<TARGET_OBJECTS:celutil>
 )

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -4692,7 +4692,7 @@ void CelestiaCore::toggleReferenceMark(const string& refMark, Selection sel)
         }
         else if (refMark == "planetographic grid")
         {
-            body->addReferenceMark(new PlanetographicGrid(*body));
+            body->addReferenceMark(new PlanetographicGrid(*getRenderer(), *body));
         }
         else if (refMark == "terminator")
         {

--- a/src/celrender/CMakeLists.txt
+++ b/src/celrender/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(CELRENDER_SOURCES
+  linerenderer.cpp
+  linerenderer.h
+)
+
+add_library(celrender OBJECT ${CELRENDER_SOURCES})

--- a/src/celrender/linerenderer.cpp
+++ b/src/celrender/linerenderer.cpp
@@ -1,0 +1,443 @@
+// linerenderer.h
+//
+// Copyright (C) 2022-present, Celestia Development Team.
+//
+// Line renderer.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <celengine/glsupport.h>        // gl::maxLineWidth
+#include <celengine/shadermanager.h>
+#include <celengine/render.h>
+#include "linerenderer.h"
+#include <iostream>
+
+namespace celestia::engine
+{
+void
+LineRenderer::draw_triangles(int count, int offset)
+{
+    assert((count + offset) <= static_cast<int>(m_segments.size()));
+
+    m_trVertexObj->draw(GL_TRIANGLES, count, offset);
+    //m_trVertexObj->orphan();
+    m_trVertexObj->unbind();
+}
+
+void
+LineRenderer::draw_triangle_strip(int count, int offset)
+{
+    assert((count + offset) <= static_cast<int>(m_verticesTr.size()));
+
+    m_trVertexObj->draw(GL_TRIANGLE_STRIP, count, offset);
+    //m_trVertexObj->orphan();
+    m_trVertexObj->unbind();
+}
+
+void
+LineRenderer::draw_lines(int count, int offset)
+{
+    assert(count + offset <= static_cast<int>(m_vertices.size()));
+
+    m_lnVertexObj->draw(static_cast<GLenum>(m_primType), count, offset);
+    //m_lnVertexObj->orphan();
+    m_lnVertexObj->unbind();
+}
+
+void
+LineRenderer::setup_shader(const Eigen::Matrix4f &projection, const Eigen::Matrix4f &modelview)
+{
+    if (m_prog == nullptr)
+    {
+        ShaderProperties props;
+        props.texUsage = ShaderProperties::VertexColors;
+        props.lightModel = ShaderProperties::UnlitModel;
+        if (m_useTriangles)
+            props.texUsage |= ShaderProperties::LineAsTriangles;
+        if ((m_hints & DISABLE_FISHEYE_TRANFORMATION) != 0)
+            props.fishEyeOverride = ShaderProperties::FisheyeOverrideModeDisabled;
+        m_prog = m_renderer.getShaderManager().getShader(props);
+        if (m_prog == nullptr)
+            return;
+    }
+
+    m_prog->use();
+    m_prog->setMVPMatrices(projection, modelview);
+    if (m_useTriangles)
+    {
+        m_prog->lineWidthX = m_width * m_renderer.getLineWidthX();
+        m_prog->lineWidthY = m_width * m_renderer.getLineWidthY();
+    }
+    else
+    {
+        glLineWidth(m_renderer.getRasterizedLineWidth(m_width));
+    }
+}
+
+void
+LineRenderer::setup_vbo()
+{
+    if (!m_useTriangles)
+    {
+        if (m_lnVertexObj != nullptr)
+        {
+            if (m_storageType == STATIC_STORAGE)
+            {
+                m_lnVertexObj->bind();
+            }
+            else
+            {
+                m_lnVertexObj->bindWritable();
+                m_lnVertexObj->allocate(m_vertices.capacity() * sizeof(m_vertices[0]), nullptr); // orphan old buffer
+                m_lnVertexObj->setBufferData(m_vertices.data());
+            }
+        }
+        else
+        {
+            auto storageType = static_cast<GLenum>(m_storageType);
+            m_lnVertexObj = std::make_unique<celgl::VertexObject>(GL_ARRAY_BUFFER, 0, storageType);
+            m_lnVertexObj->bind();
+
+            m_lnVertexObj->allocate(m_vertices.capacity() * sizeof(m_vertices[0]), m_vertices.data());
+            m_lnVertexObj->setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex,
+                                                4, GL_FLOAT, GL_FALSE, 0, 0);
+        }
+    }
+    else
+    {
+        if (m_trVertexObj != nullptr)
+        {
+            if (m_storageType == STATIC_STORAGE)
+            {
+                m_trVertexObj->bind();
+            }
+            else
+            {
+                m_trVertexObj->bindWritable();
+                if (m_primType == LINES || (m_hints & PREFER_SIMPLE_TRIANGLES) != 0)
+                {
+                    auto stride = static_cast<GLsizei>(sizeof(LineSegment));
+                    m_trVertexObj->allocate(m_segments.capacity() * stride, nullptr); // orphan old buffer
+                    m_trVertexObj->setBufferData(m_segments.data());
+                }
+                else
+                {
+                    auto stride = static_cast<GLsizei>(sizeof(LineVertex));
+                    m_trVertexObj->allocate(m_verticesTr.capacity() * stride, nullptr); // orphan old buffer
+                    m_trVertexObj->setBufferData(m_verticesTr.data());
+                }
+            }
+        }
+        else
+        {
+            auto storageType = static_cast<GLenum>(m_storageType);
+            m_trVertexObj = std::make_unique<celgl::VertexObject>(GL_ARRAY_BUFFER, 0, storageType);
+            m_trVertexObj->bind();
+
+            if (m_primType == LINES || (m_hints & PREFER_SIMPLE_TRIANGLES) != 0)
+            {
+                auto stride = static_cast<GLsizei>(sizeof(LineSegment));
+
+                m_trVertexObj->allocate(m_segments.capacity() * stride, m_segments.data());
+                m_trVertexObj->setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex,
+                                                    4, GL_FLOAT, GL_FALSE, stride, offsetof(LineSegment, point1));
+                m_trVertexObj->setVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex,
+                                                    4, GL_FLOAT, GL_FALSE, stride, offsetof(LineSegment, point2));
+                m_trVertexObj->setVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex,
+                                                    1, GL_FLOAT, GL_FALSE, stride, offsetof(LineSegment, scale));
+                m_segments.clear();
+            }
+            else
+            {
+                auto stride = static_cast<GLsizei>(sizeof(LineVertex));
+
+                m_trVertexObj->allocate(m_verticesTr.capacity() * stride, m_verticesTr.data());
+                m_trVertexObj->setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex,
+                                                    4, GL_FLOAT, GL_FALSE, stride, offsetof(LineVertex, point));
+                m_trVertexObj->setVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex,
+                                                    4, GL_FLOAT, GL_FALSE, stride, 2*stride + offsetof(LineVertex, point));
+                m_trVertexObj->setVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex,
+                                                    1, GL_FLOAT, GL_FALSE, stride, offsetof(LineVertex, scale));
+                m_verticesTr.clear();
+            }
+        }
+    }
+}
+
+void
+LineRenderer::add_segment_points(const Eigen::Vector4f &point1, const Eigen::Vector4f &point2)
+{
+    m_segments.emplace_back(point1, point2, -0.5f);
+    m_segments.emplace_back(point1, point2,  0.5f);
+    m_segments.emplace_back(point2, point1, -0.5f);
+    m_segments.emplace_back(point2, point1, -0.5f);
+    m_segments.emplace_back(point2, point1,  0.5f);
+    m_segments.emplace_back(point1, point2, -0.5f);
+}
+
+void
+LineRenderer::triangulate_segments()
+{
+    int count = static_cast<int>(m_vertices.size());
+    m_segments.reserve(count*3);
+    for (int i = 0; i < count; i+=2)
+        add_segment_points(m_vertices[i], m_vertices[i+1]);
+}
+
+void
+LineRenderer::triangulate_vertices_as_segments()
+{
+    int count = static_cast<int>(m_vertices.size());
+    int stop = m_primType == LINE_STRIP ? count-1 : count;
+    m_segments.reserve(stop*6);
+    for (int i = 0; i < stop; i++)
+        add_segment_points(m_vertices[i], m_vertices[(i + 1) % count]);
+}
+
+void
+LineRenderer::close_loop()
+{
+    // simulate loop by adding an additional endpoint (copy of vertex[0])
+    // vertex[1] is required as a next position to calculate triangle vertices
+    m_verticesTr.emplace_back(m_vertices[0], -0.5f);
+    m_verticesTr.emplace_back(m_vertices[0],  0.5f);
+    m_verticesTr.emplace_back(m_vertices[1], -0.5f);
+    m_verticesTr.emplace_back(m_vertices[1],  0.5f);
+    m_loopDone = true;
+}
+
+void
+LineRenderer::triangulate_vertices()
+{
+    m_verticesTr.reserve(m_vertices.size()*2 + (m_primType == LINE_LOOP ? 4 : 0));
+    for (const auto &vertex : m_vertices)
+    {
+        m_verticesTr.emplace_back(vertex, -0.5f);
+        m_verticesTr.emplace_back(vertex,  0.5f);
+    }
+
+    if (m_primType == LINE_LOOP && !m_loopDone)
+        close_loop();
+}
+
+void
+LineRenderer::triangulate()
+{
+    if (m_triangulated)
+    {
+        if (m_primType == LINE_LOOP && !m_loopDone)
+            close_loop();
+        return;
+    }
+
+    if ((m_hints & PREFER_SIMPLE_TRIANGLES) != 0 && m_primType != LINES)
+    {
+        triangulate_vertices_as_segments();
+    }
+    else if (m_primType == LINE_STRIP || m_primType == LINE_LOOP)
+    {
+        triangulate_vertices();
+    }
+    else
+    {
+        triangulate_segments();
+    }
+
+    m_triangulated = true;
+}
+
+#if 0
+LineRenderer::LineRenderer(const Renderer &renderer, float width, PrimType primType, VertexFormat format, StorageType storageType) :
+#else
+LineRenderer::LineRenderer(const Renderer &renderer, float width, PrimType primType, StorageType storageType) :
+#endif
+    m_renderer(renderer),
+    m_width(width),
+    m_primType(primType),
+#if 0
+    m_format(format),
+#endif
+    m_storageType(storageType)
+{
+    if (storageType == DYNAMIC_STORAGE)
+        m_useTriangles = m_renderer.shouldDrawLineAsTriangles(m_width);
+}
+
+void
+LineRenderer::clear()
+{
+    m_verticesTr.clear();
+    m_segments.clear();
+    m_vertices.clear();
+    m_triangulated = false;
+    m_loopDone = false;
+}
+
+void
+LineRenderer::render(const Matrices &mvp, const Color &color, int count, int offset)
+{
+    m_useTriangles = m_useTriangles || m_renderer.shouldDrawLineAsTriangles(m_width);
+
+    setup_shader(*mvp.projection, *mvp.modelview);
+    setup_vbo();
+#ifdef GL_ES
+    glVertexAttrib4fv(CelestiaGLProgram::ColorAttributeIndex, color.toVector4().data());
+#else
+    glVertexAttrib4Nubv(CelestiaGLProgram::ColorAttributeIndex, color.data());
+#endif
+
+    if (m_useTriangles)
+    {
+        triangulate();
+
+        if ((m_hints & PREFER_SIMPLE_TRIANGLES) != 0 && m_primType != LINES)
+        {
+            if (m_primType == LINE_STRIP)
+                count--;
+            draw_triangles(count*6, offset*6);
+        }
+        else if (m_primType == LINES)
+        {
+            draw_triangles(count*3, offset*3);
+        }
+        else
+        {
+            if (m_primType == LINE_LOOP)
+                count++;
+            draw_triangle_strip(count*2, offset*2);
+        }
+    }
+    else
+    {
+        draw_lines(count, offset);
+    }
+}
+
+void LineRenderer::addVertex(const Eigen::Vector4f &vertex)
+{
+    if (!m_useTriangles)
+    {
+        m_vertices.push_back(vertex);
+    }
+    else
+    {
+        m_verticesTr.emplace_back(vertex, -0.5f);
+        m_verticesTr.emplace_back(vertex,  0.5f);
+    }
+}
+
+void
+LineRenderer::addVertex(const Eigen::Vector3f &vertex)
+{
+    if (!m_useTriangles)
+    {
+        m_vertices.emplace_back(vertex.x(), vertex.y(), vertex.z(), 1.0f);
+    }
+    else
+    {
+        Eigen::Vector4f v(vertex.x(), vertex.y(), vertex.z(), 1.0f);
+        m_verticesTr.emplace_back(v, -0.5f);
+        m_verticesTr.emplace_back(v,  0.5f);
+    }
+}
+
+void
+LineRenderer::addVertex(float x, float y, float z, float w)
+{
+    if (!m_useTriangles)
+    {
+        m_vertices.emplace_back(x, y, z, w);
+    }
+    else
+    {
+        Eigen::Vector4f v(x, y, z, w);
+        m_verticesTr.emplace_back(v, -0.5f);
+        m_verticesTr.emplace_back(v,  0.5f);
+    }
+}
+
+void
+LineRenderer::addVertex(float x, float y, float z)
+{
+    if (!m_useTriangles)
+    {
+        m_vertices.emplace_back(x, y, z, 1.0f);
+    }
+    else
+    {
+        Eigen::Vector4f v(x, y, z, 1.0f);
+        m_verticesTr.emplace_back(v, -0.5f);
+        m_verticesTr.emplace_back(v,  0.5f);
+    }
+}
+
+void
+LineRenderer::addVertex(float x, float y)
+{
+    if (!m_useTriangles)
+    {
+        m_vertices.emplace_back(x, y, 0.0f, 1.0f);
+    }
+    else
+    {
+        Eigen::Vector4f v(x, y, 0.0f, 1.0f);
+        m_verticesTr.emplace_back(v, -0.5f);
+        m_verticesTr.emplace_back(v,  0.5f);
+    }
+}
+
+void
+LineRenderer::addSegment(const Eigen::Vector4f &vertex1, const Eigen::Vector4f &vertex2)
+{
+    if (!m_useTriangles)
+    {
+        m_vertices.push_back(vertex1);
+        m_vertices.push_back(vertex2);
+    }
+    else
+    {
+        triangulate_segments();
+    }
+}
+
+void
+LineRenderer::addSegment(const Eigen::Vector3f &vertex1, const Eigen::Vector3f &vertex2)
+{
+    if (!m_useTriangles)
+    {
+        m_vertices.push_back(Eigen::Vector4f(vertex1.x(), vertex1.y(), vertex1.z(), 1.0f));
+        m_vertices.push_back(Eigen::Vector4f(vertex2.x(), vertex2.y(), vertex2.z(), 1.0f));
+    }
+    else
+    {
+        triangulate_segments();
+    }
+}
+
+void
+LineRenderer::setPrimitive(LineRenderer::PrimType primType)
+{
+    m_primType = primType;
+}
+
+void
+LineRenderer::setVertexCount(int count)
+{
+    m_vertices.reserve(count);
+}
+
+void
+LineRenderer::setHints(int hints)
+{
+    m_hints = hints;
+}
+
+void
+LineRenderer::setCustomShader(CelestiaGLProgram *prog)
+{
+    m_prog = prog;
+}
+} // namespace

--- a/src/celrender/linerenderer.h
+++ b/src/celrender/linerenderer.h
@@ -1,0 +1,144 @@
+// linerenderer.h
+//
+// Copyright (C) 2022-present, Celestia Development Team.
+//
+// Line renderer.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <Eigen/Core>
+#include <celengine/vertexobject.h>
+#include <celutil/color.h>
+
+class CelestiaGLProgram;
+class Renderer;
+struct Matrices;
+
+namespace celestia::engine
+{
+class LineRenderer
+{
+public:
+    enum StorageType
+    {
+        STREAM_STORAGE                = 0x88E0,
+        STATIC_STORAGE                = 0x88E4,
+        DYNAMIC_STORAGE               = 0x88E8,
+    };
+
+    enum PrimType
+    {
+        LINES                         = 0x0001,
+        LINE_LOOP                     = 0x0002,
+        LINE_STRIP                    = 0x0003,
+    };
+
+    enum Hints
+    {
+        PREFER_SIMPLE_TRIANGLES       = 0x0001,
+        DISABLE_FISHEYE_TRANFORMATION = 0x0002,
+    };
+
+    enum VertexFormat
+    {
+        POSITION2F                    = 0x0002,
+        POSITION3F                    = 0x0003,
+        POSITION4F                    = 0x0004,
+        POSITION3F_COLOR4F            = 0x0043,
+        POSITION3F_COLOR4UB           = 0x00C3, //Position3fColor4ub
+    };
+
+#if 0
+    enum VertexFormat
+    {
+        VERTEX_POSITION_2F,
+        VERTEX_POSITION_3F,
+        VERTEX_POSITION_4F,
+    };
+
+    LineRenderer(const Renderer &renderer, float width = 1.0f, PrimType primType = LINES, VertexFormat format = VERTEX_POSITION_3F, StorageType storageType = DYNAMIC_STORAGE);
+#endif
+    LineRenderer(const Renderer &renderer, float width = 1.0f, PrimType primType = LINES, StorageType storageType = DYNAMIC_STORAGE);
+    ~LineRenderer() = default;
+
+    void clear();
+    void addVertex(const Eigen::Vector4f &vertex);
+    void addVertex(const Eigen::Vector3f &vertex);
+    void addVertex(float x, float y, float z, float w);
+    void addVertex(float x, float y, float z);
+    void addVertex(float x, float y);
+    void addSegment(const Eigen::Vector4f &vertex1, const Eigen::Vector4f &vertex2);
+    void addSegment(const Eigen::Vector3f &vertex1, const Eigen::Vector3f &vertex2);
+    void setVertexCount(int count);
+    void setHints(int hints);
+    void setCustomShader(CelestiaGLProgram *prog);
+    [[ deprecated ]] void setPrimitive(PrimType);
+
+    float getWidth() const { return m_width; }
+
+    void render(const Matrices &mvp, const Color &color, int count, int offset = 0);
+
+private:
+    // LineVertex is used to draw lines with triangles with GL_TRIANGLE_STRIP
+    struct LineVertex
+    {
+        LineVertex(const Eigen::Vector4f &point, float scale) :
+            point(point),
+            scale(scale)
+        {};
+        Eigen::Vector4f point;
+        float           scale;
+    };
+
+    // LineSegment is used to draw lines with triangles with GL_TRIANGLES
+    struct LineSegment
+    {
+        LineSegment(const Eigen::Vector4f &point1, const Eigen::Vector4f &point2, float scale) :
+            point1(point1),
+            point2(point2),
+            scale(scale)
+        {};
+        Eigen::Vector4f point1;
+        Eigen::Vector4f point2;
+        float           scale;
+    };
+
+    void draw_lines(int count, int offset);
+    void draw_triangles(int count, int offset);
+    void draw_triangle_strip(int count, int offset);
+    void setup_shader(const Eigen::Matrix4f &projection, const Eigen::Matrix4f &modelview);
+    void setup_vbo();
+    void triangulate();
+    void triangulate_segments();
+    void triangulate_vertices_as_segments();
+    void triangulate_vertices();
+    void close_loop();
+    void add_segment_points(const Eigen::Vector4f &point1, const Eigen::Vector4f &point2);
+
+    std::vector<LineVertex>         m_verticesTr;
+    std::vector<LineSegment>        m_segments;
+    std::vector<Eigen::Vector4f>    m_vertices;
+    std::unique_ptr<celgl::VertexObject> m_lnVertexObj;
+    std::unique_ptr<celgl::VertexObject> m_trVertexObj;
+    const Renderer                 &m_renderer;
+    float                           m_width;
+    PrimType                        m_primType;
+#if 0
+    VertexFormat                    m_format;
+#endif
+    StorageType                     m_storageType;
+    int                             m_hints             { 0     };
+    bool                            m_useTriangles      { false };
+    bool                            m_triangulated      { false };
+    bool                            m_loopDone          { false };
+    CelestiaGLProgram              *m_prog              { nullptr };
+};
+}

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -402,7 +402,8 @@ static int object_addreferencemark(lua_State* l)
         }
         else if (compareIgnoringCase(rmtype, "planetographic grid") == 0)
         {
-            PlanetographicGrid* grid = new PlanetographicGrid(*body);
+            CelestiaCore* appCore = celx.appCore(AllErrors);
+            PlanetographicGrid* grid = new PlanetographicGrid(*appCore->getRenderer(), *body);
             body->addReferenceMark(grid);
         }
     }


### PR DESCRIPTION
This PR moves all line triangulation code into a separate class.
It also cleans up `celgl::VertexObject` class, which should be separated to its own commit.

It's a WIP still, but it's usable already. On my laptop in the worst case I have -1 fps comparing to master, but sometimes +1 fps. So generally we can say that current and this code perform the same.

@levinli303 could you test as well and provide mobile builds so users can test this?