### PR TITLE
Constify the Value API

### DIFF
--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -135,13 +135,13 @@ AsterismList* ReadAsterismList(std::istream& in, const StarDatabase& stardb)
             return nullptr;
         }
 
-        ValueArray* chains = chainsValue->getArray();
+        const ValueArray* chains = chainsValue->getArray();
 
         for (const auto chain : *chains)
         {
             if (chain->getType() == Value::ArrayType)
             {
-                ValueArray* a = chain->getArray();
+                const ValueArray* a = chain->getArray();
                 // skip empty (without or only with a single star) chains
                 if (a->size() <= 1)
                     continue;

--- a/src/celengine/astroobj.cpp
+++ b/src/celengine/astroobj.cpp
@@ -100,7 +100,7 @@ bool AstroObject::isInCategory(const std::string &s) const
     return isInCategory(c);
 }
 
-bool AstroObject::loadCategories(Hash *hash, DataDisposition disposition, const std::string &domain)
+bool AstroObject::loadCategories(const Hash *hash, DataDisposition disposition, const std::string &domain)
 {
     if (disposition == DataDisposition::Replace)
         clearCategories();
@@ -114,7 +114,7 @@ bool AstroObject::loadCategories(Hash *hash, DataDisposition disposition, const 
     Value *a = hash->getValue("Category");
     if (a == nullptr)
         return false;
-    ValueArray *v = a->getArray();
+    const ValueArray *v = a->getArray();
     if (v == nullptr)
         return false;
     bool ret = true;

--- a/src/celengine/astroobj.cpp
+++ b/src/celengine/astroobj.cpp
@@ -111,7 +111,7 @@ bool AstroObject::loadCategories(const Hash *hash, DataDisposition disposition, 
             return false;
         return addToCategory(cn, true, domain);
     }
-    Value *a = hash->getValue("Category");
+    const Value *a = hash->getValue("Category");
     if (a == nullptr)
         return false;
     const ValueArray *v = a->getArray();

--- a/src/celengine/astroobj.h
+++ b/src/celengine/astroobj.h
@@ -42,6 +42,6 @@ public:
     bool isInCategory(const std::string&) const;
     int categoriesCount() const { return m_cats == nullptr ? 0 : m_cats->size(); }
     CategorySet *getCategories() const { return m_cats; };
-    bool loadCategories(Hash*, DataDisposition = DataDisposition::Add, const std::string &domain = "");
+    bool loadCategories(const Hash*, DataDisposition = DataDisposition::Add, const std::string &domain = "");
     friend UserCategory;
 };

--- a/src/celengine/deepskyobj.cpp
+++ b/src/celengine/deepskyobj.cpp
@@ -136,7 +136,7 @@ void DeepSkyObject::hsv2rgb( float *r, float *g, float *b, float h, float s, flo
     }
 }
 
-bool DeepSkyObject::load(AssociativeArray* params, const fs::path& resPath)
+bool DeepSkyObject::load(const AssociativeArray* params, const fs::path& resPath)
 {
     // Get position
     Eigen::Vector3d position(Eigen::Vector3d::Zero());

--- a/src/celengine/deepskyobj.h
+++ b/src/celengine/deepskyobj.h
@@ -80,7 +80,7 @@ class DeepSkyObject : public AstroObject
     virtual bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
                       double& distanceToPicker,
                       double& cosAngleToBoundCenter) const = 0;
-    virtual bool load(AssociativeArray*, const fs::path& resPath);
+    virtual bool load(const AssociativeArray*, const fs::path& resPath);
     virtual void render(const Eigen::Vector3f& offset,
                         const Eigen::Quaternionf& viewerOrientation,
                         float brightness,

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -248,7 +248,7 @@ bool DSODatabase::load(std::istream& in, const fs::path& resourcePath)
             return false;
         }
 
-        Hash* objParams    = objParamsValue->getHash();
+        const Hash* objParams    = objParamsValue->getHash();
         assert(objParams != nullptr);
 
         DeepSkyObject* obj = nullptr;

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -447,7 +447,7 @@ bool Galaxy::pick(const Eigen::ParametrizedLine<double, 3>& ray,
         cosAngleToBoundCenter);
 }
 
-bool Galaxy::load(AssociativeArray* params, const fs::path& resPath)
+bool Galaxy::load(const AssociativeArray* params, const fs::path& resPath)
 {
     double detail = 1.0;
     params->getNumber("Detail", detail);

--- a/src/celengine/galaxy.h
+++ b/src/celengine/galaxy.h
@@ -59,7 +59,7 @@ class Galaxy : public DeepSkyObject
     bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
               double& distanceToPicker,
               double& cosAngleToBoundCenter) const override;
-    bool load(AssociativeArray*, const fs::path&) override;
+    bool load(const AssociativeArray*, const fs::path&) override;
     void render(const Eigen::Vector3f& offset,
                 const Eigen::Quaternionf& viewerOrientation,
                 float brightness,

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -546,7 +546,7 @@ bool Globular::pick(const Eigen::ParametrizedLine<double, 3>& ray,
                                      cosAngleToBoundCenter);
 }
 
-bool Globular::load(AssociativeArray* params, const fs::path& resPath)
+bool Globular::load(const AssociativeArray* params, const fs::path& resPath)
 {
     // Load the basic DSO parameters first
 

--- a/src/celengine/globular.h
+++ b/src/celengine/globular.h
@@ -52,7 +52,7 @@ class Globular : public DeepSkyObject
     bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
               double& distanceToPicker,
               double& cosAngleToBoundCenter) const override;
-    bool load(AssociativeArray*, const fs::path&) override;
+    bool load(const AssociativeArray*, const fs::path&) override;
     void render(const Eigen::Vector3f& offset,
                 const Eigen::Quaternionf& viewerOrientation,
                 float brightness,

--- a/src/celengine/hash.cpp
+++ b/src/celengine/hash.cpp
@@ -131,7 +131,7 @@ bool AssociativeArray::getVector(const string& key, Vector3d& val) const
     if (v == nullptr || v->getType() != Value::ArrayType)
         return false;
 
-    ValueArray* arr = v->getArray();
+    const ValueArray* arr = v->getArray();
     if (arr->size() != 3)
         return false;
 
@@ -167,7 +167,7 @@ bool AssociativeArray::getVector(const string& key, Vector4d& val) const
     if (v == nullptr || v->getType() != Value::ArrayType)
         return false;
 
-    ValueArray* arr = v->getArray();
+    const ValueArray* arr = v->getArray();
     if (arr->size() != 4)
         return false;
 
@@ -215,7 +215,7 @@ bool AssociativeArray::getRotation(const string& key, Eigen::Quaternionf& val) c
     if (v == nullptr || v->getType() != Value::ArrayType)
         return false;
 
-    ValueArray* arr = v->getArray();
+    const ValueArray* arr = v->getArray();
     if (arr->size() != 4)
         return false;
 

--- a/src/celengine/hash.cpp
+++ b/src/celengine/hash.cpp
@@ -24,7 +24,7 @@ AssociativeArray::~AssociativeArray()
 }
 
 
-Value* AssociativeArray::getValue(const std::string& key) const
+const Value* AssociativeArray::getValue(const std::string& key) const
 {
     auto iter = assoc.find(key);
     if (iter == assoc.end())
@@ -42,7 +42,7 @@ void AssociativeArray::addValue(const std::string& key, Value& val)
 
 bool AssociativeArray::getNumber(const std::string& key, double& val) const
 {
-    Value* v = getValue(key);
+    const Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::NumberType)
         return false;
 
@@ -89,7 +89,7 @@ bool AssociativeArray::getNumber(const std::string& key, std::uint32_t& val) con
 
 bool AssociativeArray::getString(const std::string& key, std::string& val) const
 {
-    Value* v = getValue(key);
+    const Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::StringType)
         return false;
 
@@ -112,7 +112,7 @@ bool AssociativeArray::getPath(const std::string& key, fs::path& val) const
 
 bool AssociativeArray::getBoolean(const std::string& key, bool& val) const
 {
-    Value* v = getValue(key);
+    const Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::BooleanType)
         return false;
 
@@ -123,7 +123,7 @@ bool AssociativeArray::getBoolean(const std::string& key, bool& val) const
 
 bool AssociativeArray::getVector(const std::string& key, Eigen::Vector3d& val) const
 {
-    Value* v = getValue(key);
+    const Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::ArrayType)
         return false;
 
@@ -159,7 +159,7 @@ bool AssociativeArray::getVector(const std::string& key, Eigen::Vector3f& val) c
 
 bool AssociativeArray::getVector(const std::string& key, Eigen::Vector4d& val) const
 {
-    Value* v = getValue(key);
+    const Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::ArrayType)
         return false;
 
@@ -207,7 +207,7 @@ bool AssociativeArray::getVector(const std::string& key, Eigen::Vector4f& val) c
  */
 bool AssociativeArray::getRotation(const std::string& key, Eigen::Quaternionf& val) const
 {
-    Value* v = getValue(key);
+    const Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::ArrayType)
         return false;
 

--- a/src/celengine/hash.cpp
+++ b/src/celengine/hash.cpp
@@ -8,18 +8,14 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <utility>
+#include <celmath/mathlib.h>
 #include <celutil/color.h>
 #include <celutil/fsutils.h>
-#include <celmath/mathlib.h>
 #include "astro.h"
 #include "hash.h"
 #include "value.h"
 
-using namespace Eigen;
-using namespace std;
-using namespace celmath;
-using namespace celestia::util;
+namespace celutil = celestia::util;
 
 AssociativeArray::~AssociativeArray()
 {
@@ -28,9 +24,9 @@ AssociativeArray::~AssociativeArray()
 }
 
 
-Value* AssociativeArray::getValue(const string& key) const
+Value* AssociativeArray::getValue(const std::string& key) const
 {
-    map<string, Value*>::const_iterator iter = assoc.find(key);
+    auto iter = assoc.find(key);
     if (iter == assoc.end())
         return nullptr;
 
@@ -38,13 +34,13 @@ Value* AssociativeArray::getValue(const string& key) const
 }
 
 
-void AssociativeArray::addValue(const string& key, Value& val)
+void AssociativeArray::addValue(const std::string& key, Value& val)
 {
-    assoc.insert(map<string, Value*>::value_type(key, &val));
+    assoc.insert(std::map<std::string, Value*>::value_type(key, &val));
 }
 
 
-bool AssociativeArray::getNumber(const string& key, double& val) const
+bool AssociativeArray::getNumber(const std::string& key, double& val) const
 {
     Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::NumberType)
@@ -55,7 +51,7 @@ bool AssociativeArray::getNumber(const string& key, double& val) const
 }
 
 
