### PR TITLE
[qt] Wayland drag handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,18 +108,21 @@ jobs:
           glut: ON
           gtk3: ON
           minaudio: OFF # Requires newer g++
+          wayland: ON
         - os: ubuntu-22.04
           avif: ON
           gles: ON
           glut: ON
           gtk3: ON
           minaudio: ON
+          wayland: ON
         - os: macos-latest
           avif: ON
           gles: OFF     # Native macOS applications can't access GLES APIs
           glut: ON
           gtk3: OFF     # macOS is not a primary target for GTK frontend
           minaudio: ON
+          wayland: OFF  # Wayland is not relevant on macOS
         qtversion: [ Qt5, Qt6 ]
         exclude:
         - config:
@@ -147,11 +150,13 @@ jobs:
                             libluajit-5.1-dev \
                             libfmt-dev \
                             freeglut3-dev \
+                            libwayland-dev \
+                            wayland-protocols \
                             ninja-build
         if [ "${{matrix.qtversion}}" = "Qt5" ]; then
-            sudo apt install -y qtbase5-dev qtbase5-dev-tools
+            sudo apt install -y qtbase5-dev qtbase5-dev-tools qtbase5-private-dev
         else
-            sudo apt install -y qt6-base-dev qt6-base-dev-tools libqt6core5compat6-dev
+            sudo apt install -y qt6-base-dev qt6-base-dev-tools libqt6core5compat6-dev qt6-base-private-dev
         fi
         if [ "${{matrix.config.avif}}" = "ON" ]; then
             sudo apt install -y libavif-dev
@@ -203,6 +208,7 @@ jobs:
               -DUSE_GTK3=${{matrix.config.gtk3}}        \
               -DENABLE_QT=ON                            \
               -DUSE_QT6=${UseQt6:OFF}                   \
