### PR TITLE
Refactor resources

### DIFF
--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -204,7 +204,7 @@ std::optional<GalacticForm> buildGalacticForm(const fs::path& filename)
     int width, height, rgb, j = 0, kmin = 9;
     unsigned char value;
     float h = 0.75f;
-    Image* img = LoadImageFromFile(filename);
+    std::unique_ptr<Image> img = LoadImageFromFile(filename);
     if (img == nullptr)
     {
         celestia::util::GetLogger()->error("The galaxy template *** {} *** could not be loaded!\n", filename);
@@ -270,7 +270,6 @@ std::optional<GalacticForm> buildGalacticForm(const fs::path& filename)
         }
     }
 
-    delete img;
     galacticPoints.reserve(j);
 
     // sort to start with the galaxy center region (x^2 + y^2 + z^2 ~ 0), such that
@@ -547,7 +546,7 @@ void Galaxy::render(const Eigen::Vector3f& offset,
     if (galaxyTex == nullptr)
     {
         galaxyTex = CreateProceduralTexture(width, height, celestia::PixelFormat::RGBA,
-                                            galaxyTextureEval);
+                                            galaxyTextureEval).release();
     }
     assert(galaxyTex != nullptr);
     glActiveTexture(GL_TEXTURE0);
@@ -558,7 +557,7 @@ void Galaxy::render(const Eigen::Vector3f& offset,
         colorTex = CreateProceduralTexture(256, 1, celestia::PixelFormat::RGBA,
                                            colorTextureEval,
                                            Texture::EdgeClamp,
-                                           Texture::NoMipMaps);
+                                           Texture::NoMipMaps).release();
     }
     assert(colorTex != nullptr);
     glActiveTexture(GL_TEXTURE1);

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <memory>
 #include <optional>
 #include <utility>
 
@@ -345,7 +346,7 @@ class GlobularInfoManager
 
     std::array<GlobularForm, GlobularBuckets> globularForms{ };
     std::array<Texture*, GlobularBuckets> centerTex{ };
-    Texture* globularTex{ nullptr };
+    std::unique_ptr<Texture> globularTex{ nullptr };
 };
 
 const GlobularForm* GlobularInfoManager::getForm(std::size_t form) const
@@ -361,7 +362,7 @@ Texture* GlobularInfoManager::getCenterTex(std::size_t form)
     {
         centerTex[form] = CreateProceduralTexture(cntrTexWidth, cntrTexHeight,
                                                   celestia::PixelFormat::RGBA,
-                                                  centerCloudTexEval);
+                                                  centerCloudTexEval).release();
     }
 
     assert(centerTex[form] != nullptr);
@@ -377,7 +378,7 @@ Texture* GlobularInfoManager::getGlobularTex()
                                               globularTextureEval);
     }
     assert(globularTex != nullptr);
-    return globularTex;
+    return globularTex.get();
 }
 
 void GlobularInfoManager::initializeForms()

--- a/src/celengine/image.h
+++ b/src/celengine/image.h
@@ -38,16 +38,18 @@ class Image
     celestia::PixelFormat getFormat() const;
     int getComponents() const;
     uint8_t* getPixels();
+    const uint8_t* getPixels() const;
     uint8_t* getPixelRow(int row);
     uint8_t* getPixelRow(int mip, int row);
     uint8_t* getMipLevel(int mip);
+    const uint8_t* getMipLevel(int mip) const;
     int getSize() const;
     int getMipLevelSize(int mip) const;
 
     bool isCompressed() const;
     bool hasAlpha() const;
 
-    Image* computeNormalMap(float scale, bool wrap) const;
+    std::unique_ptr<Image> computeNormalMap(float scale, bool wrap) const;
 
     enum
     {
@@ -66,4 +68,4 @@ class Image
     std::unique_ptr<uint8_t[]> pixels;
 };
 
-Image* LoadImageFromFile(const fs::path& filename);
+std::unique_ptr<Image> LoadImageFromFile(const fs::path& filename);

--- a/src/celengine/mapmanager.h
+++ b/src/celengine/mapmanager.h
@@ -10,7 +10,9 @@
 
 #pragma once
 
