### PR TITLE
Disable use of structs in shaders by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,12 +64,18 @@ option(ENABLE_GLES          "Build for OpenGL ES 2.0 instead of OpenGL 2.1 (Defa
 option(USE_GTKGLEXT         "Use libgtkglext1 for GTK2 frontend (Default: on)" ON)
 option(USE_QT6              "Use Qt6 in Qt frontend (Default: off)" OFF)
 option(USE_GTK3             "Use Gtk3 in GTK2 frontend (Default: off)" OFF)
-option(USE_WAYLAND          "Use Wayland in Qt frontend (Default: off)" OFF)
+option(USE_GLSL_STRUCTS     "Use structs in GLSL (Default: off)" OFF)
 
 if(ENABLE_GLES)
   add_definitions(-DGL_ES)
   # Disable USE_GTKGLEXT if using OpenGL ES
   set(USE_GTKGLEXT OFF)
+endif()
+
+if(USE_GLSL_STRUCTS)
+  # GLES SL on some old Android device or with ANGLE presents a link failure with empty error when using struct.
+  # GLSL on old version of Mac OS X appears to have a bug that precludes us from using structs.
+  add_definitions(-DUSE_GLSL_STRUCTS)
 endif()
 
 if(USE_GTK3)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -341,7 +341,9 @@ List of supported parameters (passed as `-DPARAMETER=VALUE`):
 | ENABLE_DATA          | bool | OFF     | Use CelestiaContent submodule for data
 | ENABLE_GLES          | bool | OFF     | Use OpenGL ES 2.0 in rendering code
 | USE_GTKGLEXT         | bool | ON      | Use libgtkglext1 in GTK2 frontend
+| USE_QT6              | bool | OFF     | Use Qt6 in Qt frontend
 | USE_GTK3             | bool | OFF     | Use Gtk3 instead of Gtk2 in GTK2 frontend
+| USE_GLSL_STRUCTS     | bool | OFF     | Use structs in GLSL
 
 Notes:
  \* /usr/local on Unix-like systems, c:\Program Files or c:\Program Files (x86)

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -34,9 +34,6 @@ using celestia::util::GetLogger;
 
 namespace gl = celestia::gl;
 
-// GLES SL on some old Android device or with ANGLE presents a link failure with empty error when using struct.
-// GLSL on old version of Mac OS X appears to have a bug that precludes us from using structs.
-// #define USE_GLSL_STRUCTS
 #define POINT_FADE 1
 
 namespace

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -34,8 +34,9 @@ using celestia::util::GetLogger;
 
 namespace gl = celestia::gl;
 
-// GLSL on Mac OS X appears to have a bug that precludes us from using structs
-#define USE_GLSL_STRUCTS
+// GLES SL on some old Android device or with ANGLE presents a link failure with empty error when using struct.
+// GLSL on old version of Mac OS X appears to have a bug that precludes us from using structs.
+// #define USE_GLSL_STRUCTS
 #define POINT_FADE 1
 
 namespace


### PR DESCRIPTION
I think it is better to disable it by default for compatibility