### PR TITLE
Add Position to the stc file

### DIFF
--- a/src/celengine/deepskyobj.cpp
+++ b/src/celengine/deepskyobj.cpp
@@ -139,7 +139,7 @@ void DeepSkyObject::hsv2rgb( float *r, float *g, float *b, float h, float s, flo
 bool DeepSkyObject::load(const AssociativeArray* params, const fs::path& resPath)
 {
     // Get position
-    if (auto position = params->getVector3<double>("Position"); position.has_value())
+    if (auto position = params->getLengthVector<double>("Position", KM_PER_LY<double>); position.has_value())
     {
         setPosition(*position);
     }

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -1075,6 +1075,13 @@ bool StarDatabase::createStar(Star* star,
     {
         star->setPosition(barycenterPosition);
     }
+    else if (auto rectangularPos = starData->getLengthVector<float>("Position", KM_PER_LY<double>); rectangularPos.has_value())
+    {
+        // "Position" allows the position of the star to be specified in
+        // coordinates matching those used in stars.dat, allowing an exact
+        // translation of stars.dat entries to .stc.
+        star->setPosition(*rectangularPos);
+    }
     else
     {
         double ra = 0.0;


### PR DESCRIPTION
This property allows specifying a star's position in rectangular coordinates in the ecliptic reference frame, matching the coordinates used in stars.dat. This enables a 1:1 conversion of stars.dat entries into the .stc file format.

Open to suggestions for a different name for this property.