-#include <functional>
+#include <memory>
+
+#include <celcompat/filesystem.h>
 #include <celutil/resmanager.h>
 
 // File format for data used to warp an image, for
@@ -22,7 +24,8 @@ class WarpMesh
     ~WarpMesh();
 
     // Map data to triangle vertices used for drawing
-    void scopedDataForRendering(const std::function<void(float*, int)>&) const;
+    std::vector<float> scopedDataForRendering() const;
+
     int count() const; // Number of vertices
 
     // Convert a vertex coordinate to texture coordinate
@@ -34,15 +37,20 @@ class WarpMesh
     float* data;
 };
 
-class WarpMeshInfo : public ResourceInfo<WarpMesh>
+class WarpMeshInfo
 {
  public:
-    fs::path source;
+    using ResourceType = WarpMesh;
+    using ResourceKey = fs::path;
 
     WarpMeshInfo(const fs::path& source) : source(source) {};
 
-    fs::path resolve(const fs::path&) override;
-    WarpMesh* load(const fs::path&) override;
+    fs::path resolve(const fs::path&) const;
+    std::unique_ptr<WarpMesh> load(const fs::path&) const;
+
+ private:
+    fs::path source;
+    friend bool operator<(const WarpMeshInfo&, const WarpMeshInfo&);
 };
 
 inline bool operator<(const WarpMeshInfo& wi0, const WarpMeshInfo& wi1)
@@ -50,6 +58,6 @@ inline bool operator<(const WarpMeshInfo& wi0, const WarpMeshInfo& wi1)
     return wi0.source < wi1.source;
 }
 
-typedef ResourceManager<WarpMeshInfo> WarpMeshManager;
+using WarpMeshManager = ResourceManager<WarpMeshInfo>;
 
 WarpMeshManager* GetWarpMeshManager();

--- a/src/celengine/meshmanager.h
+++ b/src/celengine/meshmanager.h
@@ -9,6 +9,10 @@
 
 #pragma once
 
+#include <memory>
+#include <tuple>
+#include <utility>
+
 #include <Eigen/Core>
 
 #include <celcompat/filesystem.h>
@@ -16,25 +20,52 @@
 #include "geometry.h"
 
 
-class GeometryInfo : public ResourceInfo<Geometry>
+class GeometryInfo
 {
  public:
+    // Ensure that models with different centers get resolved to different objects by
+    // encoding the center, scale and normalization state in the key.
+    struct ResourceKey
+    {
+        fs::path resolvedPath;
+        Eigen::Vector3f center;
+        float scale;
+        bool isNormalized;
+        bool resolvedToPath;
+
+        ResourceKey(fs::path&& _resolvedPath,
+                    const Eigen::Vector3f& _center,
+                    float _scale,
+                    bool _isNormalized,
+                    bool _resolvedToPath) :
+            resolvedPath(std::move(_resolvedPath)),
+            center(_center),
+            scale(_scale),
+            isNormalized(_isNormalized),
+            resolvedToPath(_resolvedToPath)
+        {}
+    };
+
+ private:
     fs::path source;
     fs::path path;
-    bool resolvedToPath;
     Eigen::Vector3f center;
     float scale;
     bool isNormalized;
+
+    friend bool operator<(const GeometryInfo&, const GeometryInfo&);
+
+ public:
+    using ResourceType = Geometry;
 
     GeometryInfo(const fs::path& _source,
                  const fs::path& _path = "") :
         source(_source),
         path(_path),
-        resolvedToPath(false),
         center(Eigen::Vector3f::Zero()),
         scale(1.0f),
         isNormalized(true)
-        {};
+        {}
 
     GeometryInfo(const fs::path& _source,
                  const fs::path& _path,
@@ -43,32 +74,27 @@ class GeometryInfo : public ResourceInfo<Geometry>
                  bool _isNormalized) :
         source(_source),
         path(_path),
-        resolvedToPath(false),
         center(_center),
         scale(_scale),
         isNormalized(_isNormalized)
-        {};
+        {}
 
-    virtual fs::path resolve(const fs::path&);
-    virtual Geometry* load(const fs::path&);
+    ResourceKey resolve(const fs::path&) const;
+    std::unique_ptr<Geometry> load(const ResourceKey&) const;
 };
 
 inline bool operator<(const GeometryInfo& g0, const GeometryInfo& g1)
 {
-    if (g0.source != g1.source)
-        return g0.source < g1.source;
-    else if (g0.path != g1.path)
-        return g0.path < g1.path;
-    else if (g0.isNormalized != g1.isNormalized)
-        return (int) g0.isNormalized < (int) g1.isNormalized;
-    else if (g0.scale != g1.scale)
-        return g0.scale < g1.scale;
-    else if (g0.center.x() != g1.center.x())
-        return g0.center.x() < g1.center.x();
-    else if (g0.center.y() != g1.center.y())
-        return g0.center.y() < g1.center.y();
-    else
-        return g0.center.z() < g1.center.z();
+    return std::tie(g0.source, g0.path, g0.isNormalized, g0.scale, g0.center.x(), g0.center.y(), g0.center.z()) <
+           std::tie(g1.source, g1.path, g1.isNormalized, g1.scale, g1.center.x(), g1.center.y(), g1.center.z());
+}
+
+inline bool operator<(const GeometryInfo::ResourceKey& k0,
+                      const GeometryInfo::ResourceKey& k1)
+{
+    // we do not use the boolean resolvedToPath field here
+    return std::tie(k0.resolvedPath, k0.center.x(), k0.center.y(), k0.center.z(), k0.scale, k0.isNormalized) <
+           std::tie(k1.resolvedPath, k1.center.x(), k1.center.y(), k1.center.z(), k1.scale, k1.isNormalized);
 }
 
 typedef ResourceManager<GeometryInfo> GeometryManager;

