### PR TITLE
Refactor Value and Hash classes

### DIFF
--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -136,7 +136,8 @@ AsterismList* ReadAsterismList(std::istream& in, const StarDatabase& stardb)
         for (const auto& chain : *chains)
         {
             const ValueArray* a = chain.getArray();
-            if (a == nullptr) { continue; }
+            if (a == nullptr)
+                continue;
 
             // skip empty (without or only with a single star) chains
             if (a->size() <= 1)
@@ -146,17 +147,22 @@ AsterismList* ReadAsterismList(std::istream& in, const StarDatabase& stardb)
             for (const auto& i : *a)
             {
                 const std::string* iStr = i.getString();
-                if (iStr == nullptr) { continue; }
+                if (iStr == nullptr)
+                    continue;
 
-                Star* star = stardb.find(*iStr, false);
+                const Star* star = stardb.find(*iStr, false);
                 if (star == nullptr)
                     star = stardb.find(ReplaceGreekLetterAbbr(*iStr), false);
                 if (star != nullptr)
+                {
                     new_chain.push_back(star->getPosition());
+                }
                 else
+                {
                     GetLogger()->error("Error loading star \"{}\" for asterism \"{}\".\n",
                                         *iStr,
                                         ast.getName());
+                }
             }
 
             ast.addChain(std::move(new_chain));

--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -7,6 +7,9 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <memory>
+#include <utility>
+
 #include <celutil/gettext.h>
 #include <celutil/greek.h>
 #include <celutil/logger.h>
@@ -42,12 +45,12 @@ int Asterism::getChainCount() const
 
 const Asterism::Chain& Asterism::getChain(int index) const
 {
-    return *chains[index];
+    return chains[index];
 }
 
-void Asterism::addChain(Asterism::Chain& chain)
+void Asterism::addChain(Asterism::Chain&& chain)
 {
-    chains.push_back(&chain);
+    chains.emplace_back(std::move(chain));
 }
 
 
@@ -107,7 +110,7 @@ bool Asterism::isColorOverridden() const
 
 AsterismList* ReadAsterismList(std::istream& in, const StarDatabase& stardb)
 {
-    auto* asterisms = new AsterismList();
+    auto asterisms = std::make_unique<AsterismList>();
     Tokenizer tokenizer(&in);
     Parser parser(&tokenizer);
 
@@ -117,60 +120,48 @@ AsterismList* ReadAsterismList(std::istream& in, const StarDatabase& stardb)
         if (!tokenValue.has_value())
         {
             GetLogger()->error("Error parsing asterism file.\n");
-            for_each(asterisms->begin(), asterisms->end(), [](Asterism* ast) { delete ast; });
-            delete asterisms;
             return nullptr;
         }
 
-        Asterism* ast = new Asterism(*tokenValue);
+        Asterism& ast = asterisms->emplace_back(*tokenValue);
 
-        Value* chainsValue = parser.readValue();
-        if (chainsValue == nullptr || chainsValue->getType() != Value::ArrayType)
+        const Value chainsValue = parser.readValue();
+        const ValueArray* chains = chainsValue.getArray();
+        if (chains == nullptr)
         {
-            GetLogger()->error("Error parsing asterism {}\n", ast->getName());
-            for_each(asterisms->begin(), asterisms->end(), [](Asterism* ast) { delete ast; });
-            delete ast;
-            delete asterisms;
-            delete chainsValue;
+            GetLogger()->error("Error parsing asterism {}\n", ast.getName());
             return nullptr;
         }
 
-        const ValueArray* chains = chainsValue->getArray();
-
-        for (const auto chain : *chains)
+        for (const auto& chain : *chains)
         {
-            if (chain->getType() == Value::ArrayType)
+            const ValueArray* a = chain.getArray();
+            if (a == nullptr) { continue; }
+
+            // skip empty (without or only with a single star) chains
+            if (a->size() <= 1)
+                continue;
+
+            Asterism::Chain new_chain;
+            for (const auto& i : *a)
             {
-                const ValueArray* a = chain->getArray();
-                // skip empty (without or only with a single star) chains
-                if (a->size() <= 1)
-                    continue;
+                const std::string* iStr = i.getString();
+                if (iStr == nullptr) { continue; }
 
-                Asterism::Chain* new_chain = new Asterism::Chain();
-                for (const auto i : *a)
-                {
-                    if (i->getType() == Value::StringType)
-                    {
-                        Star* star = stardb.find(i->getString(), false);
-                        if (star == nullptr)
-                            star = stardb.find(ReplaceGreekLetterAbbr(i->getString()), false);
-                        if (star != nullptr)
-                            new_chain->push_back(star->getPosition());
-                        else
-                            GetLogger()->error("Error loading star \"{}\" for asterism \"{}\".\n",
-                                               i->getString(),
-                                               ast->getName());
-                    }
-                }
-
-                ast->addChain(*new_chain);
+                Star* star = stardb.find(*iStr, false);
+                if (star == nullptr)
+                    star = stardb.find(ReplaceGreekLetterAbbr(*iStr), false);
+                if (star != nullptr)
+                    new_chain.push_back(star->getPosition());
+                else
+                    GetLogger()->error("Error loading star \"{}\" for asterism \"{}\".\n",
+                                        *iStr,
+                                        ast.getName());
             }
+
+            ast.addChain(std::move(new_chain));
         }
-
-        asterisms->push_back(ast);
-
-        delete chainsValue;
     }
 
-    return asterisms;
+    return asterisms.release();
 }

--- a/src/celengine/asterism.h
+++ b/src/celengine/asterism.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <iosfwd>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -28,9 +29,9 @@ class Asterism
     ~Asterism() = default;
     Asterism() = delete;
     Asterism(const Asterism&) = delete;
-    Asterism(Asterism&&) = delete;
+    Asterism(Asterism&&) noexcept = default;
     Asterism& operator=(const Asterism&) = delete;
-    Asterism& operator=(Asterism&&) = delete;
+    Asterism& operator=(Asterism&&) noexcept = default;
 
     using Chain = std::vector<Eigen::Vector3f>;
 
@@ -46,18 +47,18 @@ class Asterism
     void unsetOverrideColor();
     bool isColorOverridden() const;
 
-    void addChain(Chain&);
+    void addChain(Chain&&);
 
  private:
     std::string name;
     std::string i18nName;
-    std::vector<Chain*> chains;
+    std::vector<Chain> chains;
     Color color;
 
     bool active             { true };
     bool useOverrideColor   { false };
 };
 
-using AsterismList = std::vector<Asterism*>;
+using AsterismList = std::vector<Asterism>;
 
 AsterismList* ReadAsterismList(std::istream&, const StarDatabase&);

--- a/src/celengine/asterismrenderer.cpp
+++ b/src/celengine/asterismrenderer.cpp
@@ -44,14 +44,14 @@ void AsterismRenderer::render(const Color &defaultColor, const Matrices &mvp)
     float opacity = defaultColor.alpha();
     for (size_t size = m_asterisms->size(), i = 0; i < size; i++)
     {
-        auto *ast = (*m_asterisms)[i];
-        if (!ast->getActive() || !ast->isColorOverridden())
+        const auto& ast = (*m_asterisms)[i];
+        if (!ast.getActive() || !ast.isColorOverridden())
         {
             offset += m_lineCount[i];
             continue;
         }
 
-        Color color = {ast->getOverrideColor(), opacity};
+        Color color = {ast.getOverrideColor(), opacity};
         m_lineRenderer.render(mvp, color, m_lineCount[i] * 2, offset * 2);
         offset += m_lineCount[i];
     }
