### PR TITLE
[qt] Synch spelling error correction #1464

### DIFF
--- a/src/celestia/qt/qtselectionpopup.cpp
+++ b/src/celestia/qt/qtselectionpopup.cpp
@@ -150,7 +150,7 @@ SelectionPopup::SelectionPopup(const Selection& sel,
 
     if (sel.star() == nullptr && sel.deepsky() == nullptr)
     {
-        QAction* syncOrbitAction = new QAction(_("S&ynch Orbit"), this);
+        QAction* syncOrbitAction = new QAction(_("S&ync Orbit"), this);
         connect(syncOrbitAction, SIGNAL(triggered()), this, SLOT(slotSyncOrbitSelection()));
         addAction(syncOrbitAction);
     }


### PR DESCRIPTION
Correction for issue #1464 Spelling problem in Qt.  Sync is spelled sync in GTK, Qt and common modules.  Only one line in a single Qt module utilizes the alternative synch spelling.  This changes the spelling to sync, making the entire Celestia code uniformly using sync.