### PR TITLE
[qt] Add items to objects in solar system browser

### DIFF
--- a/src/celestia/qt/qtsolarsystembrowser.cpp
+++ b/src/celestia/qt/qtsolarsystembrowser.cpp
@@ -865,11 +865,11 @@ void SolarSystemBrowser::slotRefreshTree()
 
     int bodyFilter = 0;
     if (planetsButton->isChecked())
-        bodyFilter |= Body::Planet | Body::DwarfPlanet | Body::Moon;
+        bodyFilter |= Body::Planet | Body::DwarfPlanet | Body::Moon | Body::MinorMoon;
     if (asteroidsButton->isChecked())
         bodyFilter |= Body::Asteroid;
     if (spacecraftsButton->isChecked())
-        bodyFilter |= Body::Spacecraft;
+        bodyFilter |= Body::Spacecraft | Body::Component;
     if (cometsButton->isChecked())
         bodyFilter |= Body::Comet;
 


### PR DESCRIPTION

Within the QT interface is a View -> Celestial Browser -> Solar System tab.  It has a filter for the objects consisting of types: Planets and moons, Asteroids, Spacecraft and Comets.  The interface uses checkboxes for this filter. 

Since the creation of the browser, moons have been split into Moons and Minor Moons.  The "Planets and moons" checkbox does not display minor moons.  Using this checkbox, Mars has no moons and Jupiter has only four.  This code revision adds the minor moons to the displayed output.

Since the creation of the browser, the classification of Components has been added to the Spacecraft object.  These components will not display when the "Spacecraft" checkbox is checked.  Components are important for spacecraft built of multiple parts such as the International Space Station, the new Chinese space station, Cassini/Huygens, etc.  This code revision adds components to the displayed output.