@@ -62,15 +62,15 @@ bool AsterismRenderer::prepare()
 {
     // calculate required vertices number
     GLsizei vtx_num = 0;
-    for (const auto ast : *m_asterisms)
+    for (const auto& ast : *m_asterisms)
     {
         GLsizei ast_vtx_num = 0;
-        for (int k = 0; k < ast->getChainCount(); k++)
+        for (int k = 0; k < ast.getChainCount(); k++)
         {
             // as we use GL_LINES we should double the number of vertices.
             // as we don't need closed figures we have only one copy of
             // the 1st and last vertexes
-            GLsizei s = ast->getChain(k).size();
+            GLsizei s = ast.getChain(k).size();
             if (s > 1)
                 ast_vtx_num += s - 1;
         }
@@ -84,11 +84,11 @@ bool AsterismRenderer::prepare()
 
     m_totalLineCount = vtx_num;
 
-    for (const auto ast : *m_asterisms)
+    for (const auto& ast : *m_asterisms)
     {
-        for (int k = 0; k < ast->getChainCount(); k++)
+        for (int k = 0; k < ast.getChainCount(); k++)
         {
-            const auto& chain = ast->getChain(k);
+            const auto& chain = ast.getChain(k);
             for (unsigned i = 1; i < chain.size(); i++)
                 m_lineRenderer.addSegment(chain[i - 1], chain[i]);
         }

--- a/src/celengine/astro.cpp
+++ b/src/celengine/astro.cpp
@@ -100,57 +100,6 @@ static const char* MonthAbbrList[12] =
 #endif
 
 
-struct UnitDefinition
-{
-    std::string_view name;
-    double conversion;
-};
-
-
-static const UnitDefinition lengthUnits[] =
-{
-    { "km", 1.0 },
-    { "m",  0.001 },
-    { "rE", EARTH_RADIUS<double> },
-    { "rJ", JUPITER_RADIUS<double> },
-    { "rS", SOLAR_RADIUS<double> },
-    { "AU", KM_PER_AU<double> },
-    { "ly", KM_PER_LY<double> },
-    { "pc", KM_PER_PARSEC<double> },
-    { "kpc", 1000.0 * KM_PER_PARSEC<double> },
-    { "Mpc", 1000000.0 * KM_PER_PARSEC<double> },
-};
-
-
-static const UnitDefinition timeUnits[] =
-{
-    { "s", 1.0 / SECONDS_PER_DAY },
-    { "min", 1.0 / MINUTES_PER_DAY },
-    { "h", 1.0 / HOURS_PER_DAY },
-    { "d", 1.0 },
-    { "y", DAYS_PER_YEAR },
-};
-
-
-static const UnitDefinition angleUnits[] =
-{
-    { "mas", 0.001 / SECONDS_PER_DEG },
-    { "arcsec", 1.0 / SECONDS_PER_DEG },
-    { "arcmin", 1.0 / MINUTES_PER_DEG },
-    { "deg", 1.0 },
-    { "hRA", DEG_PER_HRA },
-    { "rad", 180.0 / celestia::numbers::pi },
-};
-
-
-static const UnitDefinition massUnits[] =
-{
-    { "kg", 1.0 / astro::EarthMass },
-    { "mE", 1.0 },
-    { "mJ", astro::JupiterMass / astro::EarthMass },
-};
-
-
 float astro::lumToAbsMag(float lum)
 {
     return SOLAR_ABSMAG - log(lum) * LN_MAG;
@@ -762,99 +711,65 @@ astro::TAItoJDUTC(double tai)
 
 
 // Get scale of given length unit in kilometers
-bool astro::getLengthScale(std::string_view unitName, double& scale)
+std::optional<double> astro::getLengthScale(LengthUnit unit)
 {
-    unsigned int nUnits = sizeof(lengthUnits) / sizeof(lengthUnits[0]);
-    bool foundMatch = false;
-    for(unsigned int i = 0; i < nUnits; i++)
+    switch (unit)
     {
-        if (lengthUnits[i].name == unitName)
-        {
-            foundMatch = true;
-            scale = lengthUnits[i].conversion;
-            break;
-        }
+    case LengthUnit::Kilometer: return 1.0;
+    case LengthUnit::Meter: return 1e-3;
+    case LengthUnit::EarthRadius: return EARTH_RADIUS<double>;
+    case LengthUnit::JupiterRadius: return JUPITER_RADIUS<double>;
+    case LengthUnit::SolarRadius: return SOLAR_RADIUS<double>;
+    case LengthUnit::AstronomicalUnit: return KM_PER_AU<double>;
+    case LengthUnit::LightYear: return KM_PER_LY<double>;
+    case LengthUnit::Parsec: return KM_PER_PARSEC<double>;
+    case LengthUnit::Kiloparsec: return 1e3 * KM_PER_PARSEC<double>;
+    case LengthUnit::Megaparsec: return 1e6 * KM_PER_PARSEC<double>;
+    default: return std::nullopt;
     }
-
-    return foundMatch;
 }
 
 
 // Get scale of given time unit in days
-bool astro::getTimeScale(std::string_view unitName, double& scale)
+std::optional<double> astro::getTimeScale(TimeUnit unit)
 {
-    for (const auto& timeUnit : timeUnits)
+    switch (unit)
     {
-        if (timeUnit.name == unitName)
-        {
-            scale = timeUnit.conversion;
-            return true;
-        }
+    case TimeUnit::Second: return 1.0 / SECONDS_PER_DAY;
+    case TimeUnit::Minute: return 1.0 / MINUTES_PER_DAY;
+    case TimeUnit::Hour: return 1.0 / HOURS_PER_DAY;
+    case TimeUnit::Day: return 1.0;
+    case TimeUnit::JulianYear: return DAYS_PER_YEAR;
+    default: return std::nullopt;
     }
-
-    return false;
 }
 
 
 // Get scale of given angle unit in degrees
-bool astro::getAngleScale(std::string_view unitName, double& scale)
+std::optional<double> astro::getAngleScale(AngleUnit unit)
 {
-    for (const auto& angleUnit : angleUnits)
+    switch (unit)
     {
-        if (angleUnit.name == unitName)
-        {
-            scale = angleUnit.conversion;
-            return true;
-        }
+    case AngleUnit::Milliarcsecond: return 1e-3 / SECONDS_PER_DEG;
+    case AngleUnit::Arcsecond: return 1.0 / SECONDS_PER_DEG;
+    case AngleUnit::Arcminute: return 1.0 / MINUTES_PER_DEG;
+    case AngleUnit::Degree: return 1.0;
+    case AngleUnit::Hour: return DEG_PER_HRA;
+    case AngleUnit::Radian: return 180.0 / celestia::numbers::pi;
+    default: return std::nullopt;
     }
-
-    return false;
 }
 
 
-bool astro::getMassScale(std::string_view unitName, double& scale)
+std::optional<double> astro::getMassScale(MassUnit unit)
 {
-    for (const auto& massUnit : massUnits)
+    switch (unit)
     {
-        if (massUnit.name == unitName)
-        {
-            scale = massUnit.conversion;
-            return true;
-        }
+    case MassUnit::Kilogram: return 1.0 / astro::EarthMass;
+    case MassUnit::EarthMass: return 1.0;
+    case MassUnit::JupiterMass: return astro::JupiterMass / astro::EarthMass;
+    default: return std::nullopt;
     }
-
-    return false;
-}
-
-
-// Check if unit is a length unit
-bool astro::isLengthUnit(std::string_view unitName)
-{
-    double dummy;
-    return getLengthScale(unitName, dummy);
-}
-
-
-// Check if unit is a time unit
-bool astro::isTimeUnit(std::string_view unitName)
-{
-    double dummy;
-    return getTimeScale(unitName, dummy);
-}
-
-
-// Check if unit is an angle unit
-bool astro::isAngleUnit(std::string_view unitName)
-{
-    double dummy;
-    return getAngleScale(unitName, dummy);
-}
-
-
-bool astro::isMassUnit(std::string_view unitName)
-{
-    double dummy;
-    return getMassScale(unitName, dummy);
 }
 
 

--- a/src/celengine/astro.h
+++ b/src/celengine/astro.h
@@ -12,8 +12,8 @@
 
 #include <Eigen/Geometry>
 #include <iosfwd>
+#include <optional>
 #include <string>
-#include <string_view>
 #include <celmath/mathlib.h>
 #include <celutil/array_view.h>
 
@@ -213,14 +213,54 @@ namespace astro
         return jd * SECONDS_PER_DAY;
     }
 
-    bool isLengthUnit(std::string_view unitName);
-    bool isTimeUnit(std::string_view unitName);
-    bool isAngleUnit(std::string_view unitName);
-    bool isMassUnit(std::string_view unitName);
-    bool getLengthScale(std::string_view unitName, double& scale);
-    bool getTimeScale(std::string_view unitName, double& scale);
-    bool getAngleScale(std::string_view unitName, double& scale);
-    bool getMassScale(std::string_view unitName, double& scale);
+    enum class LengthUnit : std::uint8_t
+    {
+        Default = 0,
+        Kilometer,
+        Meter,
+        EarthRadius,
+        JupiterRadius,
+        SolarRadius,
+        AstronomicalUnit,
+        LightYear,
+        Parsec,
+        Kiloparsec,
+        Megaparsec,
+    };
+
+    enum class TimeUnit : std::uint8_t
+    {
+        Default = 0,
+        Second,
+        Minute,
+        Hour,
+        Day,
+        JulianYear,
+    };
+
+    enum class AngleUnit : std::uint8_t
+    {
+        Default = 0,
+        Milliarcsecond,
+        Arcsecond,
+        Arcminute,
+        Degree,
+        Hour,
+        Radian,
+    };
+
+    enum class MassUnit : std::uint8_t
+    {
+        Default = 0,
+        Kilogram,
+        EarthMass,
+        JupiterMass,
+    };
+
+    std::optional<double> getLengthScale(LengthUnit unit);
+    std::optional<double> getTimeScale(TimeUnit unit);
+    std::optional<double> getAngleScale(AngleUnit unit);
+    std::optional<double> getMassScale(MassUnit unit);
 
     void decimalToDegMinSec(double angle, int& degrees, int& minutes, double& seconds);
     double degMinSecToDecimal(int degrees, int minutes, double seconds);

--- a/src/celengine/astroobj.cpp
+++ b/src/celengine/astroobj.cpp
@@ -104,18 +104,19 @@ bool AstroObject::loadCategories(const Hash *hash, DataDisposition disposition, 
 {
     if (disposition == DataDisposition::Replace)
         clearCategories();
-    std::string cn;
-    if (hash->getString("Category", cn))
+    if (const std::string* cn = hash->getString("Category"); cn != nullptr)
     {
-        if (cn.empty())
+        if (cn->empty())
             return false;
-        return addToCategory(cn, true, domain);
+        return addToCategory(*cn, true, domain);
     }
     const Value *a = hash->getValue("Category");
-    if (a == nullptr) { return false; }
+    if (a == nullptr)
+        return false;
 
     const ValueArray *v = a->getArray();
-    if (v == nullptr) { return false; }
+    if (v == nullptr)
+        return false;
 
     bool ret = true;
     for (const auto& it : *v)

--- a/src/celengine/astroobj.cpp
+++ b/src/celengine/astroobj.cpp
@@ -112,16 +112,16 @@ bool AstroObject::loadCategories(const Hash *hash, DataDisposition disposition, 
         return addToCategory(cn, true, domain);
     }
     const Value *a = hash->getValue("Category");
-    if (a == nullptr)
-        return false;
+    if (a == nullptr) { return false; }
+
     const ValueArray *v = a->getArray();
-    if (v == nullptr)
-        return false;
+    if (v == nullptr) { return false; }
+
     bool ret = true;
-    for (auto it : *v)
+    for (const auto& it : *v)
     {
-        cn = it->getString();
-        if (!addToCategory(cn, true, domain))
+        const std::string* str = it.getString();
+        if (str == nullptr || !addToCategory(*str, true, domain))
             ret = false;
     }
     return ret;

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 
 #include <celutil/gettext.h>
 #include <celutil/logger.h>
@@ -228,16 +229,13 @@ bool DSODatabase::load(std::istream& in, const fs::path& resourcePath)
             return false;
         }
 
-        Value* objParamsValue    = parser.readValue();
-        if (objParamsValue == nullptr ||
-            objParamsValue->getType() != Value::HashType)
+        const Value objParamsValue = parser.readValue();
+        const Hash* objParams = objParamsValue.getHash();
+        if (objParams == nullptr)
         {
             GetLogger()->error("Error parsing deep sky catalog entry {}\n", objName.c_str());
             return false;
         }
-
-        const Hash* objParams    = objParamsValue->getHash();
-        assert(objParams != nullptr);
 
         DeepSkyObject* obj = nullptr;
         if (compareIgnoringCase(objType, "Galaxy") == 0)
@@ -252,7 +250,6 @@ bool DSODatabase::load(std::istream& in, const fs::path& resourcePath)
         if (obj != nullptr && obj->load(objParams, resourcePath))
         {
             obj->loadCategories(objParams, DataDisposition::Add, resourcePath.string());
-            delete objParamsValue;
 
             // Ensure that the DSO array is large enough
             if (nDSOs == capacity)
@@ -309,7 +306,6 @@ bool DSODatabase::load(std::istream& in, const fs::path& resourcePath)
         else
         {
             GetLogger()->warn("Bad Deep Sky Object definition--will continue parsing file.\n");
-            delete objParamsValue;
             return false;
         }
     }

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -458,17 +458,26 @@ bool Galaxy::pick(const Eigen::ParametrizedLine<double, 3>& ray,
 
 bool Galaxy::load(const AssociativeArray* params, const fs::path& resPath)
 {
-    double detail = 1.0;
-    params->getNumber("Detail", detail);
-    setDetail(static_cast<float>(detail));
+    setDetail(params->getNumber<float>("Detail").value_or(1.0f));
 
-    std::string customTmpName;
-    params->getString("CustomTemplate", customTmpName);
+    if (const std::string* typeName = params->getString("Type"); typeName == nullptr)
+    {
+        setType("");
+    }
+    else
+    {
+        setType(*typeName);
+    }
 
-    std::string typeName;
-    params->getString("Type", typeName);
-    setType(typeName);
-    setForm(customTmpName);
+
+    if (const std::string* customTmpName = params->getString("CustomTemplate"); customTmpName == nullptr)
+    {
+        setForm("");
+    }
+    else
+    {
+        setForm(*customTmpName);
+    }
 
     return DeepSkyObject::load(params, resPath);
 }

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -554,18 +554,14 @@ bool Globular::load(const AssociativeArray* params, const fs::path& resPath)
     if (!ok)
         return false;
 
-    if (params->getNumber("Detail", detail))
-        setDetail(static_cast<float>(detail));
+    if (auto detailVal = params->getNumber<float>("Detail"); detailVal.has_value())
+        setDetail(*detailVal);
 
-    double coreRadius;
-    if (params->getAngle("CoreRadius", coreRadius, 1.0 / MINUTES_PER_DEG))
-    {
-        r_c = coreRadius;
-        setCoreRadius(r_c);
-    }
+    if (auto coreRadius = params->getAngle<float>("CoreRadius", 1.0 / MINUTES_PER_DEG); coreRadius.has_value())
+        setCoreRadius(*coreRadius);
 
-    if (params->getNumber("KingConcentration", c))
-        setConcentration(c);
+    if (auto king = params->getNumber<float>("KingConcentration"); king.has_value())
+        setConcentration(*king);
 
     return true;
 }

--- a/src/celengine/hash.cpp
+++ b/src/celengine/hash.cpp
@@ -20,8 +20,8 @@ namespace celutil = celestia::util;
 
 // Define these here: at declaration the vector member contains an incomplete type
 AssociativeArray::~AssociativeArray() = default;
-AssociativeArray::AssociativeArray(AssociativeArray&&) = default;
-AssociativeArray& AssociativeArray::operator=(AssociativeArray&&) = default;
+AssociativeArray::AssociativeArray(AssociativeArray&&) noexcept(std::is_nothrow_move_constructible_v<AssocType>) = default;
+AssociativeArray& AssociativeArray::operator=(AssociativeArray&&) noexcept(std::is_nothrow_move_assignable_v<AssocType>) = default;
 
 
 const Value* AssociativeArray::getValue(std::string_view key) const
@@ -38,133 +38,73 @@ void AssociativeArray::addValue(std::string&& key, Value&& val)
 {
     std::size_t index = values.size();
     values.emplace_back(std::move(val));
-    assoc.emplace(std::move(key), index);
+    assoc.try_emplace(std::move(key), index);
 }
 
 
-bool AssociativeArray::getNumber(std::string_view key, double& val) const
+std::optional<double> AssociativeArray::getNumberImpl(std::string_view key) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
-    std::optional<double> dbl = v->getNumber();
-    if (!dbl.has_value()) { return false; }
+    if (v == nullptr) { return std::nullopt; }
 
-    val = *dbl;
-    return true;
+    return v->getNumber();
 }
 
 
-bool AssociativeArray::getNumber(std::string_view key, float& val) const
-{
-    double dval;
-
-    if (!getNumber(key, dval))
-        return false;
-
-    val = (float) dval;
-    return true;
-}
-
-
-bool AssociativeArray::getNumber(std::string_view key, int& val) const
-{
-    double ival;
-
-    if (!getNumber(key, ival))
-        return false;
-
-    val = (int) ival;
-    return true;
-}
-
-
-bool AssociativeArray::getNumber(std::string_view key, std::uint32_t& val) const
-{
-    double ival;
-
-    if (!getNumber(key, ival))
-        return false;
-
-    val = static_cast<std::uint32_t>(ival);
-    return true;
-}
-
-
-bool AssociativeArray::getString(std::string_view key, std::string& val) const
+const std::string* AssociativeArray::getString(std::string_view key) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
+    if (v == nullptr) { return nullptr; }
 
-    const std::string* str = v->getString();
-    if (str == nullptr) { return false; }
-
-    val = *str;
-    return true;
+    return v->getString();
 }
 
 
-bool AssociativeArray::getPath(std::string_view key, fs::path& val) const
+std::optional<fs::path> AssociativeArray::getPath(std::string_view key) const
 {
-    std::string v;
-    if (getString(key, v))
-    {
-        val = celutil::PathExp(v);
-        return true;
-    }
-    return false;
+    const std::string* v = getString(key);
+    if (v == nullptr) { return std::nullopt; }
+
+    return std::make_optional(celutil::PathExp(*v));
 }
 
 
-bool AssociativeArray::getBoolean(std::string_view key, bool& val) const
+std::optional<bool> AssociativeArray::getBoolean(std::string_view key) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
-    auto bln = v->getBoolean();
-    if (!bln.has_value()) { return false;}
+    if (v == nullptr) { return std::nullopt; }
 
-    val = *bln;
-    return true;
+    return v->getBoolean();
 }
 
 
-bool AssociativeArray::getVector(std::string_view key, Eigen::Vector3d& val) const
+std::optional<Eigen::Vector3d>
+AssociativeArray::getVector3Impl(std::string_view key) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
+    if (v == nullptr) { return std::nullopt; }
 
     const ValueArray* arr = v->getArray();
-    if (arr == nullptr || arr->size() != 3) { return false; }
+    if (arr == nullptr || arr->size() != 3) { return std::nullopt; }
 
     std::optional<double> x = (*arr)[0].getNumber();
     std::optional<double> y = (*arr)[1].getNumber();
     std::optional<double> z = (*arr)[2].getNumber();
 
-    if (!x.has_value() || !y.has_value() || !z.has_value()) { return false; }
+    if (!x.has_value() || !y.has_value() || !z.has_value()) { return std::nullopt; }
 
-    val = Eigen::Vector3d(*x, *y, *z);
-    return true;
+    return std::make_optional<Eigen::Vector3d>(*x, *y, *z);
 }
 
 
-bool AssociativeArray::getVector(std::string_view key, Eigen::Vector3f& val) const
-{
-    Eigen::Vector3d vecVal;
-
-    if (!getVector(key, vecVal))
-        return false;
-
-    val = vecVal.cast<float>();
-    return true;
-}
-
-
-bool AssociativeArray::getVector(std::string_view key, Eigen::Vector4d& val) const
+std::optional<Eigen::Vector4d>
+AssociativeArray::getVector4Impl(std::string_view key) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
+    if (v == nullptr) { return std::nullopt; }
 
     const ValueArray* arr = v->getArray();
-    if (arr == nullptr || arr->size() != 4) { return false; }
+    if (arr == nullptr || arr->size() != 4) { return std::nullopt; }
 
     std::optional<double> x = (*arr)[0].getNumber();
     std::optional<double> y = (*arr)[1].getNumber();
@@ -173,23 +113,10 @@ bool AssociativeArray::getVector(std::string_view key, Eigen::Vector4d& val) con
 
     if (!x.has_value() || !y.has_value() || !z.has_value() || !w.has_value())
     {
-        return false;
+        return std::nullopt;
     }
 
-    val = Eigen::Vector4d(*x, *y, *z, *w);
-    return true;
-}
-
-
-bool AssociativeArray::getVector(std::string_view key, Eigen::Vector4f& val) const
-{
-    Eigen::Vector4d vecVal;
-
-    if (!getVector(key, vecVal))
-        return false;
-
-    val = vecVal.cast<float>();
-    return true;
+    return std::make_optional<Eigen::Vector4d>(*x, *y, *z, *w);
 }
 
 
