### PR TITLE
Update usages of reinterpret_cast

### DIFF
--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -185,10 +185,10 @@ void draw(std::size_t vCount, const GalaxyVertex *v, std::size_t iCount, const G
 
     glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
                           4, GL_FLOAT, GL_FALSE,
-                          sizeof(GalaxyVertex), reinterpret_cast<void*>(offsetof(GalaxyVertex, position)));
+                          sizeof(GalaxyVertex), reinterpret_cast<const void*>(offsetof(GalaxyVertex, position)));
     glVertexAttribPointer(CelestiaGLProgram::TextureCoord0AttributeIndex,
                           4, GL_UNSIGNED_SHORT, GL_FALSE,
-                          sizeof(GalaxyVertex), reinterpret_cast<void*>(offsetof(GalaxyVertex, texCoord)));
+                          sizeof(GalaxyVertex), reinterpret_cast<const void*>(offsetof(GalaxyVertex, texCoord)));
     glDrawElements(GL_TRIANGLES, iCount, GL_UNSIGNED_SHORT, nullptr);
 }
 

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -795,7 +795,7 @@ static void renderRingSystem(GLuint *vboId,
     glVertexAttribPointer(CelestiaGLProgram::TextureCoord0AttributeIndex,
                           2, GL_SHORT, GL_FALSE,
                           sizeof(struct RingVertex),
-                          reinterpret_cast<GLvoid*>(offsetof(struct RingVertex, tex)));
+                          reinterpret_cast<const void*>(offsetof(struct RingVertex, tex)));
 
     glEnableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
     glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
@@ -939,7 +939,7 @@ void renderRings_GLSL(RingSystem& rings,
 
     if (rings.renderData == nullptr)
         rings.renderData = std::make_shared<GLRingRenderData>();
-    auto data = reinterpret_cast<GLRingRenderData*>(rings.renderData.get());
+    auto data = static_cast<GLRingRenderData*>(rings.renderData.get());
 
     unsigned nSections = 180;
     std::size_t i = 0;

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -342,7 +342,7 @@ static bool ApproxPlanetPickTraversal(Body* body, void* info)
 // Perform an intersection test between the pick ray and a body
 static bool ExactPlanetPickTraversal(Body* body, void* info)
 {
-    auto* pickInfo = reinterpret_cast<PlanetPickInfo*>(info);
+    auto* pickInfo = static_cast<PlanetPickInfo*>(info);
     Vector3d bpos = body->getAstrocentricPosition(pickInfo->jd);
     float radius = body->getRadius();
     double distance = -1.0;

--- a/src/celestia/qt/qtbookmark.cpp
+++ b/src/celestia/qt/qtbookmark.cpp
@@ -268,7 +268,7 @@ BookmarkTreeModel::index(int row, int column, const QModelIndex& parent) const
     Q_ASSERT(parentFolder->type() == BookmarkItem::Folder);
     Q_ASSERT(row < (int) parentFolder->childCount());
 
-    return createIndex(row, column, const_cast<void*>(reinterpret_cast<const void*>(parentFolder->child(row))));
+    return createIndex(row, column, parentFolder->child(row));
 }
 
 
@@ -283,7 +283,7 @@ BookmarkTreeModel::parent(const QModelIndex& index) const
     if (parentFolder == m_root)
         return QModelIndex();
     else
-        return createIndex(parentFolder->position(), 0, reinterpret_cast<void*>(parentFolder));
+        return createIndex(parentFolder->position(), 0, parentFolder);
 }
 
 

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -3200,7 +3200,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
                 COPYDATASTRUCT cd;
                 cd.dwData = 0;
                 cd.cbData = startURL.length();
-                cd.lpData = reinterpret_cast<void*>(const_cast<char*>(startURL.c_str()));
+                cd.lpData = startURL.data();
                 SendMessage(existingWnd, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&cd));
             }
             SetForegroundWindow(existingWnd);
@@ -3528,7 +3528,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
         COPYDATASTRUCT cd;
         cd.dwData = 0;
         cd.cbData = startURL.length();
