### PR TITLE
Remove duplicate function astro::equatorialToEclipticCartesian

### DIFF
--- a/src/celengine/astro.cpp
+++ b/src/celengine/astro.cpp
@@ -183,23 +183,6 @@ astro::equatorialToCelestialCart(double ra, double dec, double distance)
 }
 
 
-/** Convert spherical coordinates in the J2000 equatorial frame to cartesian
-  * coordinates in the J2000 ecliptic frame. RA in hours, dec in degrees.
-  */
-Eigen::Vector3f
-astro::equatorialToEclipticCartesian(float ra, float dec, float distance)
-{
-    using celestia::numbers::pi;
-    double theta = ra / 24.0 * pi * 2 + pi;
-    double phi = (dec / 90.0 - 1.0) * pi / 2;
-    double x = cos(theta) * sin(phi) * distance;
-    double y = cos(phi) * distance;
-    double z = -sin(theta) * sin(phi) * distance;
-
-    return EQUATORIAL_TO_ECLIPTIC_MATRIX_F * Eigen::Vector3f((float) x, (float) y, (float) z);
-}
-
-
 void astro::anomaly(double meanAnomaly, double eccentricity,
                     double& trueAnomaly, double& eccentricAnomaly)
 {

--- a/src/celengine/astro.h
+++ b/src/celengine/astro.h
@@ -269,8 +269,6 @@ namespace astro
     Eigen::Vector3f equatorialToCelestialCart(float ra, float dec, float distance);
     Eigen::Vector3d equatorialToCelestialCart(double ra, double dec, double distance);
 
-    Eigen::Vector3f equatorialToEclipticCartesian(float ra, float dec, float distance);
-
     Eigen::Quaterniond eclipticToEquatorial();
     Eigen::Vector3d eclipticToEquatorial(const Eigen::Vector3d& v);
     Eigen::Quaterniond equatorialToGalactic();

--- a/src/celengine/boundaries.cpp
+++ b/src/celengine/boundaries.cpp
@@ -43,7 +43,7 @@ void ConstellationBoundaries::moveto(float ra, float dec)
 {
     assert(currentChain != nullptr);
 
-    Eigen::Vector3f v = astro::equatorialToEclipticCartesian(ra, dec, BoundariesDrawDistance);
+    Eigen::Vector3f v = astro::equatorialToCelestialCart(ra, dec, BoundariesDrawDistance);
     if (currentChain->size() > 1)
     {
         chains.emplace_back(currentChain);
@@ -59,7 +59,7 @@ void ConstellationBoundaries::moveto(float ra, float dec)
 
 void ConstellationBoundaries::lineto(float ra, float dec)
 {
-    currentChain->emplace_back(astro::equatorialToEclipticCartesian(ra, dec, BoundariesDrawDistance));
+    currentChain->emplace_back(astro::equatorialToCelestialCart(ra, dec, BoundariesDrawDistance));
 }
 
 


### PR DESCRIPTION
Only used in boundaries.cpp, implementation is the same as astro::equatorialToCelestialCart