### PR TITLE
[qt] Rewrite command line parser

### DIFF
--- a/src/celestia/qt/CMakeLists.txt
+++ b/src/celestia/qt/CMakeLists.txt
@@ -22,6 +22,7 @@ set(QT_SOURCES
   qtcelestialbrowser.cpp
   qtcelestiaactions.cpp
   qtcolorswatchwidget.cpp
+  qtcommandline.cpp
   qtdeepskybrowser.cpp
   qtdraghandler.cpp
   qteventfinder.cpp
@@ -43,6 +44,7 @@ set(QT_HEADERS
   qtcelestialbrowser.h
   qtcelestiaactions.h
   qtcolorswatchwidget.h
+  qtcommandline.h
   qtdeepskybrowser.h
   qtdraghandler.h
   qteventfinder.h

--- a/src/celestia/qt/qtappwin.h
+++ b/src/celestia/qt/qtappwin.h
@@ -21,6 +21,7 @@
 class QMenu;
 class QCloseEvent;
 class QDockWidget;
+struct CelestiaCommandLineOptions;
 class CelestiaGlWidget;
 class CelestialBrowser;
 class InfoPanel;
@@ -41,9 +42,7 @@ class CelestiaAppWindow : public QMainWindow, public CelestiaCore::ContextMenuHa
     CelestiaAppWindow(QWidget* parent = nullptr);
     ~CelestiaAppWindow();
 
-    void init(const QString& configFileName,
-              const QStringList& extrasDirectories,
-              const QString& logFilename);
+    void init(const CelestiaCommandLineOptions&);
 
     void readSettings();
     void writeSettings();

--- a/src/celestia/qt/qtcommandline.cpp
+++ b/src/celestia/qt/qtcommandline.cpp
@@ -1,0 +1,56 @@
+#include "qtcommandline.h"
+
+#include <QCommandLineParser>
+#include <QDir>
+
+#include <celutil/gettext.h>
+
+CelestiaCommandLineOptions ParseCommandLine(const QCoreApplication& app)
+{
+    QCommandLineParser parser;
+    parser.setApplicationDescription("3D visualization of space");
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addOptions({
+        { "dir", _("Set the data directory."), _("datadir") },
+        { "conf", _("Set the configuraton file."), _("conf") },
+        { "extrasdir", _("Add an extras directory. This option may be specified multiple times."), _("extrasdir") },
+        { "fullscreen", _("Start in fullscreen mode.") },
+        { { "s", "nosplash" }, _("Skip the splash screen.") },
+        { { "u", "url" }, _("Set the start cel:// URL or startup script path."), _("url") },
+        { { "l", "log" }, _("Set the path to the log file."), _("logpath") },
+    });
+
+    parser.process(app);
+
+    QDir currentDirectory;
+
+    CelestiaCommandLineOptions options;
+    options.startDirectory = parser.value("dir");
+
+    // configFileName and extrasDirectories are handled AFTER changing the
+    // current directory to the startDirectory, so convert them to absolute
+    // paths here.
+    options.configFileName = currentDirectory.absoluteFilePath(parser.value("conf"));
+    options.extrasDirectories = parser.values("extrasdir");
+    for (auto& extrasDir : options.extrasDirectories)
+    {
+        extrasDir = currentDirectory.absoluteFilePath(extrasDir);
+    }
+
+    // similarly if the startURL is not a cel: URL, it will be interpreted as
+    // a path to a script, so convert that to absolute also
+    options.startURL = parser.value("url");
+    if (!options.startURL.startsWith("cel:"))
+    {
+        options.startURL = currentDirectory.absoluteFilePath(options.startURL);
+    }
+
+    // logFilename is processed before the directory change
+    options.logFilename = parser.value("log");
+
+    options.skipSplashScreen = parser.isSet("nosplash");
+    options.startFullscreen = parser.isSet("fullscreen");
+
+    return options;
+}

--- a/src/celestia/qt/qtcommandline.h
+++ b/src/celestia/qt/qtcommandline.h
@@ -1,0 +1,29 @@
+// qtcommandline.h
+//
+// Copyright (C) 2023, Celestia Development Team
+//
+// Drag handler for Qt5+ front-end.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <QCoreApplication>
+#include <QString>
+#include <QStringList>
+
+struct CelestiaCommandLineOptions
+{
+    QString logFilename{ };
+    QString startDirectory{ };
+    QStringList extrasDirectories{ };
+    QString startURL{ };
+    QString configFileName{ };
+    bool skipSplashScreen{ false };
+    bool startFullscreen{ false };
+};
+
+CelestiaCommandLineOptions ParseCommandLine(const QCoreApplication&);


### PR DESCRIPTION
Rewrite the command line parser to use `QCommandLineParser`

Wire up some properties that were parsed but not used:

* `--dir` option: fixes #1547
* `-u`/`--url`
* `-s`/`--nosplash`
* `--fullscreen`

Add `--help` and `--version` options.

The `--once` option is no longer parsed: implementing this cross-platform is somewhat non-trivial, if we need it we can add it later. This doesn't actually remove any functionality from the Qt front-end as the value wasn't used.