### PR TITLE
Fix icon on QT with Wayland

### DIFF
--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -246,6 +246,7 @@ void CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
     m_appCore->setAlerter(alerter);
 
     setWindowIcon(QIcon(":/icons/celestia.png"));
+    QGuiApplication::setDesktopFileName("celestia-qt");
 
     if (!options.logFilename.isEmpty())
     {


### PR DESCRIPTION
Should help fixing #1525 
I'm don't know much about QT, I hope to have put the line in the right place. A local build now shows the icon correctly.

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>