### PR TITLE
Reduce use of temporary vectors during autocomplete searching

### DIFF
--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -970,7 +970,7 @@ vector<Location*>* Body::getLocations() const
 }
 
 
-Location* Body::findLocation(const string& name, bool i18n) const
+Location* Body::findLocation(std::string_view name, bool i18n) const
 {
     if (!locations)
         return nullptr;
@@ -1317,7 +1317,7 @@ void PlanetarySystem::replaceBody(Body* oldBody, Body* newBody)
  *    as resolving an object name in an ssc file--it should be false. Otherwise,
  *    object lookup will behave differently based on the locale.
  */
-Body* PlanetarySystem::find(const string& _name, bool deepSearch, bool i18n) const
+Body* PlanetarySystem::find(std::string_view _name, bool deepSearch, bool i18n) const
 {
     auto firstMatch = objectIndex.find(_name);
     if (firstMatch != objectIndex.end())
@@ -1370,9 +1370,11 @@ bool PlanetarySystem::traverse(TraversalFunc func, void* info) const
     return true;
 }
 
-std::vector<std::string> PlanetarySystem::getCompletion(const std::string& _name, bool i18n, bool deepSearch) const
+void PlanetarySystem::getCompletion(std::vector<std::string>& completion,
+                                    std::string_view _name,
+                                    bool i18n,
+                                    bool deepSearch) const
 {
-    std::vector<std::string> completion;
     int _name_length = UTF8Length(_name);
 
     // Search through all names in this planetary system.
@@ -1396,14 +1398,9 @@ std::vector<std::string> PlanetarySystem::getCompletion(const std::string& _name
         for (const auto sat : satellites)
         {
             if (sat->getSatellites())
-            {
-                auto bodies = sat->getSatellites()->getCompletion(_name, i18n);
-                completion.insert(completion.end(), bodies.begin(), bodies.end());
-            }
+                sat->getSatellites()->getCompletion(completion, _name, i18n);
         }
     }
-
-    return completion;
 }
 
 

--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -21,6 +21,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <map>
 #include <memory>
@@ -62,15 +63,15 @@ class PlanetarySystem
     typedef bool (*TraversalFunc)(Body*, void*);
 
     bool traverse(TraversalFunc, void*) const;
-    Body* find(const std::string&, bool deepSearch = false, bool i18n = false) const;
-    std::vector<std::string> getCompletion(const std::string& _name, bool i18n, bool rec = true) const;
+    Body* find(std::string_view, bool deepSearch = false, bool i18n = false) const;
+    void getCompletion(std::vector<std::string>& completion, std::string_view _name, bool i18n, bool rec = true) const;
 
  private:
     void addBodyToNameIndex(Body* body);
     void removeBodyFromNameIndex(const Body* body);
 
  private:
-    typedef std::map<std::string, Body*, UTF8StringOrderingPredicate> ObjectIndex;
+    using ObjectIndex = std::map<std::string, Body*, UTF8StringOrderingPredicate>;
 
  private:
     Star* star;
@@ -315,7 +316,7 @@ class Body : public AstroObject
 
     std::vector<Location*>* getLocations() const;
     void addLocation(Location*);
-    Location* findLocation(const std::string&, bool i18n = false) const;
+    Location* findLocation(std::string_view, bool i18n = false) const;
     void computeLocations();
 
     bool isVisible() const { return visible; }

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -56,7 +56,7 @@ DeepSkyObject* DSODatabase::find(const AstroCatalog::IndexNumber catalogNumber) 
 }
 
 
-DeepSkyObject* DSODatabase::find(const std::string& name, bool i18n) const
+DeepSkyObject* DSODatabase::find(std::string_view name, bool i18n) const
 {
     if (name.empty())
         return nullptr;
@@ -72,15 +72,11 @@ DeepSkyObject* DSODatabase::find(const std::string& name, bool i18n) const
 }
 
 