-bool AssociativeArray::getNumber(const string& key, float& val) const
+bool AssociativeArray::getNumber(const std::string& key, float& val) const
 {
     double dval;
 
@@ -67,7 +63,7 @@ bool AssociativeArray::getNumber(const string& key, float& val) const
 }
 
 
-bool AssociativeArray::getNumber(const string& key, int& val) const
+bool AssociativeArray::getNumber(const std::string& key, int& val) const
 {
     double ival;
 
@@ -79,19 +75,19 @@ bool AssociativeArray::getNumber(const string& key, int& val) const
 }
 
 
-bool AssociativeArray::getNumber(const string& key, uint32_t& val) const
+bool AssociativeArray::getNumber(const std::string& key, std::uint32_t& val) const
 {
     double ival;
 
     if (!getNumber(key, ival))
         return false;
 
-    val = (uint32_t) ival;
+    val = static_cast<std::uint32_t>(ival);
     return true;
 }
 
 
-bool AssociativeArray::getString(const string& key, string& val) const
+bool AssociativeArray::getString(const std::string& key, std::string& val) const
 {
     Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::StringType)
@@ -102,19 +98,19 @@ bool AssociativeArray::getString(const string& key, string& val) const
 }
 
 
-bool AssociativeArray::getPath(const string& key, fs::path& val) const
+bool AssociativeArray::getPath(const std::string& key, fs::path& val) const
 {
-    string v;
+    std::string v;
     if (getString(key, v))
     {
-        val = PathExp(v);
+        val = celutil::PathExp(v);
         return true;
     }
     return false;
 }
 
 
-bool AssociativeArray::getBoolean(const string& key, bool& val) const
+bool AssociativeArray::getBoolean(const std::string& key, bool& val) const
 {
     Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::BooleanType)
@@ -125,7 +121,7 @@ bool AssociativeArray::getBoolean(const string& key, bool& val) const
 }
 
 
-bool AssociativeArray::getVector(const string& key, Vector3d& val) const
+bool AssociativeArray::getVector(const std::string& key, Eigen::Vector3d& val) const
 {
     Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::ArrayType)
@@ -144,14 +140,14 @@ bool AssociativeArray::getVector(const string& key, Vector3d& val) const
         z->getType() != Value::NumberType)
         return false;
 
-    val = Vector3d(x->getNumber(), y->getNumber(), z->getNumber());
+    val = Eigen::Vector3d(x->getNumber(), y->getNumber(), z->getNumber());
     return true;
 }
 
 
-bool AssociativeArray::getVector(const string& key, Vector3f& val) const
+bool AssociativeArray::getVector(const std::string& key, Eigen::Vector3f& val) const
 {
-    Vector3d vecVal;
+    Eigen::Vector3d vecVal;
 
     if (!getVector(key, vecVal))
         return false;
@@ -161,7 +157,7 @@ bool AssociativeArray::getVector(const string& key, Vector3f& val) const
 }
 
 
-bool AssociativeArray::getVector(const string& key, Vector4d& val) const
+bool AssociativeArray::getVector(const std::string& key, Eigen::Vector4d& val) const
 {
     Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::ArrayType)
@@ -182,14 +178,14 @@ bool AssociativeArray::getVector(const string& key, Vector4d& val) const
         w->getType() != Value::NumberType)
         return false;
 
-    val = Vector4d(x->getNumber(), y->getNumber(), z->getNumber(), w->getNumber());
+    val = Eigen::Vector4d(x->getNumber(), y->getNumber(), z->getNumber(), w->getNumber());
     return true;
 }
 
 
-bool AssociativeArray::getVector(const string& key, Vector4f& val) const
+bool AssociativeArray::getVector(const std::string& key, Eigen::Vector4f& val) const
 {
-    Vector4d vecVal;
+    Eigen::Vector4d vecVal;
 
     if (!getVector(key, vecVal))
         return false;
@@ -209,7 +205,7 @@ bool AssociativeArray::getVector(const string& key, Vector4f& val) const
  * @param[out] val A quaternion representing the value if present, unaffected if not.
  * @return True if the key exists in the hash, false otherwise.
  */
-bool AssociativeArray::getRotation(const string& key, Eigen::Quaternionf& val) const
+bool AssociativeArray::getRotation(const std::string& key, Eigen::Quaternionf& val) const
 {
     Value* v = getValue(key);
     if (v == nullptr || v->getType() != Value::ArrayType)
@@ -230,40 +226,40 @@ bool AssociativeArray::getRotation(const string& key, Eigen::Quaternionf& val) c
         z->getType() != Value::NumberType)
         return false;
 
-    Vector3f axis((float) x->getNumber(),
-                  (float) y->getNumber(),
-                  (float) z->getNumber());
+    Eigen::Vector3f axis((float) x->getNumber(),
+                         (float) y->getNumber(),
+                         (float) z->getNumber());
 
     double ang = w->getNumber();
     double angScale = 1.0;
     getAngleScale(key, angScale);
-    float angle = degToRad((float) (ang * angScale));
+    float angle = celmath::degToRad((float) (ang * angScale));
 
-    val = Quaternionf(AngleAxisf(angle, axis.normalized()));
+    val = Eigen::Quaternionf(Eigen::AngleAxisf(angle, axis.normalized()));
 
     return true;
 }
 
 
