### PR TITLE
Stop Sonar complaining about reinterpret_cast

### DIFF
--- a/src/celutil/align.h
+++ b/src/celutil/align.h
@@ -14,7 +14,7 @@ template<typename T> T* aligned_addr(void* addr) //NOSONAR
 {
     // alignof(T) is guaranteed to be a power of two
     constexpr auto align_one = static_cast<std::uintptr_t>(alignof(T) - 1);
-    return reinterpret_cast<T*>((reinterpret_cast<std::uintptr_t>(addr) + align_one) & (~align_one));
+    return reinterpret_cast<T*>((reinterpret_cast<std::uintptr_t>(addr) + align_one) & (~align_one)); //NOSONAR
 }
 
 /*! Returns size large enough so an object of type T can be placed


### PR DESCRIPTION
Pointer↔integer casts are necessary for the operation of this function. The way to do this in C++17 is with `reinterpret_cast`. While Sonar wants this to be replaced with a safer cast, there is no safer cast that can be used in this situation.