-std::vector<std::string> DSODatabase::getCompletion(const std::string& name, bool i18n) const
+void DSODatabase::getCompletion(std::vector<std::string>& completion, std::string_view name, bool i18n) const
 {
-    std::vector<std::string> completion;
-
     // only named DSOs are supported by completion.
     if (!name.empty() && namesDB != nullptr)
-        return namesDB->getCompletion(name, i18n);
-    else
-        return completion;
+        namesDB->getCompletion(completion, name, i18n);
 }
 
 

--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <Eigen/Core>
@@ -42,9 +43,9 @@ class DSODatabase
     inline std::uint32_t size() const;
 
     DeepSkyObject* find(const AstroCatalog::IndexNumber catalogNumber) const;
-    DeepSkyObject* find(const std::string&, bool i18n) const;
+    DeepSkyObject* find(std::string_view, bool i18n) const;
 
-    std::vector<std::string> getCompletion(const std::string&, bool i18n) const;
+    void getCompletion(std::vector<std::string>&, std::string_view, bool i18n) const;
 
     void findVisibleDSOs(DSOHandler& dsoHandler,
                          const Eigen::Vector3d& obsPosition,

--- a/src/celengine/dsoname.cpp
+++ b/src/celengine/dsoname.cpp
@@ -10,12 +10,10 @@
 //
 //
 
-#include <celengine/dsoname.h>
-
-using namespace std;
+#include "dsoname.h"
 
 //NOTE: this could be expanded in the near future, so we place it here:
-uint32_t DSONameDatabase::findCatalogNumberByName(const string& name, bool i18n) const
+std::uint32_t DSONameDatabase::findCatalogNumberByName(std::string_view name, bool i18n) const
 {
     return getCatalogNumberByName(name, i18n);
 }

--- a/src/celengine/dsoname.h
+++ b/src/celengine/dsoname.h
@@ -10,8 +10,9 @@
 //
 //
 
-#ifndef _DSONAME_H_
-#define _DSONAME_H_
+#pragma once
+
+#include <string_view>
 
 #include <celengine/name.h>
 #include <celengine/deepskyobj.h>
@@ -22,8 +23,5 @@ class DSONameDatabase: public NameDatabase
  public:
     DSONameDatabase() {};
 
-
-    uint32_t findCatalogNumberByName(const std::string&, bool i18n) const;
+    std::uint32_t findCatalogNumberByName(std::string_view, bool i18n) const;
 };
-
-#endif  // _DSONAME_H_

--- a/src/celengine/location.cpp
+++ b/src/celengine/location.cpp
@@ -99,10 +99,9 @@ FeatureNameEntry FeatureNames[] =
 };
 
 
-string Location::getName(bool i18n) const
+const std::string& Location::getName(bool i18n) const
 {
-    if (!i18n || i18nName == "") return name;
-    return i18nName;
+    return i18n && !i18nName.empty() ? i18nName : name;
 }
 
 

--- a/src/celengine/location.h
+++ b/src/celengine/location.h
@@ -25,7 +25,7 @@ public:
 
     Selection toSelection() override;
 
-    std::string getName(bool i18n = false) const;
+    const std::string& getName(bool i18n = false) const;
     void setName(const std::string&);
 
     Eigen::Vector3f getPosition() const;

--- a/src/celengine/name.cpp
+++ b/src/celengine/name.cpp
@@ -36,7 +36,7 @@ void NameDatabase::erase(const AstroCatalog::IndexNumber catalogNumber)
     numberIndex.erase(catalogNumber);
 }
 
-AstroCatalog::IndexNumber NameDatabase::getCatalogNumberByName(const std::string& name, bool i18n) const
+AstroCatalog::IndexNumber NameDatabase::getCatalogNumberByName(std::string_view name, bool i18n) const
 {
     auto iter = nameIndex.find(name);
     if (iter != nameIndex.end())
@@ -101,11 +101,10 @@ NameDatabase::NumberIndex::const_iterator NameDatabase::getFinalNameIter() const
     return numberIndex.end();
 }
 