@@ -200,16 +127,15 @@ bool AssociativeArray::getVector(std::string_view key, Eigen::Vector4f& val) con
  * \verbatim {PropertyName} [ angle axisX axisY axisZ ] \endverbatim
  *
  * @param[in] key Hash key for the rotation.
- * @param[out] val A quaternion representing the value if present, unaffected if not.
- * @return True if the key exists in the hash, false otherwise.
+ * @return The quaternion if the key exists, nullopt otherwise.
  */
-bool AssociativeArray::getRotation(std::string_view key, Eigen::Quaternionf& val) const
+std::optional<Eigen::Quaternionf> AssociativeArray::getRotation(std::string_view key) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr ) { return false; }
+    if (v == nullptr ) { return std::nullopt; }
 
     const ValueArray* arr = v->getArray();
-    if (arr == nullptr || arr->size() != 4) { return false; }
+    if (arr == nullptr || arr->size() != 4) { return std::nullopt; }
 
     std::optional<double> w = (*arr)[0].getNumber();
     std::optional<double> x = (*arr)[1].getNumber();
@@ -218,7 +144,7 @@ bool AssociativeArray::getRotation(std::string_view key, Eigen::Quaternionf& val
 
     if (!w.has_value() || !x.has_value() || !y.has_value() || !z.has_value())
     {
-        return false;
+        return std::nullopt;
     }
 
     Eigen::Vector3f axis(static_cast<float>(*x),
@@ -228,61 +154,56 @@ bool AssociativeArray::getRotation(std::string_view key, Eigen::Quaternionf& val
     double angScale = astro::getAngleScale(v->getAngleUnit()).value_or(1.0);
     auto angle = static_cast<float>(celmath::degToRad(*w * angScale));
 
-    val = Eigen::Quaternionf(Eigen::AngleAxisf(angle, axis.normalized()));
-
-    return true;
+    return std::make_optional<Eigen::Quaternionf>(Eigen::AngleAxisf(angle, axis.normalized()));
 }
 
 
-bool AssociativeArray::getColor(std::string_view key, Color& val) const
+std::optional<Color> AssociativeArray::getColor(std::string_view key) const
 {
-    Eigen::Vector4d vec4;
-    if (getVector(key, vec4))
+    if (auto vec4 = getVector4<float>(key); vec4.has_value())
     {
-        Eigen::Vector4f vec4f = vec4.cast<float>();
-        val = Color(vec4f);
-        return true;
+        return std::make_optional<Color>(*vec4);
     }
 
-    Eigen::Vector3d vec3;
-    if (getVector(key, vec3))
+    if (auto vec3 = getVector3<float>(key); vec3.has_value())
     {
-        Eigen::Vector3f vec3f = vec3.cast<float>();
-        val = Color(vec3f);
-        return true;
+        return std::make_optional<Color>(*vec3);
     }
 
-    std::string rgba;
-    if (getString(key, rgba))
+    if (const std::string* rgba = getString(key); rgba != nullptr)
     {
-        return Color::parse(rgba.c_str(), val);
+        Color color;
+        if (Color::parse(rgba->c_str(), color))
+        {
+            return color;
+        }
     }
 
-    return false;
+    return std::nullopt;
 }
 
 
 /**
  * Retrieves a numeric quantity scaled to an associated angle unit.
  * @param[in] key Hash key for the quantity.
- * @param[out] val The returned quantity if present, unaffected if not.
  * @param[in] outputScale Returned value is scaled to this value.
  * @param[in] defaultScale If no units are specified, use this scale. Defaults to outputScale.
- * @return True if the key exists in the hash, false otherwise.
+ * @return The scaled value if the key exists in the hash, nullopt otherwise.
  */
-bool
-AssociativeArray::getAngle(std::string_view key, double& val, double outputScale, double defaultScale) const
+std::optional<double>
+AssociativeArray::getAngleImpl(std::string_view key, double outputScale, double defaultScale) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
+    if (v == nullptr) { return std::nullopt; }
 
+    double val;
     if (std::optional<double> dbl = v->getNumber(); dbl.has_value())
     {
         val = *dbl;
     }
     else
     {
-        return false;
+        return std::nullopt;
     }
 
     if(auto angleScale = astro::getAngleScale(v->getAngleUnit()); angleScale.has_value())
@@ -294,46 +215,31 @@ AssociativeArray::getAngle(std::string_view key, double& val, double outputScale
         val *= defaultScale / outputScale;
     }
 
-    return true;
-}
-
-
-/** @copydoc AssociativeArray::getAngle() */
-bool
-AssociativeArray::getAngle(std::string_view key, float& val, double outputScale, double defaultScale) const
-{
-    double dval;
-
-    if (!getAngle(key, dval, outputScale, defaultScale))
-        return false;
-
-    val = ((float) dval);
-
-    return true;
+    return val;
 }
 
 
 /**
  * Retrieves a numeric quantity scaled to an associated length unit.
  * @param[in] key Hash key for the quantity.
- * @param[out] val The returned quantity if present, unaffected if not.
  * @param[in] outputScale Returned value is scaled to this value.
  * @param[in] defaultScale If no units are specified, use this scale. Defaults to outputScale.
- * @return True if the key exists in the hash, false otherwise.
+ * @return The scaled value if the key exists in the hash, otherwise nullopt.
  */
-bool
-AssociativeArray::getLength(std::string_view key, double& val, double outputScale, double defaultScale) const
+std::optional<double>
+AssociativeArray::getLengthImpl(std::string_view key, double outputScale, double defaultScale) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
+    if (v == nullptr) { return std::nullopt; }
 
+    double val;
     if (std::optional<double> dbl = v->getNumber(); dbl.has_value())
     {
         val = *dbl;
     }
     else
     {
-        return false;
+        return std::nullopt;
     }
 
     if (auto lengthScale = astro::getLengthScale(v->getLengthUnit()); lengthScale.has_value())
@@ -345,44 +251,31 @@ AssociativeArray::getLength(std::string_view key, double& val, double outputScal
         val *= defaultScale / outputScale;
     }
 
-    return true;
-}
-
-
-/** @copydoc AssociativeArray::getLength() */
-bool AssociativeArray::getLength(std::string_view key, float& val, double outputScale, double defaultScale) const
-{
-    double dval;
-
-    if (!getLength(key, dval, outputScale, defaultScale))
-        return false;
-
-    val = ((float) dval);
-
-    return true;
+    return val;
 }
 
 
 /**
  * Retrieves a numeric quantity scaled to an associated time unit.
  * @param[in] key Hash key for the quantity.
- * @param[out] val The returned quantity if present, unaffected if not.
  * @param[in] outputScale Returned value is scaled to this value.
  * @param[in] defaultScale If no units are specified, use this scale. Defaults to outputScale.
- * @return True if the key exists in the hash, false otherwise.
+ * @return The scaled value if the key exists in the hash, nullopt otherwise.
  */
-bool AssociativeArray::getTime(std::string_view key, double& val, double outputScale, double defaultScale) const
+std::optional<double>
+AssociativeArray::getTimeImpl(std::string_view key, double outputScale, double defaultScale) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
+    if (v == nullptr) { return std::nullopt; }
 
+    double val;
     if (std::optional<double> dbl = v->getNumber(); dbl.has_value())
     {
         val = *dbl;
     }
     else
     {
-        return false;
+        return std::nullopt;
     }
 
     if (auto timeScale = astro::getTimeScale(v->getTimeUnit()))
@@ -394,44 +287,31 @@ bool AssociativeArray::getTime(std::string_view key, double& val, double outputS
         val *= defaultScale / outputScale;
     }
 
-    return true;
-}
-
-
-/** @copydoc AssociativeArray::getTime() */
-bool AssociativeArray::getTime(std::string_view key, float& val, double outputScale, double defaultScale) const
-{
-    double dval;
-
-    if(!getTime(key, dval, outputScale, defaultScale))
-        return false;
-
-    val = ((float) dval);
-
-    return true;
+    return val;
 }
 
 
 /**
  * Retrieves a numeric quantity scaled to an associated mass unit.
  * @param[in] key Hash key for the quantity.
- * @param[out] val The returned quantity if present, unaffected if not.
  * @param[in] outputScale Returned value is scaled to this value.
  * @param[in] defaultScale If no units are specified, use this scale. Defaults to outputScale.
- * @return True if the key exists in the hash, false otherwise.
+ * @return The scaled value if the key exists in the hash, nullopt otherwise.
  */
-bool AssociativeArray::getMass(std::string_view key, double& val, double outputScale, double defaultScale) const
+std::optional<double>
+AssociativeArray::getMassImpl(std::string_view key, double outputScale, double defaultScale) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
+    if (v == nullptr) { return std::nullopt; }
 
+    double val;
     if (std::optional<double> dbl = v->getNumber(); dbl.has_value())
     {
         val = *dbl;
     }
     else
     {
-        return false;
+        return std::nullopt;
     }
 
     if (auto massScale = astro::getMassScale(v->getMassUnit()); massScale.has_value())
@@ -443,120 +323,77 @@ bool AssociativeArray::getMass(std::string_view key, double& val, double outputS
         val *= defaultScale / outputScale;
     }
 
-    return true;
-}
-
-
-/** @copydoc AssociativeArray::getMass() */
-bool AssociativeArray::getMass(std::string_view key, float& val, double outputScale, double defaultScale) const
-{
-    double dval;
-
-    if(!getMass(key, dval, outputScale, defaultScale))
-        return false;
-
-    val = ((float) dval);
-
-    return true;
+    return val;
 }
 
 
 /**
  * Retrieves a vector quantity scaled to an associated length unit.
  * @param[in] key Hash key for the quantity.
- * @param[out] val The returned vector if present, unaffected if not.
  * @param[in] outputScale Returned value is scaled to this value.
  * @param[in] defaultScale If no units are specified, use this scale. Defaults to outputScale.
- * @return True if the key exists in the hash, false otherwise.
+ * @return The scaled vector if the key exists in the hash, nullopt otherwise.
  */
-bool AssociativeArray::getLengthVector(std::string_view key, Eigen::Vector3d& val, double outputScale, double defaultScale) const
+std::optional<Eigen::Vector3d>
+AssociativeArray::getLengthVectorImpl(std::string_view key, double outputScale, double defaultScale) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
+    if (v == nullptr) { return std::nullopt; }
 
     const ValueArray* arr = v->getArray();
-    if (arr == nullptr || arr->size() != 3) { return false; }
+    if (arr == nullptr || arr->size() != 3) { return std::nullopt; }
 
     std::optional<double> x = (*arr)[0].getNumber();
     std::optional<double> y = (*arr)[1].getNumber();
     std::optional<double> z = (*arr)[2].getNumber();
 
-    if (!x.has_value() || !y.has_value() || !z.has_value()) { return false; }
-
-    val = Eigen::Vector3d(*x, *y, *z);
+    if (!x.has_value() || !y.has_value() || !z.has_value()) { return std::nullopt; }
 
     if (auto lengthScale = astro::getLengthScale(v->getLengthUnit()); lengthScale.has_value())
     {
-        val *= *lengthScale / outputScale;
+        auto scale = *lengthScale / outputScale;
+        return std::make_optional<Eigen::Vector3d>(*x * scale, *y * scale, *z * scale);
     }
-    else if (defaultScale != 0.0)
+
+    if (defaultScale != 0.0)
     {
-        val *= defaultScale / outputScale;
+        auto scale = defaultScale / outputScale;
+        return std::make_optional<Eigen::Vector3d>(*x * scale, *y * scale, *z * scale);
     }
 
-    return true;
-}
-
-
-/** @copydoc AssociativeArray::getLengthVector() */
-bool AssociativeArray::getLengthVector(std::string_view key, Eigen::Vector3f& val, double outputScale, double defaultScale) const
-{
-    Eigen::Vector3d vecVal;
-
-    if(!getLengthVector(key, vecVal, outputScale, defaultScale))
-        return false;
-
-    val = vecVal.cast<float>();
-    return true;
+    return std::make_optional<Eigen::Vector3d>(*x, *y, *z);
 }
 
 
 /**
  * Retrieves a spherical tuple \verbatim [longitude, latitude, altitude] \endverbatim scaled to associated angle and length units.
- * @param[in] key Hash key for the quantity.
- * @param[out] val The returned tuple in units of degrees and kilometers if present, unaffected if not.
- * @return True if the key exists in the hash, false otherwise.
+ * @return The tuple if the key exists in the hash, nullopt otherwise.
  */
-bool AssociativeArray::getSphericalTuple(std::string_view key, Eigen::Vector3d& val) const
+std::optional<Eigen::Vector3d>
+AssociativeArray::getSphericalTuple(std::string_view key) const
 {
     const Value* v = getValue(key);
-    if (v == nullptr) { return false; }
+    if (v == nullptr) { return std::nullopt; }
 
     const ValueArray* arr = v->getArray();
-    if (arr == nullptr || arr->size() != 3)
-        return false;
+    if (arr == nullptr || arr->size() != 3) { return std::nullopt; }
 
     std::optional<double> x = (*arr)[0].getNumber();
     std::optional<double> y = (*arr)[1].getNumber();
     std::optional<double> z = (*arr)[2].getNumber();
 
-    if (!x.has_value() || !y.has_value() || !z.has_value())
-        return false;
-
-    val = Eigen::Vector3d(*x, *y, *z);
+    if (!x.has_value() || !y.has_value() || !z.has_value()) { return std::nullopt; }
 
     if (auto angleScale = astro::getAngleScale(v->getAngleUnit()); angleScale.has_value())
     {
-        val.head<2>() *= *angleScale;
+        *x *= *angleScale;
+        *y *= *angleScale;
     }
 
     if (auto lengthScale = astro::getLengthScale(v->getLengthUnit()); lengthScale.has_value())
     {
-        val[2] *= *lengthScale;
+        *z *= *lengthScale;
     }
 
-    return true;
-}
-
-
-/** @copydoc AssociativeArray::getSphericalTuple */
-bool AssociativeArray::getSphericalTuple(std::string_view key, Eigen::Vector3f& val) const
-{
-    Eigen::Vector3d vecVal;
-
-    if(!getSphericalTuple(key, vecVal))
-        return false;
-
-    val = vecVal.cast<float>();
-    return true;
+    return std::make_optional<Eigen::Vector3d>(*x, *y, *z);
 }

--- a/src/celengine/hash.h
+++ b/src/celengine/hash.h
@@ -10,77 +10,76 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <string>
-#include <celcompat/filesystem.h>
-#include <celmath/mathlib.h>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Core>
 #include <Eigen/Geometry>
+
+#include <celcompat/filesystem.h>
 
 
 class Color;
 class Value;
 
