### PR TITLE
Call enableAttribArrays in unbind if VertexObject is in Initialize state

### DIFF
--- a/src/celrender/vertexobject.cpp
+++ b/src/celrender/vertexobject.cpp
@@ -83,6 +83,9 @@ void VertexObject::bindWritable() noexcept
 
 void VertexObject::unbind() noexcept
 {
+    if ((m_state & State::Initialize) != 0)
+        enableAttribArrays();
+
     if (isVAOSupported())
     {
         if ((m_state & (State::Initialize | State::Update)) != 0)


### PR DESCRIPTION
If no draw call is made between the first bind and unbind, then enableAttribArrays will not be called at all. potential fix for #1463 