-std::vector<std::string> NameDatabase::getCompletion(const std::string& name, bool i18n) const
+void NameDatabase::getCompletion(std::vector<std::string>& completion, std::string_view name, bool i18n) const
 {
     std::string name2 = ReplaceGreekLetter(name);
 
-    std::vector<std::string> completion;
     const int name_length = UTF8Length(name2);
 
     for (const auto &[n, _] : nameIndex)
@@ -121,5 +120,4 @@ std::vector<std::string> NameDatabase::getCompletion(const std::string& name, bo
                 completion.push_back(n);
         }
     }
-    return completion;
 }

--- a/src/celengine/name.h
+++ b/src/celengine/name.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <string_view>
 
 #include <celengine/astroobj.h>
 #include <celutil/stringutils.h>
@@ -38,17 +39,16 @@ class NameDatabase
     // delete all names associated with the specified catalog number
     void erase(const AstroCatalog::IndexNumber);
 
-    AstroCatalog::IndexNumber getCatalogNumberByName(const std::string&, bool i18n) const;
+    AstroCatalog::IndexNumber getCatalogNumberByName(std::string_view, bool i18n) const;
     std::string getNameByCatalogNumber(const AstroCatalog::IndexNumber) const;
 
     NumberIndex::const_iterator getFirstNameIter(const AstroCatalog::IndexNumber catalogNumber) const;
     NumberIndex::const_iterator getFinalNameIter() const;
 
-    std::vector<std::string> getCompletion(const std::string& name, bool i18n) const;
+    void getCompletion(std::vector<std::string>& completion, std::string_view name, bool i18n) const;
 
  protected:
     NameIndex   nameIndex;
     NameIndex   localizedNameIndex;
     NumberIndex numberIndex;
 };
-

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -1219,7 +1219,7 @@ getFrameCenter(const Universe& universe, const Hash* frameData, const Selection&
         return defaultCenter;
     }
 