-using HashIterator = std::map<std::string, Value*>::const_iterator;
-
 class AssociativeArray
 {
  public:
+    using AssocType = std::map<std::string, std::size_t, std::less<>>;
+
     AssociativeArray() = default;
     ~AssociativeArray();
-    AssociativeArray(AssociativeArray&&) = default;
+    AssociativeArray(AssociativeArray&&);
     AssociativeArray(const AssociativeArray&) = delete;
-    AssociativeArray& operator=(AssociativeArray&&) = default;
+    AssociativeArray& operator=(AssociativeArray&&);
     AssociativeArray& operator=(AssociativeArray&) = delete;
 
-    const Value* getValue(const std::string&) const;
-    void addValue(const std::string&, Value&);
+    const Value* getValue(std::string_view) const;
+    void addValue(std::string&&, Value&&);
 
-    bool getNumber(const std::string&, double&) const;
-    bool getNumber(const std::string&, float&) const;
-    bool getNumber(const std::string&, int&) const;
-    bool getNumber(const std::string&, std::uint32_t&) const;
-    bool getString(const std::string&, std::string&) const;
-    bool getPath(const std::string&, fs::path&) const;
-    bool getBoolean(const std::string&, bool&) const;
-    bool getVector(const std::string&, Eigen::Vector3d&) const;
-    bool getVector(const std::string&, Eigen::Vector3f&) const;
-    bool getVector(const std::string&, Eigen::Vector4d&) const;
-    bool getVector(const std::string&, Eigen::Vector4f&) const;
-    bool getRotation(const std::string&, Eigen::Quaternionf&) const;
-    bool getColor(const std::string&, Color&) const;
-    bool getAngle(const std::string&, double&, double = 1.0, double = 0.0) const;
-    bool getAngle(const std::string&, float&, double = 1.0, double = 0.0) const;
-    bool getLength(const std::string&, double&, double = 1.0, double = 0.0) const;
-    bool getLength(const std::string&, float&, double = 1.0, double = 0.0) const;
-    bool getTime(const std::string&, double&, double = 1.0, double = 0.0) const;
-    bool getTime(const std::string&, float&, double = 1.0, double = 0.0) const;
-    bool getMass(const std::string&, double&, double = 1.0, double = 0.0) const;
-    bool getMass(const std::string&, float&, double = 1.0, double = 0.0) const;
-    bool getLengthVector(const std::string&, Eigen::Vector3d&, double = 1.0, double = 0.0) const;
-    bool getLengthVector(const std::string&, Eigen::Vector3f&, double = 1.0, double = 0.0) const;
-    bool getSphericalTuple(const std::string&, Eigen::Vector3d&) const;
-    bool getSphericalTuple(const std::string&, Eigen::Vector3f&) const;
-    bool getAngleScale(const std::string&, double&) const;
-    bool getAngleScale(const std::string&, float&) const;
-    bool getLengthScale(const std::string&, double&) const;
-    bool getLengthScale(const std::string&, float&) const;
-    bool getTimeScale(const std::string&, double&) const;
-    bool getTimeScale(const std::string&, float&) const;
-    bool getMassScale(const std::string&, double&) const;
-    bool getMassScale(const std::string&, float&) const;
+    bool getNumber(std::string_view, double&) const;
+    bool getNumber(std::string_view, float&) const;
+    bool getNumber(std::string_view, int&) const;
+    bool getNumber(std::string_view, std::uint32_t&) const;
+    bool getString(std::string_view, std::string&) const;
+    bool getPath(std::string_view, fs::path&) const;
+    bool getBoolean(std::string_view, bool&) const;
+    bool getVector(std::string_view, Eigen::Vector3d&) const;
+    bool getVector(std::string_view, Eigen::Vector3f&) const;
+    bool getVector(std::string_view, Eigen::Vector4d&) const;
+    bool getVector(std::string_view, Eigen::Vector4f&) const;
+    bool getRotation(std::string_view, Eigen::Quaternionf&) const;
+    bool getColor(std::string_view, Color&) const;
+    bool getAngle(std::string_view, double&, double = 1.0, double = 0.0) const;
+    bool getAngle(std::string_view, float&, double = 1.0, double = 0.0) const;
+    bool getLength(std::string_view, double&, double = 1.0, double = 0.0) const;
+    bool getLength(std::string_view, float&, double = 1.0, double = 0.0) const;
+    bool getTime(std::string_view, double&, double = 1.0, double = 0.0) const;
+    bool getTime(std::string_view, float&, double = 1.0, double = 0.0) const;
+    bool getMass(std::string_view, double&, double = 1.0, double = 0.0) const;
+    bool getMass(std::string_view, float&, double = 1.0, double = 0.0) const;
+    bool getLengthVector(std::string_view, Eigen::Vector3d&, double = 1.0, double = 0.0) const;
+    bool getLengthVector(std::string_view, Eigen::Vector3f&, double = 1.0, double = 0.0) const;
+    bool getSphericalTuple(std::string_view, Eigen::Vector3d&) const;
+    bool getSphericalTuple(std::string_view, Eigen::Vector3f&) const;
 
-    HashIterator begin() const
+    template<typename T>
+    void for_all(T action) const
     {
-        return assoc.begin();
-    }
-    HashIterator end() const
-    {
-        return assoc.end();
+        for (const auto& pair : assoc)
+        {
+            action(pair.first, values[pair.second]);
+        }
     }
 
  private:
-    std::map<std::string, Value*> assoc;
+    std::vector<Value> values;
+    AssocType assoc;
 };
 
 using Hash = AssociativeArray;

--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -67,21 +67,13 @@ LoadCelestiaMesh(const fs::path& filename)
         return nullptr;
     }
 
-    Value* meshDefValue = parser.readValue();
-    if (meshDefValue == nullptr)
+    const Value meshDefValue = parser.readValue();
+    const Hash* meshDef = meshDefValue.getHash();
+    if (meshDef == nullptr)
     {
         GetLogger()->error("{}: Bad mesh file.\n", filename);
         return nullptr;
     }
-
-    if (meshDefValue->getType() != Value::HashType)
-    {
-        GetLogger()->error("{}: Bad mesh file.\n", filename);
-        delete meshDefValue;
-        return nullptr;
-    }
-
-    const Hash* meshDef = meshDefValue->getHash();
 
     SphereMeshParameters params{};
 
@@ -98,8 +90,6 @@ LoadCelestiaMesh(const fs::path& filename)
     meshDef->getNumber("Octaves", params.octaves);
     meshDef->getNumber("Slices", params.slices);
     meshDef->getNumber("Rings", params.rings);
