### PR TITLE
[qt] replace QCheckBox with QRadioButton in DSO browser

### DIFF
--- a/src/celestia/qt/qtdeepskybrowser.cpp
+++ b/src/celestia/qt/qtdeepskybrowser.cpp
@@ -437,19 +437,19 @@ DeepSkyBrowser::DeepSkyBrowser(CelestiaCore* _appCore, QWidget* parent, InfoPane
     QGridLayout* dsoGroupLayout = new QGridLayout();
 
     // Buttons to select filtering criterion for dsos
-    globularsButton = new QCheckBox(_("Globulars"));
+    globularsButton = new QRadioButton(_("Globulars"));
     connect(globularsButton, SIGNAL(clicked()), this, SLOT(slotRefreshTable()));
     dsoGroupLayout->addWidget(globularsButton, 0, 0);
 
-    galaxiesButton = new QCheckBox(_("Galaxies"));
+    galaxiesButton = new QRadioButton(_("Galaxies"));
     connect(galaxiesButton, SIGNAL(clicked()), this, SLOT(slotRefreshTable()));
     dsoGroupLayout->addWidget(galaxiesButton, 0, 1);
 
-    nebulaeButton = new QCheckBox(_("Nebulae"));
+    nebulaeButton = new QRadioButton(_("Nebulae"));
     connect(nebulaeButton, SIGNAL(clicked()), this, SLOT(slotRefreshTable()));
     dsoGroupLayout->addWidget(nebulaeButton, 1, 0);
 
-    openClustersButton = new QCheckBox(_("Open Clusters"));
+    openClustersButton = new QRadioButton(_("Open Clusters"));
     connect(openClustersButton, SIGNAL(clicked()), this, SLOT(slotRefreshTable()));
     dsoGroupLayout->addWidget(openClustersButton, 1, 1);
 
@@ -457,9 +457,6 @@ DeepSkyBrowser::DeepSkyBrowser(CelestiaCore* _appCore, QWidget* parent, InfoPane
     layout->addWidget(dsoGroup);
 
     globularsButton->setChecked(true);
-    galaxiesButton->setChecked(true);
-    nebulaeButton->setChecked(true);
-    openClustersButton->setChecked(true);
 
     // Additional filtering controls
     QGroupBox* filterGroup = new QGroupBox(_("Filter"));

--- a/src/celestia/qt/qtdeepskybrowser.cpp
+++ b/src/celestia/qt/qtdeepskybrowser.cpp
@@ -456,7 +456,7 @@ DeepSkyBrowser::DeepSkyBrowser(CelestiaCore* _appCore, QWidget* parent, InfoPane
     dsoGroup->setLayout(dsoGroupLayout);
     layout->addWidget(dsoGroup);
 
-    globularsButton->setChecked(true);
+    galaxiesButton->setChecked(true);
 
     // Additional filtering controls
     QGroupBox* filterGroup = new QGroupBox(_("Filter"));

--- a/src/celestia/qt/qtdeepskybrowser.h
+++ b/src/celestia/qt/qtdeepskybrowser.h
@@ -57,10 +57,10 @@ Q_OBJECT
 
     QLabel* searchResultLabel{nullptr};
 
-    QCheckBox* globularsButton{nullptr};
-    QCheckBox* galaxiesButton{nullptr};
-    QCheckBox* nebulaeButton{nullptr};
-    QCheckBox* openClustersButton{nullptr};
+    QRadioButton* globularsButton{nullptr};
+    QRadioButton* galaxiesButton{nullptr};
+    QRadioButton* nebulaeButton{nullptr};
+    QRadioButton* openClustersButton{nullptr};
 
     QLineEdit* objectTypeFilterBox{nullptr};
 


### PR DESCRIPTION
Within the QT interface is a View -> Celestial Browser -> Deep Sky Objects tab.  It has a filter for the objects consisting of types: Globulars, Galaxies, Nebulae and Open Clusters.  The interface uses check boxes for this filter.  Initially all boxes are checked, but only the Globulars are displayed.  Unchecking the Globulars will display only the Galaxies.  Unchecking the Galaxies will display only the Nebulae.  Unchecking the the Nebulae will display only the Open Clusters.  Unchecking the Open Clusters (no buttons checked) displays only the Open Clusters.  So the filter shows only one type of object, irregardless of the number of check boxes checked. This is evident in the type designation displayed and the object count at the bottom of the window.

This behavior is much closer to the behavior of radio buttons, where one button at a time can be selected and only that item is displayed.  The underlying code for the buttons behavior is close to the radio button.  Rewriting the code to behave as check boxes would affect multiple code areas.  It is simple to modify the interface to display radio buttons.  The present grouping of the buttons into the dsoGroup widget will make them exclusive (default), allowing only one button to be pressed at a time.  This will trigger the toggle signal for two buttons (pressing one and unpressing one) and a clicked signal for the button pair.  Keeping the clicked signal allows the existing code to display objects of only the pressed button type.

This behavior makes sense to the user.  Filtering to show only one object type should be expected under these circumstances.  No reports are known of users requiring multiple items to be displayed simultaneously in this tab.  The modification will not affect the way the data is displayed from the current interface.  It only affects the buttons to make them coincide with the filtered display output.