-    Selection centerObject = universe.findPath(*centerName, nullptr, 0);
+    Selection centerObject = universe.findPath(*centerName, {});
     if (centerObject.empty())
     {
         GetLogger()->error("Center object '{}' of reference frame not found.\n", *centerName);
@@ -1259,7 +1259,7 @@ CreateMeanEquatorFrame(const Universe& universe,
     Selection obj = center;
     if (const std::string* objName = frameData->getString("Object"); objName != nullptr)
     {
-        obj = universe.findPath(*objName, nullptr, 0);
+        obj = universe.findPath(*objName, {});
         if (obj.empty())
         {
             GetLogger()->error("Object '{}' for mean equator frame not found.\n", *objName);
@@ -1378,7 +1378,7 @@ getVectorTarget(const Universe& universe, const Hash* vectorData)
         return Selection();
     }
 
-    Selection targetObject = universe.findPath(*targetName, nullptr, 0);
+    Selection targetObject = universe.findPath(*targetName, {});
     if (targetObject.empty())
     {
         GetLogger()->warn("Bad two-vector frame: target object '{}' of vector not found.\n",
@@ -1405,7 +1405,7 @@ getVectorObserver(const Universe& universe, const Hash* vectorData)
         return Selection();
     }
 
-    Selection obsObject = universe.findPath(*obsName, nullptr, 0);
+    Selection obsObject = universe.findPath(*obsName, {});
     if (obsObject.empty())
     {
         GetLogger()->warn("Bad two-vector frame: observer object '{}' of vector not found.\n",
@@ -1663,7 +1663,7 @@ CreateTopocentricFrame(const Universe& universe,
         // If a center is provided, the default observer is the center and
         // the default target is the center's parent. This gives sensible results
         // when a topocentric frame is used as an orbit frame.
-        center = universe.findPath(*centerName, nullptr, 0);
+        center = universe.findPath(*centerName, {});
         if (center.empty())
         {
             GetLogger()->error("Center object '{}' for topocentric frame not found.\n", *centerName);
@@ -1693,7 +1693,7 @@ CreateTopocentricFrame(const Universe& universe,
     }
     else
     {
-        target = universe.findPath(*targetName, nullptr, 0);
+        target = universe.findPath(*targetName, {});
         if (target.empty())
         {
             GetLogger()->error("Target object '{}' for topocentric frame not found.\n", *targetName);
@@ -1715,7 +1715,7 @@ CreateTopocentricFrame(const Universe& universe,
     }
     else
     {
-        observer = universe.findPath(*observerName, nullptr, 0);
+        observer = universe.findPath(*observerName, {});
         if (observer.empty())
         {
             GetLogger()->error("Observer object '{}' for topocentric frame not found.\n", *observerName);

--- a/src/celengine/simulation.h
+++ b/src/celengine/simulation.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_SIMULATION_H_
-#define _CELENGINE_SIMULATION_H_
+#pragma once
 
 #include <memory>
 #include <celengine/texture.h>
@@ -20,6 +19,7 @@
 #include <celengine/frame.h>
 #include <celengine/observer.h>
 #include <Eigen/Core>
+#include <string_view>
 #include <vector>
 
 
@@ -58,9 +58,12 @@ class Simulation
     void setTrackedObject(const Selection&);
 
     void selectPlanet(int);
-    Selection findObject(std::string s, bool i18n = false);
-    Selection findObjectFromPath(std::string s, bool i18n = false);
-    std::vector<std::string> getObjectCompletion(std::string s, bool i18n, bool withLocations = false);
+    Selection findObject(std::string_view s, bool i18n = false) const;
+    Selection findObjectFromPath(std::string_view s, bool i18n = false) const;
+    void getObjectCompletion(std::vector<std::string>& completion,
+                             std::string_view s,
+                             bool i18n,
+                             bool withLocations = false) const;
     void gotoSelection(double gotoTime,
                        const Eigen::Vector3f& up,
                        ObserverFrame::CoordinateSystem upFrame);
@@ -136,5 +139,3 @@ class Simulation
     float faintestVisible{ 5.0f };
     bool pauseState{ false };
 };
-
-#endif // _CELENGINE_SIMULATION_H_

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -1160,7 +1160,7 @@ bool LoadSolarSystemObjects(std::istream& in,
             return false;
         }
 
-        Selection parent = universe.findPath(parentName, nullptr, 0);
+        Selection parent = universe.findPath(parentName, {});
         PlanetarySystem* parentSystem = nullptr;
 
         std::vector<std::string> names;

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -308,7 +308,7 @@ Star* StarDatabase::find(AstroCatalog::IndexNumber catalogNumber) const
 }
 
 
-AstroCatalog::IndexNumber StarDatabase::findCatalogNumberByName(const std::string& name, bool i18n) const
+AstroCatalog::IndexNumber StarDatabase::findCatalogNumberByName(std::string_view name, bool i18n) const
 {
     if (name.empty())
         return AstroCatalog::InvalidIndex;
@@ -350,7 +350,7 @@ AstroCatalog::IndexNumber StarDatabase::findCatalogNumberByName(const std::strin
 }
 
 
-Star* StarDatabase::find(const std::string& name, bool i18n) const
+Star* StarDatabase::find(std::string_view name, bool i18n) const
 {
     AstroCatalog::IndexNumber catalogNumber = findCatalogNumberByName(name, i18n);
     if (catalogNumber != AstroCatalog::InvalidIndex)
@@ -413,15 +413,11 @@ Star* StarDatabase::searchCrossIndex(const Catalog catalog, const AstroCatalog::
 }
 
 
-std::vector<std::string> StarDatabase::getCompletion(const std::string& name, bool i18n) const
+void StarDatabase::getCompletion(std::vector<std::string>& completion, std::string_view name, bool i18n) const
 {
-    std::vector<std::string> completion;
-
     // only named stars are supported by completion.
     if (!name.empty() && namesDB != nullptr)
-        return namesDB->getCompletion(name, i18n);
-    else
-        return completion;
+        namesDB->getCompletion(completion, name, i18n);
 }
 
 

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -14,6 +14,7 @@
 #include <iosfwd>
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <Eigen/Core>
@@ -43,10 +44,10 @@ class StarDatabase
     inline std::uint32_t size() const;
 
     Star* find(AstroCatalog::IndexNumber catalogNumber) const;
-    Star* find(const std::string&, bool i18n) const;
-    AstroCatalog::IndexNumber findCatalogNumberByName(const std::string&, bool i18n) const;
+    Star* find(std::string_view, bool i18n) const;
+    AstroCatalog::IndexNumber findCatalogNumberByName(std::string_view, bool i18n) const;
 
-    std::vector<std::string> getCompletion(const std::string&, bool i18n) const;
+    void getCompletion(std::vector<std::string>&, std::string_view, bool i18n) const;
 
     void findVisibleStars(StarHandler& starHandler,
                           const Eigen::Vector3f& obsPosition,

--- a/src/celengine/starname.cpp
+++ b/src/celengine/starname.cpp
@@ -18,7 +18,7 @@
 using namespace std;
 
 
-uint32_t StarNameDatabase::findCatalogNumberByName(const string& name, bool i18n) const
+std::uint32_t StarNameDatabase::findCatalogNumberByName(std::string_view name, bool i18n) const
 {
     auto catalogNumber = getCatalogNumberByName(name, i18n);
     if (catalogNumber != AstroCatalog::InvalidIndex)

--- a/src/celengine/starname.h
+++ b/src/celengine/starname.h
@@ -10,8 +10,10 @@
 //
 //
 
-#ifndef _STARNAME_H_
-#define _STARNAME_H_
+#pragma once
+
+#include <cstdint>
+#include <string_view>
 
 #include <celengine/name.h>
 #include <celengine/star.h>
@@ -22,10 +24,7 @@ class StarNameDatabase: public NameDatabase
  public:
     StarNameDatabase() {};
 
-
-    uint32_t findCatalogNumberByName(const std::string&, bool i18n) const;
+    std::uint32_t findCatalogNumberByName(std::string_view, bool i18n) const;
 
     static StarNameDatabase* readNames(std::istream&);
 };
-
-#endif // _STARNAME_H_

--- a/src/celengine/universe.h
+++ b/src/celengine/universe.h
@@ -8,8 +8,13 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_UNIVERSE_H_
-#define _CELENGINE_UNIVERSE_H_
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
 
 #include <celengine/univcoord.h>
 #include <celengine/stardb.h>
@@ -19,7 +24,7 @@
 #include <celengine/marker.h>
 #include <celengine/selection.h>
 #include <celengine/asterism.h>
-#include <vector>
+#include <celutil/array_view.h>
 
 
 class ConstellationBoundaries;
@@ -53,31 +58,18 @@ class Universe
                    float tolerance = 0.0f);
 
 
-    Selection find(const std::string& s,
-                   Selection* contexts = nullptr,
-                   int nContexts = 0,
+    Selection find(std::string_view s,
+                   celestia::util::array_view<const Selection> contexts,
                    bool i18n = false) const;
-    Selection findPath(const std::string& s,
-                       Selection* contexts = nullptr,
-                       int nContexts = 0,
+    Selection findPath(std::string_view s,
+                       celestia::util::array_view<const Selection> contexts,
                        bool i18n = false) const;
-    Selection findChildObject(const Selection& sel,
-                              const std::string& name,
-                              bool i18n = false) const;
-    Selection findObjectInContext(const Selection& sel,
-                                  const std::string& name,
-                                  bool i18n = false) const;
 
-    std::vector<std::string> getCompletion(const std::string& s,
-                                           bool i18n,
-                                           Selection* contexts = nullptr,
-                                           int nContexts = 0,
-                                           bool withLocations = false);
-    std::vector<std::string> getCompletionPath(const std::string& s,
-                                               bool i18n,
-                                               Selection* contexts = nullptr,
-                                               int nContexts = 0,
-                                               bool withLocations = false);
+    void getCompletionPath(std::vector<std::string>& completion,
+                           std::string_view s,
+                           bool i18n,
+                           celestia::util::array_view<const Selection> contexts,
+                           bool withLocations = false) const;
 
 
     SolarSystem* getNearestSolarSystem(const UniversalCoord& position) const;
@@ -100,6 +92,19 @@ class Universe
     celestia::MarkerList* getMarkers() const;
 
  private:
+    void getCompletion(std::vector<std::string>& completion,
+                       std::string_view s,
+                       bool i18n,
+                       celestia::util::array_view<const Selection> contexts,
+                       bool withLocations = false) const;
+
+    Selection findChildObject(const Selection& sel,
+                              std::string_view name,
+                              bool i18n = false) const;
+    Selection findObjectInContext(const Selection& sel,
+                                  std::string_view name,
+                                  bool i18n = false) const;
+
     Selection pickPlanet(SolarSystem& solarSystem,
                          const UniversalCoord& origin,
                          const Eigen::Vector3f& direction,
@@ -129,5 +134,3 @@ class Universe
 
     std::vector<const Star*> closeStars;
 };
-
-#endif // _CELENGINE_UNIVERSE_H_

--- a/src/celutil/array_view.h
+++ b/src/celutil/array_view.h
@@ -25,6 +25,7 @@ class array_view
 {
  public:
     using element_type = typename std::remove_cv<T>::type;
+    using size_type = std::size_t;
 
     /**
      * Create an empty array view.
@@ -35,6 +36,14 @@ class array_view
     {};
 
     ~array_view() noexcept = default;
+
+    /**
+     * Wrap a pointer and length
+     */
+    constexpr array_view(const T* ptr, size_type size) noexcept :
+        m_ptr(ptr),
+        m_size(size)
+    {};
 
     /**
      * Wrap a C-style array.
@@ -88,7 +97,7 @@ class array_view
     /**
      * Return the number of elements.
      */
-    constexpr size_t size() const noexcept
+    constexpr size_type size() const noexcept
     {
         return m_size;
     };
@@ -170,7 +179,7 @@ class array_view
 
  private:
     const element_type* m_ptr;
-    size_t m_size;
+    size_type m_size;
 };
 
 } // end namespace celestia::util

--- a/src/celutil/array_view.h
+++ b/src/celutil/array_view.h
@@ -24,7 +24,7 @@ template<typename T>
 class array_view
 {
  public:
-    using element_type = typename std::remove_cv<T>::type;
+    using element_type = std::remove_cv_t<T>;
     using size_type = std::size_t;
 
     /**
@@ -115,7 +115,7 @@ class array_view
      *
      * Calling front on an empty container is undefined.
      */
-    constexpr T front() const noexcept
+    constexpr const T& front() const noexcept
     {
         return *m_ptr;
     }
@@ -125,7 +125,7 @@ class array_view
      *
      * Calling back on an empty container is undefined.
      */
-    constexpr T back() const noexcept
+    constexpr const T& back() const noexcept
     {
         return m_ptr[m_size - 1];
     }
@@ -140,7 +140,7 @@ class array_view
      * @param pos - position of the element to return
      * @return the requested element
      */
-    constexpr element_type operator[](std::size_t pos) const noexcept
+    constexpr const T& operator[](std::size_t pos) const noexcept
     {
         return m_ptr[pos];
     }

--- a/src/celutil/stringutils.h
+++ b/src/celutil/stringutils.h
@@ -24,6 +24,8 @@ int compareIgnoringCase(std::string_view s1,
 
 struct CompareIgnoringCasePredicate
 {
+    // enable use for lookup by std::string_view with std::string keys
+    using is_transparent = void;
     bool operator()(std::string_view, std::string_view) const;
 };
 

--- a/src/celutil/utf8.h
+++ b/src/celutil/utf8.h
@@ -26,6 +26,9 @@ int  UTF8StringCompare(std::string_view s0, std::string_view s1, size_t n, bool 
 class UTF8StringOrderingPredicate
 {
  public:
+    // enable use for lookup of strings by string_view
+    using is_transparent = void;
+
     bool operator()(std::string_view s0, std::string_view s1) const
     {
         return UTF8StringCompare(s0, s1) == -1;


### PR DESCRIPTION
Instead of returning results into a newly-allocated vector, supply the destination vector as a reference parameter. Also switch the `find`/`getCompletion` methods to use `std::string_view` instead of `const std::string&`