-        cd.lpData = reinterpret_cast<void*>(const_cast<char*>(startURL.c_str()));
+        cd.lpData = startURL.data();
         SendMessage(mainWindow, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&cd));
     }
 

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -396,7 +396,7 @@ static const char* readStreamChunk(lua_State* /*unused*/, void* udata, size_t* s
     if (udata == nullptr)
         return nullptr;
 
-    auto* info = reinterpret_cast<ReadChunkInfo*>(udata);
+    auto* info = static_cast<ReadChunkInfo*>(udata);
     assert(info->buf != nullptr);
     assert(info->in != nullptr);
 

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -75,7 +75,7 @@ static fs::path GetScriptPath(lua_State* l)
 // ==================== Celestia-object ====================
 int celestia_new(lua_State* l, CelestiaCore* appCore)
 {
-    CelestiaCore** ud = reinterpret_cast<CelestiaCore**>(lua_newuserdata(l, sizeof(CelestiaCore*)));
+    CelestiaCore** ud = static_cast<CelestiaCore**>(lua_newuserdata(l, sizeof(CelestiaCore*)));
     *ud = appCore;
 
     Celx_SetClass(l, Celx_Celestia);

--- a/src/celscript/lua/celx_internal.h
+++ b/src/celscript/lua/celx_internal.h
@@ -140,7 +140,7 @@ public:
 
     template <typename T> T *newUserData()
     {
-        return reinterpret_cast<T*>(lua_newuserdata(m_lua, sizeof(T)));
+        return static_cast<T*>(lua_newuserdata(m_lua, sizeof(T)));
     }
     template <typename T> T *newUserData(T a)
     {
@@ -151,11 +151,11 @@ public:
     }
     template <typename T> T *newUserDataArray(int n)
     {
-        return reinterpret_cast<T*>(lua_newuserdata(m_lua, sizeof(T) * n));
+        return static_cast<T*>(lua_newuserdata(m_lua, sizeof(T) * n));
     }
     template <typename T> T *newUserDataArray(T *a, int n)
     {
-        T *p = reinterpret_cast<T*>(lua_newuserdata(m_lua, sizeof(T) * n));
+        T *p = static_cast<T*>(lua_newuserdata(m_lua, sizeof(T) * n));
         std::copy(a, a + n, p);
         return p;
     }
@@ -301,7 +301,7 @@ public:
         if (!safeIsValid(index))
             return nullptr;
         if (isUserData(index))
-            return reinterpret_cast<T*>(lua_touserdata(m_lua, index));
+            return static_cast<T*>(lua_touserdata(m_lua, index));
 
         if (errors & WrongType)
             doError(errorMessage);

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -102,7 +102,7 @@ int object_new(lua_State* l, const Selection& sel)
 {
     CelxLua celx(l);
 
-    Selection* ud = reinterpret_cast<Selection*>(lua_newuserdata(l, sizeof(Selection)));
+    Selection* ud = static_cast<Selection*>(lua_newuserdata(l, sizeof(Selection)));
     *ud = sel;
 
     celx.setClass(Celx_Object);

--- a/src/celscript/lua/celx_position.cpp
+++ b/src/celscript/lua/celx_position.cpp
@@ -24,7 +24,7 @@ int position_new(lua_State* l, const UniversalCoord& uc)
 {
     CelxLua celx(l);
 
-    UniversalCoord* ud = reinterpret_cast<UniversalCoord*>(lua_newuserdata(l, sizeof(UniversalCoord)));
+    UniversalCoord* ud = static_cast<UniversalCoord*>(lua_newuserdata(l, sizeof(UniversalCoord)));
     *ud = uc;
 
     celx.setClass(Celx_Position);

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -312,7 +312,7 @@ TextureFontPrivate::buildAtlas()
     uint8_t *raw_img  = new uint8_t[img_size];
     glGetTexImage(GL_TEXTURE_2D, 0, GL_BGRA, GL_UNSIGNED_BYTE, raw_img);
     ofstream f(fmt::format("/tmp/texture_{}x{}.data", m_texWidth, m_texHeight), ios::binary);
-    f.write(reinterpret_cast<char *>(raw_img), img_size);
+    f.write(reinterpret_cast<const char *>(raw_img), img_size);
     f.close();
     delete[] raw_img;
 #endif
@@ -515,13 +515,13 @@ TextureFontPrivate::flush()
                           GL_FLOAT,
                           GL_FALSE,
                           sizeof(FontVertex),
-                          reinterpret_cast<void*>(offsetof(FontVertex, x)));
+                          reinterpret_cast<const void*>(offsetof(FontVertex, x)));
     glVertexAttribPointer(CelestiaGLProgram::TextureCoord0AttributeIndex,
                           2,
                           GL_FLOAT,
                           GL_FALSE,
                           sizeof(FontVertex),
-                          reinterpret_cast<void*>(offsetof(FontVertex, u)));
+                          reinterpret_cast<const void*>(offsetof(FontVertex, u)));
     glDrawElements(GL_TRIANGLES, indexes.size(), GL_UNSIGNED_SHORT, nullptr);
     glDisableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
     glDisableVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex);

