### PR TITLE
Refactor align.h

### DIFF
--- a/src/celscript/lua/celx_rotation.cpp
+++ b/src/celscript/lua/celx_rotation.cpp
@@ -17,11 +17,14 @@
 using namespace std;
 using namespace Eigen;
 
+namespace celutil = celestia::util;
+
 int rotation_new(lua_State* l, const Quaterniond& qd)
 {
     CelxLua celx(l);
-    auto q = reinterpret_cast<Quaterniond*>(lua_newuserdata(l, aligned_sizeof<Quaterniond>()));
-    *aligned_addr(q) = qd;
+    constexpr std::size_t size = celutil::aligned_sizeof<Quaterniond>();
+    auto q = celutil::aligned_addr<Quaterniond>(lua_newuserdata(l, size));
+    *q = qd;
     celx.setClass(Celx_Rotation);
 
     return 1;
@@ -30,9 +33,7 @@ int rotation_new(lua_State* l, const Quaterniond& qd)
 Quaterniond* to_rotation(lua_State* l, int index)
 {
     CelxLua celx(l);
-    auto q = reinterpret_cast<Quaterniond*>(celx.checkUserData(index, Celx_Rotation));
-
-    return aligned_addr(q);
+    return celutil::aligned_addr<Quaterniond>(celx.checkUserData(index, Celx_Rotation));
 }
 
 static Quaterniond* this_rotation(lua_State* l)

--- a/src/celscript/lua/celx_vector.cpp
+++ b/src/celscript/lua/celx_vector.cpp
@@ -18,12 +18,15 @@
 using namespace std;
 using namespace Eigen;
 
+namespace celutil = celestia::util;
+
 int vector_new(lua_State* l, const Vector3d& v)
 {
     CelxLua celx(l);
 
-    auto v3 = reinterpret_cast<Vector3d*>(lua_newuserdata(l, aligned_sizeof<Vector3d>()));
-    *aligned_addr(v3) = v;
+    constexpr std::size_t size = celutil::aligned_sizeof<Vector3d>();
+    auto v3 = celutil::aligned_addr<Vector3d>(lua_newuserdata(l, size));
+    *v3 = v;
     celx.setClass(Celx_Vec3);
 
     return 1;
@@ -32,9 +35,7 @@ int vector_new(lua_State* l, const Vector3d& v)
 Vector3d* to_vector(lua_State* l, int index)
 {
     CelxLua celx(l);
-    auto v = reinterpret_cast<Vector3d*>(celx.checkUserData(index, Celx_Vec3));
-
-    return aligned_addr(v);
+    return celutil::aligned_addr<Vector3d>(celx.checkUserData(index, Celx_Vec3));
 }
 
 static Vector3d* this_vector(lua_State* l)

--- a/src/celutil/align.h
+++ b/src/celutil/align.h
@@ -1,26 +1,28 @@
 #pragma once
 
-#include <type_traits>
+#include <cstddef>
+#include <cstdint>
+
+namespace celestia::util
+{
 
 /*! Returns aligned position for type T inside memory region.
- *  Designed for usage with functions which allocate unalligned
+ *  Designed for usage with functions which allocate unaligned
  *  memory regions.
  */
-template<typename T> T* aligned_addr(T* addr)
+template<typename T> T* aligned_addr(void* addr)
 {
-    size_t align = std::alignment_of<T>::value;
-    return (T*) (((size_t(addr) - 1) / align + 1) * align);
-}
-
-template<typename T> T* aligned_addr(T* addr, size_t align)
-{
-    return (T*) (((size_t(addr) - 1) / align + 1) * align);
+    // alignof(T) is guaranteed to be a power of two
+    constexpr auto align_one = static_cast<std::uintptr_t>(alignof(T) - 1);
+    return reinterpret_cast<T*>((reinterpret_cast<std::uintptr_t>(addr) + align_one) & (~align_one));
 }
 
 /*! Returns size large enough so an object of type T can be placed
- *  inside allocated unalligned memory region with its address aligned.
+ *  inside allocated unaligned memory region with its address aligned.
  */
-template<typename T> size_t aligned_sizeof()
+template<typename T> constexpr std::size_t aligned_sizeof()
 {
-    return sizeof(T) + std::alignment_of<T>::value - 1;
+    return sizeof(T) + alignof(T) - 1;
+}
+
 }


### PR DESCRIPTION
- Avoid creating unaligned pointers before aligning void*
- Use celestia::util namespace
- Replace std::alignment_of with alignof, use constexpr