### PR TITLE
Optimize memory required for galaxies and globulars

### DIFF
--- a/shaders/galaxy_frag.glsl
+++ b/shaders/galaxy_frag.glsl
@@ -5,5 +5,5 @@ uniform sampler2D galaxyTex;
 
 void main(void)
 {
-    gl_FragColor = texture2D(galaxyTex, texCoord) * color;
+    gl_FragColor = vec4(color.rgb, color.a * texture2D(galaxyTex, texCoord).r);
 }

--- a/shaders/galaxy_vert.glsl
+++ b/shaders/galaxy_vert.glsl
@@ -1,7 +1,5 @@
 attribute vec4 in_Position;
 attribute vec4 in_TexCoord0;
-//attribute float in_ColorIndex;
-//attribute float in_Alpha;
 
 uniform sampler2D colorTex;
 
@@ -10,14 +8,10 @@ varying vec2 texCoord;
 
 void main(void)
 {
-    // we pass color index as short int
-    // reusing gl_MultiTexCoord0.z
-    // we use 255 only because we have 256 color indices
-    float t = in_TexCoord0.z / 255.0; // [0, 255] -> [0, 1]
-    // we pass alpha values as as short int
-    // reusing gl_MultiTexCoord0.w
-    // we use 65535 for better precision
-    float a = in_TexCoord0.w / 65535.0; // [0, 65535] -> [0, 1]
+    // we pass color index as a normalized byte reusing in_TexCoord0.z
+    float t = in_TexCoord0.z;
+    // we pass alpha values as a normalized byte reusing in_TexCoord0.w
+    float a = in_TexCoord0.w;
     color = vec4(texture2D(colorTex, vec2(t, 0.0)).rgb, a);
     texCoord = in_TexCoord0.st;
     set_vp(in_Position);

--- a/shaders/globular_frag.glsl
+++ b/shaders/globular_frag.glsl
@@ -3,5 +3,5 @@ varying vec4 color;
 
 void main(void)
 {
-    gl_FragColor = texture2D(starTex, gl_PointCoord.xy) * color;
+    gl_FragColor = vec4(color.rgb, color.a * texture2D(starTex, gl_PointCoord.xy).r);
 }

--- a/shaders/tidal_frag.glsl
+++ b/shaders/tidal_frag.glsl
@@ -4,5 +4,5 @@ varying vec2 texCoord;
 
 void main(void)
 {
-    gl_FragColor = texture2D(tidalTex, texCoord) * color;
+    gl_FragColor = vec4(color.rgb, color.a * texture2D(tidalTex, texCoord).r);
 }

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -203,6 +203,7 @@ std::optional<GalacticForm> buildGalacticForm(const fs::path& filename)
     rgb    = img->getComponents();
 
     auto& rng = celmath::getRNG();
+    rng.seed(1312);
     for (int i = 0; i < width * height; i++)
     {
         value = img->getPixels()[rgb * i];

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -109,15 +109,8 @@ constexpr const GalaxyTypeName GalaxyTypeNames[] =
 
 void galaxyTextureEval(float u, float v, float /*w*/, std::uint8_t *pixel)
 {
-    float r = 0.9f - std::sqrt(u * u + v * v );
-    if (r < 0)
-        r = 0;
-
-    auto pixVal = static_cast<std::uint8_t>(r * 255.99f);
-    pixel[0] = 255;//65;
-    pixel[1] = 255;//64;
-    pixel[2] = 255;//65;
-    pixel[3] = pixVal;
+    float r = std::max(0.0f, 0.9f - std::hypot(u, v));
+    *pixel = static_cast<std::uint8_t>(r * 255.99f);
 }
 
 void colorTextureEval(float u, float /*v*/, float /*w*/, std::uint8_t *pixel)
@@ -545,7 +538,7 @@ void Galaxy::render(const Eigen::Vector3f& offset,
 
     if (galaxyTex == nullptr)
     {
-        galaxyTex = CreateProceduralTexture(width, height, celestia::PixelFormat::RGBA,
+        galaxyTex = CreateProceduralTexture(width, height, celestia::PixelFormat::LUMINANCE,
                                             galaxyTextureEval).release();
     }
     assert(galaxyTex != nullptr);

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -76,11 +76,6 @@ constexpr unsigned int MAX_INDICES = RequiredIndexCount(MAX_VERTICES);
 constexpr float RADIUS_CORRECTION     = 0.025f;
 constexpr float MAX_SPIRAL_THICKNESS  = 0.06f;
 
-bool formsInitialized = false;
-
-Texture* galaxyTex = nullptr;
-Texture* colorTex  = nullptr;
-
 struct GalaxyTypeName
 {
     const char* name;
@@ -396,8 +391,6 @@ void GalacticFormManager::initializeStandardForms()
 
         galacticForms.push_back(std::move(ellipticalForm));
     }
-
-    formsInitialized = true;
 }
 
 GalacticFormManager* getGalacticFormManager()
@@ -516,6 +509,9 @@ void Galaxy::render(const Eigen::Vector3f& offset,
                     const Matrices& ms,
                     Renderer* renderer)
 {
+    static Texture* galaxyTex = nullptr;
+    static Texture* colorTex  = nullptr;
+
     const GalacticForm* galacticForm = getGalacticFormManager()->getForm(form);
     if (galacticForm == nullptr)
         return;


### PR DESCRIPTION
Regarding the last commit there is a speed comparison 
https://github.com/CelestiaProject/Celestia/wiki/Speed-comparision-for-vec3-vs-vec4-arithmetics

Our main targets are -O2 (RelWithDebInfo used by Debian and derivatives) and -O3 (Release). As I plan to enable geometric shaders this code will work mostly on quite old machines without modern vectorization instructions so I suppose it's a good trade off for 33% memory usage reduce.