### PR TITLE
[qt] Use spinboxes for feature size and ambient light level numeric input

### DIFF
--- a/src/celestia/qt/preferences.ui
+++ b/src/celestia/qt/preferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>456</width>
-    <height>409</height>
+    <width>479</width>
+    <height>505</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -749,7 +749,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QLineEdit" name="featureSizeEdit">
+             <widget class="QSpinBox" name="featureSizeSpinBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -758,21 +758,21 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>80</width>
+                <width>40</width>
                 <height>0</height>
                </size>
               </property>
-              <property name="maximumSize">
-               <size>
-                <width>80</width>
-                <height>16777215</height>
-               </size>
+              <property name="buttonSymbols">
+               <enum>QAbstractSpinBox::NoButtons</enum>
               </property>
-              <property name="inputMask">
-               <string>000; </string>
+              <property name="accelerated">
+               <bool>true</bool>
               </property>
-              <property name="text">
-               <string/>
+              <property name="correctionMode">
+               <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+              </property>
+              <property name="maximum">
+               <number>999</number>
               </property>
              </widget>
             </item>

--- a/src/celestia/qt/preferences.ui
+++ b/src/celestia/qt/preferences.ui
@@ -758,7 +758,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>40</width>
+                <width>0</width>
                 <height>0</height>
                </size>
               </property>
@@ -803,6 +803,19 @@
       <layout class="QHBoxLayout" name="horizontalLayout_5">
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_14">
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
          <item>
           <widget class="QGroupBox" name="textureResolutionGroupBox">
            <property name="title">
@@ -853,17 +866,58 @@
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_15">
             <item>
-             <widget class="QSlider" name="ambientLightSlider">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
+             <layout class="QHBoxLayout" name="horizontalLayout_6">
+              <property name="spacing">
+               <number>6</number>
               </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
+              <item>
+               <widget class="QSlider" name="ambientLightSlider">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="ambientLightSpinBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>30</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="frame">
+                 <bool>true</bool>
+                </property>
+                <property name="buttonSymbols">
+                 <enum>QAbstractSpinBox::NoButtons</enum>
+                </property>
+                <property name="accelerated">
+                 <bool>true</bool>
+                </property>
+                <property name="correctionMode">
+                 <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                </property>
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
              <widget class="QCheckBox" name="tintedIlluminationCheck">
@@ -934,6 +988,19 @@
        </item>
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_18">
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
          <item>
           <widget class="QGroupBox" name="starStyleGroupBox">
            <property name="title">

--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -753,8 +753,22 @@ void PreferencesDialog::on_highResolutionButton_clicked()
 void PreferencesDialog::on_ambientLightSlider_valueChanged(int value)
 {
     Renderer* renderer = appCore->getRenderer();
-    float ambient = ((float) value) / 100.0f;
+    float ambient = static_cast<float>(value) / 100.0f;
     renderer->setAmbientLightLevel(ambient);
+    ui.ambientLightSpinBox->blockSignals(true);
+    ui.ambientLightSpinBox->setValue(value);
+    ui.ambientLightSpinBox->blockSignals(false);
+}
+
+
+void PreferencesDialog::on_ambientLightSpinBox_valueChanged(int value)
+{
+    Renderer* renderer = appCore->getRenderer();
+    float ambient = static_cast<float>(value) / 100.0f;
+    renderer->setAmbientLightLevel(ambient);
+    ui.ambientLightSlider->blockSignals(true);
+    ui.ambientLightSlider->setValue(value);
+    ui.ambientLightSlider->blockSignals(false);
 }
 
 

--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -162,7 +162,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
 
     int minimumFeatureSize = (int)renderer->getMinimumFeatureSize();
     ui.featureSizeSlider->setValue(minimumFeatureSize);
-    ui.featureSizeEdit->setText(QString::number(minimumFeatureSize));
+    ui.featureSizeSpinBox->setValue(minimumFeatureSize);
 
     ui.renderPathBox->addItem(_("OpenGL 2.1"), 0);
 
@@ -682,15 +682,20 @@ void PreferencesDialog::on_otherLocationsCheck_stateChanged(int state)
 void PreferencesDialog::on_featureSizeSlider_valueChanged(int value)
 {
     Renderer* renderer = appCore->getRenderer();
-    renderer->setMinimumFeatureSize((float) value);
-    ui.featureSizeEdit->setText(QString::number(value));
+    renderer->setMinimumFeatureSize(static_cast<float>(value));
+    ui.featureSizeSpinBox->blockSignals(true);
+    ui.featureSizeSpinBox->setValue(value);
+    ui.featureSizeSpinBox->blockSignals(false);
 }
 
 
-void PreferencesDialog::on_featureSizeEdit_textEdited(const QString& text)
+void PreferencesDialog::on_featureSizeSpinBox_valueChanged(int value)
 {
-    int featureSize = text.toInt();
-    ui.featureSizeSlider->setValue(featureSize);
+    Renderer* renderer = appCore->getRenderer();
+    renderer->setMinimumFeatureSize(static_cast<float>(value));
+    ui.featureSizeSlider->blockSignals(true);
+    ui.featureSizeSlider->setValue(value);
+    ui.featureSizeSlider->blockSignals(false);
 }
 
 

--- a/src/celestia/qt/qtpreferencesdialog.h
+++ b/src/celestia/qt/qtpreferencesdialog.h
@@ -109,6 +109,7 @@ private slots:
     void on_highResolutionButton_clicked();
 
     void on_ambientLightSlider_valueChanged(int value);
+    void on_ambientLightSpinBox_valueChanged(int value);
 
     void on_pointStarsButton_clicked();
     void on_scaledDiscsButton_clicked();

--- a/src/celestia/qt/qtpreferencesdialog.h
+++ b/src/celestia/qt/qtpreferencesdialog.h
@@ -98,7 +98,7 @@ private slots:
     void on_volcanoesCheck_stateChanged(int state);
     void on_otherLocationsCheck_stateChanged(int state);
     void on_featureSizeSlider_valueChanged(int value);
-    void on_featureSizeEdit_textEdited(const QString& text);
+    void on_featureSizeSpinBox_valueChanged(int value);
 
     void on_renderPathBox_currentIndexChanged(int index);
     void on_antialiasLinesCheck_stateChanged(int state);


### PR DESCRIPTION
The feature size numeric input is extremely awkward to use. This replaces it with a spinbox, which does numeric input a lot more nicely than a masked line edit.

Also added a spinbox for ambient light level