### PR TITLE
Refactor string parser in stardb to remove C string functions

### DIFF
--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -212,7 +212,7 @@ std::string catalogNumberToString(AstroCatalog::IndexNumber catalogNumber)
 
 
 void stcError(const Tokenizer& tok,
-              const std::string& msg)
+              std::string_view msg)
 {
     GetLogger()->error(_("Error in .stc file (line {}): {}\n"), tok.getLineNumber(), msg);
 }
@@ -934,8 +934,8 @@ bool StarDatabase::createStar(Star* star,
                 // Observational-Theoretical HR Diagram", Journal of the Royal
                 // Astronomical Society of Canada, Vol 92. p36.
 
-                double logT = log10(temperature) - 4;
-                double bc = -8.499 * pow(logT, 4) + 13.421 * pow(logT, 3)
+                double logT = std::log10(temperature) - 4;
+                double bc = -8.499 * std::pow(logT, 4) + 13.421 * std::pow(logT, 3)
                             - 8.131 * logT * logT - 3.901 * logT - 0.438;
 
                 details->setBolometricCorrection((float) bc);

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -30,7 +30,7 @@
 class StarNameDatabase;
 
 
-static const unsigned int MAX_STAR_NAMES = 10;
+constexpr inline unsigned int MAX_STAR_NAMES = 10;
 
 class StarDatabase
 {
@@ -80,7 +80,7 @@ class StarDatabase
 
     // Not exact, but any star with a catalog number greater than this is assumed to not be
     // a HIPPARCOS stars.
-    static const AstroCatalog::IndexNumber MAX_HIPPARCOS_NUMBER = 999999;
+    static constexpr AstroCatalog::IndexNumber MAX_HIPPARCOS_NUMBER = 999999;
 
     struct CrossIndexEntry
     {
@@ -90,16 +90,14 @@ class StarDatabase
         bool operator<(const CrossIndexEntry&) const;
     };
 
-    typedef std::vector<CrossIndexEntry> CrossIndex;
+    using CrossIndex = std::vector<CrossIndexEntry>;
 
     bool loadCrossIndex(const Catalog, std::istream&);
     AstroCatalog::IndexNumber searchCrossIndexForCatalogNumber(const Catalog, const AstroCatalog::IndexNumber number) const;
-    Star*  searchCrossIndex(const Catalog, const AstroCatalog::IndexNumber number) const;
+    Star* searchCrossIndex(const Catalog, const AstroCatalog::IndexNumber number) const;
     AstroCatalog::IndexNumber crossIndex(const Catalog, const AstroCatalog::IndexNumber number) const;
 
     void finish();
-
-    static StarDatabase* read(std::istream&);
 
 private:
     bool createStar(Star* star,
@@ -113,7 +111,7 @@ private:
     void buildIndexes();
     Star* findWhileLoading(AstroCatalog::IndexNumber catalogNumber) const;
 
-    int nStars{ 0 };
+    std::uint32_t nStars{ 0 };
 
     Star*             stars{ nullptr };
     StarNameDatabase* namesDB{ nullptr };


### PR DESCRIPTION
The static analysis tools don't like the C string functions very much, better to use `std::string_view` for a lot of this.