+              -DUSE_WAYLAND=${{matrix.config.wayland}}  \
               -DENABLE_FFMPEG=ON                        \
               -DENABLE_LIBAVIF=${{matrix.config.avif}}  \
               -DENABLE_MINIAUDIO=${{matrix.config.minaudio}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ option(ENABLE_GLES          "Build for OpenGL ES 2.0 instead of OpenGL 2.1 (Defa
 option(USE_GTKGLEXT         "Use libgtkglext1 for GTK2 frontend (Default: on)" ON)
 option(USE_QT6              "Use Qt6 in Qt frontend (Default: off)" OFF)
 option(USE_GTK3             "Use Gtk3 in GTK2 frontend (Default: off)" OFF)
+option(USE_WAYLAND          "Use Wayland in Qt frontend (Default: off)" OFF)
 
 if(ENABLE_GLES)
   add_definitions(-DGL_ES)

--- a/cmake/FindWayland.cmake
+++ b/cmake/FindWayland.cmake
@@ -1,0 +1,60 @@
+# Finds the Wayland client libraries
+# Also supports components "protocols" and "scanner"
+
+find_package(PkgConfig QUIET)
+
+set(WaylandModules wayland-client)
+if(protocols IN_LIST Wayland_FIND_COMPONENTS)
+    list(APPEND WaylandModules wayland-protocols)
+endif()
+
+if(scanner IN_LIST Wayland_FIND_COMPONENTS)
+    list(APPEND WaylandModules wayland-scanner)
+endif()
+
+pkg_check_modules(PKG_Wayland QUIET ${WaylandModules})
+
+set(Wayland_VERSION ${PKG_Wayland_VERSION})
+set(Wayland_DEFINITIONS ${PKG_Wayland_CFLAGS})
+mark_as_advanced(Wayland_DEFINITIONS)
+
+find_path(Wayland_CLIENT_INCLUDE_DIR NAMES wayland-client.h HINTS ${PKG_Wayland_INCLUDE_DIRS})
+find_library(Wayland_CLIENT_LIBRARIES NAMES wayland-client HINTS ${PKG_Wayland_LIBRARY_DIRS})
+mark_as_advanced(Wayland_CLIENT_INCLUDE_DIR Wayland_CLIENT_LIBRARIES)
+
+if(protocols IN_LIST Wayland_FIND_COMPONENTS)
+    pkg_get_variable(Wayland_PROTOCOLS_DATADIR wayland-protocols pkgdatadir)
+    mark_as_advanced(Wayland_PROTOCOLS_DATADIR)
+endif()
+
+if(scanner IN_LIST Wayland_FIND_COMPONENTS)
+    pkg_get_variable(Wayland_SCANNER_EXECUTABLE_DIR wayland-scanner bindir)
+    find_program(Wayland_SCANNER_EXECUTABLE NAMES wayland-scanner HINTS ${Wayland_SCANNER_EXECUTABLE_DIR})
+    mark_as_advanced(Wayland_SCANNER_EXECUTABLE Wayland_SCANNER_EXECUTABLE_DIR)
+endif()
+
+set(Wayland_INCLUDE_DIR ${Wayland_CLIENT_INCLUDE_DIR})
+set(Wayland_LIBRARIES ${Wayland_CLIENT_LIBRARIES})
+set(Wayland_DATADIR ${Wayland_PROTOCOLS_DATADIR})
+
+list(REMOVE_DUPLICATES Wayland_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(Wayland
+    FOUND_VAR Wayland_FOUND
+    VERSION_VAR Wayland_VERSION
+    REQUIRED_VARS Wayland_LIBRARIES)
+
+if (Wayland_FOUND AND NOT TARGET Wayland::Client)
+    add_library(Wayland::Client UNKNOWN IMPORTED)
+    set_target_properties(Wayland::Client PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${Wayland_CLIENT_INCLUDE_DIR}"
+        IMPORTED_LOCATION "${Wayland_CLIENT_LIBRARIES}")
+endif()
+
+if (Wayland_SCANNER_EXECUTABLE AND NOT TARGET Wayland::Scanner)
+    add_executable(Wayland::Scanner IMPORTED)
+    set_target_properties(Wayland::Scanner PROPERTIES
+        IMPORTED_LOCATION "${Wayland_SCANNER_EXECUTABLE}")
+endif()

--- a/cmake/WaylandAddProtocolClient.cmake
+++ b/cmake/WaylandAddProtocolClient.cmake
@@ -1,0 +1,26 @@
+function(wayland_add_protocol_client _sources _protocol)
+    if (NOT TARGET Wayland::Scanner)
+        message(FATAL "The wayland-scanner executable has not been found on your system.")
+    endif()
+
+    if (NOT Wayland_PROTOCOLS_DATADIR)
+        message(FATAL "The wayland-protocols data directory has not been found on your system.")
+    endif()
+
+    get_filename_component(_basename "${_protocol}" NAME_WLE)
+
+    set(_source_file "${Wayland_PROTOCOLS_DATADIR}/${_protocol}")
+    set(_client_header "${CMAKE_CURRENT_BINARY_DIR}/${_basename}-client-protocol.h")
+    set(_private_code "${CMAKE_CURRENT_BINARY_DIR}/${_basename}-protocol.c")
+
+    add_custom_command(OUTPUT "${_client_header}"
+        COMMAND Wayland::Scanner client-header < ${_source_file} > ${_client_header}
+        DEPENDS ${_source_file} VERBATIM)
+
+    add_custom_command(OUTPUT "${_private_code}"
+        COMMAND Wayland::Scanner private-code < ${_source_file} > ${_private_code}
+        DEPENDS ${_source_file} VERBATIM)
+
+    list(APPEND ${_sources} "${_private_code}" "${_client_header}")
+    set(${_sources} ${${_sources}} PARENT_SCOPE)
+endfunction()

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -77,6 +77,9 @@ class CelestiaCore // : public Watchable<CelestiaCore>
         RightButton  = 0x04,
         ShiftKey     = 0x08,
         ControlKey   = 0x10,
+#ifdef __APPLE__
+        AltKey       = 0x20,
+#endif
     };
 
     enum CursorShape

--- a/src/celestia/qt/CMakeLists.txt
+++ b/src/celestia/qt/CMakeLists.txt
@@ -23,6 +23,7 @@ set(QT_SOURCES
   qtcelestiaactions.cpp
   qtcolorswatchwidget.cpp
   qtdeepskybrowser.cpp
+  qtdraghandler.cpp
   qteventfinder.cpp
   qtglwidget.cpp
   qtgotoobjectdialog.cpp
@@ -43,6 +44,7 @@ set(QT_HEADERS
   qtcelestiaactions.h
   qtcolorswatchwidget.h
   qtdeepskybrowser.h
+  qtdraghandler.h
   qteventfinder.h
   qtgettext.h
   qtgotoobjectdialog.h
@@ -55,6 +57,23 @@ set(QT_HEADERS
   qttimetoolbar.h
   xbel.h
 )
+
+if(USE_WAYLAND)
+  find_package(Wayland COMPONENTS protocols scanner REQUIRED)
+
+  include(WaylandAddProtocolClient)
+  wayland_add_protocol_client(PROTOCOL_SOURCES
+    "unstable/pointer-constraints/pointer-constraints-unstable-v1.xml")
+  wayland_add_protocol_client(PROTOCOL_SOURCES
+    "unstable/relative-pointer/relative-pointer-unstable-v1.xml")
+
+  set_source_files_properties(${PROTOCOL_SOURCES} PROPERTIES GENERATED ON)
+  add_library(wayland-protocols-helper STATIC ${PROTOCOL_SOURCES})
+  target_include_directories(wayland-protocols-helper INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+
+  list(APPEND QT_SOURCES qtwaylanddraghandler.cpp)
+  list(APPEND QT_HEADERS qtwaylanddraghandler.h)
+endif()
 
 # Instruct CMake to run moc automatically when needed
 set(CMAKE_AUTOMOC ON)
@@ -78,6 +97,15 @@ if(USE_QT6)
   target_link_libraries(celestia-qt Qt6::Widgets Qt6::OpenGLWidgets Qt6::Core5Compat celestia)
 else()
   target_link_libraries(celestia-qt Qt5::Widgets celestia)
+endif()
+if(USE_WAYLAND)
+  target_link_libraries(celestia-qt Wayland::Client wayland-protocols-helper)
+  target_compile_definitions(celestia-qt PRIVATE USE_WAYLAND)
+  if (USE_QT6)
+    target_include_directories(celestia-qt PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+  else()
+    target_include_directories(celestia-qt PRIVATE ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
+  endif()
 endif()
 if(APPLE)
   set_property(TARGET celestia-qt APPEND_STRING PROPERTY LINK_FLAGS " -framework CoreFoundation")

--- a/src/celestia/qt/qtdraghandler.cpp
+++ b/src/celestia/qt/qtdraghandler.cpp
@@ -1,0 +1,90 @@
+#include "qtdraghandler.h"
+
+#include <QCursor>
+#include <QGuiApplication>
+#ifdef USE_WAYLAND
+#include "qtwaylanddraghandler.h"
+#endif
+
+void
+DragHandler::begin(const QMouseEvent &m, qreal s, int b)
+{
+    saveCursorPos = m.globalPos();
+    scale         = s;
+    buttons       = b;
+}
+
+void
+DragHandler::move(const QMouseEvent &m, qreal s)
+{
+    if (scale != s)
+        begin(m, s, buttons);
+    auto relativeMovement = m.globalPos() - saveCursorPos;
+    appCore->mouseMove(
+        static_cast<float>(relativeMovement.x() * scale),
+        static_cast<float>(relativeMovement.y() * scale),
+        effectiveButtons());
+    saveCursorPos = m.globalPos();
+}
+
+void
+DragHandler::setButton(int button)
+{
+    buttons |= button;
+}
+
+void
+DragHandler::clearButton(int button)
+{
+    buttons &= ~button;
+}
+
+int
+DragHandler::effectiveButtons() const
+{
+#ifdef __APPLE__
+    // On the Mac, right dragging is be simulated with Option+left drag.
+    // We may want to enable this on other platforms, though it's mostly only helpful
+    // for users with single button mice.
+    if (buttons & CelestiaCore::AltKey)
+        return (buttons | CelestiaCore::RightButton) & (~CelestiaCore::LeftButton);
+#endif
+    return buttons;
+}
+
+// Warping drag handler
+
+void
+WarpingDragHandler::move(const QMouseEvent &m, qreal s)
+{
+    if (scale != s)
+        begin(m, s, buttons);
+    auto relativeMovement = m.globalPos() - saveCursorPos;
+    appCore->mouseMove(
+        static_cast<float>(relativeMovement.x() * scale),
+        static_cast<float>(relativeMovement.y() * scale),
+        effectiveButtons());
+    QCursor::setPos(saveCursorPos);
+}
+
+void
+WarpingDragHandler::finish()
+{
+    QCursor::setPos(saveCursorPos);
+}
+
+std::unique_ptr<DragHandler>
+createDragHandler([[maybe_unused]] QWidget *widget, CelestiaCore *appCore)
+{
+    QString platformName = QGuiApplication::platformName();
+
+    if (platformName == "cocoa" || platformName == "windows" || platformName == "xcb")
+        return std::make_unique<WarpingDragHandler>(appCore);
+
+#ifdef USE_WAYLAND
+    if (platformName == "wayland")
+        return std::make_unique<WaylandDragHandler>(widget, appCore);
+#endif
+
+    return std::make_unique<DragHandler>(appCore);
+}

--- a/src/celestia/qt/qtdraghandler.h
+++ b/src/celestia/qt/qtdraghandler.h
@@ -1,0 +1,65 @@
+// qtdeepskybrowser.h
+//
+// Copyright (C) 2023, Celestia Development Team
+//
+// Drag handler for Qt5+ front-end.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <QMouseEvent>
+#include <QPoint>
+#include <memory>
+#ifdef USE_WAYLAND
+#include <QWidget>
+#endif
+#include <QtGlobal>
+#include <celestia/celestiacore.h>
+
+// The base version of DragHandler is the fallback implementation for
+// platforms which do not support pointer warping
+class DragHandler
+{
+public:
+    explicit DragHandler(CelestiaCore *core) : appCore(core)
+    {
+    }
+    virtual ~DragHandler() = default;
+
+    DragHandler(const DragHandler &)            = delete;
+    DragHandler &operator=(const DragHandler &) = delete;
+    DragHandler(DragHandler &&)                 = delete;
+    DragHandler &operator=(DragHandler &&)      = delete;
+
+    virtual void begin(const QMouseEvent &, qreal, int);
+    virtual void move(const QMouseEvent &, qreal);
+    virtual void finish(){ /* nothing to do */ };
+
+    void setButton(int);
+    void clearButton(int);
+
+protected:
+    CelestiaCore *appCore;
+    QPoint        saveCursorPos{};
+    qreal         scale{};
+    int           buttons{ 0 };
+
+    int effectiveButtons() const;
+};
+
+// Implementation of DragHandler which uses pointer warping to enable infinite
+// movement
+class WarpingDragHandler : public DragHandler
+{
+public:
+    using DragHandler::DragHandler;
+
+    void move(const QMouseEvent &, qreal) override;
+    void finish() override;
+};
+
+std::unique_ptr<DragHandler> createDragHandler(QWidget *, CelestiaCore *);

--- a/src/celestia/qt/qtglwidget.h
+++ b/src/celestia/qt/qtglwidget.h
@@ -14,13 +14,15 @@
 #ifndef QTGLWIDGET_H
 #define QTGLWIDGET_H
 
+#include <string>
+#include <vector>
+
 #include <QOpenGLWidget>
 
 #include "celestia/celestiacore.h"
 #include "celengine/simulation.h"
 #include <celengine/starbrowser.h>
-#include <string>
-#include <vector>
+#include "qtdraghandler.h"
 
 /**
   *@author Christophe Teyssier
@@ -59,8 +61,7 @@ private:
     int lastX{ 0 };
     int lastY{ 0 };
     bool cursorVisible;
-    QPoint saveGlobalCursorPos;
-    QPoint saveLocalCursorPos;
+    std::unique_ptr<DragHandler> dragHandler;
     CelestiaCore::CursorShape currentCursor;
 
     //KActionCollection* actionColl;

--- a/src/celestia/qt/qtwaylanddraghandler.cpp
+++ b/src/celestia/qt/qtwaylanddraghandler.cpp
@@ -1,0 +1,208 @@
+#include "qtwaylanddraghandler.h"
+
+#include <QGuiApplication>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <qpa/qplatformnativeinterface.h>
+
+namespace
+{
+
+QPlatformNativeInterface *
+getPlatformNativeInterface()
+{
+    static QPlatformNativeInterface *pni = nullptr;
+    if (!pni)
+    {
+        pni = QGuiApplication::platformNativeInterface();
+    }
+
+    return pni;
+}
+
+void
+addRegistryItem(
+    void         *data,
+    wl_registry  *registry,
+    std::uint32_t name,
+    const char   *interface,
+    std::uint32_t version)
+{
+    auto pointerInterfaces = static_cast<WaylandDragHandler::PointerInterfaces *>(data);
+    if (std::strcmp(interface, zwp_pointer_constraints_v1_interface.name) == 0
+        && version == zwp_pointer_constraints_v1_interface.version)
+    {
+        pointerInterfaces->pointerConstraints = static_cast<zwp_pointer_constraints_v1 *>(
+            wl_registry_bind(registry, name, &zwp_pointer_constraints_v1_interface, version));
+    }
+    else if (
+        std::strcmp(interface, zwp_relative_pointer_manager_v1_interface.name) == 0
+        && version == zwp_relative_pointer_manager_v1_interface.version)
+    {
+        pointerInterfaces->relativePointerManager = static_cast<zwp_relative_pointer_manager_v1 *>(
+            wl_registry_bind(registry, name, &zwp_relative_pointer_manager_v1_interface, version));
+    }
+}
+
+void
+removeRegistryItem(void *data, wl_registry *registry, std::uint32_t name)
+{
+    // not handled
+}
+
+std::shared_ptr<WaylandDragHandler::PointerInterfaces>
+getPointerInterfaces()
+{
+    static std::weak_ptr<WaylandDragHandler::PointerInterfaces> cachedPointerInterfaces{};
+    auto pointerInterfaces = cachedPointerInterfaces.lock();
+    if (pointerInterfaces)
+        return pointerInterfaces;
+
+    QPlatformNativeInterface *pni = getPlatformNativeInterface();
+    if (!pni)
+        return nullptr;
+
+    auto display = static_cast<wl_display *>(pni->nativeResourceForIntegration("wl_display"));
+    if (!display)
+        return nullptr;
+
+    wl_registry *registry = wl_display_get_registry(display);
+    if (!registry)
+        return nullptr;
+
+    pointerInterfaces = std::make_shared<WaylandDragHandler::PointerInterfaces>(registry);
+    static const wl_registry_listener registryListener{ addRegistryItem, removeRegistryItem };
+
+    wl_registry_add_listener(registry, &registryListener, pointerInterfaces.get());
+    wl_display_roundtrip(display);
+
+    cachedPointerInterfaces = pointerInterfaces;
+    return pointerInterfaces;
+}
+
+} // end unnamed namespace
+
+const zwp_relative_pointer_v1_listener WaylandDragHandler::listener{ processRelativePointer };
+
+WaylandDragHandler::WaylandDragHandler(QWidget *_widget, CelestiaCore *_appCore) :
+    DragHandler(_appCore), widget(_widget)
+{
+}
+
+WaylandDragHandler::~WaylandDragHandler()
+{
+    if (lockedPointer)
+        zwp_locked_pointer_v1_destroy(lockedPointer);
+    if (relativePointer)
+        zwp_relative_pointer_v1_destroy(relativePointer);
+}
+
+void
+WaylandDragHandler::begin(const QMouseEvent &m, qreal s, int b)
+{
+    buttons  = b;
+    scale    = s;
+    auto pni = getPlatformNativeInterface();
+    if (!pni)
+    {
+        fallback = true;
+        DragHandler::begin(m, s, b);
+        return;
+    }
+
+    surface = static_cast<wl_surface *>(
+        pni->nativeResourceForWindow("surface", widget->window()->windowHandle()));
+    pointer = static_cast<wl_pointer *>(pni->nativeResourceForIntegration("wl_pointer"));
+    if (!surface || !pointer)
+    {
+        fallback = true;
+        DragHandler::begin(m, s, b);
+        return;
+    }
+
+    pointerInterfaces = getPointerInterfaces();
+
+    relativePointer = zwp_relative_pointer_manager_v1_get_relative_pointer(
+        pointerInterfaces->relativePointerManager,
+        pointer);
+    if (!relativePointer)
+    {
+        fallback = true;
+        DragHandler::begin(m, s, b);
+        return;
+    }
+
+    zwp_relative_pointer_v1_add_listener(relativePointer, &listener, this);
+
+    lockedPointer = zwp_pointer_constraints_v1_lock_pointer(
+        pointerInterfaces->pointerConstraints,
+        surface,
+        pointer,
+        nullptr,
+        ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT);
+    if (!lockedPointer)
+    {
+        zwp_relative_pointer_v1_destroy(relativePointer);
+        fallback = true;
+        DragHandler::begin(m, s, b);
+        return;
+    }
+}
+
+void
+WaylandDragHandler::move(const QMouseEvent &m, qreal s)
+{
+    if (fallback)
+    {
+        DragHandler::move(m, s);
+    }
+}
+
+void
+WaylandDragHandler::finish()
+{
+    if (fallback)
+    {
+        DragHandler::finish();
+        return;
+    }
+    zwp_locked_pointer_v1_destroy(lockedPointer);
+    lockedPointer = nullptr;
+
+    zwp_relative_pointer_v1_destroy(relativePointer);
+    relativePointer = nullptr;
+}
+
+void
+WaylandDragHandler::processRelativePointer(
+    void *data,
+    zwp_relative_pointer_v1 * /* pointer */,
+    std::uint32_t /* utime_hi */,
+    std::uint32_t /* utime_lo */,
+    wl_fixed_t dx,
+    wl_fixed_t dy,
+    wl_fixed_t /* dx_unaccel */,
+    wl_fixed_t /* dy_unaccel */)
+{
+    auto dragHandler = static_cast<WaylandDragHandler *>(data);
+    dragHandler->appCore->mouseMove(
+        static_cast<float>(wl_fixed_to_double(dx) * dragHandler->scale),
+        static_cast<float>(wl_fixed_to_double(dy) * dragHandler->scale),
+        dragHandler->effectiveButtons());
+}
+
+WaylandDragHandler::PointerInterfaces::PointerInterfaces(wl_registry *_registry) :
+    registry{ _registry }
+{
+}
+
+WaylandDragHandler::PointerInterfaces::~PointerInterfaces()
+{
+    if (pointerConstraints)
+        zwp_pointer_constraints_v1_destroy(pointerConstraints);
+    if (relativePointerManager)
+        zwp_relative_pointer_manager_v1_destroy(relativePointerManager);
+    if (registry)
+        wl_registry_destroy(registry);
+}

--- a/src/celestia/qt/qtwaylanddraghandler.h
+++ b/src/celestia/qt/qtwaylanddraghandler.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "qtdraghandler.h"
+
+#include <QWidget>
+#include <memory>
+#include <pointer-constraints-unstable-v1-client-protocol.h>
+#include <relative-pointer-unstable-v1-client-protocol.h>
+#include <wayland-client.h>
+
+class WaylandDragHandler : public DragHandler
+{
+public:
+    struct PointerInterfaces
+    {
+        wl_registry                     *registry;
+        zwp_pointer_constraints_v1      *pointerConstraints{ nullptr };
+        zwp_relative_pointer_manager_v1 *relativePointerManager{ nullptr };
+
+        PointerInterfaces(wl_registry *);
+        ~PointerInterfaces();
+    };
+
+    WaylandDragHandler(QWidget *, CelestiaCore *);
+    ~WaylandDragHandler();
+
+    void begin(const QMouseEvent &, qreal, int) override;
+    void move(const QMouseEvent &, qreal) override;
+    void finish() override;
+
+private:
+    QWidget                           *widget{ nullptr };
+    std::shared_ptr<PointerInterfaces> pointerInterfaces{ nullptr };
+    int                                buttons{ 0 };
+    wl_surface                        *surface{ nullptr };
+    wl_pointer                        *pointer{ nullptr };
+    zwp_relative_pointer_v1           *relativePointer{ nullptr };
+    zwp_locked_pointer_v1             *lockedPointer{ nullptr };
+    bool                               fallback{ false };
+
+    static const zwp_relative_pointer_v1_listener listener;
+
+    static void processRelativePointer(
+        void *data,
+        zwp_relative_pointer_v1 *,
+        std::uint32_t,
+        std::uint32_t,
+        wl_fixed_t,
+        wl_fixed_t,
+        wl_fixed_t,
+        wl_fixed_t);
+};


### PR DESCRIPTION
An initial attempt at fixing #1489

* Rewrites the drag handling in Qt so that it only does pointer warping on platforms that support it (Cocoa, Windows, X11)
* On Wayland, use the pointer constraints and relative pointer manager protocols to implement infinite dragging

There is a new CMake option `USE_WAYLAND` to enable this feature (at the moment this defaults to OFF, but it may be worth defaulting this to ON on Linux?) - this requires access to the private Qt headers, plus the Wayland library, protocols and scanner. On Ubuntu Qt5 these are the packages qtbase5-private-dev, libwayland-dev, wayland-protocols and libwayland-bin packages.

So far I have not tested this with Qt6, for which the Ubuntu package would be qt6-base-private-dev.

I have done some brief testing on Wayland, X11 and Windows. It would be useful to have tests with high DPI screens, and on Apple (due to the rewrites all platforms are affected, so I cannot verify that the ALT+dragging behaves as expected).