### PR TITLE
Migrate more code to use VBO + cleanups

### DIFF
--- a/shaders/comet_vert.glsl
+++ b/shaders/comet_vert.glsl
@@ -1,6 +1,6 @@
 attribute vec4 in_Position;
 attribute vec3 in_Normal;
-attribute float brightness;
+attribute float in_Brightness;
 
 uniform vec3 color;
 uniform vec3 viewDir;
@@ -10,6 +10,6 @@ varying float shade;
 
 void main(void)
 {
-    shade = abs(dot(viewDir.xyz, in_Normal.xyz) * brightness * fadeFactor);
+    shade = abs(dot(viewDir.xyz, in_Normal.xyz) * in_Brightness * fadeFactor);
     set_vp(in_Position);
 }

--- a/src/celengine/geometry.h
+++ b/src/celengine/geometry.h
@@ -1,6 +1,6 @@
 // geometry.h
 //
-// Copyright (C) 2004-2010, Celestia Development Team
+// Copyright (C) 2004-present, Celestia Development Team
 // Original version by Chris Laurel <claurel@gmail.com>
 //
 // This program is free software; you can redistribute it and/or
@@ -16,12 +16,10 @@
 
 class RenderContext;
 
-
 class Geometry
 {
 public:
-    Geometry() {};
-    virtual ~Geometry() {};
+    virtual ~Geometry() = default;
 
     //! Render the geometry in the specified OpenGL context
     virtual void render(RenderContext& rc, double t = 0.0) = 0;

--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -466,37 +466,6 @@ void Renderer::renderSelectionPointer(const Observer& observer,
     markerVO.unbind();
 }
 
-/*! Draw the J2000.0 ecliptic; trivial, since this forms the basis for
- *  Celestia's coordinate system.
- */
-void Renderer::renderEclipticLine()
-{
-    if ((renderFlags & ShowEcliptic) == 0)
-        return;
-
-    static LineRenderer *lr = nullptr;
-
-    constexpr int eclipticCount = 200;
-    if (lr == nullptr)
-    {
-        lr = new LineRenderer(*this, 1.0f, LineRenderer::PrimType::LineLoop, LineRenderer::StorageType::Static);
-        constexpr float scale = 1000.0f;
-        for (int i = 0; i < eclipticCount; i++)
-        {
-            float s, c;
-            sincos((float) (2 * i) / (float) eclipticCount * celestia::numbers::pi_v<float>, s, c);
-            lr->addVertex(c * scale, 0.0f, s * scale);
-        }
-    }
-    Renderer::PipelineState ps;
-    ps.blending = true;
-    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
-    ps.smoothLines = true;
-    setPipelineState(ps);
-    lr->render({&getProjectionMatrix(), &getModelViewMatrix()}, EclipticColor, eclipticCount);
-    lr->finish();
-}
-
 void Renderer::renderCrosshair(float selectionSizeInPixels,
                                double tsec,
                                const Color &color,

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -49,7 +49,7 @@ struct GlobularForm
     };
 
     std::vector<Blob> gblobs{ };
-    mutable VertexObject vo{ GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW };
+    mutable VertexObject vo{ 0, GL_STATIC_DRAW };
 };
 
 

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -86,10 +86,7 @@ void globularTextureEval(float u, float v, float /*w*/, std::uint8_t *pixel)
     // giving sort of a halo for the brighter (i.e.bigger) stars.
 
     static const float Lumi0 = std::exp(-LumiShape);
-    float lumi = std::exp(-LumiShape * std::sqrt(u * u + v * v)) - Lumi0;
-
-    if (lumi <= 0.0f)
-        lumi = 0.0f;
+    float lumi = std::max(0.0f, std::exp(-LumiShape * std::sqrt(u * u + v * v)) - Lumi0);
 
     auto pixVal = static_cast<std::uint8_t>(lumi * 255.99f);
     pixel[0] = 255;
@@ -508,9 +505,7 @@ bool Globular::pick(const Eigen::ParametrizedLine<double, 3>& ray,
 bool Globular::load(const AssociativeArray* params, const fs::path& resPath)
 {
     // Load the basic DSO parameters first
-
-    bool ok = DeepSkyObject::load(params, resPath);
-    if (!ok)
+    if (!DeepSkyObject::load(params, resPath))
         return false;
 
     if (auto detailVal = params->getNumber<float>("Detail"); detailVal.has_value())
@@ -653,9 +648,6 @@ void Globular::render(const Eigen::Vector3f& offset,
     glDisable(GL_POINT_SPRITE);
     glDisable(GL_VERTEX_PROGRAM_POINT_SIZE);
 #endif
-    // These should be called but stars are broken then
-    // TODO: find and fix
-    //glDisable(GL_BLEND);
 }
 
 std::uint64_t Globular::getRenderMask() const

--- a/src/celengine/lodspheremesh.h
+++ b/src/celengine/lodspheremesh.h
@@ -1,6 +1,6 @@
 // lodspheremesh.h
 //
-// Copyright (C) 2001-2010, Celestia Development Team
+// Copyright (C) 2001-present, Celestia Development Team
 // Original version by Chris Laurel <claurel@gmail.com>
 //
 // This program is free software; you can redistribute it and/or
@@ -8,11 +8,11 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef CELENGINE_LODSPHEREMESH_H_
-#define CELENGINE_LODSPHEREMESH_H_
+#pragma once
 
-#include <celengine/texture.h>
 #include <Eigen/Geometry>
+#include <celengine/texture.h>
+#include <celengine/glsupport.h>
 #include <celmath/frustum.h>
 
 
@@ -81,5 +81,3 @@ public:
     GLuint vertexBuffers[NUM_SPHERE_VERTEX_BUFFERS];
     GLuint indexBuffer{ 0 };
 };
-
-#endif // CELENGINE_LODSPHEREMESH_H_

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4104,35 +4104,6 @@ void Renderer::labelConstellations(const AsterismList& asterisms,
 }
 
 
-void Renderer::renderParticles(const vector<Particle>& particles)
-{
-    ShaderProperties shaderprop;
-    shaderprop.lightModel = ShaderProperties::ParticleModel;
-    shaderprop.texUsage = ShaderProperties::PointSprite;
-    auto *prog = shaderManager->getShader(shaderprop);
-    if (prog == nullptr)
-        return;
-    prog->use();
-
-#ifndef GL_ES
-    glEnable(GL_POINT_SPRITE);
-#endif
-    glEnableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
-    glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
-                          3, GL_FLOAT, GL_FALSE, sizeof(Particle), &particles[0].center);
-    glEnableVertexAttribArray(CelestiaGLProgram::PointSizeAttributeIndex);
-    glVertexAttribPointer(CelestiaGLProgram::PointSizeAttributeIndex,
-                          1, GL_FLOAT, GL_FALSE,
-                          sizeof(Particle), &particles[0].size);
-    glDrawArrays(GL_POINTS, 0, particles.size());
-
-    glDisableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
-    glDisableVertexAttribArray(CelestiaGLProgram::PointSizeAttributeIndex);
-#ifndef GL_ES
-    glDisable(GL_POINT_SPRITE);
-#endif
-}
-
 void
 Renderer::renderAnnotationMarker(const Annotation &a,
                                  FontStyle fs,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -5305,11 +5305,11 @@ bool Renderer::getInfo(map<string, string>& info) const
 }
 
 VertexObject&