--- a/src/tools/stardb/buildstardb.cpp
+++ b/src/tools/stardb/buildstardb.cpp
@@ -73,7 +73,7 @@ public:
 
 template<class T> void binwrite(ostream& out, T x)
 {
-    out.write(reinterpret_cast<char*>(&x), sizeof(T));
+    out.write(reinterpret_cast<const char*>(&x), sizeof(T));
 }
 
 void HipparcosStar::write(ostream& out)

--- a/src/tools/stardb/makestardb.cpp
+++ b/src/tools/stardb/makestardb.cpp
@@ -84,25 +84,25 @@ bool parseCommandLine(int argc, char* argv[])
 static void writeUint(ostream& out, uint32_t n)
 {
     LE_TO_CPU_INT32(n, n);
-    out.write(reinterpret_cast<char*>(&n), sizeof n);
+    out.write(reinterpret_cast<const char*>(&n), sizeof n);
 }
 
 static void writeFloat(ostream& out, float f)
 {
     LE_TO_CPU_FLOAT(f, f);
-    out.write(reinterpret_cast<char*>(&f), sizeof f);
+    out.write(reinterpret_cast<const char*>(&f), sizeof f);
 }
 
 static void writeUshort(ostream& out, uint16_t n)
 {
     LE_TO_CPU_INT16(n, n);
-    out.write(reinterpret_cast<char*>(&n), sizeof n);
+    out.write(reinterpret_cast<const char*>(&n), sizeof n);
 }
 
 static void writeShort(ostream& out, int16_t n)
 {
     LE_TO_CPU_INT16(n, n);
-    out.write(reinterpret_cast<char*>(&n), sizeof n);
+    out.write(reinterpret_cast<const char*>(&n), sizeof n);
 }
 
 

--- a/src/tools/stardb/makexindex.cpp
+++ b/src/tools/stardb/makexindex.cpp
@@ -70,14 +70,14 @@ bool parseCommandLine(int argc, char* argv[])
 static void writeUint(ostream& out, uint32_t n)
 {
     LE_TO_CPU_INT32(n, n);
-    out.write(reinterpret_cast<char*>(&n), sizeof n);
+    out.write(reinterpret_cast<const char*>(&n), sizeof n);
 }
 
 
 static void writeShort(ostream& out, int16_t n)
 {
     LE_TO_CPU_INT16(n, n);
-    out.write(reinterpret_cast<char*>(&n), sizeof n);
+    out.write(reinterpret_cast<const char*>(&n), sizeof n);
 }
 
 

--- a/src/tools/xyzv2bin/xyzv2bin.cpp
+++ b/src/tools/xyzv2bin/xyzv2bin.cpp
@@ -84,7 +84,7 @@ static bool xyzvToBinary(const std::string& inFilename, const std::string& outFi
     }
 
     // write empty header, will update it later
-    if (!out.write(reinterpret_cast<char*>(&header), sizeof(header)))
+    if (!out.write(reinterpret_cast<const char*>(&header), sizeof(header)))
         return false;
 
     decltype(XYZVBinaryHeader::count) counter = 0;
@@ -128,7 +128,7 @@ static bool xyzvToBinary(const std::string& inFilename, const std::string& outFi
     std::memcpy(header.data() + offsetof(XYZVBinaryHeader, count), &counter, sizeof(counter));
 
     out.seekp(0);
-    return !!out.write(reinterpret_cast<char*>(&header), sizeof(header));
+    return !!out.write(reinterpret_cast<const char*>(&header), sizeof(header));
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
* Remove or replace with static_cast where possible.
* Prefer casting to const pointers.