### PR TITLE
Make GL pipeline state changes explicit

### DIFF
--- a/src/celengine/axisarrow.cpp
+++ b/src/celengine/axisarrow.cpp
@@ -309,20 +309,18 @@ ArrowReferenceMark::render(Renderer* renderer,
     Quaterniond q;
     q.setFromTwoVectors(Vector3d::UnitZ(), v);
 
+    Renderer::PipelineState ps;
+    ps.depthTest = true;
     if (opacity == 1.0f)
     {
-        // Enable depth buffering
-        renderer->enableDepthTest();
-        renderer->enableDepthMask();
-        renderer->disableBlending();
+        ps.depthMask = true;
     }
     else
     {
-        renderer->enableDepthTest();
-        renderer->disableDepthMask();
-        renderer->enableBlending();
-        renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        ps.blending = true;
+        ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
     }
+    renderer->setPipelineState(ps);
 
     Affine3f transform = Translation3f(position) * q.cast<float>() * Scaling(size);
     Matrix4f mv = (*m.modelview) * transform.matrix();
@@ -338,9 +336,6 @@ ArrowReferenceMark::render(Renderer* renderer,
 
     auto &vo = renderer->getVertexObject(VOType::AxisArrow, GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW);
     RenderArrow(vo);
-
-    renderer->enableBlending();
-    renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE);
 }
 
 