-Renderer::getVertexObject(VOType owner, GLenum type, GLsizeiptr size, GLenum stream)
+Renderer::getVertexObject(VOType owner, GLenum /*type*/, GLsizeiptr size, GLenum stream)
 {
-    auto i = static_cast<size_t>(owner);
+    auto i = static_cast<int>(owner);
     if (m_VertexObjects[i] == nullptr)
-        m_VertexObjects[i] = new VertexObject(type, size, stream);
+        m_VertexObjects[i] = new VertexObject(size, stream);
 
     return *m_VertexObjects[i];
 }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -57,6 +57,7 @@
 #include <celmath/geomutil.h>
 #include <celrender/atmosphererenderer.h>
 #include <celrender/cometrenderer.h>
+#include <celrender/eclipticlinerenderer.h>
 #include <celrender/linerenderer.h>
 #include <celrender/vertexobject.h>
 #include <celutil/logger.h>
@@ -86,6 +87,7 @@ using celestia::render::CometRenderer;
 using celestia::render::LineRenderer;
 using celestia::render::VertexObject;
 using celestia::render::AtmosphereRenderer;
+using celestia::render::EclipticLineRenderer;
 
 #define FOV           45.0f
 #define NEAR_DIST      0.5f
@@ -269,7 +271,8 @@ Renderer::Renderer() :
     settingsChanged(true),
     objectAnnotationSetOpen(false),
     m_atmosphereRenderer(std::make_unique<AtmosphereRenderer>(*this)),
-    m_cometRenderer(std::make_unique<CometRenderer>(*this))
+    m_cometRenderer(std::make_unique<CometRenderer>(*this)),
+    m_eclipticLineRenderer(std::make_unique<EclipticLineRenderer>(*this))
 {
     pointStarVertexBuffer = new PointStarVertexBuffer(*this, 2048);
     glareVertexBuffer = new PointStarVertexBuffer(*this, 2048);
@@ -5439,4 +5442,10 @@ Renderer::setPipelineState(const Renderer::PipelineState &ps) noexcept
 #endif
         m_pipelineState.smoothLines = ps.smoothLines;
     }
+}
+
+void Renderer::renderEclipticLine()
+{
+    if ((renderFlags & ShowEcliptic) != 0)
+        m_eclipticLineRenderer->render();
 }

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -40,6 +40,10 @@ class FramebufferObject;
 namespace celestia
 {
 class Rect;
+namespace render
+{
+class CometRenderer;
+}
 }
 
 namespace celmath
@@ -305,6 +309,11 @@ class Renderer
                       float size,
                       const Color &color,
                       const Matrices &m);
+
+    celestia::util::array_view<const Star*> getNearStars() const
+    {
+        return nearStars;
+    }
 
     const Eigen::Matrix4f& getModelViewMatrix() const
     {
@@ -619,6 +628,7 @@ class Renderer
     void renderCometTail(const Body& body,
                          const Eigen::Vector3f& pos,
                          const Observer& observer,
+                         float dustTailLength,
                          float discSizeInPixels,
                          const Matrices&);
 
@@ -839,6 +849,8 @@ class Renderer
 
     // Saturation magnitude used to calculate a point star size
     float satPoint;
+
+    std::unique_ptr<celestia::render::CometRenderer> m_cometRenderer;
 
     // Location markers
  public:

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -44,6 +44,7 @@ namespace render
 {
 class AtmosphereRenderer;
 class CometRenderer;
+class EclipticLineRenderer;
 }
 }
 
@@ -786,9 +787,6 @@ class Renderer
 
     bool settingsChanged;
 
-    std::unique_ptr<AsterismRenderer> m_asterismRenderer;
-    std::unique_ptr<BoundariesRenderer> m_boundariesRenderer;
-
     // True if we're in between a begin/endObjectAnnotations
     bool objectAnnotationSetOpen;
 
@@ -808,8 +806,11 @@ class Renderer
     // Saturation magnitude used to calculate a point star size
     float satPoint;
 
+    std::unique_ptr<AsterismRenderer> m_asterismRenderer;
+    std::unique_ptr<BoundariesRenderer> m_boundariesRenderer;
     std::unique_ptr<celestia::render::AtmosphereRenderer> m_atmosphereRenderer;
     std::unique_ptr<celestia::render::CometRenderer> m_cometRenderer;
+    std::unique_ptr<celestia::render::EclipticLineRenderer> m_eclipticLineRenderer;
 
     // Location markers
  public:

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -466,17 +466,6 @@ class Renderer
     FramebufferObject* getShadowFBO(int) const;
 
  public:
-    // Internal types
-    // TODO: Figure out how to make these private.  Even with a friend
-    //
-    struct Particle
-    {
-        Eigen::Vector3f center;
-        float size;
-        Color color;
-        float pad0, pad1, pad2;
-    };
-
     struct RenderProperties
     {
         Surface* surface{ nullptr };
@@ -653,8 +642,6 @@ class Renderer
 
     void labelConstellations(const AsterismList& asterisms,
                              const Observer& observer);
-    void renderParticles(const std::vector<Particle>& particles);
-
 
     void addAnnotation(std::vector<Annotation>&,
                        const celestia::MarkerRepresentation*,
@@ -755,7 +742,6 @@ class Renderer
     std::vector<RenderListEntry> renderList;
     std::vector<SecondaryIlluminator> secondaryIlluminators;
     std::vector<DepthBufferPartition> depthPartitions;
-    std::vector<Particle> glareParticles;
     std::vector<Annotation> backgroundAnnotations;
     std::vector<Annotation> foregroundAnnotations;
     std::vector<Annotation> depthSortedAnnotations;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -431,8 +431,6 @@ class Renderer
     const Eigen::Quaternionf& getCameraOrientation() const;
     float getNearPlaneDistance() const;
 
-    void clearAnnotations(std::vector<Annotation>&);
-
     void invalidateOrbitCache();
 
     struct OrbitPathListEntry
@@ -484,32 +482,6 @@ class Renderer
     OctreeProcStats m_starProcStats;
     OctreeProcStats m_dsoProcStats;
 #endif
- private:
-    template <class OBJ> struct ObjectLabel
-    {
-        OBJ*        obj{ nullptr };
-        std::string label;
-
-        ObjectLabel(OBJ* _obj, const std::string& _label) :
-            obj  (_obj),
-            label(_label)
-        {};
-
-        ObjectLabel(const ObjectLabel& objLbl) :
-            obj  (objLbl.obj),
-            label(objLbl.label)
-        {};
-
-        ObjectLabel& operator = (const ObjectLabel& objLbl)
-        {
-            obj   = objLbl.obj;
-            label = objLbl.label;
-            return *this;
-        };
-    };
-
-    typedef ObjectLabel<Star>          StarLabel;
-    typedef ObjectLabel<DeepSkyObject> DSOLabel;    // currently not used
 
     struct DepthBufferPartition
     {

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -42,6 +42,7 @@ namespace celestia
 class Rect;
 namespace render
 {
+class AtmosphereRenderer;
 class CometRenderer;
 }
 }
@@ -494,21 +495,6 @@ class Renderer
     OctreeProcStats m_dsoProcStats;
 #endif
  private:
-    struct SkyVertex
-    {
-        float x, y, z;
-        unsigned char color[4];
-    };
-
-    struct SkyContourPoint
-    {
-        Eigen::Vector3f v;
-        Eigen::Vector3f eyeDir;
-        float centerDist;
-        float eyeDist;
-        float cosSkyCapAltitude;
-    };
-
     template <class OBJ> struct ObjectLabel
     {
         OBJ*        obj{ nullptr };
@@ -647,16 +633,6 @@ class Renderer
                              bool useHalos,
                              bool emissive,
                              const Matrices&);
-
-    void renderEllipsoidAtmosphere(const Atmosphere& atmosphere,
-                                   const Eigen::Vector3f& center,
-                                   const Eigen::Quaternionf& orientation,
-                                   const Eigen::Vector3f& semiAxes,
-                                   const Eigen::Vector3f& sunDirection,
-                                   const LightingState& ls,
-                                   float fade,
-                                   bool lit,
-                                   const Matrices&);
 
     void locationsToAnnotations(const Body& body,
                                 const Eigen::Vector3d& bodyPosition,
@@ -818,10 +794,6 @@ class Renderer
     float minFeatureSize;
     uint64_t locationFilter;
 
-    SkyVertex* skyVertices;
-    uint32_t* skyIndices;
-    SkyContourPoint* skyContour;
-
     const ColorTemperatureTable* colorTemp;
 
     Selection highlightObject;
@@ -850,6 +822,7 @@ class Renderer
     // Saturation magnitude used to calculate a point star size
     float satPoint;
 
+    std::unique_ptr<celestia::render::AtmosphereRenderer> m_atmosphereRenderer;
     std::unique_ptr<celestia::render::CometRenderer> m_cometRenderer;
 
     // Location markers

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -254,8 +254,7 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
     {
         if (ls.shadows[li] && !ls.shadows[li]->empty())
         {
-            unsigned int nShadows = static_cast<unsigned int>(std::min(static_cast<std::size_t>(MaxShaderEclipseShadows),
-                                                                       ls.shadows[li]->size()));
+            auto nShadows = std::min(MaxShaderEclipseShadows, static_cast<unsigned int>(ls.shadows[li]->size()));
             shadprop.setEclipseShadowCountForLight(li, nShadows);
             totalShadows += nShadows;
         }
@@ -616,8 +615,8 @@ void renderClouds_GLSL(const RenderInfo& ri,
     {
         if (ls.shadows[li] && !ls.shadows[li]->empty())
         {
-            unsigned int nShadows = static_cast<unsigned int>(std::min(static_cast<std::size_t>(MaxShaderEclipseShadows),
-                                                                       ls.shadows[li]->size()));
+            unsigned int nShadows = std::min(MaxShaderEclipseShadows,
+                                             static_cast<unsigned int>(ls.shadows[li]->size()));
             shadprop.setEclipseShadowCountForLight(li, nShadows);
             totalShadows += nShadows;
         }

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -3810,20 +3810,20 @@ CelestiaGLProgram::setEclipseShadowParameters(const LightingState& ls,
     Eigen::Affine3f rotation(orientation.conjugate());
     Eigen::Matrix4f modelToWorld = (rotation * Eigen::Scaling(scaleFactors)).matrix();
 
+    // The shadow bias matrix maps from
+    Eigen::Matrix4f shadowBias;
+    shadowBias << 0.5f, 0.0f, 0.0f, 0.5f,
+                  0.0f, 0.5f, 0.0f, 0.5f,
+                  0.0f, 0.0f, 0.5f, 0.5f,
+                  0.0f, 0.0f, 0.0f, 1.0f;
+
     for (unsigned int li = 0;
          li < std::min(ls.nLights, MaxShaderLights);
          li++)
     {
         if (ls.shadows[li] != nullptr)
         {
-            unsigned int nShadows = std::min(static_cast<std::size_t>(MaxShaderEclipseShadows), ls.shadows[li]->size());
-
-            // The shadow bias matrix maps from
-            Eigen::Matrix4f shadowBias;
-            shadowBias << 0.5f, 0.0f, 0.0f, 0.5f,
-                          0.0f, 0.5f, 0.0f, 0.5f,
-                          0.0f, 0.0f, 0.5f, 0.5f,
-                          0.0f, 0.0f, 0.0f, 1.0f;
+            auto nShadows = std::min(MaxShaderEclipseShadows, static_cast<unsigned int>(ls.shadows[li]->size()));
 
             for (unsigned int i = 0; i < nShadows; i++)
             {
@@ -3873,7 +3873,7 @@ CelestiaGLProgram::setAtmosphereParameters(const Atmosphere& atmosphere,
                                            float objRadius)
 {
     // Compute the radius of the sky sphere to render; the density of the atmosphere
-    // fallse off exponentially with height above the planet's surface, so the actual
+    // falls off exponentially with height above the planet's surface, so the actual
     // radius is infinite. That's a bit impractical, so well just render the portion
     // out to the point where the density is some fraction of the surface density.
     float skySphereRadius = atmPlanetRadius + -atmosphere.mieScaleHeight * std::log(AtmosphereExtinctionThreshold);

--- a/src/celengine/vecgl.h
+++ b/src/celengine/vecgl.h
@@ -130,4 +130,12 @@ translate(T x, T y, T z)
 {
     return Eigen::Transform<T,3,Eigen::Affine>(Eigen::Translation<T,3>(Eigen::Matrix<T,3,1>(x,y,z))).matrix();
 }
+
+template <typename T, typename F, std::enable_if_t<std::is_floating_point_v<F>, bool> = true>
+inline T
+mix(const T &x, const T &y, F a)
+{
+    return x * (static_cast<F>(1.0) - a) + y * a;
+}
+
 } // end namespace celestia::vecgl

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -41,7 +41,7 @@ bool ViewportEffect::distortXY(float &x, float &y)
 
 PassthroughViewportEffect::PassthroughViewportEffect() :
     ViewportEffect(),
-    vo(GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW)
+    vo(0, GL_STATIC_DRAW)
 {
 }
 
@@ -91,7 +91,7 @@ void PassthroughViewportEffect::draw(VertexObject& vo)
 
 WarpMeshViewportEffect::WarpMeshViewportEffect(WarpMesh *mesh) :
     ViewportEffect(),
-    vo(GL_ARRAY_BUFFER, 0, GL_STATIC_DRAW),
+    vo(0, GL_STATIC_DRAW),
     mesh(mesh)
 {
 }

--- a/src/celrender/CMakeLists.txt
+++ b/src/celrender/CMakeLists.txt
@@ -3,6 +3,8 @@ set(CELRENDER_SOURCES
   atmosphererenderer.h
   cometrenderer.cpp
   cometrenderer.h
+  eclipticlinerenderer.cpp
+  eclipticlinerenderer.h
   linerenderer.cpp
   linerenderer.h
   vertexobject.cpp

--- a/src/celrender/CMakeLists.txt
+++ b/src/celrender/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(CELRENDER_SOURCES
+  cometrenderer.cpp
+  cometrenderer.h
   linerenderer.cpp
   linerenderer.h
   vertexobject.cpp

--- a/src/celrender/CMakeLists.txt
+++ b/src/celrender/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(CELRENDER_SOURCES
+  atmosphererenderer.cpp
+  atmosphererenderer.h
   cometrenderer.cpp
   cometrenderer.h
   linerenderer.cpp

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -1,0 +1,411 @@
+// atmosphererenderer.cpp
+//
+// Copyright (C) 2001-present, Celestia Development Team
+// Original version Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <iostream>
+#include <celengine/atmosphere.h>
+#include <celengine/lightenv.h>
+#include <celengine/lodspheremesh.h>
+#include <celengine/render.h>
+#include <celengine/renderinfo.h>
+#include <celengine/shadermanager.h>
+#include <celengine/vecgl.h>
+#include <celutil/color.h>
+#include <celutil/indexlist.h>
+#include "atmosphererenderer.h"
+
+using celestia::util::BuildIndexList;
+using celestia::util::IndexListCapacity;
+using ushort = unsigned short;
+
+namespace
+{
+constexpr int MaxSkyRings = 32;
+constexpr int MaxSkySlices = 180;
+constexpr int MinSkySlices = 30;
+
+constexpr int MaxVertices = MaxSkySlices * (MaxSkyRings + 1);
+constexpr int MaxIndices = IndexListCapacity(MaxSkySlices,  MaxSkyRings + 1);
+}
+
+namespace celestia::render
+{
+AtmosphereRenderer::AtmosphereRenderer(Renderer &renderer) :
+    m_renderer(renderer)
+{
+}
+
+void AtmosphereRenderer::initGL()
+{
+    if (m_initialized)
+        return;
+
+    m_initialized = true;
+
+    m_skyVertices.reserve(MaxVertices);
+    m_skyIndices.reserve(MaxIndices);
+    m_skyContour.reserve(MaxSkySlices + 1);
+
+    m_vo = std::make_unique<IndexedVertexObject>(
+        MaxVertices * sizeof(SkyVertex),
+        GL_STREAM_DRAW,
+        GL_UNSIGNED_SHORT,
+        MaxIndices * sizeof(unsigned short));
+}
+
+void AtmosphereRenderer::deinitGL()
+{
+    m_initialized = false;
+    m_vo = nullptr;
+}
+
+void
+AtmosphereRenderer::computeLegacy(
+    const Atmosphere         &atmosphere,
+    const LightingState      &ls,
+    const Eigen::Vector3f    &center,
+    const Eigen::Quaternionf &orientation,
+    const Eigen::Vector3f    &semiAxes,
+    const Eigen::Vector3f    &sunDirection,
+    float                     pixSize,
+    bool                      lit)
+{
+    // Gradually fade in the atmosphere if it's thickness on screen is just
+    // over one pixel.
+    float fade = std::clamp(pixSize - 2.0f, 0.0f, 1.0f);
+
+    Eigen::Matrix3f rot = orientation.toRotationMatrix();
+    Eigen::Matrix3f irot = orientation.conjugate().toRotationMatrix();
+
+    Eigen::Vector3f eyePos(Eigen::Vector3f::Zero());
+    float radius = semiAxes.maxCoeff();
+    Eigen::Vector3f eyeVec = center - eyePos;
+    eyeVec = rot * eyeVec;
+    double centerDist = eyeVec.norm();
+
+    float height = atmosphere.height / radius;
+    Eigen::Vector3f recipSemiAxes = semiAxes.cwiseInverse();
+
+    // ellipDist is not the true distance from the surface unless the
+    // planet is spherical.  Computing the true distance requires finding
+    // the roots of a sixth degree polynomial, and isn't actually what we
+    // want anyhow since the atmosphere region is just the planet ellipsoid
+    // multiplied by a uniform scale factor.  The value that we do compute
+    // is the distance to the surface along a line from the eye position to
+    // the center of the ellipsoid.
+    float ellipDist = (eyeVec.cwiseProduct(recipSemiAxes)).norm() - 1.0f;
+    bool within = ellipDist < height;
+
+    // Adjust the tesselation of the sky dome/ring based on distance from the
+    // planet surface.
+    int nSlices = MaxSkySlices;
+    if (ellipDist < 0.25f)
+    {
+        nSlices = MinSkySlices + std::max(0, static_cast<int>((ellipDist * 4.0f)) * (MaxSkySlices - MinSkySlices));
+        nSlices &= ~1;
+    }
+
+    int nRings = std::min(1 + static_cast<int>(pixSize) / 5, 6);
+    int nHorizonRings = nRings;
+    if (within)
+        nRings += 12;
+
+    float horizonHeight = height;
+    if (within)
+    {
+        if (ellipDist <= 0.0f)
+            horizonHeight = 0.0f;
+        else
+            horizonHeight *= std::max(std::pow(ellipDist / height, 0.33f), 0.001f);
+    }
+
+    Eigen::Vector3f e = -eyeVec;
+    Eigen::Vector3f e_ = e.cwiseProduct(recipSemiAxes);
+    float ee = e_.dot(e_);
+
+    // Compute the cosine of the altitude of the sun.  This is used to compute
+    // the degree of sunset/sunrise coloration.
+    float cosSunAltitude = 0.0f;
+    {
+        // Check for a sun either directly behind or in front of the viewer
+        float cosSunAngle = sunDirection.dot(e) / static_cast<float>(centerDist);
+        if (cosSunAngle < -1.0f + 1.0e-6f)
+        {
+            cosSunAltitude = 0.0f;
+        }
+        else if (cosSunAngle > 1.0f - 1.0e-6f)
+        {
+            cosSunAltitude = 0.0f;
+        }
+        else
+        {
+            Eigen::Vector3f v = (rot * -sunDirection) * static_cast<float>(centerDist);
+            Eigen::Vector3f tangentPoint = center + irot * celmath::ellipsoidTangent(recipSemiAxes, v, e, e_, ee);
+            Eigen::Vector3f tangentDir = (tangentPoint - eyePos).normalized();
+            cosSunAltitude = sunDirection.dot(tangentDir);
+        }
+    }
+
+    Eigen::Vector3f normal = eyeVec / static_cast<float>(centerDist);
+
+    Eigen::Vector3f uAxis, vAxis;
+    if (std::abs(normal.x()) < std::abs(normal.y()) && std::abs(normal.x()) < std::abs(normal.z()))
+    {
+        uAxis = Eigen::Vector3f::UnitX().cross(normal);
+    }
+    else if (abs(eyeVec.y()) < abs(normal.z()))
+    {
+        uAxis = Eigen::Vector3f::UnitY().cross(normal);
+    }
+    else
+    {
+        uAxis = Eigen::Vector3f::UnitZ().cross(normal);
+    }
+    uAxis.normalize();
+    vAxis = uAxis.cross(normal);
+
+    // Compute the contour of the ellipsoid
+    for (int i = 0; i <= nSlices; i++)
+    {
+        SkyContourPoint p;
+        // We want rays with an origin at the eye point and tangent to the the
+        // ellipsoid.
+        float theta = static_cast<float>(i) / static_cast<float>(nSlices) * 2.0f * numbers::pi_v<float>;
+        Eigen::Vector3f w = std::cos(theta) * uAxis + std::sin(theta) * vAxis;
+        w *= static_cast<float>(centerDist);
+
+        Eigen::Vector3f toCenter = celmath::ellipsoidTangent(recipSemiAxes, w, e, e_, ee);
+        p.v = irot * toCenter;
+        p.centerDist = p.v.norm();
+        p.eyeDir = p.v + (center - eyePos);
+        p.eyeDist = p.eyeDir.norm();
+        p.eyeDir.normalize();
+
+        float skyCapDist = std::hypot(p.eyeDist, horizonHeight * radius);
+        p.cosSkyCapAltitude = p.eyeDist / skyCapDist;
+        m_skyContour.push_back(p);
+    }
+
+    Eigen::Vector3f botColor = atmosphere.lowerColor.toVector3();
+    Eigen::Vector3f topColor = atmosphere.upperColor.toVector3();
+    Eigen::Vector3f sunsetColor = atmosphere.sunsetColor.toVector3();
+
+    if (within)
+    {
+        Eigen::Vector3f skyColor = atmosphere.skyColor.toVector3();
+        if (ellipDist < 0.0f)
+            topColor = skyColor;
+        else
+            topColor = skyColor + (topColor - skyColor) * (ellipDist / height);
+    }
+
+    if (ls.nLights == 0 && lit)
+    {
+        botColor = topColor = sunsetColor = Eigen::Vector3f::Zero();
+    }
+
+    Eigen::Vector3f zenith = m_skyContour[0].v + m_skyContour[nSlices / 2].v;
+    zenith.normalize();
+    zenith *= m_skyContour[0].centerDist * (1.0f + horizonHeight * 2.0f);
+
+    float minOpacity = within ? (1.0f - ellipDist / height) * 0.75f : 0.0f;
+    float sunset = cosSunAltitude < 0.9f ? 0.0f : (cosSunAltitude - 0.9f) * 10.0f;
+
+    // Build the list of vertices
+    for (int i = 0; i <= nRings; i++)
+    {
+        SkyVertex vtx;
+        float h = std::min(1.0f, static_cast<float>(i) / static_cast<float>(nHorizonRings));
+        float hh = std::sqrt(h);
+        float u = i <= nHorizonRings ? 0.0f :
+            static_cast<float>(i - nHorizonRings) / static_cast<float>(nRings - nHorizonRings);
+        float r = celmath::lerp(h, 1.0f - (horizonHeight * 0.05f), 1.0f + horizonHeight);
+
+        for (int j = 0; j < nSlices; j++)
+        {
+            Eigen::Vector3f v;
+            if (i <= nHorizonRings)
+                v = m_skyContour[j].v * r;
+            else
+                v = vecgl::mix(m_skyContour[j].v, zenith, u) * r;
+            Eigen::Vector3f p = center + v;
+
+            Eigen::Vector3f viewDir = p.normalized();
+            float cosSunAngle = viewDir.dot(sunDirection);
+            float cosAltitude = viewDir.dot(m_skyContour[j].eyeDir);
+            float brightness = 1.0f;
+            float coloration = 0.0f;
+            if (lit)
+            {
+                if (sunset > 0.0f && cosSunAngle > 0.7f && cosAltitude > 0.98f)
+                {
+                    coloration =  (1.0f / 0.30f) * (cosSunAngle - 0.70f);
+                    coloration *= 50.0f * (cosAltitude - 0.98f);
+                    coloration *= sunset;
+                }
+
+                cosSunAngle = m_skyContour[j].v.dot(sunDirection) / m_skyContour[j].centerDist;
+                if (cosSunAngle <= -0.2f)
+                    brightness = 0.0f;
+                else if (cosSunAngle >= 0.3f)
+                    brightness = 1.0f;
+                else
+                    brightness = (cosSunAngle + 0.2f) * 2.0f;
+            }
+
+            memcpy(&vtx.position[0], p.data(), vtx.position.size() * sizeof(vtx.position[0]));
+
+            float atten = 1.0f - hh;
+            Eigen::Vector3f color = vecgl::mix(botColor, topColor, hh);
+            brightness *= minOpacity + (1.0f - minOpacity) * fade * atten;
+            if (coloration != 0.0f)
+                color = vecgl::mix(color, sunsetColor, coloration);
+
+            Color(brightness * color.x(),
+                  brightness * color.y(),
+                  brightness * color.z(),
+                  fade * (minOpacity + (1.0f - minOpacity)) * atten).get(&vtx.color[0]);
+            m_skyVertices.push_back(vtx);
+        }
+    }
+    m_skyContour.clear();
+
+    // Create the index list
+    BuildIndexList(static_cast<ushort>(nRings), static_cast<ushort>(nSlices), m_skyIndices);
+}
+
+void
+AtmosphereRenderer::initVertexObject()
+{
+    m_vo->bind();
+    m_vo->setVertexAttribArray(
+        CelestiaGLProgram::VertexCoordAttributeIndex,
+        3,
+        GL_FLOAT,
+        false,
+        sizeof(SkyVertex),
+        offsetof(SkyVertex, position));
+    m_vo->setVertexAttribArray(
+        CelestiaGLProgram::ColorAttributeIndex,
+        4,
+        GL_UNSIGNED_BYTE,
+        true,
+        sizeof(SkyVertex),
+        offsetof(SkyVertex, color));
+}
+
+void
+AtmosphereRenderer::renderLegacy(
+    const Atmosphere         &atmosphere,
+    const LightingState      &ls,
+    const Eigen::Vector3f    &center,
+    const Eigen::Quaternionf &orientation,
+    const Eigen::Vector3f    &semiAxes,
+    const Eigen::Vector3f    &sunDirection,
+    float                     pixSize,
+    bool                      lit,
+    const Matrices           &m)
+{
+    computeLegacy(atmosphere, ls, center, orientation, semiAxes, sunDirection, pixSize, lit);
+
+    ShaderProperties shadprop;
+    shadprop.texUsage = ShaderProperties::VertexColors;
+    shadprop.lightModel = ShaderProperties::UnlitModel;
+    auto *prog = m_renderer.getShaderManager().getShader(shadprop);
+    if (prog == nullptr)
+        return;
+
+    Renderer::PipelineState ps;
+    ps.depthTest = true;
+    ps.blending = true;
+    ps.blendFunc = {GL_ONE, GL_ONE_MINUS_SRC_ALPHA};
+    m_renderer.setPipelineState(ps);
+
+    if (m_vo->initialized())
+        m_vo->bindWritable();
+    else
+        initVertexObject();
+
+    m_vo->allocate(nullptr, nullptr); // allocate or orphan GPU memory buffers
+
+    m_vo->setBufferData(m_skyVertices.data(), 0, m_skyVertices.size() * sizeof(SkyVertex));
+    m_vo->setIndexBufferData(m_skyIndices.data(), 0, m_skyIndices.size() * sizeof(unsigned short));
+
+    prog->use();
+    prog->setMVPMatrices(*m.projection, *m.modelview);
+    m_vo->draw(GL_TRIANGLE_STRIP, static_cast<int>(m_skyIndices.size()), 0);
+    m_vo->unbind();
+
+    m_skyIndices.clear();
+    m_skyVertices.clear();
+}
+
+void
+AtmosphereRenderer::render(
+    const RenderInfo         &ri,
+    const Atmosphere         &atmosphere,
+    const LightingState      &ls,
+    const Eigen::Quaternionf &/*planetOrientation*/,
+    float                     radius,
+    const celmath::Frustum   &frustum,
+    const Matrices           &m)
+{
+    // Currently, we just skip rendering an atmosphere when there are no
+    // light sources, even though the atmosphere would still the light
+    // of planets and stars behind it.
+    if (ls.nLights == 0)
+        return;
+
+    ShaderProperties shadprop;
+    shadprop.nLights = static_cast<ushort>(ls.nLights);
+
+    shadprop.texUsage |= ShaderProperties::Scattering;
+    shadprop.lightModel = ShaderProperties::AtmosphereModel;
+
+    // Get a shader for the current rendering configuration
+    CelestiaGLProgram* prog = m_renderer.getShaderManager().getShader(shadprop);
+    if (prog == nullptr)
+        return;
+
+    prog->use();
+
+    prog->setLightParameters(ls, ri.color, ri.specularColor, Color::Black);
+    prog->ambientColor = Eigen::Vector3f::Zero();
+
+    float atmosphereRadius = radius + -atmosphere.mieScaleHeight * std::log(AtmosphereExtinctionThreshold);
+    float atmScale = atmosphereRadius / radius;
+
+    prog->eyePosition = ls.eyePos_obj / atmScale;
+    prog->setAtmosphereParameters(atmosphere, radius, atmosphereRadius);
+
+#if 0
+    // Currently eclipse shadows are ignored when rendering atmospheres
+    if (shadprop.shadowCounts != 0)
+        prog->setEclipseShadowParameters(ls, radius, planetOrientation);
+#endif
+
+    prog->setMVPMatrices(*m.projection, (*m.modelview) * vecgl::scale(atmScale));
+
+    glFrontFace(GL_CW);
+
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_ONE, GL_SRC_ALPHA};
+    ps.depthTest = true;
+    m_renderer.setPipelineState(ps);
+
+    g_lodSphere->render(LODSphereMesh::Normals,
+                        frustum,
+                        ri.pixWidth,
+                        nullptr);
+
+    glFrontFace(GL_CCW);
+}
+
+} // namespace celestia::render

--- a/src/celrender/atmosphererenderer.h
+++ b/src/celrender/atmosphererenderer.h
@@ -1,0 +1,102 @@
+// atmosphererenderer.h
+//
+// Copyright (C) 2001-present, Celestia Development Team
+// Original version Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <memory>
+#include <array>
+#include <vector>
+#include <Eigen/Core>
+
+class Atmosphere;
+class Renderer;
+class RenderInfo;
+class LightingState;
+struct Matrices;
+
+namespace celmath
+{
+class Frustum;
+}
+
+namespace celestia::render
+{
+class IndexedVertexObject;
+
+class AtmosphereRenderer
+{
+public:
+    explicit AtmosphereRenderer(Renderer &renderer);
+    ~AtmosphereRenderer() = default;
+    AtmosphereRenderer(const AtmosphereRenderer&) = delete;
+    AtmosphereRenderer(AtmosphereRenderer&&) = delete;
+    AtmosphereRenderer& operator=(const AtmosphereRenderer&) = delete;
+    AtmosphereRenderer& operator=(AtmosphereRenderer&&) = delete;
+
+    void renderLegacy(
+        const Atmosphere         &atmosphere,
+        const LightingState      &ls,
+        const Eigen::Vector3f    &center,
+        const Eigen::Quaternionf &orientation,
+        const Eigen::Vector3f    &semiAxes,
+        const Eigen::Vector3f    &sunDirection,
+        float                     pixSize,
+        bool                      lit,
+        const Matrices           &m);
+
+    void render(
+        const RenderInfo         &ri,
+        const Atmosphere         &atmosphere,
+        const LightingState      &ls,
+        const Eigen::Quaternionf &planetOrientation,
+        float                     radius,
+        const celmath::Frustum   &frustum,
+        const Matrices           &m);
+
+    void initGL();
+    void deinitGL();
+
+private:
+    void computeLegacy(
+        const Atmosphere         &atmosphere,
+        const LightingState      &ls,
+        const Eigen::Vector3f    &center,
+        const Eigen::Quaternionf &orientation,
+        const Eigen::Vector3f    &semiAxes,
+        const Eigen::Vector3f    &sunDirection,
+        float                     pixSize,
+        bool                      lit);
+
+    void initVertexObject();
+
+    struct SkyVertex
+    {
+        std::array<float,   3> position;
+        std::array<uint8_t, 4> color;
+    };
+
+    struct SkyContourPoint
+    {
+        Eigen::Vector3f v;
+        Eigen::Vector3f eyeDir;
+        float centerDist;
+        float eyeDist;
+        float cosSkyCapAltitude;
+    };
+
+    Renderer                               &m_renderer;
+    std::vector<SkyVertex>                  m_skyVertices;
+    std::vector<unsigned short>             m_skyIndices;
+    std::vector<SkyContourPoint>            m_skyContour;
+    std::unique_ptr<IndexedVertexObject>    m_vo;
+
+    bool                                    m_initialized   { false };
+};
+} // namespace celestia::render

--- a/src/celrender/cometrenderer.cpp
+++ b/src/celrender/cometrenderer.cpp
@@ -1,0 +1,261 @@
+// cometrenderer.h
+//
+// Copyright (C) 2001-present, the Celestia Development Team
+// Original version by Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <algorithm>
+#include <vector>
+#include <celengine/body.h>
+#include <celengine/observer.h>
+#include <celengine/render.h>
+#include <celengine/vecgl.h>
+#include <celmath/mathlib.h>
+#include <celutil/indexlist.h>
+#include "cometrenderer.h"
+
+using celestia::util::BuildIndexList;
+using celestia::util::IndexListCapacity;
+using ushort = unsigned short;
+
+namespace
+{
+
+constexpr int MaxCometTailPoints = 120;
+constexpr int MaxCometTailSlices = 48;
+constexpr int MaxVertices = MaxCometTailPoints*MaxCometTailSlices;
+constexpr int MaxIndices = IndexListCapacity(MaxCometTailSlices, MaxCometTailPoints);
+
+// Distance from the Sun at which comet tails will start to fade out
+constexpr float CometTailAttenDistSol = astro::AUtoKilometers(5.0f);
+}
+
+namespace celestia::render
+{
+
+CometRenderer::CometRenderer(Renderer &renderer) :
+    m_renderer(renderer),
+    m_vertices(std::make_unique<CometTailVertex[]>(MaxVertices)),
+    m_indices(std::make_unique<unsigned short[]>(MaxIndices))
+{
+}
+
+void
+CometRenderer::initGL()
+{
+    if (m_initialized)
+        return;
+
+    m_initialized = true;
+
+    m_prog = m_renderer.getShaderManager().getShader("comet");
+    m_brightnessLoc = m_prog->attribIndex("in_Brightness");
+
+    m_vo = std::make_unique<IndexedVertexObject>(
+            MaxVertices * sizeof(CometTailVertex),
+            GL_STREAM_DRAW,
+            GL_UNSIGNED_SHORT,
+            MaxIndices * sizeof(unsigned short));
+}
+
+void
+CometRenderer::deinitGL()
+{
+    m_initialized = false;
+    m_vo = nullptr;
+}
+
+void
+CometRenderer::initVertexObject()
+{
+    m_vo->bind();
+    m_vo->setVertexAttribArray(
+        CelestiaGLProgram::VertexCoordAttributeIndex,
+        3,
+        GL_FLOAT,
+        GL_FALSE,
+        sizeof(CometTailVertex),
+        offsetof(CometTailVertex, point));
+    m_vo->setVertexAttribArray(
+        CelestiaGLProgram::NormalAttributeIndex,
+        3,
+        GL_FLOAT,
+        GL_FALSE,
+        sizeof(CometTailVertex),
+        offsetof(CometTailVertex, normal));
+    m_vo->setVertexAttribArray(
+        m_brightnessLoc,
+        1,
+        GL_FLOAT,
+        GL_FALSE,
+        sizeof(CometTailVertex),
+        offsetof(CometTailVertex, brightness));
+}
+
+void
+CometRenderer::render(const Body &body,
+                      const Observer &observer,
+                      const Eigen::Vector3f &pos,
+                      float dustTailLength,
+                      float discSizeInPixels,
+                      const Matrices &m)
+{
+    if (m_prog == nullptr)
+        return;
+
+    double now = observer.getTime();
+
+    Eigen::Vector3f cometPoints[MaxCometTailPoints];
+#if 0
+    Eigen::Vector3d pos0 = body.getOrbit(now)->positionAtTime(now);
+    Eigen::Vector3d pos1 = body.getOrbit(now)->positionAtTime(now - 0.01);
+    Eigen::Vector3d vd = pos1 - pos0;
+#endif
+
+    // Adjust the amount of triangles used for the comet tail based on
+    // the screen size of the comet.
+    float lod = std::clamp(discSizeInPixels / 1000.0f, 0.2f, 1.0f);
+    auto nTailPoints = static_cast<int>(MaxCometTailPoints * lod);
+    auto nTailSlices = static_cast<int>(MaxCometTailSlices * lod);
+
+    float irradiance_max = 0.0f;
+    // Find the sun with the largest irrradiance of light onto the comet
+    // as function of the comet's position;
+    // irradiance = sun's luminosity / square(distanceFromSun);
+    Eigen::Vector3d sunPos(Eigen::Vector3d::Zero());
+    for (const auto star : m_renderer.getNearStars())
+    {
+        if (star->getVisibility())
+        {
+            Eigen::Vector3d p = star->getPosition(now).offsetFromKm(observer.getPosition());
+            float distanceFromSun = static_cast<float>((pos.cast<double>() - p).norm());
+            float irradiance = star->getBolometricLuminosity() / celmath::square(distanceFromSun);
+
+            if (irradiance > irradiance_max)
+            {
+                irradiance_max = irradiance;
+                sunPos = p;
+            }
+        }
+    }
+
+    float fadeDistance = 1.0f / (CometTailAttenDistSol * std::sqrt(irradiance_max));
+
+    // direction to sun with dominant light irradiance:
+    Eigen::Vector3f sunDir = (pos.cast<double>() - sunPos).cast<float>().normalized();
+
+    float dustTailRadius = dustTailLength * 0.1f;
+
+    Eigen::Vector3f origin = -sunDir * (body.getRadius() * 100);
+
+    for (int i = 0; i < nTailPoints; i++)
+    {
+        float alpha = static_cast<float>(i) / static_cast<float>(nTailPoints);
+        alpha = alpha * alpha;
+        cometPoints[i] = origin + sunDir * (dustTailLength * alpha);
+    }
+
+    // We need three axes to define the coordinate system for rendering the
+    // comet. The first axis is the sun-to-comet direction, and the other
+    // two are chose orthogonal to each other and the primary axis.
+    Eigen::Vector3f v = (cometPoints[1] - cometPoints[0]).normalized();
+    Eigen::Quaternionf q = body.getEclipticToEquatorial(now).cast<float>();
+    Eigen::Vector3f u = v.unitOrthogonal();
+    Eigen::Vector3f w = u.cross(v);
+
+    for (int i = 0; i < nTailPoints; i++)
+    {
+        float brightness = 1.0f - static_cast<float>(i) / static_cast<float>(nTailPoints - 1);
+        Eigen::Vector3f v0, v1;
+        float w0, w1;
+        // Special case for the first vertex in the comet tail
+        if (i == 0)
+        {
+            v0 = cometPoints[1] - cometPoints[0];
+            v0.normalize();
+            v1 = v0;
+            w0 = 1.0f;
+            w1 = 0.0f;
+        }
+        else
+        {
+            v0 = cometPoints[i] - cometPoints[i - 1];
+            float sectionLength = v0.norm();
+            v0.normalize();
+
+            if (i == nTailPoints - 1)
+            {
+                v1 = v0;
+            }
+            else
+            {
+                v1 = (cometPoints[i + 1] - cometPoints[i]).normalized();
+                q.setFromTwoVectors(v0, v1);
+                Eigen::Matrix3f rot = q.toRotationMatrix();
+                u = rot * u;
+                v = rot * v;
+                w = rot * w;
+            }
+            float dr = dustTailRadius / static_cast<float>(nTailPoints) / sectionLength;
+            w0 = std::atan(dr);
+            float d = std::sqrt(1.0f + w0 * w0);
+            w1 = 1.0f / d;
+            w0 = w0 / d;
+        }
+
+        float radius = static_cast<float>(i) / static_cast<float>(nTailPoints) * dustTailRadius;
+        for (int j = 0; j < nTailSlices; j++)
+        {
+            float theta = 2.0f * numbers::pi_v<float> * static_cast<float>(j) / static_cast<float>(nTailSlices);
+            float s, c;
+            celmath::sincos(theta, s, c);
+            CometTailVertex& vtx = m_vertices[i * nTailSlices + j];
+            vtx.normal = u * (s * w1) + w * (c * w1) + v * w0;
+            vtx.normal.normalize();
+            s *= radius;
+            c *= radius;
+
+            vtx.point = cometPoints[i] + u * s + w * c;
+            vtx.brightness = brightness;
+        }
+    }
+
+    BuildIndexList(static_cast<ushort>(nTailPoints-1), static_cast<ushort>(nTailSlices), m_indices.get());
+
+    // If fadeDistFromSun = x/x0 >= 1.0, comet tail starts fading,
+    // i.e. fadeFactor quickly transits from 1 to 0.
+    float fadeFactor = 0.5f * (1.0f - std::tanh(fadeDistance - 1.0f / fadeDistance));
+
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE};
+    ps.depthTest = true;
+    m_renderer.setPipelineState(ps);
+
+    m_prog->use();
+    m_prog->setMVPMatrices(*m.projection, (*m.modelview) * vecgl::translate(pos));
+    m_prog->vec3Param("color") = body.getCometTailColor().toVector3();
+    m_prog->vec3Param("viewDir") = pos.normalized();
+    m_prog->floatParam("fadeFactor") = fadeFactor;
+
+    if (m_vo->initialized())
+        m_vo->bindWritable();
+    else
+        initVertexObject();
+
+    m_vo->allocate(nullptr, nullptr); // allocate or orphan GPU memory buffers
+
+    m_vo->setBufferData(m_vertices.get(), 0, sizeof(CometTailVertex) * nTailPoints * nTailSlices);
+    int count = IndexListCapacity(nTailSlices, nTailPoints);
+    m_vo->setIndexBufferData(m_indices.get(), 0, count * sizeof(m_indices[0]));
+
+    glDisable(GL_CULL_FACE);
+    m_vo->draw(GL_TRIANGLE_STRIP, count, 0);
+    m_vo->unbind();
+    glEnable(GL_CULL_FACE);
+}
+}

--- a/src/celrender/cometrenderer.h
+++ b/src/celrender/cometrenderer.h
@@ -1,0 +1,66 @@
+// cometrenderer.h
+//
+// Copyright (C) 2001-present, the Celestia Development Team
+// Original version by Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <utility>
+#include <Eigen/Core>
+
+class Body;
+class Observer;
+class Renderer;
+class CelestiaGLProgram;
+struct Matrices;
+
+namespace celestia::render
+{
+class IndexedVertexObject;
+
+class CometRenderer
+{
+public:
+    explicit CometRenderer(Renderer &renderer);
+    ~CometRenderer() = default;
+    CometRenderer(const CometRenderer&) = delete;
+    CometRenderer(CometRenderer&&) = delete;
+    CometRenderer& operator=(const CometRenderer&) = delete;
+    CometRenderer& operator=(CometRenderer&&) = delete;
+
+    void render(const Body &body,
+                const Observer &observer,
+                const Eigen::Vector3f &pos,
+                float dustTailLength,
+                float discSizeInPixels,
+                const Matrices &m);
+
+    void initGL();
+    void deinitGL();
+
+private:
+
+    void initVertexObject();
+
+    struct CometTailVertex
+    {
+        Eigen::Vector3f point;
+        Eigen::Vector3f normal;
+        float brightness;
+    };
+
+    Renderer                               &m_renderer;
+    CelestiaGLProgram                      *m_prog              { nullptr };
+    int                                     m_brightnessLoc     { -1 };
+    bool                                    m_initialized       { false };
+
+    std::unique_ptr<CometTailVertex[]>      m_vertices;
+    std::unique_ptr<unsigned short[]>       m_indices;
+    std::unique_ptr<IndexedVertexObject>    m_vo;
+};
+}

--- a/src/celrender/eclipticlinerenderer.cpp
+++ b/src/celrender/eclipticlinerenderer.cpp
@@ -1,0 +1,57 @@
+// eclipticlinerenderer.cpp
+//
+// Copyright (C) 2001-present, Celestia Development Team
+// Original version Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <celmath/mathlib.h> // sincos
+#include <celengine/render.h>
+
+#include "eclipticlinerenderer.h"
+
+constexpr float kEclipticScale = 1000.0f;
+constexpr int kEclipticCount = 200;
+
+constexpr float PI = celestia::numbers::pi_v<float>;
+
+namespace celestia::render
+{
+EclipticLineRenderer::EclipticLineRenderer(Renderer &renderer) :
+    m_renderer(renderer),
+    m_lineRenderer(renderer, 1.0f, LineRenderer::PrimType::LineLoop, LineRenderer::StorageType::Static)
+{
+}
+
+void
+EclipticLineRenderer::init()
+{
+    m_initialized = true;
+    for (int i = 0; i < kEclipticCount; i++)
+    {
+        float s, c;
+        float angle = static_cast<float>(2 * i) / static_cast<float>(kEclipticCount) * PI;
+        celmath::sincos(angle, s, c);
+        m_lineRenderer.addVertex(c * kEclipticScale, 0.0f, s * kEclipticScale);
+    }
+}
+
+void
+EclipticLineRenderer::render()
+{
+    if (!m_initialized)
+        init();
+
+    Renderer::PipelineState ps;
+    ps.blending = true;
+    ps.blendFunc = {GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA};
+    ps.smoothLines = true;
+    m_renderer.setPipelineState(ps);
+
+    m_lineRenderer.render({&m_renderer.getProjectionMatrix(), &m_renderer.getModelViewMatrix()}, Renderer::EclipticColor, kEclipticCount);
+    m_lineRenderer.finish();
+}
+}

--- a/src/celrender/eclipticlinerenderer.h
+++ b/src/celrender/eclipticlinerenderer.h
@@ -1,0 +1,37 @@
+// eclipticlinerenderer.h
+//
+// Copyright (C) 2001-present, Celestia Development Team
+// Original version by Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include "linerenderer.h"
+
+class Renderer;
+
+namespace celestia::render
+{
+/*! Draw the J2000.0 ecliptic; trivial, since this forms the basis for
+ *  Celestia's coordinate system.
+ */
+class EclipticLineRenderer
+{
+public:
+    EclipticLineRenderer(Renderer &renderer);
+    ~EclipticLineRenderer() = default;
+
+    void render();
+
+private:
+    void init();
+
+    Renderer    &m_renderer;
+    LineRenderer m_lineRenderer;
+    bool         m_initialized  { false };
+};
+} // namespace celestia::render

--- a/src/celrender/linerenderer.cpp
+++ b/src/celrender/linerenderer.cpp
@@ -108,7 +108,7 @@ void
 LineRenderer::create_vbo_lines()
 {
     auto storageType = static_cast<GLenum>(m_storageType);
-    m_lnVertexObj    = std::make_unique<VertexObject>(GL_ARRAY_BUFFER, 0, storageType);
+    m_lnVertexObj    = std::make_unique<VertexObject>(0, storageType);
     m_lnVertexObj->bind();
 
     m_lnVertexObj->allocate(m_vertices.capacity() * sizeof(m_vertices[0]), m_vertices.data());
@@ -164,7 +164,7 @@ void
 LineRenderer::create_vbo_triangles()
 {
     auto storageType = static_cast<GLenum>(m_storageType);
-    m_trVertexObj    = std::make_unique<VertexObject>(GL_ARRAY_BUFFER, 0, storageType);
+    m_trVertexObj    = std::make_unique<VertexObject>(0, storageType);
     m_trVertexObj->bind();
 
     GLsizei               stride;

--- a/src/celrender/vertexobject.cpp
+++ b/src/celrender/vertexobject.cpp
@@ -154,6 +154,25 @@ void VertexObject::disableAttribArrays() const noexcept
         glDisableVertexAttribArray(p.location);
 }
 
+void
+VertexObject::disableVertexAttribArray(GLint location) const noexcept
+{
+    glDisableVertexAttribArray(location);
+}
+
+void
+VertexObject::setVertexAttribConstant(GLint location, float value) const noexcept
+{
+    disableVertexAttribArray(location);
+    glVertexAttrib1f(location, value);
+}
+
+void
+VertexObject::enableVertexAttribArray(GLint location) const noexcept
+{
+    glEnableVertexAttribArray(location);
+}
+
 void VertexObject::setVertexAttribArray(GLint location, GLint count, GLenum type, bool normalized, GLsizei stride, GLsizeiptr offset)
 {
     assert(location >= 0);

--- a/src/celrender/vertexobject.h
+++ b/src/celrender/vertexobject.h
@@ -141,6 +141,29 @@ class VertexObject
      */
     void setVertexAttribArray(GLint location, GLint count, GLenum type, bool normalized = false, GLsizei stride = 0, GLsizeiptr offset = 0);
 
+
+    /**
+     *  Disable vertex attribute.
+     *
+     *  @param location Specifies the index of the generic vertex attribute.
+     */
+    void disableVertexAttribArray(GLint location) const noexcept;
+
+    /**
+     *  Enable vertex attribute.
+     *
+     *  @param location Specifies the index of the generic vertex attribute.
+     */
+    void enableVertexAttribArray(GLint location) const noexcept;
+
+    /**
+     *  Disable vertex attribute and use a contant value.
+     *
+     *  @param location Specifies the index of the generic vertex attribute.
+     *  @param value Value to provide in shaders when this attribute is used.
+     */
+    void setVertexAttribConstant(GLint location, float value) const noexcept;
+
     //! Return the buffer's initialization state.
     inline bool initialized() const noexcept
     {

--- a/src/celutil/indexlist.h
+++ b/src/celutil/indexlist.h
@@ -1,0 +1,87 @@
+// indexlist.h
+//
+// Copyright (C) 2023-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <limits>
+#include <vector>
+
+namespace celestia::util
+{
+template <
+    typename T,
+    std::enable_if_t<std::is_integral_v<T>, bool> = true
+>
+constexpr T
+IndexListCapacity(T nSlices, T nPoints)
+{
+    return (nSlices * 2 + 4) * (nPoints - 1) - 2;
+}
+
+template <
+    typename T,
+    std::enable_if_t<std::is_integral_v<T>, bool> = true
+>
+void
+BuildIndexList(T I, T J, std::vector<T> &out)
+{
+    assert(std::numeric_limits<T>::max() / I >= J);
+
+    out.reserve(IndexListCapacity(I, J)); // noop if current capacity >= new one
+
+    for (auto i = static_cast<T>(0); i < I; i++)
+    {
+        T baseVertex = i * J;
+
+        if (i > static_cast<T>(0))
+            out.push_back(baseVertex); // degenerate triangle
+
+        for (auto j = static_cast<T>(0); j < J; j++)
+        {
+            T v = baseVertex + j;
+            out.push_back(v);
+            out.push_back(v + J);
+        }
+        out.push_back(baseVertex);
+        out.push_back(baseVertex + J);
+
+        if (i < I - static_cast<T>(1))
+            out.push_back(baseVertex + J); // degenerate triangle
+    }
+}
+
+template <
+    typename T,
+    std::enable_if_t<std::is_integral_v<T>, bool> = true
+>
+void
+BuildIndexList(T I, T J, T* out)
+{
+    assert(std::numeric_limits<T>::max() / I >= J);
+
+    for (auto i = static_cast<T>(0); i < I; i++)
+    {
+        T baseVertex = i * J;
+
+        if (i > static_cast<T>(0))
+            *out++ = baseVertex; // degenerate triangle
+
+        for (auto j = static_cast<T>(0); j < J; j++)
+        {
+            T v = baseVertex + j;
+            *out++ = v;
+            *out++ = v + J;
+        }
+        *out++ = baseVertex;
+        *out++ = baseVertex + J;
+
+        if (i < I - static_cast<T>(1))
+            *out++ = baseVertex + J; // degenerate triangle
+    }
+}
+
+}


### PR DESCRIPTION
Comet tail and atmosphere rendering were moved to their own files.

Only rectangle rendering is using client-side memory now. I'll take care of it and remove Renderer::getVertexObject in the next pr.