-
-    delete meshDefValue;
 
     auto model = std::make_unique<cmod::Model>();
     SphereMesh sphereMesh(params.size,

--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -77,19 +77,12 @@ LoadCelestiaMesh(const fs::path& filename)
 
     SphereMeshParameters params{};
 
-    params.size = Eigen::Vector3f::Ones();
-    params.offset = Eigen::Vector3f::Constant(10.0f);
-    params.featureHeight = 0.0f;
-    params.octaves = 1;
-    params.slices = 20;
-    params.rings = 20;
-
-    meshDef->getVector("Size", params.size);
-    meshDef->getVector("NoiseOffset", params.offset);
-    meshDef->getNumber("FeatureHeight", params.featureHeight);
-    meshDef->getNumber("Octaves", params.octaves);
-    meshDef->getNumber("Slices", params.slices);
-    meshDef->getNumber("Rings", params.rings);
+    params.size = meshDef->getVector3<float>("Size").value_or(Eigen::Vector3f::Ones());
+    params.offset = meshDef->getVector3<float>("NoiseOffset").value_or(Eigen::Vector3f::Constant(10.0f));
+    params.featureHeight = meshDef->getNumber<float>("FeatureHeight").value_or(0.0f);
+    params.octaves = meshDef->getNumber<float>("Octaves").value_or(1.0f);
+    params.slices = meshDef->getNumber<float>("Slices").value_or(20.0f);
+    params.rings = meshDef->getNumber<float>("Rings").value_or(20.0f);
 
     auto model = std::make_unique<cmod::Model>();
     SphereMesh sphereMesh(params.size,

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -68,10 +68,9 @@ bool Nebula::pick(const Eigen::ParametrizedLine<double, 3>& ray,
 
 bool Nebula::load(const AssociativeArray* params, const fs::path& resPath)
 {
-    string t;
-    if (params->getString("Mesh", t))
+    if (const std::string* t = params->getString("Mesh"); t != nullptr)
     {
-        fs::path geometryFileName(t);
+        fs::path geometryFileName(*t);
         ResourceHandle geometryHandle =
             GetGeometryManager()->getHandle(GeometryInfo(geometryFileName, resPath));
         setGeometry(geometryHandle);

--- a/src/celengine/parser.cpp
+++ b/src/celengine/parser.cpp
@@ -7,11 +7,113 @@
 // modify it under the terms of the GNU General Public License
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
+#include <map>
+#include <string_view>
 #include <utility>
+#include <variant>
 
 #include <celutil/tokenizer.h>
 #include "astro.h"
 #include "parser.h"
+
+using namespace std::string_view_literals;
+
+
+namespace
+{
+
+using MeasurementUnit = std::variant<std::monostate,
+                                     astro::LengthUnit,
+                                     astro::TimeUnit,
+                                     astro::AngleUnit,
+                                     astro::MassUnit>;
+
+class UnitsVisitor
+{
+public:
+    explicit UnitsVisitor(Value::Units* _units) : units(_units) {}
+
+    void operator()(std::monostate) const { /* nothing to update */ }
+    void operator()(astro::LengthUnit unit) const { units->length = unit; }
+    void operator()(astro::TimeUnit unit) const { units->time = unit; }
+    void operator()(astro::AngleUnit unit) const { units->angle = unit; }
+    void operator()(astro::MassUnit unit) const { units->mass = unit; }
+
+private:
+    Value::Units* units;
+};
+
+
+MeasurementUnit parseUnit(std::string_view name)
+{
+    static const std::map<std::string_view, MeasurementUnit>* unitMap = nullptr;
+
+    if (!unitMap)
+    {
+        unitMap = new std::map<std::string_view, MeasurementUnit>
+        {
+            { "km"sv, astro::LengthUnit::Kilometer },
+            { "m"sv, astro::LengthUnit::Meter },
+            { "rE"sv, astro::LengthUnit::EarthRadius },
+            { "rJ"sv, astro::LengthUnit::JupiterRadius },
+            { "rS"sv, astro::LengthUnit::SolarRadius },
+            { "AU"sv, astro::LengthUnit::AstronomicalUnit },
+            { "ly"sv, astro::LengthUnit::LightYear },
+            { "pc"sv, astro::LengthUnit::Parsec },
+            { "kpc"sv, astro::LengthUnit::Kiloparsec },
+            { "Mpc"sv, astro::LengthUnit::Megaparsec },
+
+            { "s"sv, astro::TimeUnit::Second },
+            { "min"sv, astro::TimeUnit::Minute },
+            { "h"sv, astro::TimeUnit::Hour },
+            { "d"sv, astro::TimeUnit::Day },
+            { "y"sv, astro::TimeUnit::JulianYear },
+
+            { "mas"sv, astro::AngleUnit::Milliarcsecond },
+            { "arcsec"sv, astro::AngleUnit::Arcsecond },
+            { "arcmin"sv, astro::AngleUnit::Arcminute },
+            { "deg"sv, astro::AngleUnit::Degree },
+            { "hRA"sv, astro::AngleUnit::Hour },
+            { "rad"sv, astro::AngleUnit::Radian },
+
+            { "kg"sv, astro::MassUnit::Kilogram },
+            { "mE"sv, astro::MassUnit::EarthMass },
+            { "mJ"sv, astro::MassUnit::JupiterMass },
+        };
+    }
+
+    auto it = unitMap->find(name);
+    return it == unitMap->end()
+        ? MeasurementUnit(std::in_place_type<std::monostate>)
+        : it->second;
+}
+
+
+Value::Units readUnits(Tokenizer& tokenizer)
+{
+    Value::Units units;
+
+    if (tokenizer.nextToken() != Tokenizer::TokenBeginUnits)
+    {
+        tokenizer.pushBack();
+        return units;
+    }
+
+    UnitsVisitor visitor(&units);
+
+    while (tokenizer.nextToken() != Tokenizer::TokenEndUnits)
+    {
+        auto tokenValue = tokenizer.getNameValue();
+        if (!tokenValue.has_value()) { continue; }
+
+        MeasurementUnit unit = parseUnit(*tokenValue);
+        std::visit(visitor, unit);
+    }
+
+    return units;
+}
+
+} // end unnamed namespace
 
 
 /****** Parser method implementation ******/
@@ -33,10 +135,10 @@ std::unique_ptr<ValueArray> Parser::readArray()
 
     auto array = std::make_unique<ValueArray>();
 
-    Value* v = readValue();
-    while (v != nullptr)
+    Value v = readValue();
+    while (!v.isNull())
     {
-        array->push_back(v);
+        array->push_back(std::move(v));
         v = readValue();
     }
 
@@ -76,21 +178,16 @@ std::unique_ptr<Hash> Parser::readHash()
             return nullptr;
         }
 
-#ifndef USE_POSTFIX_UNITS
-        readUnits(name, hash.get());
-#endif
+        Value::Units units = readUnits(*tokenizer);
 
-        Value* value = readValue();
-        if (value == nullptr)
+        Value value = readValue();
+        if (value.isNull())
         {
             return nullptr;
         }
 
-        hash->addValue(name, *value);
-
-#ifdef USE_POSTFIX_UNITS
-        readUnits(name, hash);
-#endif
+        value.setUnits(units);
+        hash->addValue(std::move(name), std::move(value));
 
         tok = tokenizer->nextToken();
     }
@@ -99,90 +196,26 @@ std::unique_ptr<Hash> Parser::readHash()
 }
 
 
-/**
- * Reads a units section into the hash.
- * @param[in] propertyName Name of the current property.
- * @param[in] hash Hash to add units quantities into.
- * @return True if a units section was successfully read, false otherwise.
- */
-bool Parser::readUnits(const std::string& propertyName, Hash* hash)
-{
-    Tokenizer::TokenType tok = tokenizer->nextToken();
-    if (tok != Tokenizer::TokenBeginUnits)
-    {
-        tokenizer->pushBack();
-        return false;
-    }
-
-    tok = tokenizer->nextToken();
-    while (tok != Tokenizer::TokenEndUnits)
-    {
-        std::string_view unit;
-        if (auto tokenValue = tokenizer->getNameValue(); tokenValue.has_value())
-        {
-            unit = *tokenValue;
-        }
-        else
-        {
-            tokenizer->pushBack();
-            return false;
-        }
-
-        Value* value = new Value(unit);
-
-        if (astro::isLengthUnit(unit))
-        {
-            std::string keyName(propertyName + "%Length");
-            hash->addValue(keyName, *value);
-        }
-        else if (astro::isTimeUnit(unit))
-        {
-            std::string keyName(propertyName + "%Time");
-            hash->addValue(keyName, *value);
-        }
-        else if (astro::isAngleUnit(unit))
-        {
-            std::string keyName(propertyName + "%Angle");
-            hash->addValue(keyName, *value);
-        }
-        else if (astro::isMassUnit(unit))
-        {
-            std::string keyName(propertyName + "%Mass");
-            hash->addValue(keyName, *value);
-        }
-        else
-        {
-            delete value;
-            return false;
-        }
-
-        tok = tokenizer->nextToken();
-    }
-
-    return true;
-}
-
-
-Value* Parser::readValue()
+Value Parser::readValue()
 {
     Tokenizer::TokenType tok = tokenizer->nextToken();
     switch (tok)
     {
     case Tokenizer::TokenNumber:
-        return new Value(*tokenizer->getNumberValue());
+        return Value(*tokenizer->getNumberValue());
 
     case Tokenizer::TokenString:
-        return new Value(*tokenizer->getStringValue());
+        return Value(*tokenizer->getStringValue());
 
     case Tokenizer::TokenName:
         if (tokenizer->getNameValue() == "false")
-            return new Value(false);
+            return Value(false);
         else if (tokenizer->getNameValue() == "true")
-            return new Value(true);
+            return Value(true);
         else
         {
             tokenizer->pushBack();
-            return nullptr;
+            return Value();
         }
 
     case Tokenizer::TokenBeginArray:
@@ -190,9 +223,9 @@ Value* Parser::readValue()
         {
             std::unique_ptr<ValueArray> array = readArray();
             if (array == nullptr)
-                return nullptr;
+                return Value();
             else
-                return new Value(std::move(array));
+                return Value(std::move(array));
         }
 
     case Tokenizer::TokenBeginGroup:
@@ -200,13 +233,13 @@ Value* Parser::readValue()
         {
             std::unique_ptr<Hash> hash = readHash();
             if (hash == nullptr)
-                return nullptr;
+                return Value();
             else
-                return new Value(std::move(hash));
+                return Value(std::move(hash));
         }
 
     default:
         tokenizer->pushBack();
-        return nullptr;
+        return Value();
     }
 }

--- a/src/celengine/parser.h
+++ b/src/celengine/parser.h
@@ -11,7 +11,6 @@
 #pragma once
 
 #include <memory>
-#include <string>
 
 #include "hash.h"
 #include "value.h"
@@ -24,12 +23,11 @@ class Parser
  public:
     Parser(Tokenizer*);
 
-    Value* readValue();
+    Value readValue();
 
  private:
     Tokenizer* tokenizer;
 
-    bool readUnits(const std::string&, Hash*);
     std::unique_ptr<ValueArray> readArray();
     std::unique_ptr<Hash> readHash();
 };

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4510,11 +4510,11 @@ void Renderer::labelConstellations(const AsterismList& asterisms,
 {
     Vector3f observerPos = observer.getPosition().toLy().cast<float>();
 
-    for (auto ast : asterisms)
+    for (const auto& ast : asterisms)
     {
-        if (ast->getChainCount() > 0 && ast->getActive())
+        if (ast.getChainCount() > 0 && ast.getActive())
         {
-            const Asterism::Chain& chain = ast->getChain(0);
+            const Asterism::Chain& chain = ast.getChain(0);
 
             if (!chain.empty())
             {
@@ -4551,11 +4551,11 @@ void Renderer::labelConstellations(const AsterismList& asterisms,
                     // Use the default label color unless the constellation has an
                     // override color set.
                     Color labelColor = ConstellationLabelColor;
-                    if (ast->isColorOverridden())
-                        labelColor = ast->getOverrideColor();
+                    if (ast.isColorOverridden())
+                        labelColor = ast.getOverrideColor();
 
                     addBackgroundAnnotation(nullptr,
-                                            ast->getName((labelMode & I18nConstellationLabels) != 0),
+                                            ast.getName((labelMode & I18nConstellationLabels) != 0),
                                             Color(labelColor, opacity),
                                             rpos,
                                             AlignCenter, VerticalAlignCenter);

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -1393,20 +1393,13 @@ bool StarDatabase::load(std::istream& in, const fs::path& resourcePath)
 
         tokenizer.pushBack();
 
-        Value* starDataValue = parser.readValue();
-        if (starDataValue == nullptr)
-        {
-            GetLogger()->error("Error reading star at line {}.\n", tokenizer.getLineNumber());
-            return false;
-        }
-
-        if (starDataValue->getType() != Value::HashType)
+        const Value starDataValue = parser.readValue();
+        const Hash* starData = starDataValue.getHash();
+        if (starData == nullptr)
         {
             GetLogger()->error("Bad star definition at line {}.\n", tokenizer.getLineNumber());
-            delete starDataValue;
             return false;
         }
-        const Hash* starData = starDataValue->getHash();
 
         if (isNewStar)
             star = new Star();
@@ -1421,7 +1414,6 @@ bool StarDatabase::load(std::istream& in, const fs::path& resourcePath)
             ok = createStar(star, disposition, catalogNumber, starData, resourcePath, !isStar);
             star->loadCategories(starData, disposition, resourcePath.string());
         }
-        delete starDataValue;
 
         if (ok)
         {

--- a/src/celengine/value.cpp
+++ b/src/celengine/value.cpp
@@ -12,22 +12,54 @@
 
 /****** Value method implementations *******/
 
+Value::Value(Value&& other) noexcept
+    : type(other.type),
+      units(other.units),
+      data(other.data)
+{
+    other.type = ValueType::NullType;
+}
+
+
+Value& Value::operator=(Value&& other) noexcept
+{
+    if (this != &other)
+    {
+        switch (type)
+        {
+        case ValueType::StringType:
+            delete data.s;
+            break;
+        case ValueType::ArrayType:
+            delete data.a;
+            break;
+        case ValueType::HashType:
+            delete data.h;
+            break;
+        default:
+            break;
+        }
+        type = other.type;
+        units = other.units;
+        data = other.data;
+        other.type = ValueType::NullType;
+    }
+
+    return *this;
+}
+
+
 Value::~Value()
 {
     switch (type)
     {
-    case StringType:
+    case ValueType::StringType:
         delete data.s;
         break;
-    case ArrayType:
-        if (data.a != nullptr)
-        {
-            for (auto *p : *data.a)
-                delete p;
-            delete data.a;
-        }
+    case ValueType::ArrayType:
+        delete data.a;
         break;
-    case HashType:
+    case ValueType::HashType:
         delete data.h;
         break;
     default:

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -375,18 +375,15 @@ static VirtualTexture* LoadVirtualTexture(istream& in, const fs::path& path)
         return nullptr;
     }
 
-    Value* texParamsValue = parser.readValue();
-    if (texParamsValue == nullptr || texParamsValue->getType() != Value::HashType)
+    const Value texParamsValue = parser.readValue();
+    const Hash* texParams = texParamsValue.getHash();
+    if (texParams == nullptr)
     {
         GetLogger()->error("Error parsing virtual texture\n");
-        delete texParamsValue;
         return nullptr;
     }
 
-    const Hash* texParams = texParamsValue->getHash();
-
     VirtualTexture* virtualTex  = CreateVirtualTexture(texParams, path);
-    delete texParamsValue;
 
     return virtualTex;
 }

--- a/src/celephem/scriptobject.cpp
+++ b/src/celephem/scriptobject.cpp
@@ -99,31 +99,31 @@ SafeGetLuaNumber(lua_State* state,
 void
 SetLuaVariables(lua_State* state, const Hash* parameters)
 {
-    for (const auto& param : *parameters)
+    parameters->for_all([state](const std::string& key, const Value& value)
     {
-        std::size_t percentPos = param.first.find('%');
+        std::size_t percentPos = key.find('%');
         if (percentPos == std::string::npos)
         {
-            switch (param.second->getType())
+            switch (value.getType())
             {
-            case Value::NumberType:
-                lua_pushstring(state, param.first.c_str());
-                lua_pushnumber(state, param.second->getNumber());
+            case ValueType::NumberType:
+                lua_pushstring(state, key.c_str());
+                lua_pushnumber(state, *value.getNumber());
                 lua_settable(state, -3);
                 break;
-            case Value::StringType:
-                lua_pushstring(state, param.first.c_str());
-                lua_pushstring(state, param.second->getString().c_str());
+            case ValueType::StringType:
+                lua_pushstring(state, key.c_str());
+                lua_pushstring(state, value.getString()->c_str());
                 lua_settable(state, -3);
                 break;
-            case Value::BooleanType:
-                lua_pushstring(state, param.first.c_str());
-                lua_pushboolean(state, param.second->getBoolean());
+            case ValueType::BooleanType:
+                lua_pushstring(state, key.c_str());
+                lua_pushboolean(state, *value.getBoolean());
                 lua_settable(state, -3);
                 break;
             default:
                 break;
             }
         }
-    }
+    });
 }

--- a/src/celephem/scriptorbit.cpp
+++ b/src/celephem/scriptorbit.cpp
@@ -43,7 +43,7 @@ using celestia::util::GetLogger;
  *         z coordinates. Units for the position are kilometers.
  */
 bool
-ScriptedOrbit::initialize(const std::string& moduleName,
+ScriptedOrbit::initialize(const std::string* moduleName,
                           const std::string& funcName,
                           const Hash* parameters,
                           const fs::path& path)
@@ -58,7 +58,7 @@ ScriptedOrbit::initialize(const std::string& moduleName,
         return false;
     }
 
-    if (!moduleName.empty())
+    if (moduleName != nullptr && !moduleName->empty())
     {
         lua_getglobal(luaState, "require");
         if (!lua_isfunction(luaState, -1))
@@ -68,7 +68,7 @@ ScriptedOrbit::initialize(const std::string& moduleName,
             return false;
         }
 
-        lua_pushstring(luaState, moduleName.c_str());
+        lua_pushstring(luaState, moduleName->c_str());
         if (lua_pcall(luaState, 1, 1, 0) != 0)
         {
             GetLogger()->error("Failed to load module for ScriptedOrbit: {}\n", lua_tostring(luaState, -1));

--- a/src/celephem/scriptorbit.h
+++ b/src/celephem/scriptorbit.h
@@ -23,7 +23,7 @@ class ScriptedOrbit : public CachingOrbit
     ScriptedOrbit() = default;
     ~ScriptedOrbit() = default;
 
-    bool initialize(const std::string& moduleName,
+    bool initialize(const std::string* moduleName,
                     const std::string& funcName,
                     const Hash* parameters,
                     const fs::path& path);

--- a/src/celephem/scriptrotation.cpp
+++ b/src/celephem/scriptrotation.cpp
@@ -41,7 +41,7 @@ using celestia::util::GetLogger;
  *         quaternion (w, x, y, z).
  */
 bool
-ScriptedRotation::initialize(const std::string& moduleName,
+ScriptedRotation::initialize(const std::string* moduleName,
                              const std::string& funcName,
                              const Hash* parameters,
                              const fs::path& path)
@@ -56,7 +56,7 @@ ScriptedRotation::initialize(const std::string& moduleName,
         return false;
     }
 
-    if (!moduleName.empty())
+    if (moduleName != nullptr && !moduleName->empty())
     {
         lua_getglobal(luaState, "require");
         if (!lua_isfunction(luaState, -1))
@@ -66,7 +66,7 @@ ScriptedRotation::initialize(const std::string& moduleName,
             return false;
         }
 
-        lua_pushstring(luaState, moduleName.c_str());
+        lua_pushstring(luaState, moduleName->c_str());
         if (lua_pcall(luaState, 1, 1, 0) != 0)
         {
             GetLogger()->error("Failed to load module for ScriptedRotation: {}\n", lua_tostring(luaState, -1));

--- a/src/celephem/scriptrotation.h
+++ b/src/celephem/scriptrotation.h
@@ -23,7 +23,7 @@ class ScriptedRotation : public RotationModel
     ScriptedRotation() = default;
     ~ScriptedRotation() = default;
 
-    bool initialize(const std::string& moduleName,
+    bool initialize(const std::string* moduleName,
                     const std::string& funcName,
                     const Hash* parameters,
                     const fs::path& path);

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -20,17 +20,6 @@
 using namespace std;
 using namespace celestia::util;
 
-static unsigned int getUint(const Hash* params,
-                            const string& paramName,
-                            unsigned int defaultValue)
-{
-    double value = 0.0;
-    if (params->getNumber(paramName, value))
-        return (unsigned int) value;
-
-    return defaultValue;
-}
-
 
 CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *config)
 {
@@ -65,68 +54,85 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
 
 #ifdef CELX
     config->configParams = configParams;
-    configParams->getPath("LuaHook", config->luaHook);
+    if (auto path = configParams->getPath("LuaHook"); path.has_value())
+        config->luaHook = *path;
 #endif
 
-    config->faintestVisible = 6.0f;
-    configParams->getNumber("FaintestVisibleMagnitude", config->faintestVisible);
-    configParams->getPath("FavoritesFile", config->favoritesFile);
-    configParams->getPath("DestinationFile", config->destinationsFile);
-    configParams->getPath("InitScript", config->initScriptFile);
-    configParams->getPath("DemoScript", config->demoScriptFile);
-    configParams->getPath("AsterismsFile", config->asterismsFile);
-    configParams->getPath("BoundariesFile", config->boundariesFile);
-    configParams->getPath("StarDatabase", config->starDatabaseFile);
-    configParams->getPath("StarNameDatabase", config->starNamesFile);
-    configParams->getPath("HDCrossIndex", config->HDCrossIndexFile);
-    configParams->getPath("SAOCrossIndex", config->SAOCrossIndexFile);
-    configParams->getPath("GlieseCrossIndex", config->GlieseCrossIndexFile);
-    configParams->getPath("LeapSecondsFile", config->leapSecondsFile);
-    configParams->getString("Font", config->mainFont);
-    configParams->getString("LabelFont", config->labelFont);
-    configParams->getString("TitleFont", config->titleFont);
-    configParams->getPath("LogoTexture", config->logoTextureFile);
-    configParams->getString("Cursor", config->cursor);
-    configParams->getString("ProjectionMode", config->projectionMode);
-    configParams->getString("ViewportEffect", config->viewportEffect);
-    configParams->getString("WarpMeshFile", config->warpMeshFile);
-    configParams->getString("X264EncoderOptions", config->x264EncoderOptions);
-    configParams->getString("FFVHEncoderOptions", config->ffvhEncoderOptions);
-    configParams->getString("MeasurementSystem", config->measurementSystem);
-    configParams->getString("TemperatureScale", config->temperatureScale);
+    config->faintestVisible = configParams->getNumber<float>("FaintestVisibleMagnitude").value_or(6.0f);
+    if (auto path = configParams->getPath("FavoritesFile"); path.has_value())
+        config->favoritesFile = *path;
+    if (auto path = configParams->getPath("DestinationFile"); path.has_value())
+        config->destinationsFile = *path;
+    if (auto path = configParams->getPath("InitScript"); path.has_value())
+        config->initScriptFile = *path;
+    if (auto path = configParams->getPath("DemoScript"); path.has_value())
+        config->demoScriptFile = *path;
+    if (auto path = configParams->getPath("AsterismsFile"); path.has_value())
+        config->asterismsFile = *path;
+    if (auto path = configParams->getPath("BoundariesFile"); path.has_value())
+        config->boundariesFile = *path;
+    if (auto path = configParams->getPath("StarDatabase"); path.has_value())
+        config->starDatabaseFile = *path;
+    if (auto path = configParams->getPath("StarNameDatabase"); path.has_value())
+        config->starNamesFile = *path;
+    if (auto path = configParams->getPath("HDCrossIndex"); path.has_value())
+        config->HDCrossIndexFile = *path;
+    if (auto path = configParams->getPath("SAOCrossIndex"); path.has_value())
+        config->SAOCrossIndexFile = *path;
+    if (auto path = configParams->getPath("GlieseCrossIndex"); path.has_value())
+        config->GlieseCrossIndexFile = *path;
+    if (auto path = configParams->getPath("LeapSecondsFile"); path.has_value())
+        config->leapSecondsFile = *path;
+    if (const std::string* font = configParams->getString("Font"); font != nullptr)
+        config->mainFont = *font;
+    if (const std::string* labelFont = configParams->getString("LabelFont"); labelFont != nullptr)
+        config->labelFont = *labelFont;
+    if (const std::string* titleFont = configParams->getString("TitleFont"); titleFont != nullptr)
+        config->titleFont = *titleFont;
+    if (const std::string* logoTextureFile = configParams->getString("LogoTexture"); logoTextureFile != nullptr)
+        config->logoTextureFile = *logoTextureFile;
+    if (const std::string* cursor = configParams->getString("Cursor"); cursor != nullptr)
+        config->cursor = *cursor;
+    if (const std::string* projectionMode = configParams->getString("ProjectionMode"); projectionMode != nullptr)
+        config->projectionMode = *projectionMode;
+    if (const std::string* viewportEffect = configParams->getString("ViewportEffect"); viewportEffect != nullptr)
+        config->viewportEffect = *viewportEffect;
+    if (const std::string* warpMeshFile = configParams->getString("WarpMeshFile"); warpMeshFile != nullptr)
+        config->warpMeshFile = *warpMeshFile;
+    if (const std::string* x264EncoderOptions = configParams->getString("X264EncoderOptions"); x264EncoderOptions != nullptr)
+        config->x264EncoderOptions = *x264EncoderOptions;
+    if (const std::string* ffvhEncoderOptions = configParams->getString("FFVHEncoderOptions"); ffvhEncoderOptions != nullptr)
+        config->ffvhEncoderOptions = *ffvhEncoderOptions;
+    if (const std::string* measurementSystem = configParams->getString("MeasurementSystem"); measurementSystem != nullptr)
+        config->measurementSystem = *measurementSystem;
+    if (const std::string* temperatureScale = configParams->getString("TemperatureScale"); temperatureScale != nullptr)
+        config->temperatureScale = *temperatureScale;
 
-    float maxDist = 1.0;
-    configParams->getNumber("SolarSystemMaxDistance", maxDist);
-    config->SolarSystemMaxDistance = min(max(maxDist, 1.0f), 10.0f);
+    auto maxDist = configParams->getNumber<float>("SolarSystemMaxDistance").value_or(1.0f);
+    config->SolarSystemMaxDistance = std::clamp(maxDist, 1.0f, 10.0f);
 
-    config->ShadowMapSize = getUint(configParams, "ShadowMapSize", 0);
+    config->ShadowMapSize = configParams->getNumber<unsigned int>("ShadowMapSize").value_or(0u);
 
-    double aaSamples = 1;
-    configParams->getNumber("AntialiasingSamples", aaSamples);
-    config->aaSamples = (unsigned int) aaSamples;
+    config->aaSamples = configParams->getNumber<unsigned int>("AntialiasingSamples").value_or(1u);
 
-    config->rotateAcceleration = 120.0f;
-    configParams->getNumber("RotateAcceleration", config->rotateAcceleration);
-    config->mouseRotationSensitivity = 1.0f;
-    configParams->getNumber("MouseRotationSensitivity", config->mouseRotationSensitivity);
-    config->reverseMouseWheel = false;
-    configParams->getBoolean("ReverseMouseWheel", config->reverseMouseWheel);
-    configParams->getPath("ScriptScreenshotDirectory", config->scriptScreenshotDirectory);
+    config->rotateAcceleration = configParams->getNumber<float>("RotateAcceleration").value_or(120.0f);
+    config->mouseRotationSensitivity = configParams->getNumber<float>("MouseRotationSensitivity").value_or(1.0f);
+    config->reverseMouseWheel = configParams->getBoolean("ReverseMouseWheel").value_or(false);
+    if (auto path = configParams->getPath("ScriptScreenshotDirectory"); path.has_value())
+        config->scriptScreenshotDirectory = *path;
     config->scriptSystemAccessPolicy = "ask";
-    configParams->getString("ScriptSystemAccessPolicy", config->scriptSystemAccessPolicy);
+    if (const std::string* scriptSystemAccessPolicy = configParams->getString("ScriptSystemAccessPolicy"); scriptSystemAccessPolicy != nullptr)
+        config->scriptSystemAccessPolicy = *scriptSystemAccessPolicy;
 
-    config->orbitWindowEnd = 0.5f;
-    configParams->getNumber("OrbitWindowEnd", config->orbitWindowEnd);
-    config->orbitPeriodsShown = 1.0f;
-    configParams->getNumber("OrbitPeriodsShown", config->orbitPeriodsShown);
-    config->linearFadeFraction = 0.0f;
-    configParams->getNumber("LinearFadeFraction", config->linearFadeFraction);
+    config->orbitWindowEnd = configParams->getNumber<float>("OrbitWindowEnd").value_or(0.5f);
+    config->orbitPeriodsShown = configParams->getNumber<float>("OrbitPeriodsShown").value_or(1.0f);
+    config->linearFadeFraction = configParams->getNumber<float>("LinearFadeFraction").value_or(0.0f);
 
-    config->orbitPathSamplePoints = getUint(configParams, "OrbitPathSamplePoints", 100);
-    config->shadowTextureSize = getUint(configParams, "ShadowTextureSize", 256);
-    config->eclipseTextureSize = getUint(configParams, "EclipseTextureSize", 128);
+    config->orbitPathSamplePoints = configParams->getNumber<unsigned int>("OrbitPathSamplePoints").value_or(100u);
+    config->shadowTextureSize = configParams->getNumber<unsigned int>("ShadowTextureSize").value_or(256u);
+    config->eclipseTextureSize = configParams->getNumber<unsigned int>("EclipseTextureSize").value_or(128u);
 
-    config->consoleLogRows = getUint(configParams, "LogSize", 200);
+    config->consoleLogRows = configParams->getNumber<unsigned int>("LogSize").value_or(200u);
 
     if (const Value* solarSystemsVal = configParams->getValue("SolarSystemCatalogs"); solarSystemsVal != nullptr)
     {
@@ -277,41 +283,54 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         else
         {
             string starTexNames[StellarClass::Spectral_Count];
-            starTexTable->getString("O", starTexNames[StellarClass::Spectral_O]);
-            starTexTable->getString("B", starTexNames[StellarClass::Spectral_B]);
-            starTexTable->getString("A", starTexNames[StellarClass::Spectral_A]);
-            starTexTable->getString("F", starTexNames[StellarClass::Spectral_F]);
-            starTexTable->getString("G", starTexNames[StellarClass::Spectral_G]);
-            starTexTable->getString("K", starTexNames[StellarClass::Spectral_K]);
-            starTexTable->getString("M", starTexNames[StellarClass::Spectral_M]);
-            starTexTable->getString("R", starTexNames[StellarClass::Spectral_R]);
-            starTexTable->getString("S", starTexNames[StellarClass::Spectral_S]);
-            starTexTable->getString("N", starTexNames[StellarClass::Spectral_N]);
-            starTexTable->getString("WC", starTexNames[StellarClass::Spectral_WC]);
-            starTexTable->getString("WN", starTexNames[StellarClass::Spectral_WN]);
-            starTexTable->getString("WO", starTexNames[StellarClass::Spectral_WO]);
-            starTexTable->getString("Unknown", starTexNames[StellarClass::Spectral_Unknown]);
-            starTexTable->getString("L", starTexNames[StellarClass::Spectral_L]);
-            starTexTable->getString("T", starTexNames[StellarClass::Spectral_T]);
-            starTexTable->getString("Y", starTexNames[StellarClass::Spectral_Y]);
-            starTexTable->getString("C", starTexNames[StellarClass::Spectral_C]);
+            if (const std::string* texName = starTexTable->getString("O"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_O] = *texName;
+            if (const std::string* texName = starTexTable->getString("B"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_B] = *texName;
+            if (const std::string* texName = starTexTable->getString("A"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_A] = *texName;
+            if (const std::string* texName = starTexTable->getString("F"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_F] = *texName;
+            if (const std::string* texName = starTexTable->getString("G"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_G] = *texName;
+            if (const std::string* texName = starTexTable->getString("K"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_K] = *texName;
+            if (const std::string* texName = starTexTable->getString("M"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_M] = *texName;
+            if (const std::string* texName = starTexTable->getString("R"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_R] = *texName;
+            if (const std::string* texName = starTexTable->getString("S"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_S] = *texName;
+            if (const std::string* texName = starTexTable->getString("N"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_N] = *texName;
+            if (const std::string* texName = starTexTable->getString("WC"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_WC] = *texName;
+            if (const std::string* texName = starTexTable->getString("WN"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_WN] = *texName;
+            if (const std::string* texName = starTexTable->getString("WO"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_WO] = *texName;
+            if (const std::string* texName = starTexTable->getString("Unknown"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_Unknown] = *texName;
+            if (const std::string* texName = starTexTable->getString("L"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_L] = *texName;
+            if (const std::string* texName = starTexTable->getString("T"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_T] = *texName;
+            if (const std::string* texName = starTexTable->getString("Y"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_Y] = *texName;
+            if (const std::string* texName = starTexTable->getString("C"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_C] = *texName;
 
             // One texture for all white dwarf types; not sure if this needs to be
             // changed. White dwarfs vary widely in temperature, so texture choice
             // should probably be based on that instead of spectral type.
-            starTexTable->getString("WD", starTexNames[StellarClass::Spectral_D]);
+            if (const std::string* texName = starTexTable->getString("WD"); texName != nullptr)
+                starTexNames[StellarClass::Spectral_D] = *texName;
 
-            string neutronStarTexName;
-            if (starTexTable->getString("NeutronStar", neutronStarTexName))
-            {
-                config->starTextures.neutronStarTex.setTexture(neutronStarTexName, "textures");
-            }
+            if (const std::string* texName = starTexTable->getString("NeutronStar"); texName != nullptr)
+                config->starTextures.neutronStarTex.setTexture(*texName, "textures");
 
-            string defaultTexName;
-            if (starTexTable->getString("Default", defaultTexName))
-            {
-                config->starTextures.defaultTex.setTexture(defaultTexName, "textures");
-            }
+            if (const std::string* texName = starTexTable->getString("Default"); texName != nullptr)
+                config->starTextures.defaultTex.setTexture(*texName, "textures");
 
             for (unsigned int i = 0; i < (unsigned int) StellarClass::Spectral_Count; i++)
             {
@@ -331,16 +350,4 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
 #endif
 
     return config;
-}
-
-
-float
-CelestiaConfig::getFloatValue(const string& name)
-{
-    assert(params != nullptr);
-
-    double x = 0.0;
-    params->getNumber(name, x);
-
-    return (float) x;
 }

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -52,14 +52,13 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         return config;
     }
 
-    Value* configParamsValue = parser.readValue();
-    if (configParamsValue == nullptr || configParamsValue->getType() != Value::HashType)
+    const Value configParamsValue = parser.readValue();
+    const Hash* configParams = configParamsValue.getHash();
+    if (configParams == nullptr)
     {
         GetLogger()->error("{}: Bad configuration file.\n", filename);
         return config;
     }
-
-    const Hash* configParams = configParamsValue->getHash();
 
     if (config == nullptr)
         config = new CelestiaConfig();
@@ -129,112 +128,91 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
 
     config->consoleLogRows = getUint(configParams, "LogSize", 200);
 
-    const Value* solarSystemsVal = configParams->getValue("SolarSystemCatalogs");
-    if (solarSystemsVal != nullptr)
+    if (const Value* solarSystemsVal = configParams->getValue("SolarSystemCatalogs"); solarSystemsVal != nullptr)
     {
-        if (solarSystemsVal->getType() != Value::ArrayType)
+        if (const ValueArray* solarSystems = solarSystemsVal->getArray(); solarSystems == nullptr)
         {
             GetLogger()->error("{}: SolarSystemCatalogs must be an array.\n", filename);
         }
         else
         {
-            const ValueArray* solarSystems = solarSystemsVal->getArray();
-            // assert(solarSystems != nullptr);
-
-            for (const auto catalogNameVal : *solarSystems)
+            for (const auto& catalogNameVal : *solarSystems)
             {
-                // assert(catalogNameVal != nullptr);
-                if (catalogNameVal->getType() == Value::StringType)
-                {
-                    config->solarSystemFiles.push_back(PathExp(catalogNameVal->getString()));
-                }
-                else
+                const std::string* catalogName = catalogNameVal.getString();
+                if (catalogName == nullptr)
                 {
                     GetLogger()->error("{}: Solar system catalog name must be a string.\n", filename);
+                    continue;
                 }
+
+                config->solarSystemFiles.push_back(PathExp(*catalogName));
             }
         }
     }
 
-    const Value* starCatalogsVal = configParams->getValue("StarCatalogs");
-    if (starCatalogsVal != nullptr)
+    if (const Value* starCatalogsVal = configParams->getValue("StarCatalogs"); starCatalogsVal != nullptr)
     {
-        if (starCatalogsVal->getType() != Value::ArrayType)
+        if (const ValueArray* starCatalogs = starCatalogsVal->getArray(); starCatalogs == nullptr)
         {
             GetLogger()->error("{}: StarCatalogs must be an array.\n", filename);
         }
         else
         {
-            const ValueArray* starCatalogs = starCatalogsVal->getArray();
-            assert(starCatalogs != nullptr);
-
-            for (const auto catalogNameVal : *starCatalogs)
+            for (const auto& catalogNameVal : *starCatalogs)
             {
-                assert(catalogNameVal != nullptr);
-
-                if (catalogNameVal->getType() == Value::StringType)
-                {
-                    config->starCatalogFiles.push_back(PathExp(catalogNameVal->getString()));
-                }
-                else
+                const std::string* catalogName = catalogNameVal.getString();
+                if (catalogName == nullptr)
                 {
                     GetLogger()->error("{}: Star catalog name must be a string.\n", filename);
+                    continue;
                 }
+
+                config->starCatalogFiles.push_back(PathExp(*catalogName));
             }
         }
     }
 
-    const Value* dsoCatalogsVal = configParams->getValue("DeepSkyCatalogs");
-    if (dsoCatalogsVal != nullptr)
+    if (const Value* dsoCatalogsVal = configParams->getValue("DeepSkyCatalogs"); dsoCatalogsVal != nullptr)
     {
-        if (dsoCatalogsVal->getType() != Value::ArrayType)
+        if (const ValueArray* dsoCatalogs = dsoCatalogsVal->getArray(); dsoCatalogs == nullptr)
         {
             GetLogger()->error("{}: DeepSkyCatalogs must be an array.\n", filename);
         }
         else
         {
-            const ValueArray* dsoCatalogs = dsoCatalogsVal->getArray();
-            assert(dsoCatalogs != nullptr);
-
-            for (const auto catalogNameVal : *dsoCatalogs)
+            for (const auto& catalogNameVal : *dsoCatalogs)
             {
-                assert(catalogNameVal != nullptr);
-
-                if (catalogNameVal->getType() == Value::StringType)
-                {
-                    config->dsoCatalogFiles.push_back(PathExp(catalogNameVal->getString()));
-                }
-                else
+                const std::string* catalogName = catalogNameVal.getString();
+                if (catalogName == nullptr)
                 {
                     GetLogger()->error("{}: DeepSky catalog name must be a string.\n", filename);
+                    continue;
                 }
+
+                config->dsoCatalogFiles.push_back(PathExp(*catalogName));
             }
         }
     }
 
-    const Value* extrasDirsVal = configParams->getValue("ExtrasDirectories");
-    if (extrasDirsVal != nullptr)
+    if (const Value* extrasDirsVal = configParams->getValue("ExtrasDirectories"); extrasDirsVal != nullptr)
     {
-        if (extrasDirsVal->getType() == Value::ArrayType)
+        if (const ValueArray* extrasDirs = extrasDirsVal->getArray(); extrasDirs != nullptr)
         {
-            const ValueArray* extrasDirs = extrasDirsVal->getArray();
-            assert(extrasDirs != nullptr);
-
-            for (const auto dirNameVal : *extrasDirs)
+            for (const auto& dirNameVal : *extrasDirs)
             {
-                if (dirNameVal->getType() == Value::StringType)
-                {
-                    config->extrasDirs.push_back(PathExp(dirNameVal->getString()));
-                }
-                else
+                const std::string* dirName = dirNameVal.getString();
+                if (dirName == nullptr)
                 {
                     GetLogger()->error("{}: Extras directory name must be a string.\n", filename);
+                    continue;
                 }
+
+                config->extrasDirs.push_back(PathExp(*dirName));
             }
         }
-        else if (extrasDirsVal->getType() == Value::StringType)
+        else if (const std::string* dirName = extrasDirsVal->getString(); dirName != nullptr)
         {
-            config->extrasDirs.push_back(PathExp(extrasDirsVal->getString()));
+            config->extrasDirs.push_back(PathExp(*dirName));
         }
         else
         {
@@ -242,29 +220,25 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
     }
 
-    const Value* skipExtrasVal = configParams->getValue("SkipExtras");
-    if (skipExtrasVal != nullptr)
+    if (const Value* skipExtrasVal = configParams->getValue("SkipExtras"); skipExtrasVal != nullptr)
     {
-        if (skipExtrasVal->getType() == Value::ArrayType)
+        if (const ValueArray* skipExtras = skipExtrasVal->getArray(); skipExtras != nullptr)
         {
-            const ValueArray* skipExtras = skipExtrasVal->getArray();
-            assert(skipExtras != nullptr);
-
-            for (const auto fileNameVal : *skipExtras)
+            for (const auto& fileNameVal : *skipExtras)
             {
-                if (fileNameVal->getType() == Value::StringType)
-                {
-                    config->skipExtras.push_back(PathExp(fileNameVal->getString()));
-                }
-                else
+                const std::string* fileName = fileNameVal.getString();
+                if (fileName == nullptr)
                 {
                     GetLogger()->error("{}: Skipped file name must be a string.\n", filename);
+                    continue;
                 }
+
+                config->skipExtras.push_back(PathExp(*fileName));
             }
         }
-        else if (skipExtrasVal->getType() == Value::StringType)
+        else if (const std::string* fileName = skipExtrasVal->getString(); fileName != nullptr)
         {
-            config->skipExtras.push_back(PathExp(skipExtrasVal->getString()));
+            config->skipExtras.push_back(PathExp(*fileName));
         }
         else
         {
@@ -272,41 +246,36 @@ CelestiaConfig* ReadCelestiaConfig(const fs::path& filename, CelestiaConfig *con
         }
     }
 
-    const Value* ignoreExtVal = configParams->getValue("IgnoreGLExtensions");
-    if (ignoreExtVal != nullptr)
+    if (const Value* ignoreExtVal = configParams->getValue("IgnoreGLExtensions"); ignoreExtVal != nullptr)
     {
-        if (ignoreExtVal->getType() != Value::ArrayType)
+        if (const ValueArray* ignoreExt = ignoreExtVal->getArray(); ignoreExt == nullptr)
         {
             GetLogger()->error("{}: IgnoreGLExtensions must be an array.\n", filename);
         }
         else
         {
-            const ValueArray* ignoreExt = ignoreExtVal->getArray();
-
-            for (const auto extVal : *ignoreExt)
+            for (const auto& extVal : *ignoreExt)
             {
-                if (extVal->getType() == Value::StringType)
-                {
-                    config->ignoreGLExtensions.push_back(extVal->getString());
-                }
-                else
+                const std::string* ext = extVal.getString();
+                if (ext == nullptr)
                 {
                     GetLogger()->error("{}: extension name must be a string.\n", filename);
+                    continue;
                 }
+
+                config->ignoreGLExtensions.push_back(*ext);
             }
         }
     }
 
-    const Value* starTexValue = configParams->getValue("StarTextures");
-    if (starTexValue != nullptr)
+    if (const Value* starTexValue = configParams->getValue("StarTextures"); starTexValue != nullptr)
     {
-        if (starTexValue->getType() != Value::HashType)
+        if (const Hash* starTexTable = starTexValue->getHash(); starTexTable == nullptr)
         {
             GetLogger()->error("{}: StarTextures must be a property list.\n", filename);
         }
         else
         {
-            const Hash* starTexTable = starTexValue->getHash();
             string starTexNames[StellarClass::Spectral_Count];
             starTexTable->getString("O", starTexNames[StellarClass::Spectral_O]);
             starTexTable->getString("B", starTexNames[StellarClass::Spectral_B]);
@@ -374,17 +343,4 @@ CelestiaConfig::getFloatValue(const string& name)
     params->getNumber(name, x);
 
     return (float) x;
-}
-
-
-const string
-CelestiaConfig::getStringValue(const string& name)
-{
-    assert(params != nullptr);
-
-    const Value* v = params->getValue(name);
-    if (v == nullptr || v->getType() != Value::StringType)
-        return string("");
-
-    return v->getString();
 }

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -71,8 +71,6 @@ public:
 
     const Hash* params;
 
-    float getFloatValue(const std::string& name);
-
     float SolarSystemMaxDistance;
     unsigned ShadowMapSize;
 

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -72,7 +72,6 @@ public:
     const Hash* params;
 
     float getFloatValue(const std::string& name);
-    const std::string getStringValue(const std::string& name);
 
     float SolarSystemMaxDistance;
     unsigned ShadowMapSize;

--- a/src/celestia/destination.cpp
+++ b/src/celestia/destination.cpp
@@ -37,18 +37,16 @@ DestinationList* ReadDestinationList(std::istream& in)
         }
         tokenizer.pushBack();
 
-        Value* destValue = parser.readValue();
-        if (destValue == nullptr || destValue->getType() != Value::HashType)
+        const Value destValue = parser.readValue();
+        const Hash* destParams = destValue.getHash();
+        if (destParams == nullptr)
         {
             GetLogger()->error("Error parsing destination.\n");
             std::for_each(destinations->begin(), destinations->end(), [](Destination* dest) { delete dest; });
             delete destinations;
-            if (destValue != nullptr)
-                delete destValue;
             return nullptr;
         }
 
-        const Hash* destParams = destValue->getHash();
         Destination* dest = new Destination();
 
         if (!destParams->getString("Name", dest->name))
@@ -74,8 +72,6 @@ DestinationList* ReadDestinationList(std::istream& in)
 
             destinations->push_back(dest);
         }
-
-        delete destValue;
     }
 
     return destinations;

--- a/src/celestia/destination.cpp
+++ b/src/celestia/destination.cpp
@@ -49,24 +49,27 @@ DestinationList* ReadDestinationList(std::istream& in)
 
         Destination* dest = new Destination();
 
-        if (!destParams->getString("Name", dest->name))
+        if (const std::string* destName = destParams->getString("Name"); destName == nullptr)
         {
             GetLogger()->warn("Skipping unnamed destination\n");
             delete dest;
         }
         else
         {
-            destParams->getString("Target", dest->target);
-            destParams->getString("Description", dest->description);
-            destParams->getNumber("Distance", dest->distance);
+            dest->name = *destName;
+            if (const std::string* target = destParams->getString("Target"); target != nullptr)
+                dest->target = *target;
+            if (const std::string* description = destParams->getString("Description"); description != nullptr)
+                dest->description = *description;
+            if (auto distance = destParams->getNumber<double>("Distance"); distance.has_value())
+                dest->distance = *distance;
 
             // Default unit of distance is the light year
-            std::string distanceUnits;
-            if (destParams->getString("DistanceUnits", distanceUnits))
+            if (const std::string* distanceUnits = destParams->getString("DistanceUnits"); distanceUnits != nullptr)
             {
-                if (!compareIgnoringCase(distanceUnits, "km"))
+                if (!compareIgnoringCase(*distanceUnits, "km"))
                     dest->distance = astro::kilometersToLightYears(dest->distance);
-                else if (!compareIgnoringCase(distanceUnits, "au"))
+                else if (!compareIgnoringCase(*distanceUnits, "au"))
                     dest->distance = astro::AUtoLightYears(dest->distance);
             }
 

--- a/src/celestia/favorites.cpp
+++ b/src/celestia/favorites.cpp
@@ -41,19 +41,16 @@ FavoritesList* ReadFavoritesList(std::istream& in)
         FavoritesEntry* fav = new FavoritesEntry(); // FIXME: check
         fav->name = *tokenizer.getStringValue();
 
-        Value* favParamsValue = parser.readValue();
-        if (favParamsValue == nullptr || favParamsValue->getType() != Value::HashType)
+        const Value favParamsValue = parser.readValue();
+        const Hash* favParams = favParamsValue.getHash();
+        if (favParams == nullptr)
         {
             GetLogger()->error("Error parsing favorites entry {}\n", fav->name);
             std::for_each(favorites->begin(), favorites->end(), [](FavoritesEntry* fav) { delete fav; });
             delete favorites;
-            if (favParamsValue != nullptr)
-                delete favParamsValue;
             delete fav;
             return nullptr;
         }
-
-        const Hash* favParams = favParamsValue->getHash();
 
         //If this is a folder, don't get any other params.
         if(!favParams->getBoolean("isFolder", fav->isFolder))

--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -151,14 +151,14 @@ Command* CommandParser::parseCommand()
         return nullptr;
     }
 
-    Value* paramListValue = parser->readValue();
-    if (paramListValue == nullptr || paramListValue->getType() != Value::HashType)
+    const Value paramListValue = parser->readValue();
+    const Hash* paramList = paramListValue.getHash();
+    if (paramList == nullptr)
     {
         error("Bad parameter list");
         return nullptr;
     }
 
-    const Hash* paramList = paramListValue->getHash();
     Command* cmd = nullptr;
 
     if (commandName == "wait")
@@ -878,8 +878,6 @@ Command* CommandParser::parseCommand()
         error("Unknown command name '" + commandName + "'");
         cmd = nullptr;
     }
-
-    delete paramListValue;
 
     return cmd;
 }

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -1003,24 +1003,24 @@ void CommandConstellations::process(ExecutionEnvironment& env)
         return;
 
     AsterismList& asterisms = *u->getAsterisms();
-    for (const auto ast : asterisms)
+    for (auto& ast : asterisms)
     {
         if (flags.none)
         {
-            ast->setActive(false);
+            ast.setActive(false);
         }
         else if (flags.all)
         {
-            ast->setActive(true);
+            ast.setActive(true);
         }
         else
         {
-            auto name = ast->getName(false);
+            auto name = ast.getName(false);
             auto it = std::find_if(constellations.begin(), constellations.end(),
                                    [&name](Cons& c){ return compareIgnoringCase(c.name, name) == 0; });
 
             if (it != constellations.end())
-                ast->setActive(it->active);
+                ast.setActive(it->active);
         }
     }
 }
@@ -1051,28 +1051,28 @@ void CommandConstellationColor::process(ExecutionEnvironment& env)
         return;
 
     AsterismList& asterisms = *u->getAsterisms();
-    for (const auto ast : asterisms)
+    for (auto& ast : asterisms)
     {
         if (flags.none)
         {
-            ast->unsetOverrideColor();
+            ast.unsetOverrideColor();
         }
         else if (flags.all)
         {
-            ast->setOverrideColor(rgb);
+            ast.setOverrideColor(rgb);
         }
         else
         {
-            auto name = ast->getName(false);
+            auto name = ast.getName(false);
             auto it = std::find_if(constellations.begin(), constellations.end(),
                                    [&name](string& c){ return compareIgnoringCase(c, name) == 0; });
 
             if (it != constellations.end())
             {
                 if (flags.unset)
-                    ast->unsetOverrideColor();
+                    ast.unsetOverrideColor();
                 else
-                    ast->setOverrideColor(rgb);
+                    ast.setOverrideColor(rgb);
             }
         }
     }

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -1423,18 +1423,17 @@ bool CelxLua::isType(int index, int type) const
     return Celx_istype(m_lua, index, type);
 }
 
-Value *CelxLua::getValue(int index)
+Value CelxLua::getValue(int index)
 {
-    Value *v = nullptr;
     if (isInteger(index))
-        v = new Value((double)getInt(index));
-    else if (isNumber(index))
-        v = new Value(getNumber(index));
-    else if (isBoolean(index))
-        v = new Value(getBoolean(index));
-    else if (isString(index))
-        v = new Value(getString(index));
-    else if (isTable(index))
+        return Value((double)getInt(index));
+    if (isNumber(index))
+        return Value(getNumber(index));
+    if (isBoolean(index))
+        return Value(getBoolean(index));
+    if (isString(index))
+        return Value(getString(index));
+    if (isTable(index))
     {
         auto array = std::make_unique<ValueArray>();
         auto hash = std::make_unique<Hash>();
@@ -1460,7 +1459,7 @@ Value *CelxLua::getValue(int index)
                 }
                 if (hash != nullptr)
                 {
-                    hash->addValue(getString(-2), *getValue(-1));
+                    hash->addValue(getString(-2), getValue(-1));
                 }
             }
             pop(1);
@@ -1469,11 +1468,12 @@ Value *CelxLua::getValue(int index)
         }
         pop(1);
         if (hash != nullptr)
-            v = new Value(std::move(hash));
+            return Value(std::move(hash));
         else if (array != nullptr)
-            v = new Value(std::move(array));
+            return Value(std::move(array));
     }
-    return v;
+
+    return Value();
 }
 
 void CelxLua::setClass(int id)

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -2657,10 +2657,9 @@ static int celestia_getparamstring(lua_State* l)
     Celx_CheckArgs(l, 2, 2, "One argument expected to celestia:getparamstring()");
     CelestiaCore* appCore = this_celestia(l);
     const char* s = Celx_SafeGetString(l, 2, AllErrors, "Argument to celestia:getparamstring must be a string");
-    std::string paramString; // HWR
     CelestiaConfig* config = appCore->getConfig();
-    config->configParams->getString(s, paramString);
-    lua_pushstring(l,paramString.c_str());
+    const std::string* paramString = config->configParams->getString(s);
+    lua_pushstring(l, paramString == nullptr ? "" : paramString->c_str());
     return 1;
 }
 

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -599,8 +599,8 @@ static int celestia_showconstellations(lua_State* l)
 
     if (lua_type(l, 2) == LUA_TNONE) // No argument passed
     {
-        for (const auto ast : *asterisms)
-            ast->setActive(true);
+        for (auto& ast : *asterisms)
+            ast.setActive(true);
     }
     else if (!lua_istable(l, 2))
     {
@@ -622,10 +622,10 @@ static int celestia_showconstellations(lua_State* l)
                 Celx_DoError(l, "Values in table-argument to celestia:showconstellations() must be strings");
                 return 0;
             }
-            for (const auto ast : *asterisms)
+            for (auto& ast : *asterisms)
             {
-                if (compareIgnoringCase(constellation, ast->getName(false)) == 0)
-                    ast->setActive(true);
+                if (compareIgnoringCase(constellation, ast.getName(false)) == 0)
+                    ast.setActive(true);
             }
             lua_pop(l,1);
         }
@@ -644,8 +644,8 @@ static int celestia_hideconstellations(lua_State* l)
 
     if (lua_type(l, 2) == LUA_TNONE) // No argument passed
     {
-        for (const auto ast : *asterisms)
-            ast->setActive(false);
+        for (auto& ast : *asterisms)
+            ast.setActive(false);
     }
     else if (!lua_istable(l, 2))
     {
@@ -667,10 +667,10 @@ static int celestia_hideconstellations(lua_State* l)
                 Celx_DoError(l, "Values in table-argument to celestia:hideconstellations() must be strings");
                 return 0;
             }
-            for (const auto ast : *asterisms)
+            for (auto& ast : *asterisms)
             {
-                if (compareIgnoringCase(constellation, ast->getName(false)) == 0)
-                    ast->setActive(false);
+                if (compareIgnoringCase(constellation, ast.getName(false)) == 0)
+                    ast.setActive(false);
             }
             lua_pop(l,1);
         }
@@ -694,8 +694,8 @@ static int celestia_setconstellationcolor(lua_State* l)
 
     if (lua_type(l, 5) == LUA_TNONE) // Fourth argument omited
     {
-        for (const auto ast : *asterisms)
-            ast->setOverrideColor(constellationColor);
+        for (auto& ast : *asterisms)
+            ast.setOverrideColor(constellationColor);
     }
     else if (!lua_istable(l, 5))
     {
@@ -710,9 +710,9 @@ static int celestia_setconstellationcolor(lua_State* l)
             if (lua_isstring(l, -1))
             {
                 const char* constellation = lua_tostring(l, -1);
-                for (const auto ast : *asterisms)
-                    if (compareIgnoringCase(constellation, ast->getName(false)) == 0)
-                        ast->setOverrideColor(constellationColor);
+                for (auto& ast : *asterisms)
+                    if (compareIgnoringCase(constellation, ast.getName(false)) == 0)
+                        ast.setOverrideColor(constellationColor);
             }
             else
             {

--- a/src/celscript/lua/celx_internal.h
+++ b/src/celscript/lua/celx_internal.h
@@ -227,7 +227,7 @@ public:
     double getNumber(int n = 0) const { return lua_tonumber(m_lua, n); }
     bool getBoolean(int n = 0) const { return lua_toboolean(m_lua, n) == 1; }
     const char *getString(int n = 0) const { return lua_tostring(m_lua, n); }
-    Value *getValue(int n = 0);
+    Value getValue(int n = 0);
     template<typename T> T *getUserData(int n = 0) const
     {
         return static_cast<T*>(lua_touserdata(m_lua, n));

--- a/test/unit/hash_test.cpp
+++ b/test/unit/hash_test.cpp
@@ -30,18 +30,18 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
             auto val = h.getValue("color");
             REQUIRE(val->getType() == ValueType::ArrayType);
 
-            Eigen::Vector3d vec;
-            auto v2 = h.getVector("color", vec);
-            REQUIRE(vec.x() == .23);
-            REQUIRE(vec.y() == .34);
-            REQUIRE(vec.z() == .45);
+            auto vec = h.getVector3<double>("color");
+            REQUIRE(vec.has_value());
+            REQUIRE(vec->x() == .23);
+            REQUIRE(vec->y() == .34);
+            REQUIRE(vec->z() == .45);
 
-            Color c;
-            h.getColor("color", c);
-            REQUIRE(c.red()   == Approx(C(.23f)));
-            REQUIRE(c.green() == Approx(C(.34f)));
-            REQUIRE(c.blue()  == Approx(C(.45f)));
-            REQUIRE(c.alpha() == Approx(1.0));
+            auto c = h.getColor("color");
+            REQUIRE(c.has_value());
+            REQUIRE(c->red()   == Approx(C(.23f)));
+            REQUIRE(c->green() == Approx(C(.34f)));
+            REQUIRE(c->blue()  == Approx(C(.45f)));
+            REQUIRE(c->alpha() == Approx(1.0));
         }
 
         SECTION("Defined as Vector4")
@@ -57,19 +57,19 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
             auto val = h.getValue("color");
             REQUIRE(val->getType() == ValueType::ArrayType);
 
-            Eigen::Vector4d vec;
-            auto v2 = h.getVector("color", vec);
-            REQUIRE(vec.x() == .23);
-            REQUIRE(vec.y() == .34);
-            REQUIRE(vec.z() == .45);
-            REQUIRE(vec.w() == .56);
+            auto vec = h.getVector4<double>("color");
+            REQUIRE(vec.has_value());
+            REQUIRE(vec->x() == .23);
+            REQUIRE(vec->y() == .34);
+            REQUIRE(vec->z() == .45);
+            REQUIRE(vec->w() == .56);
 
-            Color c;
-            h.getColor("color", c);
-            REQUIRE(c.red()   == Approx(C(.23f)));
-            REQUIRE(c.green() == Approx(C(.34f)));
-            REQUIRE(c.blue()  == Approx(C(.45f)));
-            REQUIRE(c.alpha() == Approx(C(.56f)));
+            auto c = h.getColor("color");
+            REQUIRE(c.has_value());
+            REQUIRE(c->red()   == Approx(C(.23f)));
+            REQUIRE(c->green() == Approx(C(.34f)));
+            REQUIRE(c->blue()  == Approx(C(.45f)));
+            REQUIRE(c->alpha() == Approx(C(.56f)));
 
         }
 
@@ -78,12 +78,12 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
             AssociativeArray h;
             h.addValue("color", Value("#123456"));
 
-            Color c;
-            h.getColor("color", c);
-            REQUIRE(c.red()   == Approx(0x12 / 255.).epsilon(EPSILON));
-            REQUIRE(c.green() == Approx(0x34 / 255.).epsilon(EPSILON));
-            REQUIRE(c.blue()  == Approx(0x56 / 255.).epsilon(EPSILON));
-            REQUIRE(c.alpha() == Approx(1.0).epsilon(EPSILON));
+            auto c = h.getColor("color");
+            REQUIRE(c.has_value());
+            REQUIRE(c->red()   == Approx(0x12 / 255.).epsilon(EPSILON));
+            REQUIRE(c->green() == Approx(0x34 / 255.).epsilon(EPSILON));
+            REQUIRE(c->blue()  == Approx(0x56 / 255.).epsilon(EPSILON));
+            REQUIRE(c->alpha() == Approx(1.0).epsilon(EPSILON));
         }
 
         SECTION("Defined as rrggbbaa string")
@@ -91,12 +91,12 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
             AssociativeArray h;
             h.addValue("color", Value("#12345678"));
 
-            Color c;
-            h.getColor("color", c);
-            REQUIRE(c.red()   == Approx(0x12 / 255.).epsilon(EPSILON));
-            REQUIRE(c.green() == Approx(0x34 / 255.).epsilon(EPSILON));
-            REQUIRE(c.blue()  == Approx(0x56 / 255.).epsilon(EPSILON));
-            REQUIRE(c.alpha() == Approx(0x78 / 255.).epsilon(EPSILON));
+            auto c = h.getColor("color");
+            REQUIRE(c.has_value());
+            REQUIRE(c->red()   == Approx(0x12 / 255.).epsilon(EPSILON));
+            REQUIRE(c->green() == Approx(0x34 / 255.).epsilon(EPSILON));
+            REQUIRE(c->blue()  == Approx(0x56 / 255.).epsilon(EPSILON));
+            REQUIRE(c->alpha() == Approx(0x78 / 255.).epsilon(EPSILON));
         }
     }
 }

--- a/test/unit/hash_test.cpp
+++ b/test/unit/hash_test.cpp
@@ -22,14 +22,13 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
         {
             AssociativeArray h;
             auto ary = std::make_unique<ValueArray>();
-            ary->push_back(new Value(.23));
-            ary->push_back(new Value(.34));
-            ary->push_back(new Value(.45));
-            auto *v = new Value(std::move(ary));
-            h.addValue("color", *v);
+            ary->emplace_back(.23);
+            ary->emplace_back(.34);
+            ary->emplace_back(.45);
+            h.addValue("color", Value(std::move(ary)));
 
             auto val = h.getValue("color");
-            REQUIRE(val->getType() == Value::ArrayType);
+            REQUIRE(val->getType() == ValueType::ArrayType);
 
             Eigen::Vector3d vec;
             auto v2 = h.getVector("color", vec);
@@ -49,15 +48,14 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
         {
             AssociativeArray h;
             auto ary = std::make_unique<ValueArray>();
-            ary->push_back(new Value(.23));
-            ary->push_back(new Value(.34));
-            ary->push_back(new Value(.45));
-            ary->push_back(new Value(.56));
-            auto *v = new Value(std::move(ary));
-            h.addValue("color", *v);
+            ary->emplace_back(.23);
+            ary->emplace_back(.34);
+            ary->emplace_back(.45);
+            ary->emplace_back(.56);
+            h.addValue("color", Value(std::move(ary)));
 
             auto val = h.getValue("color");
-            REQUIRE(val->getType() == Value::ArrayType);
+            REQUIRE(val->getType() == ValueType::ArrayType);
 
             Eigen::Vector4d vec;
             auto v2 = h.getVector("color", vec);
@@ -78,8 +76,7 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
         SECTION("Defined as rrggbb string")
         {
             AssociativeArray h;
-            auto *v = new Value("#123456");
-            h.addValue("color", *v);
+            h.addValue("color", Value("#123456"));
 
             Color c;
             h.getColor("color", c);
@@ -92,8 +89,7 @@ TEST_CASE("AssociativeArray", "[AssociativeArray]")
         SECTION("Defined as rrggbbaa string")
         {
             AssociativeArray h;
-            auto *v = new Value("#12345678");
-            h.addValue("color", *v);
+            h.addValue("color", Value("#12345678"));
 
             Color c;
             h.getColor("color", c);


### PR DESCRIPTION
Various refactoring of the value and parser system. The main points as follows:

* A less hacky way of handling units: store them in the `Value` itself instead of creating additional keys in the containing hash. This does not increase the size of the `Value` class due to the alignment constraints of the `Value::Data` union.
* Fix an issue where moving a `Value` could lead to double deletion.
* Enforce that `Value` creation from a `Hash` or `ValueArray` is done from a `unique_ptr` to indicate ownership.
* C++17 allows storing incomplete types in `std::vector`, so alter the definition of `ValueArray` accordingly, this should ensure that contained values get properly destructed.
* Do type tests and use `std::optional` in the `Value` getters. Some parts of the codebase were already assuming this was the case, which would only be enforced by debug asserts.
* Use comparators with deduced return type (e.g. `std::less<>`) to allow looking up `std::string`-keyed `std::map`s with `std::string_view`.
* Rewrite the `AssociativeArray` (=`Hash`) to return `std::optional` types, or in the case of `getString` a nullable pointer.

My intention is to squash this before merging, keeping it separated for the moment in case any bugs show up.