### PR TITLE
Remove unreachable catalog number code in dsodb.cpp

### DIFF
--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -214,19 +214,7 @@ bool DSODatabase::load(std::istream& in, const fs::path& resourcePath)
             return false;
         }
 
-        bool autoGenCatalogNumber = true;
-        AstroCatalog::IndexNumber objCatalogNumber = AstroCatalog::InvalidIndex;
-        if (auto tokenValue = tokenizer.getNumberValue(); tokenValue.has_value())
-        {
-            autoGenCatalogNumber   = false;
-            objCatalogNumber       = static_cast<AstroCatalog::IndexNumber>(*tokenValue);
-            tokenizer.nextToken();
-        }
-
-        if (autoGenCatalogNumber)
-        {
-            objCatalogNumber   = nextAutoCatalogNumber--;
-        }
+        AstroCatalog::IndexNumber objCatalogNumber = nextAutoCatalogNumber--;
 
         tokenizer.nextToken();
         std::string objName;


### PR DESCRIPTION
This code appears to be intended to allow specifying the DSO catalog number in .dsc files, however since the tokenizer is not advanced from its position on the string token specifying the name list, the result of `getNumberValue()` will always be false. The equivalent logic in the 1.6.x branch also contains this issue, so apparently this was never working, and it's not clear what catalog would actually be used here.

1.6.x branch:
https://github.com/CelestiaProject/Celestia/blob/b85ed7aa94145ca9098047f8823769850a729e85/src/celengine/dsodb.cpp#L245-L264