### PR TITLE
Remove Array alias that potentially conflicts with Eigen

### DIFF
--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -134,13 +134,13 @@ AsterismList* ReadAsterismList(std::istream& in, const StarDatabase& stardb)
             return nullptr;
         }
 
-        Array* chains = chainsValue->getArray();
+        ValueArray* chains = chainsValue->getArray();
 
         for (const auto chain : *chains)
         {
             if (chain->getType() == Value::ArrayType)
             {
-                Array* a = chain->getArray();
+                ValueArray* a = chain->getArray();
                 // skip empty (without or only with a single star) chains
                 if (a->size() <= 1)
                     continue;

--- a/src/celengine/parser.h
+++ b/src/celengine/parser.h
@@ -27,6 +27,6 @@ class Parser
     Tokenizer* tokenizer;
 
     bool readUnits(const std::string&, Hash*);
-    Array* readArray();
+    ValueArray* readArray();
     Hash* readHash();
 };

--- a/src/celengine/value.h
+++ b/src/celengine/value.h
@@ -18,8 +18,7 @@
 #include "hash.h"
 
 class Value;
-using Array = std::vector<Value*>;
-using ValueArray = Array;
+using ValueArray = std::vector<Value*>;
 
 class Value
 {
@@ -57,7 +56,7 @@ class Value
     {
         data.s = new std::string(s);
     }
-    Value(Array *a) : type(ArrayType)
+    Value(ValueArray *a) : type(ArrayType)
     {
         data.a = a;
     }
@@ -88,7 +87,7 @@ class Value
         assert(type == StringType);
         return *data.s;
     }
-    Array* getArray() const
+    ValueArray* getArray() const
     {
         assert(type == ArrayType);
         return data.a;
@@ -109,7 +108,7 @@ class Value
     {
         std::string *s;
         double       d;
-        Array       *a;
+        ValueArray  *a;
         Hash        *h;
     };
 

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -144,7 +144,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
         else
         {
-            Array* solarSystems = solarSystemsVal->getArray();
+            ValueArray* solarSystems = solarSystemsVal->getArray();
             // assert(solarSystems != nullptr);
 
             for (const auto catalogNameVal : *solarSystems)
@@ -171,7 +171,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
         else
         {
-            Array* starCatalogs = starCatalogsVal->getArray();
+            ValueArray* starCatalogs = starCatalogsVal->getArray();
             assert(starCatalogs != nullptr);
 
             for (const auto catalogNameVal : *starCatalogs)
@@ -199,7 +199,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
         else
         {
-            Array* dsoCatalogs = dsoCatalogsVal->getArray();
+            ValueArray* dsoCatalogs = dsoCatalogsVal->getArray();
             assert(dsoCatalogs != nullptr);
 
             for (const auto catalogNameVal : *dsoCatalogs)
@@ -223,7 +223,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
     {
         if (extrasDirsVal->getType() == Value::ArrayType)
         {
-            Array* extrasDirs = extrasDirsVal->getArray();
+            ValueArray* extrasDirs = extrasDirsVal->getArray();
             assert(extrasDirs != nullptr);
 
             for (const auto dirNameVal : *extrasDirs)
@@ -253,7 +253,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
     {
         if (skipExtrasVal->getType() == Value::ArrayType)
         {
-            Array* skipExtras = skipExtrasVal->getArray();
+            ValueArray* skipExtras = skipExtrasVal->getArray();
             assert(skipExtras != nullptr);
 
             for (const auto fileNameVal : *skipExtras)
@@ -287,7 +287,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
         else
         {
-            Array* ignoreExt = ignoreExtVal->getArray();
+            ValueArray* ignoreExt = ignoreExtVal->getArray();
 
             for (const auto extVal : *ignoreExt)
             {

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -1436,7 +1436,7 @@ Value *CelxLua::getValue(int index)
         v = new Value(getString(index));
     else if (isTable(index))
     {
-        ::Array *array = new ::Array;
+        ValueArray *array = new ValueArray;
         Hash *hash = new Hash;
         push();
         while(lua_next(m_lua, index) != 0)


### PR DESCRIPTION
Since we still have a bunch of `using namespace Eigen` directives in the code which opens the potential for ambiguity with the name of this alias, let's replace the usages of `Array` with the existing `ValueArray` alternative.