### PR TITLE
Use AppStream-conformant application ID

### DIFF
--- a/debian/celestia-gtk.install
+++ b/debian/celestia-gtk.install
@@ -1,5 +1,5 @@
 usr/bin/celestia-gtk
 usr/share/celestia/celestiaui.xml
 usr/share/applications/celestia-gtk.desktop
-usr/share/metainfo/space.celestia-gtk.metainfo.xml
+usr/share/metainfo/space.celestia.celestia_gtk.metainfo.xml
 usr/share/man/man1/celestia-gtk.1

--- a/debian/celestia-qt.install
+++ b/debian/celestia-qt.install
@@ -1,4 +1,4 @@
 usr/bin/celestia-qt
 usr/share/applications/celestia-qt.desktop
-usr/share/metainfo/space.celestia-qt.metainfo.xml
+usr/share/metainfo/space.celestia.celestia_qt.metainfo.xml
 usr/share/man/man1/celestia-qt.1

--- a/src/celestia/gtk/data/CMakeLists.txt
+++ b/src/celestia/gtk/data/CMakeLists.txt
@@ -2,7 +2,7 @@ install(FILES celestiaui.xml
         DESTINATION "${DATADIR}")
 install(FILES celestia-gtk.desktop
         DESTINATION "${CMAKE_INSTALL_DATADIR}/applications")
-install(FILES space.celestia-gtk.metainfo.xml
+install(FILES space.celestia.celestia_gtk.metainfo.xml
         DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo")
 install(FILES celestia-gtk.1
         DESTINATION "${CMAKE_INSTALL_DATADIR}/man/man1")

--- a/src/celestia/gtk/data/space.celestia.celestia_gtk.metainfo.xml
+++ b/src/celestia/gtk/data/space.celestia.celestia_gtk.metainfo.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2022 Mattia Verga <mattia.verga@proton.me> -->
 <component type="desktop-application">
-    <id>space.celestia-qt</id>
+    <id>space.celestia.celestia_gtk</id>
     <metadata_license>MIT</metadata_license>
     <project_license>GPL-2.0+</project_license>
-    <name>Celestia (QT)</name>
+    <name>Celestia (GTK)</name>
     <summary>Explore the universe</summary>
     <description>
     <p>
@@ -18,7 +18,7 @@
       is used as a visualization tool by space mission designers.
     </p>
   </description>
-  <launchable type="desktop-id">celestia-qt.desktop</launchable>
+  <launchable type="desktop-id">celestia-gtk.desktop</launchable>
   <url type="homepage">https://celestia.space</url>
   <screenshots>
     <screenshot type="default">https://celestia.space/images/gallery/cassini.jpg</screenshot>

--- a/src/celestia/qt/data/CMakeLists.txt
+++ b/src/celestia/qt/data/CMakeLists.txt
@@ -1,6 +1,6 @@
 install(FILES celestia-qt.desktop
         DESTINATION "${CMAKE_INSTALL_DATADIR}/applications")
-install(FILES space.celestia-qt.metainfo.xml
+install(FILES space.celestia.celestia_qt.metainfo.xml
         DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo")
 install(FILES celestia-qt.1
         DESTINATION "${CMAKE_INSTALL_DATADIR}/man/man1")

--- a/src/celestia/qt/data/space.celestia.celestia_qt.metainfo.xml
+++ b/src/celestia/qt/data/space.celestia.celestia_qt.metainfo.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2022 Mattia Verga <mattia.verga@proton.me> -->
 <component type="desktop-application">
-    <id>space.celestia-gtk</id>
+    <id>space.celestia.celestia_qt</id>
     <metadata_license>MIT</metadata_license>
     <project_license>GPL-2.0+</project_license>
-    <name>Celestia (GTK)</name>
+    <name>Celestia (QT)</name>
     <summary>Explore the universe</summary>
     <description>
     <p>
@@ -18,7 +18,7 @@
       is used as a visualization tool by space mission designers.
     </p>
   </description>
-  <launchable type="desktop-id">celestia-gtk.desktop</launchable>
+  <launchable type="desktop-id">celestia-qt.desktop</launchable>
   <url type="homepage">https://celestia.space</url>
   <screenshots>
     <screenshot type="default">https://celestia.space/images/gallery/cassini.jpg</screenshot>


### PR DESCRIPTION
The [AppStream spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic) requires, and Flatpak enforces, a minimum three part application ID, and discourages capital letters and hyphens.

/cc @mattiaverga 