### PR TITLE
Fix use of Lua string pointer after stack pop issue

### DIFF
--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -170,8 +170,9 @@ bool Celx_istype(lua_State* l, int index, int id)
     }
 
     const char* classname = lua_tostring(l, -1);
+    bool result = classname != nullptr && strcmp(classname, CelxLua::ClassNames[id]) == 0;
     lua_pop(l, 1);
-    return classname != nullptr && strcmp(classname, CelxLua::ClassNames[id]) == 0;
+    return result;
 }
 
 // Verify that an object at location index on the stack is of the


### PR DESCRIPTION
From the [documentation of `lua_tolstring`](https://www.lua.org/manual/5.3/manual.html#lua_tolstring) (which `lua_tostring` is an alias for)

> Because Lua has garbage collection, there is no guarantee that the pointer returned by `lua_tolstring` will be valid after the corresponding Lua value is removed from the stack.