### PR TITLE
Virtual texture filetype fix

### DIFF
--- a/src/celengine/image.cpp
+++ b/src/celengine/image.cpp
@@ -309,22 +309,22 @@ std::unique_ptr<Image> LoadImageFromFile(const fs::path& filename)
 
     switch (type)
     {
-    case Content_JPEG:
+    case ContentType::JPEG:
         img = LoadJPEGImage(filename);
         break;
-    case Content_BMP:
+    case ContentType::BMP:
         img = LoadBMPImage(filename);
         break;
-    case Content_PNG:
+    case ContentType::PNG:
         img = LoadPNGImage(filename);
         break;
 #ifdef USE_LIBAVIF
-    case Content_AVIF:
+    case ContentType::AVIF:
         img = LoadAVIFImage(filename);
         break;
 #endif
-    case Content_DDS:
-    case Content_DXT5NormalMap:
+    case ContentType::DDS:
+    case ContentType::DXT5NormalMap:
         img = LoadDDSImage(filename);
         break;
     default:

--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -445,13 +445,13 @@ GeometryInfo::load(const ResourceKey& key) const
 
     switch (ContentType fileType = DetermineFileType(key.resolvedPath); fileType)
     {
-    case Content_3DStudio:
+    case ContentType::_3DStudio:
         model = Load3DSModel(key, path);
         break;
-    case Content_CelestiaModel:
+    case ContentType::CelestiaModel:
         model = LoadCMODModel(key, path);
         break;
-    case Content_CelestiaMesh:
+    case ContentType::CelestiaMesh:
         model = LoadCMSModel(key);
         break;
     default:

--- a/src/celengine/texture.cpp
+++ b/src/celengine/texture.cpp
@@ -925,7 +925,7 @@ LoadTextureFromFile(const fs::path& filename,
     // Check for a Celestia texture--these need to be handled specially.
     ContentType contentType = DetermineFileType(filename);
 
-    if (contentType == Content_CelestiaTexture)
+    if (contentType == ContentType::CelestiaTexture)
         return LoadVirtualTexture(filename);
 
     // All other texture types are handled by first loading an image, then
@@ -936,7 +936,7 @@ LoadTextureFromFile(const fs::path& filename,
 
     std::unique_ptr<Texture> tex = CreateTextureFromImage(*img, addressMode, mipMode);
 
-    if (contentType == Content_DXT5NormalMap)
+    if (contentType == ContentType::DXT5NormalMap)
     {
         // If the texture came from a .dxt5nm file then mark it as a dxt5
         // compressed normal map. There's no separate OpenGL format for dxt5

--- a/src/celengine/trajmanager.cpp
+++ b/src/celengine/trajmanager.cpp
@@ -53,7 +53,7 @@ TrajectoryInfo::load(const ResourceKey& key) const
     // TODO use unique_ptr here and replace the use of .release()
     std::unique_ptr<celestia::ephem::Orbit> sampTrajectory = nullptr;
 
-    if (filetype == Content_CelestiaXYZVTrajectory)
+    if (filetype == ContentType::CelestiaXYZVTrajectory)
     {
         switch (key.precision)
         {
@@ -68,7 +68,7 @@ TrajectoryInfo::load(const ResourceKey& key) const
             break;
         }
     }
-    else if (filetype == Content_CelestiaXYZVBinary)
+    else if (filetype == ContentType::CelestiaXYZVBinary)
     {
         switch (key.precision)
         {

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -76,7 +76,7 @@ VirtualTexture::VirtualTexture(const fs::path& _tilePath,
     tileExt = fmt::format(".{:s}", _tileType);
     populateTileTree();
 
-    if (DetermineFileType(tileExt) == ContentType::DXT5NormalMap)
+    if (DetermineFileType(tileExt, true) == ContentType::DXT5NormalMap)
         setFormatOptions(Texture::DXT5NormalMap);
 }
 

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -76,7 +76,7 @@ VirtualTexture::VirtualTexture(const fs::path& _tilePath,
     tileExt = fmt::format(".{:s}", _tileType);
     populateTileTree();
 
-    if (DetermineFileType(tileExt) == Content_DXT5NormalMap)
+    if (DetermineFileType(tileExt) == ContentType::DXT5NormalMap)
         setFormatOptions(Texture::DXT5NormalMap);
 }
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3673,7 +3673,7 @@ class SolarSystemLoader
 
     void process(const fs::path& filepath)
     {
-        if (DetermineFileType(filepath) != Content_CelestiaCatalog)
+        if (DetermineFileType(filepath) != ContentType::CelestiaCatalog)
             return;
 
         if (find(begin(skip), end(skip), filepath) != end(skip))
@@ -3857,7 +3857,7 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
     {
         vector<fs::path> entries;
         DeepSkyLoader loader(dsoDB, "deep sky object",
-                             Content_CelestiaDeepSkyCatalog,
+                             ContentType::CelestiaDeepSkyCatalog,
                              progressNotifier,
                              config->skipExtras);
         for (const auto& dir : config->extrasDirs)
@@ -4219,7 +4219,7 @@ bool CelestiaCore::readStars(const CelestiaConfig& cfg,
         vector<fs::path> entries;
         StarLoader loader(starDB,
                           "star",
-                          Content_CelestiaStarCatalog,
+                          ContentType::CelestiaStarCatalog,
                           progressNotifier,
                           config->skipExtras);
         for (const auto& dir : config->extrasDirs)
@@ -4806,10 +4806,10 @@ bool CelestiaCore::captureImage(std::uint8_t* buffer,
 
 bool CelestiaCore::saveScreenShot(const fs::path& filename, ContentType type) const
 {
-    if (type == Content_Unknown)
+    if (type == ContentType::Unknown)
         type = DetermineFileType(filename);
 
-    if (type != Content_JPEG && type != Content_PNG)
+    if (type != ContentType::JPEG && type != ContentType::PNG)
     {
         GetLogger()->error(_("Unsupported image type: {}!\n"), filename);
         return false;
@@ -4824,9 +4824,9 @@ bool CelestiaCore::saveScreenShot(const fs::path& filename, ContentType type) co
 
     switch (type)
     {
-    case Content_JPEG:
+    case ContentType::JPEG:
         return SaveJPEGImage(filename, image);
-    case Content_PNG:
+    case ContentType::PNG:
         return SavePNGImage(filename, image);
     default:
         break;

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -394,7 +394,7 @@ class CelestiaCore // : public Watchable<CelestiaCore>
 
     void getCaptureInfo(std::array<int, 4>& viewport, celestia::PixelFormat& format) const;
     bool captureImage(std::uint8_t* buffer, const std::array<int, 4>& viewport, celestia::PixelFormat format) const;
-    bool saveScreenShot(const fs::path&, ContentType = Content_Unknown) const;
+    bool saveScreenShot(const fs::path&, ContentType = ContentType::Unknown) const;
 
 #ifdef USE_MINIAUDIO
     bool isPlayingAudio(int channel) const;

--- a/src/celestia/gtk/actions.cpp
+++ b/src/celestia/gtk/actions.cpp
@@ -1091,7 +1091,7 @@ static void openScript(const char* filename, AppData* app)
 static void captureImage(const char* filename, AppData* app)
 {
     ContentType type = DetermineFileType(filename);
-    if (type != Content_JPEG && type != Content_PNG)
+    if (type != ContentType::JPEG && type != ContentType::PNG)
     {
         GtkWidget* errBox = gtk_message_dialog_new(GTK_WINDOW(app->mainWindow),
                                                    GTK_DIALOG_DESTROY_WITH_PARENT,

--- a/src/celestia/scriptmenu.cpp
+++ b/src/celestia/scriptmenu.cpp
@@ -26,10 +26,10 @@ static void process(const fs::path& p, vector<ScriptMenuItem>* menuItems)
 {
     auto type = DetermineFileType(p);
 #ifndef CELX
-    if (type != Content_CelestiaLegacyScript)
+    if (type != ContentType::CelestiaLegacyScript)
 #else
-    if (type != Content_CelestiaScript &&
-        type != Content_CelestiaLegacyScript)
+    if (type != ContentType::CelestiaScript &&
+        type != ContentType::CelestiaLegacyScript)
 #endif
         return;
 

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -2714,7 +2714,7 @@ static void HandleCaptureImage(HWND hWnd)
         }
 
         ContentType type = DetermineFileType(Ofn.lpstrFile);
-        if (type != Content_JPEG && type != Content_PNG)
+        if (type != ContentType::JPEG && type != ContentType::PNG)
         {
             MessageBox(hWnd,
                        _("Please use a name ending in '.jpg' or '.png'."),
@@ -2813,7 +2813,7 @@ static void HandleCaptureMovie(HWND hWnd)
         {
             switch (DetermineFileType(Ofn.lpstrFile))
             {
-            case Content_MKV:
+            case ContentType::MKV:
                 nFileType = 1;
                 break;
             default:

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -666,14 +666,14 @@ CommandCapture::CommandCapture(std::string _type,
 
 void CommandCapture::process(ExecutionEnvironment& env)
 {
-    ContentType _type = Content_Unknown;
+    ContentType _type = ContentType::Unknown;
     if (type == "jpeg" || type == "jpg")
-        _type = Content_JPEG;
+        _type = ContentType::JPEG;
     else if (type == "png")
-        _type = Content_PNG;
+        _type = ContentType::PNG;
 #ifdef USE_LIBAVIF
     else if (type == "avif")
-        _type = Content_AVIF;
+        _type = ContentType::AVIF;
 #endif
     env.getCelestiaCore()->saveScreenShot(filename, _type);
 }

--- a/src/celutil/filetype.cpp
+++ b/src/celutil/filetype.cpp
@@ -48,9 +48,11 @@ constexpr std::string_view ContentWarpMeshExt = ".map"sv;
 
 } // end unnamed namespace
 
-ContentType DetermineFileType(const fs::path& filename)
+ContentType DetermineFileType(const fs::path& filename, bool isExtension)
 {
-    const std::string ext = filename.extension().string();
+    const std::string ext = isExtension
+        ? filename.string()
+        : filename.extension().string();
 
     if (compareIgnoringCase(JPEGExt, ext) == 0 ||
         compareIgnoringCase(JPGExt, ext) == 0 ||

--- a/src/celutil/filetype.cpp
+++ b/src/celutil/filetype.cpp
@@ -7,89 +7,97 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include "stringutils.h"
 #include "filetype.h"
 
-using namespace std;
+#include <string>
+#include <string_view>
 
+#include "stringutils.h"
 
-static const char JPEGExt[] = ".jpeg";
-static const char JPGExt[] = ".jpg";
-static const char JFIFExt[] = ".jif";
-static const char BMPExt[] = ".bmp";
-static const char TargaExt[] = ".tga";
-static const char PNGExt[] = ".png";
+using namespace std::string_view_literals;
+
+namespace
+{
+
+constexpr std::string_view JPEGExt = ".jpeg"sv;
+constexpr std::string_view JPGExt = ".jpg"sv;
+constexpr std::string_view JFIFExt = ".jif"sv;
+constexpr std::string_view BMPExt = ".bmp"sv;
+constexpr std::string_view TargaExt = ".tga"sv;
+constexpr std::string_view PNGExt = ".png"sv;
 #ifdef USE_LIBAVIF
-static const char AVIFExt[] = ".avif";
+constexpr std::string_view AVIFExt = ".avif"sv;
 #endif
-static const char ThreeDSExt[] = ".3ds";
-static const char CelestiaTextureExt[] = ".ctx";
-static const char CelestiaMeshExt[] = ".cms";
-static const char CelestiaCatalogExt[] = ".ssc";
-static const char CelestiaStarCatalogExt[] = ".stc";
-static const char CelestiaDeepSkyCatalogExt[] = ".dsc";
-static const char MKVExt[] = ".mkv";
-static const char DDSExt[] = ".dds";
-static const char DXT5NormalMapExt[] = ".dxt5nm";
-static const char CelestiaLegacyScriptExt[] = ".cel";
-static const char CelestiaScriptExt[] = ".clx";
-static const char CelestiaScriptExt2[] = ".celx";
-static const char CelestiaModelExt[] = ".cmod";
-static const char CelestiaXYZTrajectoryExt[] = ".xyz";
-static const char CelestiaXYZVTrajectoryExt[] = ".xyzv";
-static const char ContentXYZVBinaryExt[] = ".xyzvbin";
-static const char ContentWarpMeshExt[] = ".map";
+constexpr std::string_view ThreeDSExt = ".3ds"sv;
+constexpr std::string_view CelestiaTextureExt = ".ctx"sv;
+constexpr std::string_view CelestiaMeshExt = ".cms"sv;
+constexpr std::string_view CelestiaCatalogExt = ".ssc"sv;
+constexpr std::string_view CelestiaStarCatalogExt = ".stc"sv;
+constexpr std::string_view CelestiaDeepSkyCatalogExt = ".dsc"sv;
+constexpr std::string_view MKVExt = ".mkv"sv;
+constexpr std::string_view DDSExt = ".dds"sv;
+constexpr std::string_view DXT5NormalMapExt = ".dxt5nm"sv;
+constexpr std::string_view CelestiaLegacyScriptExt = ".cel"sv;
+constexpr std::string_view CelestiaScriptExt = ".clx"sv;
+constexpr std::string_view CelestiaScriptExt2 = ".celx"sv;
+constexpr std::string_view CelestiaModelExt = ".cmod"sv;
+constexpr std::string_view CelestiaXYZTrajectoryExt = ".xyz"sv;
+constexpr std::string_view CelestiaXYZVTrajectoryExt = ".xyzv"sv;
+constexpr std::string_view ContentXYZVBinaryExt = ".xyzvbin"sv;
+constexpr std::string_view ContentWarpMeshExt = ".map"sv;
+
+} // end unnamed namespace
 
 ContentType DetermineFileType(const fs::path& filename)
 {
-    const string ext = filename.extension().string();
+    const std::string ext = filename.extension().string();
 
     if (compareIgnoringCase(JPEGExt, ext) == 0 ||
         compareIgnoringCase(JPGExt, ext) == 0 ||
         compareIgnoringCase(JFIFExt, ext) == 0)
-        return Content_JPEG;
+        return ContentType::JPEG;
     if (compareIgnoringCase(BMPExt, ext) == 0)
-        return Content_BMP;
+        return ContentType::BMP;
     if (compareIgnoringCase(TargaExt, ext) == 0)
-        return Content_Targa;
+        return ContentType::Targa;
     if (compareIgnoringCase(PNGExt, ext) == 0)
-        return Content_PNG;
+        return ContentType::PNG;
 #ifdef USE_LIBAVIF
     if (compareIgnoringCase(AVIFExt, ext) == 0)
-        return Content_AVIF;
+        return ContentType::AVIF;
 #endif
     if (compareIgnoringCase(ThreeDSExt, ext) == 0)
-        return Content_3DStudio;
+        return ContentType::_3DStudio;
     if (compareIgnoringCase(CelestiaTextureExt, ext) == 0)
-        return Content_CelestiaTexture;
+        return ContentType::CelestiaTexture;
     if (compareIgnoringCase(CelestiaMeshExt, ext) == 0)
-        return Content_CelestiaMesh;
+        return ContentType::CelestiaMesh;
     if (compareIgnoringCase(CelestiaCatalogExt, ext) == 0)
-        return Content_CelestiaCatalog;
+        return ContentType::CelestiaCatalog;
     if (compareIgnoringCase(CelestiaStarCatalogExt, ext) == 0)
-        return Content_CelestiaStarCatalog;
+        return ContentType::CelestiaStarCatalog;
     if (compareIgnoringCase(CelestiaDeepSkyCatalogExt, ext) == 0)
-        return Content_CelestiaDeepSkyCatalog;
+        return ContentType::CelestiaDeepSkyCatalog;
     if (compareIgnoringCase(MKVExt, ext) == 0)
-        return Content_MKV;
+        return ContentType::MKV;
     if (compareIgnoringCase(DDSExt, ext) == 0)
-        return Content_DDS;
+        return ContentType::DDS;
     if (compareIgnoringCase(CelestiaLegacyScriptExt, ext) == 0)
-        return Content_CelestiaLegacyScript;
+        return ContentType::CelestiaLegacyScript;
     if (compareIgnoringCase(CelestiaScriptExt, ext) == 0 ||
         compareIgnoringCase(CelestiaScriptExt2, ext) == 0)
-        return Content_CelestiaScript;
+        return ContentType::CelestiaScript;
     if (compareIgnoringCase(CelestiaModelExt, ext) == 0)
-        return Content_CelestiaModel;
+        return ContentType::CelestiaModel;
     if (compareIgnoringCase(DXT5NormalMapExt, ext) == 0)
-        return Content_DXT5NormalMap;
+        return ContentType::DXT5NormalMap;
     if (compareIgnoringCase(CelestiaXYZTrajectoryExt, ext) == 0)
-        return Content_CelestiaXYZTrajectory;
+        return ContentType::CelestiaXYZTrajectory;
     if (compareIgnoringCase(CelestiaXYZVTrajectoryExt, ext) == 0)
-        return Content_CelestiaXYZVTrajectory;
+        return ContentType::CelestiaXYZVTrajectory;
     if (compareIgnoringCase(ContentWarpMeshExt, ext) == 0)
-        return Content_WarpMesh;
+        return ContentType::WarpMesh;
     if (compareIgnoringCase(ContentXYZVBinaryExt, ext) == 0)
-        return Content_CelestiaXYZVBinary;
-    return Content_Unknown;
+        return ContentType::CelestiaXYZVBinary;
+    return ContentType::Unknown;
 }

--- a/src/celutil/filetype.h
+++ b/src/celutil/filetype.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <string>
 #include <celcompat/filesystem.h>
 
 enum class ContentType
@@ -42,4 +41,4 @@ enum class ContentType
     Unknown                = -1,
 };
 
-ContentType DetermineFileType(const fs::path& filename);
+ContentType DetermineFileType(const fs::path& filename, bool isExtension = false);

--- a/src/celutil/filetype.h
+++ b/src/celutil/filetype.h
@@ -7,42 +7,39 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _FILETYPE_H_
-#define _FILETYPE_H_
+#pragma once
 
 #include <string>
 #include <celcompat/filesystem.h>
 
-enum ContentType
+enum class ContentType
 {
-    Content_JPEG                   = 1,
-    Content_BMP                    = 2,
-    Content_GIF                    = 3,
-    Content_PNG                    = 4,
-    Content_Targa                  = 5,
-    Content_CelestiaTexture        = 6,
-    Content_3DStudio               = 7,
-    Content_CelestiaMesh           = 8,
-    Content_MKV                    = 9,
-    Content_CelestiaCatalog        = 10,
-    Content_DDS                    = 11,
-    Content_CelestiaStarCatalog    = 12,
-    Content_CelestiaDeepSkyCatalog = 13,
-    Content_CelestiaScript         = 14,
-    Content_CelestiaLegacyScript   = 15,
-    Content_CelestiaModel          = 16,
-    Content_DXT5NormalMap          = 17,
-    Content_CelestiaXYZTrajectory  = 18,
-    Content_CelestiaXYZVTrajectory = 19,
- // Content_CelestiaParticleSystem = 20,
-    Content_WarpMesh               = 21,
-    Content_CelestiaXYZVBinary     = 22,
+    JPEG                   = 1,
+    BMP                    = 2,
+    GIF                    = 3,
+    PNG                    = 4,
+    Targa                  = 5,
+    CelestiaTexture        = 6,
+    _3DStudio              = 7,
+    CelestiaMesh           = 8,
+    MKV                    = 9,
+    CelestiaCatalog        = 10,
+    DDS                    = 11,
+    CelestiaStarCatalog    = 12,
+    CelestiaDeepSkyCatalog = 13,
+    CelestiaScript         = 14,
+    CelestiaLegacyScript   = 15,
+    CelestiaModel          = 16,
+    DXT5NormalMap          = 17,
+    CelestiaXYZTrajectory  = 18,
+    CelestiaXYZVTrajectory = 19,
+ // CelestiaParticleSystem = 20,
+    WarpMesh               = 21,
+    CelestiaXYZVBinary     = 22,
 #ifdef USE_LIBAVIF
-    Content_AVIF                   = 23,
+    AVIF                   = 23,
 #endif
-    Content_Unknown                = -1,
+    Unknown                = -1,
 };
 
 ContentType DetermineFileType(const fs::path& filename);
-
-#endif // _FILETYPE_H_


### PR DESCRIPTION
Virtual textures pass just the file extension to `DetermineFileType`, which gets interpreted by `path::extension()` as an extensionless filename. To work around this, add an optional `isExtension` parameter to `DetermineFileType` to allow skipping the call to `path::extension()`.

Also refactor `ContentType` to be an `enum class` and store the string constants as `constexpr std::string_view`s.

Fixes #1544 
Fixes #1545