### PR TITLE
Fix an MSVC warning about reinterpret_cast

### DIFF
--- a/src/celrender/vertexobject.cpp
+++ b/src/celrender/vertexobject.cpp
@@ -9,8 +9,9 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <cassert>
 #include "vertexobject.h"
+
+#include <cassert>
 
 namespace
 {
@@ -247,7 +248,8 @@ IndexedVertexObject::draw(GLenum primitive, GLsizei count, GLint first) const no
     if ((m_state & State::Initialize) != 0)
         enableAttribArrays();
 
-    glDrawElements(primitive, count, m_indexType, reinterpret_cast<void*>(first));
+    glDrawElements(primitive, count, m_indexType,
+                   reinterpret_cast<const void*>(static_cast<std::intptr_t>(first)));
 }
 
 void

--- a/src/celrender/vertexobject.h
+++ b/src/celrender/vertexobject.h
@@ -11,8 +11,10 @@
 
 #pragma once
 
-#include <celengine/glsupport.h>
+#include <cstdint>
 #include <vector>
+
+#include <celengine/glsupport.h>
 
 namespace celestia::render
 {
@@ -183,14 +185,14 @@ class VertexObject
     void setStreamType(GLenum streamType) noexcept     { m_streamType = streamType; }
 
  protected:
-    enum State : uint16_t
+    enum State : std::uint16_t
     {
         NormalState = 0x0000,
         Initialize  = 0x0001,
         Update      = 0x0002
     };
 
-    uint16_t   m_state              { State::Initialize };
+    std::uint16_t m_state { State::Initialize };
 
     struct PtrParams;
 


### PR DESCRIPTION
Fixes the following warning:

```
warning C4312: 'reinterpret_cast': conversion from 'GLint' to 'void *' of greater size
```