### PR TITLE
Remove unused move operations for AssociativeArray

### DIFF
--- a/src/celengine/hash.cpp
+++ b/src/celengine/hash.cpp
@@ -20,8 +20,6 @@ namespace celutil = celestia::util;
 
 // Define these here: at declaration the vector member contains an incomplete type
 AssociativeArray::~AssociativeArray() = default;
-AssociativeArray::AssociativeArray(AssociativeArray&&) noexcept(std::is_nothrow_move_constructible_v<AssocType>) = default;
-AssociativeArray& AssociativeArray::operator=(AssociativeArray&&) noexcept(std::is_nothrow_move_assignable_v<AssocType>) = default;
 
 
 const Value* AssociativeArray::getValue(std::string_view key) const

--- a/src/celengine/hash.h
+++ b/src/celengine/hash.h
@@ -36,10 +36,9 @@ class AssociativeArray
 
     AssociativeArray() = default;
     ~AssociativeArray();
-    // implementations differ in whether std::map is nothrow moveable
-    AssociativeArray(AssociativeArray&&) noexcept(std::is_nothrow_move_constructible_v<AssocType>);
+    AssociativeArray(AssociativeArray&&) = delete;
     AssociativeArray(const AssociativeArray&) = delete;
-    AssociativeArray& operator=(AssociativeArray&&) noexcept(std::is_nothrow_move_assignable_v<AssocType>);
+    AssociativeArray& operator=(AssociativeArray&&) = delete;
     AssociativeArray& operator=(AssociativeArray&) = delete;
 
     const Value* getValue(std::string_view) const;


### PR DESCRIPTION
SonarScanner complains about them not being unconditionally `noexcept` (which they can't be because `std::map` doesn't guarantee nothrow moves), and we don't actually move this type anyway because it's always behind a pointer. 