-bool AssociativeArray::getColor(const string& key, Color& val) const
+bool AssociativeArray::getColor(const std::string& key, Color& val) const
 {
-    Vector4d vec4;
+    Eigen::Vector4d vec4;
     if (getVector(key, vec4))
     {
-        Vector4f vec4f = vec4.cast<float>();
+        Eigen::Vector4f vec4f = vec4.cast<float>();
         val = Color(vec4f);
         return true;
     }
 
-    Vector3d vec3;
+    Eigen::Vector3d vec3;
     if (getVector(key, vec3))
     {
-        Vector3f vec3f = vec3.cast<float>();
+        Eigen::Vector3f vec3f = vec3.cast<float>();
         val = Color(vec3f);
         return true;
     }
 
-    string rgba;
+    std::string rgba;
     if (getString(key, rgba))
     {
         return Color::parse(rgba.c_str(), val);
@@ -282,7 +278,7 @@ bool AssociativeArray::getColor(const string& key, Color& val) const
  * @return True if the key exists in the hash, false otherwise.
  */
 bool
-AssociativeArray::getAngle(const string& key, double& val, double outputScale, double defaultScale) const
+AssociativeArray::getAngle(const std::string& key, double& val, double outputScale, double defaultScale) const
 {
     if (!getNumber(key, val))
         return false;
@@ -305,7 +301,7 @@ AssociativeArray::getAngle(const string& key, double& val, double outputScale, d
 
 /** @copydoc AssociativeArray::getAngle() */
 bool
-AssociativeArray::getAngle(const string& key, float& val, double outputScale, double defaultScale) const
+AssociativeArray::getAngle(const std::string& key, float& val, double outputScale, double defaultScale) const
 {
     double dval;
 
@@ -327,7 +323,7 @@ AssociativeArray::getAngle(const string& key, float& val, double outputScale, do
  * @return True if the key exists in the hash, false otherwise.
  */
 bool
-AssociativeArray::getLength(const string& key, double& val, double outputScale, double defaultScale) const
+AssociativeArray::getLength(const std::string& key, double& val, double outputScale, double defaultScale) const
 {
     if(!getNumber(key, val))
         return false;
@@ -349,7 +345,7 @@ AssociativeArray::getLength(const string& key, double& val, double outputScale, 
 
 
 /** @copydoc AssociativeArray::getLength() */
-bool AssociativeArray::getLength(const string& key, float& val, double outputScale, double defaultScale) const
+bool AssociativeArray::getLength(const std::string& key, float& val, double outputScale, double defaultScale) const
 {
     double dval;
 
@@ -370,7 +366,7 @@ bool AssociativeArray::getLength(const string& key, float& val, double outputSca
  * @param[in] defaultScale If no units are specified, use this scale. Defaults to outputScale.
  * @return True if the key exists in the hash, false otherwise.
  */
-bool AssociativeArray::getTime(const string& key, double& val, double outputScale, double defaultScale) const
+bool AssociativeArray::getTime(const std::string& key, double& val, double outputScale, double defaultScale) const
 {
     if(!getNumber(key, val))
         return false;
@@ -392,7 +388,7 @@ bool AssociativeArray::getTime(const string& key, double& val, double outputScal
 
 
 /** @copydoc AssociativeArray::getTime() */
-bool AssociativeArray::getTime(const string& key, float& val, double outputScale, double defaultScale) const
+bool AssociativeArray::getTime(const std::string& key, float& val, double outputScale, double defaultScale) const
 {
     double dval;
 
@@ -413,7 +409,7 @@ bool AssociativeArray::getTime(const string& key, float& val, double outputScale
  * @param[in] defaultScale If no units are specified, use this scale. Defaults to outputScale.
  * @return True if the key exists in the hash, false otherwise.
  */
-bool AssociativeArray::getMass(const string& key, double& val, double outputScale, double defaultScale) const
+bool AssociativeArray::getMass(const std::string& key, double& val, double outputScale, double defaultScale) const
 {
     if(!getNumber(key, val))
         return false;
@@ -435,7 +431,7 @@ bool AssociativeArray::getMass(const string& key, double& val, double outputScal
 
 
 /** @copydoc AssociativeArray::getMass() */
-bool AssociativeArray::getMass(const string& key, float& val, double outputScale, double defaultScale) const
+bool AssociativeArray::getMass(const std::string& key, float& val, double outputScale, double defaultScale) const
 {
     double dval;
 
@@ -456,7 +452,7 @@ bool AssociativeArray::getMass(const string& key, float& val, double outputScale
  * @param[in] defaultScale If no units are specified, use this scale. Defaults to outputScale.
  * @return True if the key exists in the hash, false otherwise.
  */
-bool AssociativeArray::getLengthVector(const string& key, Eigen::Vector3d& val, double outputScale, double defaultScale) const
+bool AssociativeArray::getLengthVector(const std::string& key, Eigen::Vector3d& val, double outputScale, double defaultScale) const
 {
     if(!getVector(key, val))
         return false;
@@ -478,9 +474,9 @@ bool AssociativeArray::getLengthVector(const string& key, Eigen::Vector3d& val, 
 
 
 /** @copydoc AssociativeArray::getLengthVector() */
-bool AssociativeArray::getLengthVector(const string& key, Eigen::Vector3f& val, double outputScale, double defaultScale) const
+bool AssociativeArray::getLengthVector(const std::string& key, Eigen::Vector3f& val, double outputScale, double defaultScale) const
 {
-    Vector3d vecVal;
+    Eigen::Vector3d vecVal;
 
     if(!getLengthVector(key, vecVal, outputScale, defaultScale))
         return false;
@@ -496,7 +492,7 @@ bool AssociativeArray::getLengthVector(const string& key, Eigen::Vector3f& val, 
  * @param[out] val The returned tuple in units of degrees and kilometers if present, unaffected if not.
  * @return True if the key exists in the hash, false otherwise.
  */
-bool AssociativeArray::getSphericalTuple(const string& key, Vector3d& val) const
+bool AssociativeArray::getSphericalTuple(const std::string& key, Eigen::Vector3d& val) const
 {
     if(!getVector(key, val))
         return false;
@@ -517,9 +513,9 @@ bool AssociativeArray::getSphericalTuple(const string& key, Vector3d& val) const
 
 
 /** @copydoc AssociativeArray::getSphericalTuple */
-bool AssociativeArray::getSphericalTuple(const string& key, Vector3f& val) const
+bool AssociativeArray::getSphericalTuple(const std::string& key, Eigen::Vector3f& val) const
 {
-    Vector3d vecVal;
+    Eigen::Vector3d vecVal;
 
     if(!getSphericalTuple(key, vecVal))
         return false;
@@ -535,10 +531,10 @@ bool AssociativeArray::getSphericalTuple(const string& key, Vector3f& val) const
  * @param[out] scale The returned angle unit scaled to degrees if present, unaffected if not.
  * @return True if an angle unit has been specified for the property, false otherwise.
  */
-bool AssociativeArray::getAngleScale(const string& key, double& scale) const
+bool AssociativeArray::getAngleScale(const std::string& key, double& scale) const
 {
-    string unitKey(key + "%Angle");
-    string unit;
+    std::string unitKey(key + "%Angle");
+    std::string unit;
 
     if (!getString(unitKey, unit))
         return false;
@@ -548,7 +544,7 @@ bool AssociativeArray::getAngleScale(const string& key, double& scale) const
 
 
 /** @copydoc AssociativeArray::getAngleScale() */
-bool AssociativeArray::getAngleScale(const string& key, float& scale) const
+bool AssociativeArray::getAngleScale(const std::string& key, float& scale) const
 {
     double dscale;
     if (!getAngleScale(key, dscale))
@@ -565,10 +561,10 @@ bool AssociativeArray::getAngleScale(const string& key, float& scale) const
  * @param[out] scale The returned length unit scaled to kilometers if present, unaffected if not.
  * @return True if a length unit has been specified for the property, false otherwise.
  */
-bool AssociativeArray::getLengthScale(const string& key, double& scale) const
+bool AssociativeArray::getLengthScale(const std::string& key, double& scale) const
 {
-    string unitKey(key + "%Length");
-    string unit;
+    std::string unitKey(key + "%Length");
+    std::string unit;
 
     if (!getString(unitKey, unit))
         return false;
@@ -578,7 +574,7 @@ bool AssociativeArray::getLengthScale(const string& key, double& scale) const
 
 
 /** @copydoc AssociativeArray::getLengthScale() */
-bool AssociativeArray::getLengthScale(const string& key, float& scale) const
+bool AssociativeArray::getLengthScale(const std::string& key, float& scale) const
 {
     double dscale;
     if (!getLengthScale(key, dscale))
@@ -595,10 +591,10 @@ bool AssociativeArray::getLengthScale(const string& key, float& scale) const
  * @param[out] scale The returned time unit scaled to days if present, unaffected if not.
  * @return True if a time unit has been specified for the property, false otherwise.
  */
-bool AssociativeArray::getTimeScale(const string& key, double& scale) const
+bool AssociativeArray::getTimeScale(const std::string& key, double& scale) const
 {
-    string unitKey(key + "%Time");
-    string unit;
+    std::string unitKey(key + "%Time");
+    std::string unit;
 
     if (!getString(unitKey, unit))
         return false;
@@ -608,7 +604,7 @@ bool AssociativeArray::getTimeScale(const string& key, double& scale) const
 
 
 /** @copydoc AssociativeArray::getTimeScale() */
-bool AssociativeArray::getTimeScale(const string& key, float& scale) const
+bool AssociativeArray::getTimeScale(const std::string& key, float& scale) const
 {
     double dscale;
     if (!getTimeScale(key, dscale))
@@ -625,10 +621,10 @@ bool AssociativeArray::getTimeScale(const string& key, float& scale) const
  * @param[out] scale The returned mass unit scaled to Earth mass if present, unaffected if not.
  * @return True if a mass unit has been specified for the property, false otherwise.
  */
-bool AssociativeArray::getMassScale(const string& key, double& scale) const
+bool AssociativeArray::getMassScale(const std::string& key, double& scale) const
 {
-    string unitKey(key + "%Mass");
-    string unit;
+    std::string unitKey(key + "%Mass");
+    std::string unit;
 
     if (!getString(unitKey, unit))
         return false;
@@ -638,7 +634,7 @@ bool AssociativeArray::getMassScale(const string& key, double& scale) const
 
 
 /** @copydoc AssociativeArray::getMassScale() */
-bool AssociativeArray::getMassScale(const string& key, float& scale) const
+bool AssociativeArray::getMassScale(const std::string& key, float& scale) const
 {
     double dscale;
     if (!getMassScale(key, dscale))

--- a/src/celengine/hash.h
+++ b/src/celengine/hash.h
@@ -10,7 +10,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
+#include <string>
 #include <celcompat/filesystem.h>
 #include <celmath/mathlib.h>
 #include <Eigen/Geometry>
@@ -37,7 +39,7 @@ class AssociativeArray
     bool getNumber(const std::string&, double&) const;
     bool getNumber(const std::string&, float&) const;
     bool getNumber(const std::string&, int&) const;
-    bool getNumber(const std::string&, uint32_t&) const;
+    bool getNumber(const std::string&, std::uint32_t&) const;
     bool getString(const std::string&, std::string&) const;
     bool getPath(const std::string&, fs::path&) const;
     bool getBoolean(const std::string&, bool&) const;

--- a/src/celengine/hash.h
+++ b/src/celengine/hash.h
@@ -33,7 +33,7 @@ class AssociativeArray
     AssociativeArray& operator=(AssociativeArray&&) = default;
     AssociativeArray& operator=(AssociativeArray&) = delete;
 
-    Value* getValue(const std::string&) const;
+    const Value* getValue(const std::string&) const;
     void addValue(const std::string&, Value&);
 
     bool getNumber(const std::string&, double&) const;

--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -81,7 +81,7 @@ LoadCelestiaMesh(const fs::path& filename)
         return nullptr;
     }
 
-    Hash* meshDef = meshDefValue->getHash();
+    const Hash* meshDef = meshDefValue->getHash();
 
     SphereMeshParameters params{};
 

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -66,7 +66,7 @@ bool Nebula::pick(const Eigen::ParametrizedLine<double, 3>& ray,
 }
 
 
-bool Nebula::load(AssociativeArray* params, const fs::path& resPath)
+bool Nebula::load(const AssociativeArray* params, const fs::path& resPath)
 {
     string t;
     if (params->getString("Mesh", t))

--- a/src/celengine/nebula.h
+++ b/src/celengine/nebula.h
@@ -25,7 +25,7 @@ class Nebula : public DeepSkyObject
     bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
               double& distanceToPicker,
               double& cosAngleToBoundCenter) const override;
-    bool load(AssociativeArray*, const fs::path&) override;
+    bool load(const AssociativeArray*, const fs::path&) override;
     void render(const Eigen::Vector3f& offset,
                 const Eigen::Quaternionf& viewerOrientation,
                 float brightness,

--- a/src/celengine/opencluster.cpp
+++ b/src/celengine/opencluster.cpp
@@ -54,7 +54,7 @@ bool OpenCluster::pick(const Eigen::ParametrizedLine<double, 3>& ray,
 }
 
 
-bool OpenCluster::load(AssociativeArray* params, const fs::path& resPath)
+bool OpenCluster::load(const AssociativeArray* params, const fs::path& resPath)
 {
     // No parameters specific to open cluster, though a list of member stars
     // could be useful.

--- a/src/celengine/opencluster.h
+++ b/src/celengine/opencluster.h
@@ -27,7 +27,7 @@ class OpenCluster : public DeepSkyObject
     bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
               double& distanceToPicker,
               double& cosAngleToBoundCenter) const override;
-    bool load(AssociativeArray*, const fs::path&) override;
+    bool load(const AssociativeArray*, const fs::path&) override;
     void render(const Eigen::Vector3f& offset,
                 const Eigen::Quaternionf& viewerOrientation,
                 float brightness,

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -339,7 +339,7 @@ ParseStringList(const Hash* table,
                 const string& propertyName,
                 list<string>& stringList)
 {
-    Value* v = table->getValue(propertyName);
+    const Value* v = table->getValue(propertyName);
     if (v == nullptr)
         return false;
 
@@ -455,8 +455,8 @@ CreateSpiceOrbit(const Hash* orbitData,
 
     // Either a complete time interval must be specified with Beginning/Ending, or
     // else neither field can be present.
-    Value* beginningDate = orbitData->getValue("Beginning");
-    Value* endingDate = orbitData->getValue("Ending");
+    const Value* beginningDate = orbitData->getValue("Beginning");
+    const Value* endingDate = orbitData->getValue("Ending");
     if (beginningDate != nullptr && endingDate == nullptr)
     {
         GetLogger()->error("Beginning specified for SPICE orbit, but ending is missing.\n");
@@ -578,8 +578,8 @@ CreateSpiceRotation(const Hash* rotationData,
 
     // Either a complete time interval must be specified with Beginning/Ending, or
     // else neither field can be present.
-    Value* beginningDate = rotationData->getValue("Beginning");
-    Value* endingDate = rotationData->getValue("Ending");
+    const Value* beginningDate = rotationData->getValue("Beginning");
+    const Value* endingDate = rotationData->getValue("Ending");
     if (beginningDate != nullptr && endingDate == nullptr)
     {
         GetLogger()->error("Beginning specified for SPICE rotation, but ending is missing.\n");
@@ -691,7 +691,7 @@ CreateOrbit(const Selection& centralObject,
     }
 
 #ifdef USE_SPICE
-    Value* spiceOrbitDataValue = planetData->getValue("SpiceOrbit");
+    const Value* spiceOrbitDataValue = planetData->getValue("SpiceOrbit");
     if (spiceOrbitDataValue != nullptr)
     {
         if (spiceOrbitDataValue->getType() != Value::HashType)
@@ -713,7 +713,7 @@ CreateOrbit(const Selection& centralObject,
 #endif
 
     // Trajectory calculated by Lua script
-    Value* scriptedOrbitValue = planetData->getValue("ScriptedOrbit");
+    const Value* scriptedOrbitValue = planetData->getValue("ScriptedOrbit");
     if (scriptedOrbitValue != nullptr)
     {
         if (scriptedOrbitValue->getType() != Value::HashType)
@@ -729,7 +729,7 @@ CreateOrbit(const Selection& centralObject,
 
     // New 1.5.0 style for sampled trajectories. Permits specification of
     // precision and interpolation type.
-    Value* sampledTrajDataValue = planetData->getValue("SampledTrajectory");
+    const Value* sampledTrajDataValue = planetData->getValue("SampledTrajectory");
     if (sampledTrajDataValue != nullptr)
     {
         if (sampledTrajDataValue->getType() != Value::HashType)
@@ -760,7 +760,7 @@ CreateOrbit(const Selection& centralObject,
         GetLogger()->error("Could not load sampled orbit file '{}'\n", sampOrbitFile);
     }
 
-    Value* orbitDataValue = planetData->getValue("EllipticalOrbit");
+    const Value* orbitDataValue = planetData->getValue("EllipticalOrbit");
     if (orbitDataValue != nullptr)
     {
         if (orbitDataValue->getType() != Value::HashType)
@@ -786,7 +786,7 @@ CreateOrbit(const Selection& centralObject,
     //
     // In addition to Rectangular, other coordinate types for fixed position are
     // Planetographic and Planetocentric.
-    Value* fixedPositionValue = planetData->getValue("FixedPosition");
+    const Value* fixedPositionValue = planetData->getValue("FixedPosition");
     if (fixedPositionValue != nullptr)
     {
         Vector3d fixedPosition = Vector3d::Zero();
@@ -1075,7 +1075,7 @@ CreateRotationModel(const Hash* planetData,
     }
 
 #ifdef USE_SPICE
-    Value* spiceRotationDataValue = planetData->getValue("SpiceRotation");
+    const Value* spiceRotationDataValue = planetData->getValue("SpiceRotation");
     if (spiceRotationDataValue != nullptr)
     {
         if (spiceRotationDataValue->getType() != Value::HashType)
@@ -1095,7 +1095,7 @@ CreateRotationModel(const Hash* planetData,
     }
 #endif
 
-    Value* scriptedRotationValue = planetData->getValue("ScriptedRotation");
+    const Value* scriptedRotationValue = planetData->getValue("ScriptedRotation");
     if (scriptedRotationValue != nullptr)
     {
         if (scriptedRotationValue->getType() != Value::HashType)
@@ -1125,7 +1125,7 @@ CreateRotationModel(const Hash* planetData,
         GetLogger()->error("Could not load rotation model file '{}'\n", sampOrientationFile);
     }
 
-    Value* precessingRotationValue = planetData->getValue("PrecessingRotation");
+    const Value* precessingRotationValue = planetData->getValue("PrecessingRotation");
     if (precessingRotationValue != nullptr)
     {
         if (precessingRotationValue->getType() != Value::HashType)
@@ -1138,7 +1138,7 @@ CreateRotationModel(const Hash* planetData,
                                              syncRotationPeriod);
     }
 
-    Value* uniformRotationValue = planetData->getValue("UniformRotation");
+    const Value* uniformRotationValue = planetData->getValue("UniformRotation");
     if (uniformRotationValue != nullptr)
     {
         if (uniformRotationValue->getType() != Value::HashType)
@@ -1150,7 +1150,7 @@ CreateRotationModel(const Hash* planetData,
                                           syncRotationPeriod);
     }
 
-    Value* fixedRotationValue = planetData->getValue("FixedRotation");
+    const Value* fixedRotationValue = planetData->getValue("FixedRotation");
     if (fixedRotationValue != nullptr)
     {
         if (fixedRotationValue->getType() != Value::HashType)
@@ -1162,7 +1162,7 @@ CreateRotationModel(const Hash* planetData,
         return CreateFixedRotationModel(fixedRotationValue->getHash());
     }
 
-    Value* fixedAttitudeValue = planetData->getValue("FixedAttitude");
+    const Value* fixedAttitudeValue = planetData->getValue("FixedAttitude");
     if (fixedAttitudeValue != nullptr)
     {
         if (fixedAttitudeValue->getType() != Value::HashType)
@@ -1495,9 +1495,7 @@ CreateFrameVector(const Universe& universe,
                   const Selection& center,
                   const Hash* vectorData)
 {
-    Value* value = nullptr;
-
-    value = vectorData->getValue("RelativePosition");
+    const Value* value = vectorData->getValue("RelativePosition");
     if (value != nullptr && value->getHash() != nullptr)
     {
         const Hash* relPosData = value->getHash();
@@ -1546,7 +1544,7 @@ CreateFrameVector(const Universe& universe,
         // The frame for the vector is optional; a nullptr frame indicates
         // J2000 ecliptic.
         ReferenceFrame::SharedConstPtr f;
-        Value* frameValue = constVecData->getValue("Frame");
+        const Value* frameValue = constVecData->getValue("Frame");
         if (frameValue != nullptr)
         {
             f = CreateReferenceFrame(universe, frameValue, center, nullptr);
@@ -1574,7 +1572,7 @@ CreateTwoVectorFrame(const Universe& universe,
         return nullptr;
 
     // Primary and secondary vector definitions are required
-    Value* primaryValue = frameData->getValue("Primary");
+    const Value* primaryValue = frameData->getValue("Primary");
     if (primaryValue == nullptr)
     {
         GetLogger()->error("Primary axis missing from two-vector frame.\n");
@@ -1588,7 +1586,7 @@ CreateTwoVectorFrame(const Universe& universe,
         return nullptr;
     }
 
-    Value* secondaryValue = frameData->getValue("Secondary");
+    const Value* secondaryValue = frameData->getValue("Secondary");
     if (secondaryValue == nullptr)
     {
         GetLogger()->error("Secondary axis missing from two-vector frame.\n");
@@ -1808,7 +1806,7 @@ CreateTopocentricFrame(const Universe& universe,
 static ReferenceFrame::SharedConstPtr
 CreateComplexFrame(const Universe& universe, const Hash* frameData, const Selection& defaultCenter, Body* defaultObserver)
 {
-    Value* value = frameData->getValue("BodyFixed");
+    const Value* value = frameData->getValue("BodyFixed");
     if (value != nullptr)
     {
         if (value->getType() != Value::HashType)
@@ -1887,9 +1885,9 @@ CreateComplexFrame(const Universe& universe, const Hash* frameData, const Select
 
 
 ReferenceFrame::SharedConstPtr CreateReferenceFrame(const Universe& universe,
-                                     Value* frameValue,
-                                     const Selection& defaultCenter,
-                                     Body* defaultObserver)
+                                                    const Value* frameValue,
+                                                    const Selection& defaultCenter,
+                                                    Body* defaultObserver)
 {
     if (frameValue->getType() == Value::StringType)
     {

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -80,7 +80,7 @@ GetDefaultUnits(bool usePlanetUnits, double& distanceScale)
 
 
 bool
-ParseDate(Hash* hash, const string& name, double& jd)
+ParseDate(const Hash* hash, const string& name, double& jd)
 {
     // Check first for a number value representing a Julian date
     if (hash->getNumber(name, jd))
@@ -136,7 +136,7 @@ ParseDate(Hash* hash, const string& name, double& jd)
  *     SemiMajorAxis or PericenterDistance is in kilometers.
  */
 static EllipticalOrbit*
-CreateEllipticalOrbit(Hash* orbitData,
+CreateEllipticalOrbit(const Hash* orbitData,
                       bool usePlanetUnits)
 {
 
@@ -230,7 +230,7 @@ CreateEllipticalOrbit(Hash* orbitData,
  * DoublePrecision defaults to true.
  */
 static Orbit*
-CreateSampledTrajectory(Hash* trajData, const fs::path& path)
+CreateSampledTrajectory(const Hash* trajData, const fs::path& path)
 {
     string sourceName;
     if (!trajData->getString("Source", sourceName))
@@ -284,7 +284,7 @@ CreateSampledTrajectory(Hash* trajData, const fs::path& path)
  * is BodyFixed.
  */
 static Orbit*
-CreateFixedPosition(Hash* trajData, const Selection& centralObject, bool usePlanetUnits)
+CreateFixedPosition(const Hash* trajData, const Selection& centralObject, bool usePlanetUnits)
 {
     double distanceScale;
     GetDefaultUnits(usePlanetUnits, distanceScale);
@@ -335,7 +335,7 @@ CreateFixedPosition(Hash* trajData, const Selection& centralObject, bool usePlan
  * Parse a string list--either a single string or an array of strings is permitted.
  */
 static bool
-ParseStringList(Hash* table,
+ParseStringList(const Hash* table,
                 const string& propertyName,
                 list<string>& stringList)
 {
@@ -351,7 +351,7 @@ ParseStringList(Hash* table,
     }
     if (v->getType() == Value::ArrayType)
     {
-        ValueArray* array = v->getArray();
+        const ValueArray* array = v->getArray();
         ValueArray::const_iterator iter;
 
         // Verify that all array entries are strings
@@ -404,7 +404,7 @@ ParseStringList(Hash* table,
  *  used.
  */
 static SpiceOrbit*
-CreateSpiceOrbit(Hash* orbitData,
+CreateSpiceOrbit(const Hash* orbitData,
                  const fs::path& path,
                  bool usePlanetUnits)
 {
@@ -544,7 +544,7 @@ CreateSpiceOrbit(Hash* orbitData,
  *  as sidereal day length.
  */
 static SpiceRotation*
-CreateSpiceRotation(Hash* rotationData,
+CreateSpiceRotation(const Hash* rotationData,
                     const fs::path& path)
 {
     string frameName;
@@ -636,7 +636,7 @@ CreateSpiceRotation(Hash* rotationData,
 
 
 static ScriptedOrbit*
-CreateScriptedOrbit(Hash* orbitData,
+CreateScriptedOrbit(const Hash* orbitData,
                     const fs::path& path)
 {
 #if !defined(CELX)
@@ -656,11 +656,11 @@ CreateScriptedOrbit(Hash* orbitData,
     string moduleName;
     orbitData->getString("Module", moduleName);
 
-    Value* pathValue = new Value(path.string());
-    orbitData->addValue("AddonPath", *pathValue);
+    //Value* pathValue = new Value(path.string());
+    //orbitData->addValue("AddonPath", *pathValue);
 
     ScriptedOrbit* scriptedOrbit = new ScriptedOrbit();
-    if (!scriptedOrbit->initialize(moduleName, funcName, orbitData))
+    if (!scriptedOrbit->initialize(moduleName, funcName, orbitData, path))
     {
         delete scriptedOrbit;
         scriptedOrbit = nullptr;
@@ -673,7 +673,7 @@ CreateScriptedOrbit(Hash* orbitData,
 
 Orbit*
 CreateOrbit(const Selection& centralObject,
-            Hash* planetData,
+            const Hash* planetData,
             const fs::path& path,
             bool usePlanetUnits)
 {
@@ -845,7 +845,7 @@ CreateFixedRotationModel(double offset,
 
 
 static RotationModel*
-CreateUniformRotationModel(Hash* rotationData,
+CreateUniformRotationModel(const Hash* rotationData,
                            double syncRotationPeriod)
 {
     // Default to synchronous rotation
@@ -893,7 +893,7 @@ CreateUniformRotationModel(Hash* rotationData,
 
 
 static ConstantOrientation*
-CreateFixedRotationModel(Hash* rotationData)
+CreateFixedRotationModel(const Hash* rotationData)
 {
     double offset = 0.0;
     if (rotationData->getAngle("MeridianAngle", offset))
@@ -922,7 +922,7 @@ CreateFixedRotationModel(Hash* rotationData)
 
 
 static ConstantOrientation*
-CreateFixedAttitudeRotationModel(Hash* rotationData)
+CreateFixedAttitudeRotationModel(const Hash* rotationData)
 {
     double heading = 0.0;
     if (rotationData->getAngle("Heading", heading))
@@ -951,7 +951,7 @@ CreateFixedAttitudeRotationModel(Hash* rotationData)
 
 
 static RotationModel*
-CreatePrecessingRotationModel(Hash* rotationData,
+CreatePrecessingRotationModel(const Hash* rotationData,
                               double syncRotationPeriod)
 {
     // Default to synchronous rotation
@@ -1005,7 +1005,7 @@ CreatePrecessingRotationModel(Hash* rotationData,
 
 
 static ScriptedRotation*
-CreateScriptedRotation(Hash* rotationData,
+CreateScriptedRotation(const Hash* rotationData,
                        const fs::path& path)
 {
 #if !defined(CELX)
@@ -1025,11 +1025,11 @@ CreateScriptedRotation(Hash* rotationData,
     string moduleName;
     rotationData->getString("Module", moduleName);
 
-    Value* pathValue = new Value(path.string());
-    rotationData->addValue("AddonPath", *pathValue);
+    //Value* pathValue = new Value(path.string());
+    //rotationData->addValue("AddonPath", *pathValue);
 
     ScriptedRotation* scriptedRotation = new ScriptedRotation();
-    if (!scriptedRotation->initialize(moduleName, funcName, rotationData))
+    if (!scriptedRotation->initialize(moduleName, funcName, rotationData, path))
     {
          delete scriptedRotation;
          scriptedRotation = nullptr;
@@ -1047,7 +1047,7 @@ CreateScriptedRotation(Hash* rotationData,
  * appear in the top level structure.
  */
 RotationModel*
-CreateRotationModel(Hash* planetData,
+CreateRotationModel(const Hash* planetData,
                     const fs::path& path,
                     double syncRotationPeriod)
 {
@@ -1281,7 +1281,7 @@ RotationModel* CreateDefaultRotationModel(double syncRotationPeriod)
  * if it's missing or refers to an object that doesn't exist.
  */
 static Selection
-getFrameCenter(const Universe& universe, Hash* frameData, const Selection& defaultCenter)
+getFrameCenter(const Universe& universe, const Hash* frameData, const Selection& defaultCenter)
 {
     string centerName;
     if (!frameData->getString("Center", centerName))
@@ -1308,7 +1308,7 @@ getFrameCenter(const Universe& universe, Hash* frameData, const Selection& defau
 
 static BodyFixedFrame::SharedConstPtr
 CreateBodyFixedFrame(const Universe& universe,
-                     Hash* frameData,
+                     const Hash* frameData,
                      const Selection& defaultCenter)
 {
     Selection center = getFrameCenter(universe, frameData, defaultCenter);
@@ -1321,7 +1321,7 @@ CreateBodyFixedFrame(const Universe& universe,
 
 static BodyMeanEquatorFrame::SharedConstPtr
 CreateMeanEquatorFrame(const Universe& universe,
-                       Hash* frameData,
+                       const Hash* frameData,
                        const Selection& defaultCenter)
 {
     Selection center = getFrameCenter(universe, frameData, defaultCenter);
@@ -1402,7 +1402,7 @@ parseAxisLabel(const std::string& label)
 
 
 static int
-getAxis(Hash* vectorData)
+getAxis(const Hash* vectorData)
 {
     string axisLabel;
     if (!vectorData->getString("Axis", axisLabel))
@@ -1442,7 +1442,7 @@ getAxis(Hash* vectorData)
  * empty selection if it's missing or refers to an object that doesn't exist.
  */
 static Selection
-getVectorTarget(const Universe& universe, Hash* vectorData)
+getVectorTarget(const Universe& universe, const Hash* vectorData)
 {
     string targetName;
     if (!vectorData->getString("Target", targetName))
@@ -1468,7 +1468,7 @@ getVectorTarget(const Universe& universe, Hash* vectorData)
  * empty selection if it's missing or refers to an object that doesn't exist.
  */
 static Selection
-getVectorObserver(const Universe& universe, Hash* vectorData)
+getVectorObserver(const Universe& universe, const Hash* vectorData)
 {
     string obsName;
     if (!vectorData->getString("Observer", obsName))
@@ -1493,14 +1493,14 @@ getVectorObserver(const Universe& universe, Hash* vectorData)
 static FrameVector*
 CreateFrameVector(const Universe& universe,
                   const Selection& center,
-                  Hash* vectorData)
+                  const Hash* vectorData)
 {
     Value* value = nullptr;
 
     value = vectorData->getValue("RelativePosition");
     if (value != nullptr && value->getHash() != nullptr)
     {
-        Hash* relPosData = value->getHash();
+        const Hash* relPosData = value->getHash();
         Selection observer = getVectorObserver(universe, relPosData);
         Selection target = getVectorTarget(universe, relPosData);
         // Default observer is the frame center
@@ -1516,7 +1516,7 @@ CreateFrameVector(const Universe& universe,
     value = vectorData->getValue("RelativeVelocity");
     if (value != nullptr && value->getHash() != nullptr)
     {
-        Hash* relVData = value->getHash();
+        const Hash* relVData = value->getHash();
         Selection observer = getVectorObserver(universe, relVData);
         Selection target = getVectorTarget(universe, relVData);
         // Default observer is the frame center
@@ -1532,7 +1532,7 @@ CreateFrameVector(const Universe& universe,
     value = vectorData->getValue("ConstantVector");
     if (value != nullptr && value->getHash() != nullptr)
     {
-        Hash* constVecData = value->getHash();
+        const Hash* constVecData = value->getHash();
         Vector3d vec = Vector3d::UnitZ();
         constVecData->getVector("Vector", vec);
         if (vec.norm() == 0.0)
@@ -1566,7 +1566,7 @@ CreateFrameVector(const Universe& universe,
 
 static shared_ptr<const TwoVectorFrame>
 CreateTwoVectorFrame(const Universe& universe,
-                     Hash* frameData,
+                     const Hash* frameData,
                      const Selection& defaultCenter)
 {
     Selection center = getFrameCenter(universe, frameData, defaultCenter);
@@ -1581,7 +1581,7 @@ CreateTwoVectorFrame(const Universe& universe,
         return nullptr;
     }
 
-    Hash* primaryData = primaryValue->getHash();
+    const Hash* primaryData = primaryValue->getHash();
     if (primaryData == nullptr)
     {
         GetLogger()->error("Bad syntax for primary axis of two-vector frame.\n");
@@ -1595,7 +1595,7 @@ CreateTwoVectorFrame(const Universe& universe,
         return nullptr;
     }
 
-    Hash* secondaryData = secondaryValue->getHash();
+    const Hash* secondaryData = secondaryValue->getHash();
     if (secondaryData == nullptr)
     {
         GetLogger()->error("Bad syntax for secondary axis of two-vector frame.\n");
@@ -1640,7 +1640,7 @@ CreateTwoVectorFrame(const Universe& universe,
 
 static shared_ptr<const J2000EclipticFrame>
 CreateJ2000EclipticFrame(const Universe& universe,
-                         Hash* frameData,
+                         const Hash* frameData,
                          const Selection& defaultCenter)
 {
     Selection center = getFrameCenter(universe, frameData, defaultCenter);
@@ -1654,7 +1654,7 @@ CreateJ2000EclipticFrame(const Universe& universe,
 
 static shared_ptr<const J2000EquatorFrame>
 CreateJ2000EquatorFrame(const Universe& universe,
-                        Hash* frameData,
+                        const Hash* frameData,
                         const Selection& defaultCenter)
 {
     Selection center = getFrameCenter(universe, frameData, defaultCenter);
@@ -1725,7 +1725,7 @@ CreateTopocentricFrame(const Selection& center,
  */
 static shared_ptr<const TwoVectorFrame>
 CreateTopocentricFrame(const Universe& universe,
-                       Hash* frameData,
+                       const Hash* frameData,
                        const Selection& defaultTarget,
                        const Selection& defaultObserver)
 {
@@ -1806,7 +1806,7 @@ CreateTopocentricFrame(const Universe& universe,
 
 
 static ReferenceFrame::SharedConstPtr
-CreateComplexFrame(const Universe& universe, Hash* frameData, const Selection& defaultCenter, Body* defaultObserver)
+CreateComplexFrame(const Universe& universe, const Hash* frameData, const Selection& defaultCenter, Body* defaultObserver)
 {
     Value* value = frameData->getValue("BodyFixed");
     if (value != nullptr)

--- a/src/celengine/parseobject.h
+++ b/src/celengine/parseobject.h
@@ -47,10 +47,10 @@ RotationModel* CreateRotationModel(const Hash* rotationData,
 RotationModel* CreateDefaultRotationModel(double syncRotationPeriod);
 
 ReferenceFrame::SharedConstPtr CreateReferenceFrame(const Universe& universe,
-                                     Value* frameValue,
-                                     const Selection& defaultCenter,
-                                     Body* defaultObserver);
+                                                    const Value* frameValue,
+                                                    const Selection& defaultCenter,
+                                                    Body* defaultObserver);
 
 std::shared_ptr<const TwoVectorFrame> CreateTopocentricFrame(const Selection& center,
-                                       const Selection& target,
-                                       const Selection& observer);
+                                                             const Selection& target,
+                                                             const Selection& observer);

--- a/src/celengine/parseobject.h
+++ b/src/celengine/parseobject.h
@@ -33,14 +33,14 @@ enum class DataDisposition
 };
 
 
-bool ParseDate(Hash* hash, const std::string& name, double& jd);
+bool ParseDate(const Hash* hash, const std::string& name, double& jd);
 
 Orbit* CreateOrbit(const Selection& centralObject,
-                   Hash* planetData,
+                   const Hash* planetData,
                    const fs::path& path,
                    bool usePlanetUnits);
 
-RotationModel* CreateRotationModel(Hash* rotationData,
+RotationModel* CreateRotationModel(const Hash* rotationData,
                                    const fs::path& path,
                                    double syncRotationPeriod);
 

--- a/src/celengine/parser.h
+++ b/src/celengine/parser.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "hash.h"
@@ -29,6 +30,6 @@ class Parser
     Tokenizer* tokenizer;
 
     bool readUnits(const std::string&, Hash*);
-    ValueArray* readArray();
-    Hash* readHash();
+    std::unique_ptr<ValueArray> readArray();
+    std::unique_ptr<Hash> readHash();
 };

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -153,7 +153,7 @@ bool isFrameCircular(const ReferenceFrame& frame, ReferenceFrame::FrameType fram
 
 
 
-Location* CreateLocation(Hash* locationData,
+Location* CreateLocation(const Hash* locationData,
                          Body* body)
 {
     Location* location = new Location();
@@ -197,7 +197,7 @@ inline void SetOrUnset(Dst &dst, Flag flag, bool cond)
 }
 
 
-void FillinSurface(Hash* surfaceData,
+void FillinSurface(const Hash* surfaceData,
                    Surface* surface,
                    const fs::path& path)
 {
@@ -282,7 +282,7 @@ Selection GetParentObject(PlanetarySystem* system)
 
 TimelinePhase::SharedConstPtr CreateTimelinePhase(Body* body,
                                                   Universe& universe,
-                                                  Hash* phaseData,
+                                                  const Hash* phaseData,
                                                   const fs::path& path,
                                                   const ReferenceFrame::SharedConstPtr& defaultOrbitFrame,
                                                   const ReferenceFrame::SharedConstPtr& defaultBodyFrame,
@@ -385,7 +385,7 @@ TimelinePhase::SharedConstPtr CreateTimelinePhase(Body* body,
 
 Timeline* CreateTimelineFromArray(Body* body,
                                   Universe& universe,
-                                  ValueArray* timelineArray,
+                                  const ValueArray* timelineArray,
                                   const fs::path& path,
                                   const ReferenceFrame::SharedConstPtr& defaultOrbitFrame,
                                   const ReferenceFrame::SharedConstPtr& defaultBodyFrame)
@@ -395,7 +395,7 @@ Timeline* CreateTimelineFromArray(Body* body,
 
     for (ValueArray::const_iterator iter = timelineArray->begin(); iter != timelineArray->end(); iter++)
     {
-        Hash* phaseData = (*iter)->getHash();
+        const Hash* phaseData = (*iter)->getHash();
         if (phaseData == nullptr)
         {
             GetLogger()->error("Error in timeline of '{}': phase {} is not a property group.\n", body->getName(), iter - timelineArray->begin() + 1);
@@ -432,7 +432,7 @@ Timeline* CreateTimelineFromArray(Body* body,
 bool CreateTimeline(Body* body,
                     PlanetarySystem* system,
                     Universe& universe,
-                    Hash* planetData,
+                    const Hash* planetData,
                     const fs::path& path,
                     DataDisposition disposition,
                     BodyType bodyType)
@@ -681,7 +681,7 @@ Body* CreateBody(const std::string& name,
                  PlanetarySystem* system,
                  Universe& universe,
                  Body* existingBody,
-                 Hash* planetData,
+                 const Hash* planetData,
                  const fs::path& path,
                  DataDisposition disposition,
                  BodyType bodyType)
@@ -919,7 +919,7 @@ Body* CreateBody(const std::string& name,
             }
             else
             {
-                Hash* atmosData = atmosDataValue->getHash();
+                const Hash* atmosData = atmosDataValue->getHash();
                 assert(atmosData != nullptr);
 
                 Atmosphere* atmosphere = nullptr;
@@ -996,7 +996,7 @@ Body* CreateBody(const std::string& name,
             }
             else
             {
-                Hash* ringsData = ringsDataValue->getHash();
+                const Hash* ringsData = ringsDataValue->getHash();
                 // ASSERT(ringsData != nullptr);
 
                 RingSystem rings(0.0f, 0.0f);
@@ -1057,7 +1057,7 @@ Body* CreateReferencePoint(const std::string& name,
                            PlanetarySystem* system,
                            Universe& universe,
                            Body* existingBody,
-                           Hash* refPointData,
+                           const Hash* refPointData,
                            const fs::path& path,
                            DataDisposition disposition)
 {
@@ -1196,7 +1196,7 @@ bool LoadSolarSystemObjects(std::istream& in,
             delete objectDataValue;
             return false;
         }
-        Hash* objectData = objectDataValue->getHash();
+        const Hash* objectData = objectDataValue->getHash();
 
         Selection parent = universe.findPath(parentName, nullptr, 0);
         PlanetarySystem* parentSystem = nullptr;

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -313,7 +313,7 @@ TimelinePhase::SharedConstPtr CreateTimelinePhase(Body* body,
 
     // Get the orbit reference frame.
     ReferenceFrame::SharedConstPtr orbitFrame;
-    Value* frameValue = phaseData->getValue("OrbitFrame");
+    const Value* frameValue = phaseData->getValue("OrbitFrame");
     if (frameValue != nullptr)
     {
         orbitFrame = CreateReferenceFrame(universe, frameValue, defaultOrbitFrame->getCenter(), body);
@@ -330,7 +330,7 @@ TimelinePhase::SharedConstPtr CreateTimelinePhase(Body* body,
 
     // Get the body reference frame
     ReferenceFrame::SharedConstPtr bodyFrame;
-    Value* bodyFrameValue = phaseData->getValue("BodyFrame");
+    const Value* bodyFrameValue = phaseData->getValue("BodyFrame");
     if (bodyFrameValue != nullptr)
     {
         bodyFrame = CreateReferenceFrame(universe, bodyFrameValue, defaultBodyFrame->getCenter(), body);
@@ -473,7 +473,7 @@ bool CreateTimeline(Body* body,
 
     // If there's an explicit timeline definition, parse that. Otherwise, we'll do
     // things the old way.
-    Value* value = planetData->getValue("Timeline");
+    const Value* value = planetData->getValue("Timeline");
     if (value != nullptr)
     {
         if (value->getType() != Value::ArrayType)
@@ -527,7 +527,7 @@ bool CreateTimeline(Body* body,
 
     // Get the object's orbit reference frame.
     bool newOrbitFrame = false;
-    Value* frameValue = planetData->getValue("OrbitFrame");
+    const Value* frameValue = planetData->getValue("OrbitFrame");
     if (frameValue != nullptr)
     {
         auto frame = CreateReferenceFrame(universe, frameValue, parentObject, body);
@@ -541,7 +541,7 @@ bool CreateTimeline(Body* body,
 
     // Get the object's body frame.
     bool newBodyFrame = false;
-    Value* bodyFrameValue = planetData->getValue("BodyFrame");
+    const Value* bodyFrameValue = planetData->getValue("BodyFrame");
     if (bodyFrameValue != nullptr)
     {
         auto frame = CreateReferenceFrame(universe, bodyFrameValue, parentObject, body);
@@ -910,7 +910,7 @@ Body* CreateBody(const std::string& name,
 
     // Read the atmosphere
     {
-        Value* atmosDataValue = planetData->getValue("Atmosphere");
+        const Value* atmosDataValue = planetData->getValue("Atmosphere");
         if (atmosDataValue != nullptr)
         {
             if (atmosDataValue->getType() != Value::HashType)
@@ -987,7 +987,7 @@ Body* CreateBody(const std::string& name,
 
     // Read the ring system
     {
-        Value* ringsDataValue = planetData->getValue("Rings");
+        const Value* ringsDataValue = planetData->getValue("Rings");
         if (ringsDataValue != nullptr)
         {
             if (ringsDataValue->getType() != Value::HashType)

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -833,7 +833,7 @@ void StarDatabase::finish()
 bool StarDatabase::createStar(Star* star,
                               DataDisposition disposition,
                               AstroCatalog::IndexNumber catalogNumber,
-                              Hash* starData,
+                              const Hash* starData,
                               const fs::path& path,
                               bool isBarycenter)
 {
@@ -1406,7 +1406,7 @@ bool StarDatabase::load(std::istream& in, const fs::path& resourcePath)
             delete starDataValue;
             return false;
         }
-        Hash* starData = starDataValue->getHash();
+        const Hash* starData = starDataValue->getHash();
 
         if (isNewStar)
             star = new Star();

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -102,7 +102,7 @@ private:
     bool createStar(Star* star,
                     DataDisposition disposition,
                     AstroCatalog::IndexNumber catalogNumber,
-                    Hash* starData,
+                    const Hash* starData,
                     const fs::path& path,
                     const bool isBarycenter);
 

--- a/src/celengine/value.h
+++ b/src/celengine/value.h
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 #include "hash.h"
@@ -40,11 +41,11 @@ class Value
     Value& operator=(const Value&) = delete;
     Value& operator=(Value&&) = default;
 
-    Value(double d) : type(NumberType)
+    explicit Value(double d) : type(NumberType)
     {
         data.d = d;
     }
-    Value(const char *s) : type(StringType)
+    explicit Value(const char *s) : type(StringType)
     {
         data.s = new std::string(s);
     }
@@ -56,15 +57,19 @@ class Value
     {
         data.s = new std::string(s);
     }
-    Value(ValueArray *a) : type(ArrayType)
+    explicit Value(ValueArray *a) : type(ArrayType)
     {
         data.a = a;
     }
-    Value(Hash *h) : type(HashType)
+    explicit Value(Hash *h) : type(HashType)
     {
         data.h = h;
     }
-    Value(bool b) : type(BooleanType)
+
+    // C++ likes implicit conversions to bool, so use template magic
+    // to restrict this constructor to exactly bool
+    template<typename T, std::enable_if_t<std::is_same_v<T, bool>, int> = 0>
+    explicit Value(T b) : type(BooleanType)
     {
         data.d = b ? 1.0 : 0.0;
     }
@@ -87,12 +92,12 @@ class Value
         assert(type == StringType);
         return *data.s;
     }
-    ValueArray* getArray() const
+    const ValueArray* getArray() const
     {
         assert(type == ArrayType);
         return data.a;
     }
-    Hash* getHash() const
+    const Hash* getHash() const
     {
         assert(type == HashType);
         return data.h;

--- a/src/celengine/value.h
+++ b/src/celengine/value.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <cassert>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -57,13 +58,13 @@ class Value
     {
         data.s = new std::string(s);
     }
-    explicit Value(ValueArray *a) : type(ArrayType)
+    explicit Value(std::unique_ptr<ValueArray>&& a) : type(ArrayType)
     {
-        data.a = a;
+        data.a = a.release();
     }
-    explicit Value(Hash *h) : type(HashType)
+    explicit Value(std::unique_ptr<Hash>&& h) : type(HashType)
     {
-        data.h = h;
+        data.h = h.release();
     }
 
     // C++ likes implicit conversions to bool, so use template magic

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -311,7 +311,7 @@ void VirtualTexture::addTileToTree(Tile* tile, unsigned int lod, unsigned int u,
 }
 
 
-static VirtualTexture* CreateVirtualTexture(Hash* texParams,
+static VirtualTexture* CreateVirtualTexture(const Hash* texParams,
                                             const fs::path& path)
 {
     string imageDirectory;
@@ -383,7 +383,7 @@ static VirtualTexture* LoadVirtualTexture(istream& in, const fs::path& path)
         return nullptr;
     }
 
-    Hash* texParams = texParamsValue->getHash();
+    const Hash* texParams = texParamsValue->getHash();
 
     VirtualTexture* virtualTex  = CreateVirtualTexture(texParams, path);
     delete texParamsValue;

--- a/src/celephem/scriptobject.cpp
+++ b/src/celephem/scriptobject.cpp
@@ -97,7 +97,7 @@ SafeGetLuaNumber(lua_State* state,
  *  only number, string, and boolean values are converted.
  */
 void
-SetLuaVariables(lua_State* state, Hash* parameters)
+SetLuaVariables(lua_State* state, const Hash* parameters)
 {
     for (const auto& param : *parameters)
     {

--- a/src/celephem/scriptobject.h
+++ b/src/celephem/scriptobject.h
@@ -38,4 +38,4 @@ double SafeGetLuaNumber(lua_State* state,
                         const std::string& key,
                         double defaultValue);
 
-void SetLuaVariables(lua_State* state, Hash* parameters);
+void SetLuaVariables(lua_State* state, const Hash* parameters);

--- a/src/celephem/scriptorbit.cpp
+++ b/src/celephem/scriptorbit.cpp
@@ -45,7 +45,8 @@ using celestia::util::GetLogger;
 bool
 ScriptedOrbit::initialize(const std::string& moduleName,
                           const std::string& funcName,
-                          Hash* parameters)
+                          const Hash* parameters,
+                          const fs::path& path)
 {
     if (parameters == nullptr)
         return false;
@@ -92,6 +93,13 @@ ScriptedOrbit::initialize(const std::string& moduleName,
     lua_newtable(luaState);
 
     SetLuaVariables(luaState, parameters);
+    // set the addon path
+    {
+        std::string pathStr = path.string();
+        lua_pushstring(luaState, "AddonPath");
+        lua_pushstring(luaState, pathStr.c_str());
+        lua_settable(luaState, -3);
+    }
 
     // Call the generator function
     if (lua_pcall(luaState, 1, 1, 0) != 0)

--- a/src/celephem/scriptorbit.h
+++ b/src/celephem/scriptorbit.h
@@ -25,7 +25,8 @@ class ScriptedOrbit : public CachingOrbit
 
     bool initialize(const std::string& moduleName,
                     const std::string& funcName,
-                    Hash* parameters);
+                    const Hash* parameters,
+                    const fs::path& path);
 
     virtual Eigen::Vector3d computePosition(double tjd) const;
     //virtual Vec3d computeVelocity(double tjd) const;

--- a/src/celephem/scriptrotation.cpp
+++ b/src/celephem/scriptrotation.cpp
@@ -43,7 +43,8 @@ using celestia::util::GetLogger;
 bool
 ScriptedRotation::initialize(const std::string& moduleName,
                              const std::string& funcName,
-                             Hash* parameters)
+                             const Hash* parameters,
+                             const fs::path& path)
 {
     if (parameters == nullptr)
         return false;
@@ -90,6 +91,13 @@ ScriptedRotation::initialize(const std::string& moduleName,
     lua_newtable(luaState);
 
     SetLuaVariables(luaState, parameters);
+    // set the addon path
+    {
+        std::string pathStr = path.string();
+        lua_pushstring(luaState, "AddonPath");
+        lua_pushstring(luaState, pathStr.c_str());
+        lua_settable(luaState, -3);
+    }
 
     // Call the generator function
     if (lua_pcall(luaState, 1, 1, 0) != 0)

--- a/src/celephem/scriptrotation.h
+++ b/src/celephem/scriptrotation.h
@@ -25,7 +25,8 @@ class ScriptedRotation : public RotationModel
 
     bool initialize(const std::string& moduleName,
                     const std::string& funcName,
-                    Hash* parameters);
+                    const Hash* parameters,
+                    const fs::path& path);
 
     virtual Eigen::Quaterniond spin(double tjd) const;
 

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -129,7 +129,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
 
     config->consoleLogRows = getUint(configParams, "LogSize", 200);
 
-    Value* solarSystemsVal = configParams->getValue("SolarSystemCatalogs");
+    const Value* solarSystemsVal = configParams->getValue("SolarSystemCatalogs");
     if (solarSystemsVal != nullptr)
     {
         if (solarSystemsVal->getType() != Value::ArrayType)
@@ -156,7 +156,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
     }
 
-    Value* starCatalogsVal = configParams->getValue("StarCatalogs");
+    const Value* starCatalogsVal = configParams->getValue("StarCatalogs");
     if (starCatalogsVal != nullptr)
     {
         if (starCatalogsVal->getType() != Value::ArrayType)
@@ -184,7 +184,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
     }
 
-    Value* dsoCatalogsVal = configParams->getValue("DeepSkyCatalogs");
+    const Value* dsoCatalogsVal = configParams->getValue("DeepSkyCatalogs");
     if (dsoCatalogsVal != nullptr)
     {
         if (dsoCatalogsVal->getType() != Value::ArrayType)
@@ -212,7 +212,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
     }
 
-    Value* extrasDirsVal = configParams->getValue("ExtrasDirectories");
+    const Value* extrasDirsVal = configParams->getValue("ExtrasDirectories");
     if (extrasDirsVal != nullptr)
     {
         if (extrasDirsVal->getType() == Value::ArrayType)
@@ -242,7 +242,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
     }
 
-    Value* skipExtrasVal = configParams->getValue("SkipExtras");
+    const Value* skipExtrasVal = configParams->getValue("SkipExtras");
     if (skipExtrasVal != nullptr)
     {
         if (skipExtrasVal->getType() == Value::ArrayType)
@@ -272,7 +272,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
     }
 
-    Value* ignoreExtVal = configParams->getValue("IgnoreGLExtensions");
+    const Value* ignoreExtVal = configParams->getValue("IgnoreGLExtensions");
     if (ignoreExtVal != nullptr)
     {
         if (ignoreExtVal->getType() != Value::ArrayType)
@@ -297,7 +297,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
     }
 
-    Value* starTexValue = configParams->getValue("StarTextures");
+    const Value* starTexValue = configParams->getValue("StarTextures");
     if (starTexValue != nullptr)
     {
         if (starTexValue->getType() != Value::HashType)
@@ -382,7 +382,7 @@ CelestiaConfig::getStringValue(const string& name)
 {
     assert(params != nullptr);
 
-    Value* v = params->getValue(name);
+    const Value* v = params->getValue(name);
     if (v == nullptr || v->getType() != Value::StringType)
         return string("");
 

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -20,7 +20,7 @@
 using namespace std;
 using namespace celestia::util;
 
-static unsigned int getUint(Hash* params,
+static unsigned int getUint(const Hash* params,
                             const string& paramName,
                             unsigned int defaultValue)
 {
@@ -59,7 +59,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         return config;
     }
 
-    Hash* configParams = configParamsValue->getHash();
+    const Hash* configParams = configParamsValue->getHash();
 
     if (config == nullptr)
         config = new CelestiaConfig();
@@ -138,7 +138,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
         else
         {
-            ValueArray* solarSystems = solarSystemsVal->getArray();
+            const ValueArray* solarSystems = solarSystemsVal->getArray();
             // assert(solarSystems != nullptr);
 
             for (const auto catalogNameVal : *solarSystems)
@@ -165,7 +165,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
         else
         {
-            ValueArray* starCatalogs = starCatalogsVal->getArray();
+            const ValueArray* starCatalogs = starCatalogsVal->getArray();
             assert(starCatalogs != nullptr);
 
             for (const auto catalogNameVal : *starCatalogs)
@@ -193,7 +193,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
         else
         {
-            ValueArray* dsoCatalogs = dsoCatalogsVal->getArray();
+            const ValueArray* dsoCatalogs = dsoCatalogsVal->getArray();
             assert(dsoCatalogs != nullptr);
 
             for (const auto catalogNameVal : *dsoCatalogs)
@@ -217,7 +217,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
     {
         if (extrasDirsVal->getType() == Value::ArrayType)
         {
-            ValueArray* extrasDirs = extrasDirsVal->getArray();
+            const ValueArray* extrasDirs = extrasDirsVal->getArray();
             assert(extrasDirs != nullptr);
 
             for (const auto dirNameVal : *extrasDirs)
@@ -247,7 +247,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
     {
         if (skipExtrasVal->getType() == Value::ArrayType)
         {
-            ValueArray* skipExtras = skipExtrasVal->getArray();
+            const ValueArray* skipExtras = skipExtrasVal->getArray();
             assert(skipExtras != nullptr);
 
             for (const auto fileNameVal : *skipExtras)
@@ -281,7 +281,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
         else
         {
-            ValueArray* ignoreExt = ignoreExtVal->getArray();
+            const ValueArray* ignoreExt = ignoreExtVal->getArray();
 
             for (const auto extVal : *ignoreExt)
             {
@@ -306,7 +306,7 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
         else
         {
-            Hash* starTexTable = starTexValue->getHash();
+            const Hash* starTexTable = starTexValue->getHash();
             string starTexNames[StellarClass::Spectral_Count];
             starTexTable->getString("O", starTexNames[StellarClass::Spectral_O]);
             starTexTable->getString("B", starTexNames[StellarClass::Spectral_B]);

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -51,7 +51,7 @@ public:
     std::string scriptSystemAccessPolicy;
 #ifdef CELX
     fs::path luaHook;
-    Hash* configParams;
+    const Hash* configParams;
 #endif
 
     fs::path HDCrossIndexFile;
@@ -69,7 +69,7 @@ public:
 
     unsigned int consoleLogRows;
 
-    Hash* params;
+    const Hash* params;
 
     float getFloatValue(const std::string& name);
     const std::string getStringValue(const std::string& name);

--- a/src/celestia/destination.cpp
+++ b/src/celestia/destination.cpp
@@ -48,7 +48,7 @@ DestinationList* ReadDestinationList(std::istream& in)
             return nullptr;
         }
 
-        Hash* destParams = destValue->getHash();
+        const Hash* destParams = destValue->getHash();
         Destination* dest = new Destination();
 
         if (!destParams->getString("Name", dest->name))

--- a/src/celestia/favorites.cpp
+++ b/src/celestia/favorites.cpp
@@ -53,7 +53,7 @@ FavoritesList* ReadFavoritesList(std::istream& in)
             return nullptr;
         }
 
-        Hash* favParams = favParamsValue->getHash();
+        const Hash* favParams = favParamsValue->getHash();
 
         //If this is a folder, don't get any other params.
         if(!favParams->getBoolean("isFolder", fav->isFolder))

--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -158,7 +158,7 @@ Command* CommandParser::parseCommand()
         return nullptr;
     }
 
-    Hash* paramList = paramListValue->getHash();
+    const Hash* paramList = paramListValue->getHash();
     Command* cmd = nullptr;
 
     if (commandName == "wait")

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -1436,8 +1436,8 @@ Value *CelxLua::getValue(int index)
         v = new Value(getString(index));
     else if (isTable(index))
     {
-        ValueArray *array = new ValueArray;
-        Hash *hash = new Hash;
+        auto array = std::make_unique<ValueArray>();
+        auto hash = std::make_unique<Hash>();
         push();
         while(lua_next(m_lua, index) != 0)
         {
@@ -1445,7 +1445,6 @@ Value *CelxLua::getValue(int index)
             {
                 if (hash != nullptr)
                 {
-                    delete hash;
                     hash = nullptr;
                 }
                 if (array != nullptr)
@@ -1457,7 +1456,6 @@ Value *CelxLua::getValue(int index)
             {
                 if (array != nullptr)
                 {
-                    delete array;
                     array = nullptr;
                 }
                 if (hash != nullptr)
@@ -1471,9 +1469,9 @@ Value *CelxLua::getValue(int index)
         }
         pop(1);
         if (hash != nullptr)
-            v = new Value(hash);
+            v = new Value(std::move(hash));
         else if (array != nullptr)
-            v = new Value(array);
+            v = new Value(std::move(array));
     }
     return v;
 }

--- a/test/unit/hash_test.cpp
+++ b/test/unit/hash_test.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+#include <utility>
+
 #include <celengine/hash.h>
 #include <celengine/value.h>
 #include <celutil/color.h>
@@ -18,11 +21,11 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
         SECTION("Defined as Vector3")
         {
             AssociativeArray h;
-            auto *ary = new ValueArray;
+            auto ary = std::make_unique<ValueArray>();
             ary->push_back(new Value(.23));
             ary->push_back(new Value(.34));
             ary->push_back(new Value(.45));
-            auto *v = new Value(ary);
+            auto *v = new Value(std::move(ary));
             h.addValue("color", *v);
 
             auto val = h.getValue("color");
@@ -45,12 +48,12 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
         SECTION("Defined as Vector4")
         {
             AssociativeArray h;
-            auto *ary = new ValueArray;
+            auto ary = std::make_unique<ValueArray>();
             ary->push_back(new Value(.23));
             ary->push_back(new Value(.34));
             ary->push_back(new Value(.45));
             ary->push_back(new Value(.56));
-            auto *v = new Value(ary);
+            auto *v = new Value(std::move(ary));
             h.addValue("color", *v);
 
             auto val = h.getValue("color");


### PR DESCRIPTION
* Protect `Value`'s `bool` constructor against C++ implicit conversions
* Change the constructors taking `ValueArray` and `Hash` (=`AssociativeArray`) to take `unique_ptr`, since these classes get `delete`d in the destructor
* Make the `getArray()` and `getHash()` methods return `const` pointers
* Make the `getValue()` method of `AssociativeArray` return a `const` pointer