@@ -379,20 +374,18 @@ AxesReferenceMark::render(Renderer* renderer,
 {
     Quaterniond q = getOrientation(tdb);
 
+    Renderer::PipelineState ps;
+    ps.depthTest = true;
     if (opacity == 1.0f)
     {
-        // Enable depth buffering
-        renderer->enableDepthTest();
-        renderer->enableDepthMask();
-        renderer->disableBlending();
+        ps.depthMask = true;
     }
     else
     {
-        renderer->enableDepthTest();
-        renderer->disableDepthMask();
-        renderer->enableBlending();
-        renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        ps.blending = true;
+        ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
     }
+    renderer->setPipelineState(ps);
 
     Affine3f transform = Translation3f(position) * q.cast<float>() * Scaling(size);
     Matrix4f projection = *m.projection;
@@ -475,9 +468,6 @@ AxesReferenceMark::render(Renderer* renderer,
     RenderZ(letterVo, lineAsTriangles);
 
     letterVo.unbind();
-
-    renderer->enableBlending();
-    renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE);
 }
 
 

--- a/src/celengine/console.cpp
+++ b/src/celengine/console.cpp
@@ -78,8 +78,11 @@ void Console::begin()
 {
     projection = Ortho2D(0.0f, (float)xscale, 0.0f, (float)yscale);
 
-    renderer.enableBlending();
-    renderer.setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+    ps.depthMask = true;
+    renderer.setPipelineState(ps);
 
     global.reset();
 }

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -574,6 +574,12 @@ void Galaxy::render(const Eigen::Vector3f& offset,
     prog->samplerParam("galaxyTex") = 0;
     prog->samplerParam("colorTex") = 1;
 
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+    ps.smoothLines = true;
+    renderer->setPipelineState(ps);
+
     std::size_t vertex = 0, index = 0;
     for (unsigned int i = 0; i < nPoints; ++i)
     {

--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -496,10 +496,6 @@ void Renderer::renderSelectionPointer(const Observer& observer,
     double distance = position.norm();
     position *= cursorDistance / distance;
 
-    disableDepthTest();
-    enableBlending();
-    setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
     float vfov = (float) observer.getFOV();
     float h = tan(vfov / 2);
     float w = h * getAspectRatio();
@@ -522,6 +518,12 @@ void Renderer::renderSelectionPointer(const Observer& observer,
     if (!markerVO.initialized())
         initVO(markerVO);
 
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+    ps.depthMask = true;
+    setPipelineState(ps);
+
     prog->use();
     const Vector3f &center = cameraMatrix.col(2);
     prog->setMVPMatrices(getProjectionMatrix(), getModelViewMatrix() * vecgl::translate(Vector3f(-center)));
@@ -534,9 +536,7 @@ void Renderer::renderSelectionPointer(const Observer& observer,
     prog->vec3Param("u") = u;
     prog->vec3Param("v") = v;
     markerVO.draw(GL_TRIANGLES, SelPointerCount, SelPointerOffset);
-
     markerVO.unbind();
-    enableDepthTest();
 }
 
 /*! Draw the J2000.0 ecliptic; trivial, since this forms the basis for
@@ -544,9 +544,6 @@ void Renderer::renderSelectionPointer(const Observer& observer,
  */
 void Renderer::renderEclipticLine()
 {
-    if ((renderFlags & ShowEcliptic) == 0)
-        return;
-
     using AttributesType = celgl::VertexObject::AttributesType;
 
     ShaderProperties shadprop;
@@ -567,6 +564,12 @@ void Renderer::renderEclipticLine()
         initEclipticVO(eclipticVO);
 
     glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, EclipticColor);
+
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+    ps.smoothLines = true;
+    setPipelineState(ps);
 
     prog->use();
     prog->setMVPMatrices(getProjectionMatrix(), getModelViewMatrix());

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -621,9 +621,6 @@ void Globular::render(const Eigen::Vector3f& offset,
 
     GlobularInfoManager* globularInfoManager = getGlobularInfoManager();
 
-    renderer->enableBlending();
-    renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
 #ifndef GL_ES
     glEnable(GL_POINT_SPRITE);
     glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);
@@ -653,6 +650,12 @@ void Globular::render(const Eigen::Vector3f& offset,
     tidalProg->floatParam("tidalSize") = tidalSize;
     tidalProg->mat3Param("viewMat") = viewMat;
     tidalProg->samplerParam("tidalTex") = 0;
+
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+    ps.smoothLines = true;
+    renderer->setPipelineState(ps);
 
     vo.draw(GL_TRIANGLE_FAN, 4);
 

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -94,7 +94,9 @@ void Nebula::render(const Vector3f& /*offset*/,
     if (g == nullptr)
         return;
 
-    renderer->disableBlending();
+    Renderer::PipelineState ps;
+    ps.smoothLines = true;
+    renderer->setPipelineState(ps);
 
     Matrix4f mv = vecgl::rotate(vecgl::scale(*m.modelview, getRadius()),
                                 getOrientation());
@@ -102,8 +104,6 @@ void Nebula::render(const Vector3f& /*offset*/,
     GLSLUnlit_RenderContext rc(renderer, getRadius(), &mv, m.projection);
     rc.setPointScale(2.0f * getRadius() / pixelSize);
     g->render(rc);
-
-    renderer->enableBlending();
 }
 
 

--- a/src/celengine/overlay.cpp
+++ b/src/celengine/overlay.cpp
@@ -36,8 +36,11 @@ void Overlay::begin()
     projection = Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight);
     // ModelView is Identity
 
-    renderer.enableBlending();
-    renderer.setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+    ps.depthMask = true;
+    renderer.setPipelineState(ps);
 
     global.reset();
     useTexture = false;

--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -125,10 +125,11 @@ PlanetographicGrid::render(Renderer* renderer,
     Vector3f vn  = renderer->getCameraOrientation().conjugate() * -Vector3f::UnitZ();
     Vector3d viewNormal = vn.cast<double>();
 
-    // Enable depth buffering
-    renderer->enableDepthTest();
-    renderer->enableDepthMask();
-    renderer->disableBlending();
+    Renderer::PipelineState ps;
+    ps.depthMask = true;
+    ps.depthTest = true;
+    ps.smoothLines = true;
+    renderer->setPipelineState(ps);
 
     Affine3f transform = Translation3f(pos) * qf.conjugate() * Scaling(scale * semiAxes);
     Matrix4f projection = *m.projection;
@@ -309,9 +310,6 @@ PlanetographicGrid::render(Renderer* renderer,
         glDisableVertexAttribArray(CelestiaGLProgram::NextVCoordAttributeIndex);
         glDisableVertexAttribArray(CelestiaGLProgram::ScaleFactorAttributeIndex);
     }
-
-    renderer->enableBlending();
-    renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE);
 }
 
 

--- a/src/celengine/rendcontext.cpp
+++ b/src/celengine/rendcontext.cpp
@@ -716,37 +716,29 @@ GLSL_RenderContext::makeCurrent(const cmod::Material& m)
     if (newBlendMode != blendMode)
     {
         blendMode = newBlendMode;
+        Renderer::PipelineState ps;
         switch (blendMode)
         {
         case cmod::BlendMode::NormalBlend:
-            renderer->enableBlending();
-            renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            if (disableDepthWriteOnBlend)
-                renderer->disableDepthMask();
-            else
-                renderer->enableDepthMask();
+            ps.blending = true;
+            ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+            ps.depthMask = !disableDepthWriteOnBlend;
             break;
         case cmod::BlendMode::AdditiveBlend:
-            renderer->enableBlending();
-            renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE);
-            if (disableDepthWriteOnBlend)
-                renderer->disableDepthMask();
-            else
-                renderer->enableDepthMask();
+            ps.blending = true;
+            ps.blendFunc = {GL_SRC_ALPHA, GL_ONE};
+            ps.depthMask = !disableDepthWriteOnBlend;
             break;
         case cmod::BlendMode::PremultipliedAlphaBlend:
-            renderer->enableBlending();
-            renderer->setBlendingFactors(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-            if (disableDepthWriteOnBlend)
-                renderer->disableDepthMask();
-            else
-                renderer->enableDepthMask();
+            ps.blending = true;
+            ps.blendFunc = {GL_ONE, GL_ONE_MINUS_SRC_ALPHA};
+            ps.depthMask = !disableDepthWriteOnBlend;
             break;
         default:
-            renderer->disableBlending();
-            renderer->enableDepthMask();
+            ps.depthMask = true;
             break;
         }
+        renderer->setPipelineState(ps);
     }
 }
 
@@ -886,27 +878,25 @@ GLSLUnlit_RenderContext::makeCurrent(const cmod::Material& m)
     if (newBlendMode != blendMode)
     {
         blendMode = newBlendMode;
+        Renderer::PipelineState ps;
         switch (blendMode)
         {
         case cmod::BlendMode::NormalBlend:
-            renderer->enableBlending();
-            renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            renderer->disableDepthMask();
+            ps.blending = true;
+            ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
             break;
         case cmod::BlendMode::AdditiveBlend:
-            renderer->enableBlending();
-            renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE);
-            renderer->disableDepthMask();
+            ps.blending = true;
+            ps.blendFunc = {GL_SRC_ALPHA, GL_ONE};
             break;
         case cmod::BlendMode::PremultipliedAlphaBlend:
-            renderer->enableBlending();
-            renderer->setBlendingFactors(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-            renderer->disableDepthMask();
+            ps.blending = true;
+            ps.blendFunc = {GL_ONE, GL_ONE_MINUS_SRC_ALPHA};
             break;
         default:
-            renderer->disableBlending();
-            renderer->enableDepthMask();
+            ps.depthMask = true;
             break;
         }
+        renderer->setPipelineState(ps);
     }
 }

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -109,6 +109,22 @@ class Renderer
     Renderer();
     ~Renderer();
 
+    struct PipelineState
+    {
+        bool blending       { false };
+        bool scissor        { false };
+        bool multisample    { false };
+        bool depthMask      { false };
+        bool depthTest      { false };
+        bool smoothLines    { false };
+
+        struct
+        {
+            GLenum src      { GL_NONE };
+            GLenum dst      { GL_NONE };
+        } blendFunc;
+    };
+
     struct DetailOptions
     {
         DetailOptions();
@@ -285,15 +301,7 @@ class Renderer
     void disableMSAA() noexcept;
     bool isMSAAEnabled() const noexcept;
 
-    void enableBlending() noexcept;
-    void disableBlending() noexcept;
-    void setBlendingFactors(GLenum, GLenum) noexcept;
-
-    void enableDepthMask() noexcept;
-    void disableDepthMask() noexcept;
-
-    void enableDepthTest() noexcept;
-    void disableDepthTest() noexcept;
+    void setPipelineState(const PipelineState &ps) noexcept;
 
     celestia::PixelFormat getPreferredCaptureFormat() const noexcept;
 
@@ -740,9 +748,6 @@ class Renderer
 
     void createShadowFBO();
 
-    void enableSmoothLines();
-    void disableSmoothLines();
-
  private:
     ShaderManager* shaderManager{ nullptr };
 
@@ -807,17 +812,7 @@ class Renderer
 
     int currentIntervalIndex{ 0 };
 
-    struct State
-    {
-        bool blending    : 1;
-        bool scissor     : 1;
-        bool multisample : 1;
-        bool depthMask   : 1;
-        bool depthTest   : 1;
-
-        GLenum sfactor, dfactor; // blending
-    };
-    State m_GLState { false, false, false, false, false };
+    PipelineState m_pipelineState;
 
     std::array<int, 4> m_viewport { 0, 0, 0, 0 };
 

--- a/src/celengine/renderglsl.h
+++ b/src/celengine/renderglsl.h
@@ -90,6 +90,7 @@ void renderRings_GLSL(RingSystem& rings,
                       bool renderShadow,
                       float segmentSizeInPixels,
                       const Matrices &m,
+                      bool inside,
                       Renderer* renderer);
 
 void renderGeometry_GLSL_Unlit(Geometry* geometry,

--- a/src/celengine/skygrid.cpp
+++ b/src/celengine/skygrid.cpp
@@ -606,6 +606,13 @@ SkyGrid::render(Renderer& renderer,
             buffer[2 * j] = {position, -0.5f};
             buffer[2 * j + 1] =  {position, 0.5f};
         }
+
+        Renderer::PipelineState ps;
+        ps.blending = true;
+        ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+        ps.smoothLines = true;
+        renderer.setPipelineState(ps);
+
         if (lineAsTriangles)
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 2 * (ARC_SUBDIVISIONS + 1));
         else

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -14,6 +14,8 @@
 #include "shadermanager.h"
 #include "mapmanager.h"
 
+static const Renderer::PipelineState ps;
+
 bool ViewportEffect::preprocess(Renderer* renderer, FramebufferObject* fbo)
 {
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &oldFboId);
@@ -41,15 +43,6 @@ PassthroughViewportEffect::PassthroughViewportEffect() :
 {
 }
 
-bool PassthroughViewportEffect::prerender(Renderer* renderer, FramebufferObject* fbo)
-{
-    if (!ViewportEffect::prerender(renderer, fbo))
-        return false;
-
-    renderer->disableDepthTest();
-    return true;
-}
-
 bool PassthroughViewportEffect::render(Renderer* renderer, FramebufferObject* fbo, int width, int height)
 {
     CelestiaGLProgram *prog = renderer->getShaderManager().getShader("passthrough");
@@ -63,6 +56,7 @@ bool PassthroughViewportEffect::render(Renderer* renderer, FramebufferObject* fb
     prog->use();
     prog->samplerParam("tex") = 0;
     glBindTexture(GL_TEXTURE_2D, fbo->colorTexture());
+    renderer->setPipelineState(ps);
     draw(vo);
     glBindTexture(GL_TEXTURE_2D, 0);
     vo.unbind();
@@ -103,11 +97,7 @@ bool WarpMeshViewportEffect::prerender(Renderer* renderer, FramebufferObject* fb
     if (mesh == nullptr)
         return false;
 
-    if (!ViewportEffect::prerender(renderer, fbo))
-        return false;
-
-    renderer->disableDepthTest();
-    return true;
+    return ViewportEffect::prerender(renderer, fbo);
 }
 
 bool WarpMeshViewportEffect::render(Renderer* renderer, FramebufferObject* fbo, int width, int height)
@@ -124,6 +114,7 @@ bool WarpMeshViewportEffect::render(Renderer* renderer, FramebufferObject* fbo, 
     prog->samplerParam("tex") = 0;
     prog->floatParam("screenRatio") = (float)height / width;
     glBindTexture(GL_TEXTURE_2D, fbo->colorTexture());
+    renderer->setPipelineState(ps);
     draw(vo);
     glBindTexture(GL_TEXTURE_2D, 0);
     vo.unbind();

--- a/src/celengine/viewporteffect.h
+++ b/src/celengine/viewporteffect.h
@@ -39,7 +39,6 @@ class PassthroughViewportEffect : public ViewportEffect
     PassthroughViewportEffect();
     ~PassthroughViewportEffect() override = default;
 
-    bool prerender(Renderer*, FramebufferObject* fbo) override;
     bool render(Renderer*, FramebufferObject*, int width, int height) override;
 
  private:

--- a/src/celengine/visibleregion.cpp
+++ b/src/celengine/visibleregion.cpp
@@ -184,11 +184,13 @@ VisibleRegion::render(Renderer* renderer,
 
     Vector3f semiAxes = m_body.getSemiAxes();
 
-    // Enable depth buffering
-    renderer->enableDepthTest();
-    renderer->enableDepthMask();
-    renderer->enableBlending();
-    renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+    ps.depthMask = true;
+    ps.depthTest = true;
+    ps.smoothLines = true;
+    renderer->setPipelineState(ps);
 
     double maxSemiAxis = m_body.getRadius();
 
@@ -233,9 +235,6 @@ VisibleRegion::render(Renderer* renderer,
     Affine3f transform = Translation3f(position) * qf.conjugate();
     Matrix4f modelView = (*m.modelview) * transform.matrix();
     renderTerminator(renderer, pos, Color(m_color, opacity), { m.projection, &modelView });
-
-    renderer->enableBlending();
-    renderer->setBlendingFactors(GL_SRC_ALPHA, GL_ONE);
 }
 
 


### PR DESCRIPTION
I hate to jump over different files to understand the current pipeline state and reset it back after rendering.

I also hate to see useless state changes when we don't have anything to render, but we change it and the reset back, e.g.

glEnable(GL_BLENDING)
glDisable(GL_BLENDING)
glEnable(GL_BLENDING)
glDisable(GL_BLENDING)
glEnable(GL_BLENDING)
glDisable(GL_BLENDING)

I haven't decided yet if we should do the same for rarely used things like glFrontFace() or face culling.
