### PR TITLE
Don't use alpha as both alpha and specular

### DIFF
--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -2646,7 +2646,7 @@ ShaderManager::buildFragmentShader(const ShaderProperties& props)
     {
         // Add in the specular color
         if (props.texUsage & ShaderProperties::SpecularInDiffuseAlpha)
-            source += "gl_FragColor = color * diff + float(color.a) * spec;\n";
+            source += "gl_FragColor = vec4(color.rgb, 1.0) * diff + float(color.a) * spec;\n";
         else if (props.texUsage & ShaderProperties::SpecularTexture)
             source += "gl_FragColor = color * diff + texture2D(specTex, " + specTexCoord + ".st) * spec;\n";
         else


### PR DESCRIPTION
Potential fix for some of the transparency issues, e.g. the Earth continents issue in the screenshots in #1551