### PR TITLE
Workaround for cases when mesh has 0 primitive groups

### DIFF
--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -100,6 +100,10 @@ ConvertTriangleMesh(const M3DTriangleMesh& mesh,
     int nVertices  = mesh.getVertexCount();
     int nTexCoords = mesh.getTexCoordCount();
 
+    // Some community addons ships buggy meshes.
+    if (mesh.getMeshMaterialGroupCount() == 0 || nFaces == 0 || nVertices == 0)
+        return {};
+
     // Texture coordinates are optional. Check for tex coord count >= nVertices because some
     // convertors generate extra texture coordinates.
     bool hasTextureCoords = nTexCoords >= nVertices;
@@ -338,7 +342,11 @@ Convert3DSModel(const M3DScene& scene, const fs::path& texPath)
                 const M3DTriangleMesh* mesh = model3ds->getTriMesh(j);
                 if (mesh)
                 {
-                    model->addMesh(ConvertTriangleMesh(*mesh, scene));
+                    cmod::Mesh cmodmesh = ConvertTriangleMesh(*mesh, scene);
+                    if (cmodmesh.getGroupCount() > 0)
+                        model->addMesh(std::move(cmodmesh));
+                    else
+                        GetLogger()->warn("Skipping mesh with 0 primitive groups!\n");
                 }
             }
         }

--- a/src/celmodel/mesh.cpp
+++ b/src/celmodel/mesh.cpp
@@ -356,7 +356,7 @@ void
 Mesh::optimize()
 {
 #ifdef HAVE_MESHOPTIMIZER
-    if (groups.size() > 1)
+    if (groups.size() != 1)
         return;
 
     auto &g = groups.front();

--- a/src/celmodel/model.cpp
+++ b/src/celmodel/model.cpp
@@ -343,6 +343,8 @@ Model::sortMeshes(const MeshComparator& comparator)
 
     for (size_t i = 1; i < meshes.size(); i++)
     {
+        if (meshes[i].getGroupCount() == 0)
+            continue;
         auto &p = newMeshes.back();
         if (!p.canMerge(meshes[i], materials))
         {


### PR DESCRIPTION
-This is not a proper fix but as Celestia loads bad models it should not crash.-

Up: now it should be treated as a fix. @ajtribick could you review again?

Closes: #1614 