### PR TITLE
[gtk] fix warning

### DIFF
--- a/src/celestia/gtk/splash.cpp
+++ b/src/celestia/gtk/splash.cpp
@@ -42,7 +42,7 @@ GtkSplashProgressNotifier::~GtkSplashProgressNotifier() {};
 
 
 /* ENTRY: Creates a new SplashData struct, starts the splash screen */
-SplashData* splashStart(AppData* app, gboolean showSplash, gchar* installDir, gchar* defaultDir)
+SplashData* splashStart(AppData* app, gboolean showSplash, const gchar* installDir, const gchar* defaultDir)
 {
     SplashData* ss = g_new0(SplashData, 1);
 

--- a/src/celestia/gtk/splash.h
+++ b/src/celestia/gtk/splash.h
@@ -47,7 +47,7 @@ struct _SplashData {
 
 
 /* Entry Functions */
-SplashData* splashStart(AppData* app, gboolean showSplash, gchar* installDir, gchar* defaultDir);
+SplashData* splashStart(AppData* app, gboolean showSplash, const gchar* installDir, const gchar* defaultDir);
 void splashEnd(SplashData* ss);
 void splashSetText(SplashData* ss, const char* text);
 


### PR DESCRIPTION
ISO C++ forbids converting a string constant to ‘gchar* {aka char*}’ [-Wwrite-strings]