--- a/src/celengine/modelgeometry.cpp
+++ b/src/celengine/modelgeometry.cpp
@@ -52,6 +52,10 @@ ModelGeometry::ModelGeometry(std::unique_ptr<cmod::Model>&& model) :
 }
 
 
+// Needs to be defined at a point where ModelOpenGLData is complete
+ModelGeometry::~ModelGeometry() = default;
+
+
 bool
 ModelGeometry::pick(const Eigen::ParametrizedLine<double, 3>& r, double& distance) const
 {

--- a/src/celengine/modelgeometry.h
+++ b/src/celengine/modelgeometry.h
@@ -25,7 +25,7 @@ class ModelGeometry : public Geometry
 {
  public:
     ModelGeometry(std::unique_ptr<cmod::Model>&& model);
-    ~ModelGeometry() = default;
+    ~ModelGeometry();
 
     /*! Find the closest intersection between the ray and the
      *  model.  If the ray intersects the model, return true

--- a/src/celengine/rotationmanager.h
+++ b/src/celengine/rotationmanager.h
@@ -7,41 +7,43 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef CELENGINE_ROTATIONMANAGER_H_
-#define CELENGINE_ROTATIONMANAGER_H_
+#pragma once
 
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include <celcompat/filesystem.h>
 #include <celephem/rotation.h>
 #include <celutil/resmanager.h>
-#include <string>
-#include <map>
 
 
-class RotationModelInfo : public ResourceInfo<celestia::ephem::RotationModel>
+class RotationModelInfo
 {
- public:
+ private:
     std::string source;
     fs::path path;
+
+    friend bool operator<(const RotationModelInfo&, const RotationModelInfo&);
+
+ public:
+    using ResourceType = celestia::ephem::RotationModel;
+    using ResourceKey = fs::path;
 
     RotationModelInfo(const std::string& _source,
                       const fs::path& _path = "") :
         source(_source), path(_path) {};
 
-    fs::path resolve(const fs::path&) override;
-    celestia::ephem::RotationModel* load(const fs::path&) override;
+    fs::path resolve(const fs::path&) const;
+    std::unique_ptr<celestia::ephem::RotationModel> load(const fs::path&) const;
 };
 
 inline bool operator<(const RotationModelInfo& ti0,
                       const RotationModelInfo& ti1)
 {
-    if (ti0.source == ti1.source)
-        return ti0.path < ti1.path;
-    else
-        return ti0.source < ti1.source;
+    return std::tie(ti0.source, ti0.path) < std::tie(ti1.source, ti1.path);
 }
 
 typedef ResourceManager<RotationModelInfo> RotationModelManager;
 
 extern RotationModelManager* GetRotationModelManager();
-
-#endif // CELENGINE_ROTATIONMANAGER_H_
-

--- a/src/celengine/texmanager.h
+++ b/src/celengine/texmanager.h
@@ -7,22 +7,30 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _TEXMANAGER_H_
-#define _TEXMANAGER_H_
+#pragma once
 
+#include <memory>
+#include <tuple>
+
+#include <celcompat/filesystem.h>
 #include <celutil/resmanager.h>
-#include <celengine/texture.h>
 #include "multitexture.h"
+#include "texture.h"
 
-
-class TextureInfo : public ResourceInfo<Texture>
+class TextureInfo
 {
- public:
+ private:
     fs::path source;
     fs::path path;
     unsigned int flags;
     float bumpHeight;
     unsigned int resolution;
+
+    friend bool operator<(const TextureInfo&, const TextureInfo&);
+
+ public:
+    using ResourceType = Texture;
+    using ResourceKey = fs::path;
 
     enum {
         WrapTexture      = 0x1,
@@ -63,28 +71,16 @@ class TextureInfo : public ResourceInfo<Texture>
         bumpHeight(0.0f),
         resolution(_resolution) {};
 
-    fs::path resolve(const fs::path&) override;
-    Texture* load(const fs::path&) override;
+    fs::path resolve(const fs::path&) const;
+    std::unique_ptr<Texture> load(const fs::path&) const;
 };
 
 inline bool operator<(const TextureInfo& ti0, const TextureInfo& ti1)
 {
-    if (ti0.resolution == ti1.resolution)
-    {
-        if (ti0.source == ti1.source)
-            return ti0.path < ti1.path;
-        else
-            return ti0.source < ti1.source;
-    }
-    else
-    {
-        return ti0.resolution < ti1.resolution;
-    }
+    return std::tie(ti0.resolution, ti0.source, ti0.path) <
+           std::tie(ti1.resolution, ti1.source, ti1.path);
 }
 
-typedef ResourceManager<TextureInfo> TextureManager;
+using TextureManager = ResourceManager<TextureInfo>;
 
 extern TextureManager* GetTextureManager();
-
-#endif // _TEXMANAGER_H_
-

--- a/src/celengine/texture.h
+++ b/src/celengine/texture.h
@@ -7,15 +7,16 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_TEXTURE_H_
-#define _CELENGINE_TEXTURE_H_
+#pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
+
 #include <celutil/color.h>
 #include <celcompat/filesystem.h>
 #include <celengine/image.h>
-
+#include <celutil/array_view.h>
 
 typedef void (*ProceduralTexEval)(float, float, float, std::uint8_t*);
 
@@ -118,7 +119,7 @@ class Texture
 class ImageTexture : public Texture
 {
  public:
-    ImageTexture(Image& img, AddressMode, MipMapMode);
+    ImageTexture(const Image& img, AddressMode, MipMapMode);
     ~ImageTexture();
 
     virtual const TextureTile getTile(int lod, int u, int v);
@@ -135,7 +136,7 @@ class ImageTexture : public Texture
 class TiledTexture : public Texture
 {
  public:
-    TiledTexture(Image& img, int _uSplit, int _vSplit, MipMapMode);
+    TiledTexture(const Image& img, int _uSplit, int _vSplit, MipMapMode);
     ~TiledTexture();
 
     virtual const TextureTile getTile(int lod, int u, int v);
@@ -155,7 +156,7 @@ class TiledTexture : public Texture
 class CubeMap : public Texture
 {
  public:
-    CubeMap(Image* faces[]);
+    explicit CubeMap(celestia::util::array_view<const Image*>);
     ~CubeMap();
 
     virtual const TextureTile getTile(int lod, int u, int v);
@@ -167,26 +168,30 @@ class CubeMap : public Texture
 };
 
 
-extern Texture* CreateProceduralTexture(int width, int height,
-                                        celestia::PixelFormat format,
-                                        ProceduralTexEval func,
-                                        Texture::AddressMode addressMode = Texture::EdgeClamp,
-                                        Texture::MipMapMode mipMode = Texture::DefaultMipMaps);
-extern Texture* CreateProceduralTexture(int width, int height,
-                                        celestia::PixelFormat format,
-                                        TexelFunctionObject& func,
-                                        Texture::AddressMode addressMode = Texture::EdgeClamp,
-                                        Texture::MipMapMode mipMode = Texture::DefaultMipMaps);
-extern Texture* CreateProceduralCubeMap(int size, celestia::PixelFormat format,
-                                        ProceduralTexEval func);
+std::unique_ptr<Texture>
+CreateProceduralTexture(int width, int height,
+                        celestia::PixelFormat format,
+                        ProceduralTexEval func,
+                        Texture::AddressMode addressMode = Texture::EdgeClamp,
+                        Texture::MipMapMode mipMode = Texture::DefaultMipMaps);
 
-extern Texture* LoadTextureFromFile(const fs::path& filename,
-                                    Texture::AddressMode addressMode = Texture::EdgeClamp,
-                                    Texture::MipMapMode mipMode = Texture::DefaultMipMaps);
+std::unique_ptr<Texture>
+CreateProceduralTexture(int width, int height,
+                        celestia::PixelFormat format,
+                        TexelFunctionObject& func,
+                        Texture::AddressMode addressMode = Texture::EdgeClamp,
+                        Texture::MipMapMode mipMode = Texture::DefaultMipMaps);
 
-extern Texture* LoadHeightMapFromFile(const fs::path& filename,
-                                      float height,
-                                      Texture::AddressMode addressMode = Texture::EdgeClamp);
+std::unique_ptr<Texture>
+CreateProceduralCubeMap(int size, celestia::PixelFormat format,
+                        ProceduralTexEval func);
 
+std::unique_ptr<Texture>
+LoadTextureFromFile(const fs::path& filename,
+                    Texture::AddressMode addressMode = Texture::EdgeClamp,
+                    Texture::MipMapMode mipMode = Texture::DefaultMipMaps);
 
-#endif // _CELENGINE_TEXTURE_H_
+std::unique_ptr<Texture>
+LoadHeightMapFromFile(const fs::path& filename,
+                      float height,
+                      Texture::AddressMode addressMode = Texture::EdgeClamp);

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -127,15 +127,14 @@ bool WarpMeshViewportEffect::render(Renderer* renderer, FramebufferObject* fbo, 
 
 void WarpMeshViewportEffect::initializeVO(VertexObject& vo)
 {
-    mesh->scopedDataForRendering([&vo](float *data, int size){
-        vo.allocate(size, data);
-        vo.setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex,
-                                2, GL_FLOAT, false, 5 * sizeof(float), 0);
-        vo.setVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex,
-                                2, GL_FLOAT, false, 5 * sizeof(float), 2 * sizeof(float));
-        vo.setVertexAttribArray(CelestiaGLProgram::IntensityAttributeIndex,
-                                1, GL_FLOAT, false, 5 * sizeof(float), 4 * sizeof(float));
-    });
+    std::vector<float> scopedData = mesh->scopedDataForRendering();
+    vo.allocate(static_cast<GLsizeiptr>(scopedData.size() * sizeof(float)), scopedData.data());
+    vo.setVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex,
+                            2, GL_FLOAT, false, 5 * sizeof(float), 0);
+    vo.setVertexAttribArray(CelestiaGLProgram::TextureCoord0AttributeIndex,
+                            2, GL_FLOAT, false, 5 * sizeof(float), 2 * sizeof(float));
+    vo.setVertexAttribArray(CelestiaGLProgram::IntensityAttributeIndex,
+                            1, GL_FLOAT, false, 5 * sizeof(float), 4 * sizeof(float));
 }
 
 void WarpMeshViewportEffect::draw(VertexObject& vo)

--- a/src/celengine/virtualtex.h
+++ b/src/celengine/virtualtex.h
@@ -7,10 +7,12 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_VIRTUALTEX_H_
-#define _CELENGINE_VIRTUALTEX_H_
+#pragma once
 
+#include <memory>
 #include <string>
+
+#include <celcompat/filesystem.h>
 #include <celengine/texture.h>
 
 
@@ -78,6 +80,5 @@ class VirtualTexture : public Texture
 };
 
 
-VirtualTexture* LoadVirtualTexture(const fs::path& filename);
-
-#endif // _CELENGINE_VIRTUALTEX_H_
+std::unique_ptr<VirtualTexture>
+LoadVirtualTexture(const fs::path& filename);

--- a/src/celestia/win32/winsplash.cpp
+++ b/src/celestia/win32/winsplash.cpp
@@ -159,7 +159,7 @@ SplashWindow::init()
     if (winSetLayeredWindowAttributes != NULL && winUpdateLayeredWindow != NULL)
         useLayeredWindow = true;
 
-    image = LoadImageFromFile(imageFileName);
+    image = LoadImageFromFile(imageFileName).release();
 }
 
 

--- a/src/celimage/imageformats.h
+++ b/src/celimage/imageformats.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <celcompat/filesystem.h>
 #include <celengine/image.h>
 
 Image* LoadJPEGImage(const fs::path& filename,

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -2670,7 +2670,7 @@ static int celestia_loadtexture(lua_State* l)
     celx.checkArgs(2, 2, "Need one argument for celestia:loadtexture()");
     string s = celx.safeGetString(2, AllErrors, "Argument to celestia:loadtexture() must be a string");
     fs::path base_dir = GetScriptPath(l);
-    Texture* t = LoadTextureFromFile(base_dir / s);
+    Texture* t = LoadTextureFromFile(base_dir / s).release();
     if (t == nullptr) return 0;
     return celx.pushClass(t);
 }

--- a/src/celutil/fsutils.cpp
+++ b/src/celutil/fsutils.cpp
@@ -101,11 +101,11 @@ fs::path PathExp(const fs::path& filename)
 }
 
 fs::path ResolveWildcard(const fs::path& wildcard,
-                         array_view<const char*> extensions)
+                         array_view<std::string_view> extensions)
 {
     fs::path filename(wildcard);
 
-    for (const auto *ext : extensions)
+    for (std::string_view ext : extensions)
     {
         filename.replace_extension(ext);
         ifstream in(filename.string());

--- a/src/celutil/fsutils.h
+++ b/src/celutil/fsutils.h
@@ -12,8 +12,10 @@
 
 #pragma once
 
-#include <celutil/array_view.h>
+#include <string_view>
+
 #include <celcompat/filesystem.h>
+#include <celutil/array_view.h>
 
 namespace celestia::util
 {
@@ -21,7 +23,7 @@ namespace celestia::util
 fs::path LocaleFilename(const fs::path& filename);
 fs::path PathExp(const fs::path& filename);
 fs::path ResolveWildcard(const fs::path& wildcard,
-                         array_view<const char*> extensions);
+                         array_view<std::string_view> extensions);
 #ifndef PORTABLE_BUILD
 fs::path HomeDir();
 fs::path WriteableDataPath();

--- a/src/celutil/reshandle.h
+++ b/src/celutil/reshandle.h
@@ -7,13 +7,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _RESHANDLE_H_
-#define _RESHANDLE_H_
+#pragma once
 
-typedef int ResourceHandle;
+using ResourceHandle = int;
 
-enum {
-    InvalidResource = -1
-};
-
-#endif // _RESHANDLE_H_
+constexpr inline ResourceHandle InvalidResource = -1;


### PR DESCRIPTION
Refactoring of the resource manager. The abstract base class `ResourceInfo` is removed as unnecessary given the templates, should fix the Sonar bug about ensuring that `TrajectoryInfo` is moveable and a few instances of manual memory management.

Along the way fixed an issue with the warp meshes that allocates 4× as much memory as necessary when allocating a `float` array.

The out-of-bounds memory access bug repoted by Sonar here looks weird, I'm guessing it's assuming the `int`s can be negative but not sure. Maybe something to look at in the next PR.