### PR TITLE
Legacy scripts code cleanup

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2506,7 +2506,7 @@ Simulation* CelestiaCore::getSimulation() const
     return sim;
 }
 
-void CelestiaCore::showText(const std::string &s,
+void CelestiaCore::showText(std::string_view s,
                             int horig, int vorig,
                             int hoff, int voff,
                             double duration)
@@ -2514,18 +2514,18 @@ void CelestiaCore::showText(const std::string &s,
     if (!titleFont)
         return;
 
-    messageText = s;
+    messageText.replace(messageText.begin(), messageText.end(), s);
     messageTextPosition = std::make_unique<RelativeTextPrintPosition>(horig, vorig, hoff, voff, titleFont->getWidth("M"), titleFont->getHeight());
     messageStart = currentTime;
     messageDuration = duration;
 }
 
-void CelestiaCore::showTextAtPixel(const std::string &s, int x, int y, double duration)
+void CelestiaCore::showTextAtPixel(std::string_view s, int x, int y, double duration)
 {
     if (!titleFont)
         return;
 
-    messageText = s;
+    messageText.replace(messageText.begin(), messageText.end(), s);
     messageTextPosition = std::make_unique<AbsoluteTextPrintPosition>(x, y);
     messageStart = currentTime;
     messageDuration = duration;

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <string>
 #include <functional>
+#include <string_view>
 #include <tuple>
 #include <celutil/filetype.h>
 #include <celutil/timer.h>
@@ -257,11 +258,11 @@ class CelestiaCore // : public Watchable<CelestiaCore>
 
     Simulation* getSimulation() const;
     Renderer* getRenderer() const;
-    void showText(const std::string &s,
+    void showText(std::string_view s,
                   int horig = 0, int vorig = 0,
                   int hoff = 0, int voff = 0,
                   double duration = 1.0e9);
-    void showTextAtPixel(const std::string &s,
+    void showTextAtPixel(std::string_view s,
                          int x = 0, int y = 0,
                          double duration = 1.0e9);
     int getTextWidth(const std::string &s) const;

--- a/src/celscript/common/script.h
+++ b/src/celscript/common/script.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <memory>
+
 #include <celcompat/filesystem.h>
 
 class CelestiaCore;

--- a/src/celscript/common/scriptmaps.cpp
+++ b/src/celscript/common/scriptmaps.cpp
@@ -1,7 +1,9 @@
+#include "scriptmaps.h"
+
 #include <celengine/body.h>
+#include <celengine/location.h>
 #include <celengine/render.h>
 #include <celestia/celestiacore.h>
-#include "scriptmaps.h"
 
 using namespace std::string_view_literals;
 

--- a/src/celscript/common/scriptmaps.h
+++ b/src/celscript/common/scriptmaps.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <string_view>
-#include <celutil/color.h>
+
+class Color;
 
 namespace celestia::scripts
 {
@@ -11,9 +13,9 @@ namespace celestia::scripts
 constexpr inline std::size_t FlagMapNameLength = 20;
 
 // String to flag mappings
-typedef std::map<std::string_view, uint32_t> FlagMap;
-typedef std::map<std::string_view, uint64_t> FlagMap64;
-typedef std::map<std::string_view, Color*>   ColorMap;
+using FlagMap   = std::map<std::string_view, std::uint32_t>;
+using FlagMap64 = std::map<std::string_view, std::uint64_t>;
+using ColorMap  = std::map<std::string_view, Color*>;
 
 class ScriptMaps
 {

--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -9,930 +9,55 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <algorithm>
-#include <iostream>
-#include <sstream>
-#include <string_view>
-#include <Eigen/Geometry>
-#include <celutil/logger.h>
-#include <celmath/mathlib.h>
-#include <celengine/astro.h>
-#include <celengine/parser.h>
-#include <celutil/stringutils.h>
-#include <celutil/tokenizer.h>
-#include <celestia/audiosession.h>
 #include "cmdparser.h"
 
-using namespace std;
-using namespace celmath;
-using namespace celestia;
-using namespace celestia::scripts;
+#ifdef USE_MINIAUDIO
+#include <algorithm>
+#endif
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <initializer_list>
+#include <istream>
+#include <map>
+#include <optional>
+#include <sstream>
+#include <variant>
+
+#include <Eigen/Core>
+#include <fmt/format.h>
+
+#include <celengine/hash.h>
+#include <celengine/parser.h>
+#include <celengine/render.h>
+#include <celengine/value.h>
+#ifdef USE_MINIAUDIO
+#include <celestia/audiosession.h>
+#endif
+#include <celmath/mathlib.h>
+#include <celscript/common/scriptmaps.h>
+#include <celutil/logger.h>
+#include <celutil/r128util.h>
+#include <celutil/stringutils.h>
+#include <celutil/tokenizer.h>
+
+using namespace std::string_view_literals;
 using celestia::util::GetLogger;
 using celestia::util::DecodeFromBase64;
 
-
-static uint64_t parseRenderFlags(const string&, const FlagMap64&);
-static int parseLabelFlags(const string&, const FlagMap&);
-static int parseOrbitFlags(const string&, const FlagMap&);
-static int parseConstellations(CommandConstellations* cmd, const string &s, int act);
-int parseConstellationColor(CommandConstellationColor* cmd, const string &s, Eigen::Vector3d *col, int act);
-
-CommandParser::CommandParser(istream& in, const shared_ptr<ScriptMaps> &sm) :
-    scriptMaps(sm)
+namespace celestia::scripts
 {
-    tokenizer = new Tokenizer(&in);
-    parser = new Parser(tokenizer);
-}
-
-CommandParser::CommandParser(Tokenizer& tok, const shared_ptr<ScriptMaps> &sm) :
-    scriptMaps(sm)
+namespace
 {
-    tokenizer = &tok;
-    parser = new Parser(tokenizer);
-}
 
-CommandParser::~CommandParser()
+std::uint64_t
+parseRenderFlags(const std::string &s, const celestia::scripts::FlagMap64& RenderFlagMap)
 {
-    delete parser;
-    delete tokenizer;
-}
-
-
-CommandSequence* CommandParser::parse()
-{
-    CommandSequence* seq = new CommandSequence();
-
-    if (tokenizer->nextToken() != Tokenizer::TokenBeginGroup)
-    {
-        error("'{' expected at start of script.");
-        delete seq;
-        return nullptr;
-    }
-
-    Tokenizer::TokenType ttype = tokenizer->nextToken();
-    while (ttype != Tokenizer::TokenEnd && ttype != Tokenizer::TokenEndGroup)
-    {
-        tokenizer->pushBack();
-        Command* cmd = parseCommand();
-        if (cmd == nullptr)
-        {
-            for_each(seq->begin(), seq->end(), [](Command* cmd) { delete cmd; });
-            delete seq;
-            return nullptr;
-        }
-        else
-        {
-            seq->push_back(cmd);
-        }
-
-        ttype = tokenizer->nextToken();
-    }
-
-    if (ttype != Tokenizer::TokenEndGroup)
-    {
-        error("Missing '}' at end of script.");
-        for_each(seq->begin(), seq->end(), [](Command* cmd) { delete cmd; });
-        delete seq;
-        return nullptr;
-    }
-
-    return seq;
-}
-
-
-auto CommandParser::getErrors() const
-    -> celestia::util::array_view<std::string>
-{
-    return errorList;
-}
-
-
-void CommandParser::error(string errMsg)
-{
-    errorList.emplace_back(std::move(errMsg));
-}
-
-
-static ObserverFrame::CoordinateSystem parseCoordinateSystem(const string& name)
-{
-    // 'geographic' is a deprecated name for the bodyfixed coordinate system,
-    // maintained here for compatibility with older scripts.
-    if (compareIgnoringCase(name, "observer") == 0)
-        return ObserverFrame::ObserverLocal;
-    else if (compareIgnoringCase(name, "bodyfixed") == 0)
-        return ObserverFrame::BodyFixed;
-    else if (compareIgnoringCase(name, "geographic") == 0)
-        return ObserverFrame::BodyFixed;
-    else if (compareIgnoringCase(name, "equatorial") == 0)
-        return ObserverFrame::Equatorial;
-    else if (compareIgnoringCase(name, "ecliptical") == 0)
-        return ObserverFrame::Ecliptical;
-    else if (compareIgnoringCase(name, "universal") == 0)
-        return ObserverFrame::Universal;
-    else if (compareIgnoringCase(name, "lock") == 0)
-        return ObserverFrame::PhaseLock;
-    else if (compareIgnoringCase(name, "chase") == 0)
-        return ObserverFrame::Chase;
-    else
-        return ObserverFrame::ObserverLocal;
-}
-
-
-Command* CommandParser::parseCommand()
-{
-    tokenizer->nextToken();
-    std::string commandName;
-    if (auto tokenValue = tokenizer->getNameValue(); tokenValue.has_value())
-    {
-        commandName = *tokenValue;
-    }
-    else
-    {
-        error("Invalid command name");
-        return nullptr;
-    }
-
-    const Value paramListValue = parser->readValue();
-    const Hash* paramList = paramListValue.getHash();
-    if (paramList == nullptr)
-    {
-        error("Bad parameter list");
-        return nullptr;
-    }
-
-    Command* cmd = nullptr;
-
-    if (commandName == "wait")
-    {
-        auto duration = paramList->getNumber<double>("duration").value_or(1.0);
-        cmd = new CommandWait(duration);
-    }
-    else if (commandName == "set")
-    {
-        double value = 0.0;
-        const std::string* name = paramList->getString("name");
-        if (name == nullptr)
-        {
-            error("Missing name");
-            return nullptr;
-        }
-        if (auto valueOpt = paramList->getNumber<double>("value"); valueOpt.has_value())
-        {
-            value = *valueOpt;
-        }
-        else if (const std::string* valstr = paramList->getString("value"); valstr != nullptr)
-        {
-            // Some values may be specified via strings
-            if (compareIgnoringCase(*valstr, "fuzzypoints") == 0)
-                value = (double) Renderer::FuzzyPointStars;
-            else if (compareIgnoringCase(*valstr, "points") == 0)
-                value = (double) Renderer::PointStars;
-            else if (compareIgnoringCase(*valstr, "scaleddiscs") == 0)
-                value = (double) Renderer::ScaledDiscStars;
-        }
-
-        cmd = new CommandSet(*name, value);
-    }
-    else if (commandName == "select")
-    {
-        string object;
-        if (const std::string* objStr = paramList->getString("object"); objStr != nullptr)
-        {
-            object = *objStr;
-        }
-
-        cmd = new CommandSelect(object);
-    }
-    else if (commandName == "setframe")
-    {
-        const std::string* refName = paramList->getString("ref");
-        if (refName == nullptr)
-        {
-            error("Missing ref parameter to setframe");
-            return nullptr;
-        }
-
-        const std::string* targetName = paramList->getString("target");
-        if (targetName == nullptr)
-        {
-            error("Missing target parameter to setframe");
-            return nullptr;
-        }
-
-        ObserverFrame::CoordinateSystem coordSys;
-        if (const std::string* coordSysName = paramList->getString("coordsys"); coordSysName == nullptr)
-            coordSys = ObserverFrame::Universal;
-        else
-            coordSys = parseCoordinateSystem(*coordSysName);
-
-        cmd = new CommandSetFrame(coordSys, *refName, *targetName);
-    }
-    else if (commandName == "setsurface")
-    {
-        const std::string* name = paramList->getString("name");
-        if (name == nullptr)
-        {
-            error("Missing name parameter to setsurface");
-            return nullptr;
-        }
-
-        cmd = new CommandSetSurface(*name);
-    }
-    else if (commandName == "goto")
-    {
-        auto t = paramList->getNumber<double>("time").value_or(1.0);
-        auto distance = paramList->getNumber<double>("distance").value_or(5.0);
-
-        ObserverFrame::CoordinateSystem upFrame = ObserverFrame::ObserverLocal;
-        if (const std::string* frameString = paramList->getString("upframe"); frameString != nullptr)
-            upFrame = parseCoordinateSystem(*frameString);
-
-        auto up = paramList->getVector3<double>("up").value_or(Eigen::Vector3d::UnitY());
-
-        cmd = new CommandGoto(t,
-                              distance,
-                              up.cast<float>(),
-                              upFrame);
-    }
-    else if (commandName == "gotolonglat")
-    {
-        auto t = paramList->getNumber<double>("time").value_or(1.0);
-        auto distance = paramList->getNumber<double>("distance").value_or(5.0);
-        auto up = paramList->getVector3<double>("up").value_or(Eigen::Vector3d::UnitY());
-        auto longitude = paramList->getNumber<double>("longitude").value_or(0.0);
-        auto latitude = paramList->getNumber<double>("latitude").value_or(0.0);
-
-        cmd = new CommandGotoLongLat(t,
-                                     distance,
-                                     (float) degToRad(longitude),
-                                     (float) degToRad(latitude),
-                                     up.cast<float>());
-    }
-    else if (commandName == "gotoloc")
-    {
-        auto t = paramList->getNumber<double>("time").value_or(1.0);
-
-        if (auto pos = paramList->getVector3<double>("position"); pos.has_value())
-        {
-            *pos *= astro::kilometersToMicroLightYears(1.0);
-            auto xrot = paramList->getNumber<double>("xrot").value_or(0.0);
-            auto yrot = paramList->getNumber<double>("yrot").value_or(0.0);
-            auto zrot = paramList->getNumber<double>("zrot").value_or(0.0);
-            auto rotation = Eigen::Quaterniond(Eigen::AngleAxisd(degToRad(xrot), Eigen::Vector3d::UnitX()) *
-                                               Eigen::AngleAxisd(degToRad(yrot), Eigen::Vector3d::UnitY()) *
-                                               Eigen::AngleAxisd(degToRad(zrot), Eigen::Vector3d::UnitZ()));
-            cmd = new CommandGotoLocation(t, *pos, rotation);
-        }
-        else
-        {
-            const std::string* x = paramList->getString("x");
-            const std::string* y = paramList->getString("y");
-            const std::string* z = paramList->getString("z");
-            double xpos = x == nullptr ? 0.0 : static_cast<double>(DecodeFromBase64(*x));
-            double ypos = y == nullptr ? 0.0 : static_cast<double>(DecodeFromBase64(*y));
-            double zpos = z == nullptr ? 0.0 : static_cast<double>(DecodeFromBase64(*z));
-            auto ow = paramList->getNumber<double>("ow").value_or(0.0);
-            auto ox = paramList->getNumber<double>("ox").value_or(0.0);
-            auto oy = paramList->getNumber<double>("oy").value_or(0.0);
-            auto oz = paramList->getNumber<double>("oz").value_or(0.0);
-            Eigen::Quaterniond orientation(ow, ox, oy, oz);
-            cmd = new CommandGotoLocation(t, Eigen::Vector3d(xpos, ypos, zpos), orientation);
-        }
-    }
-    else if (commandName == "seturl")
-    {
-        const std::string* url = paramList->getString("url");
-        if (url == nullptr)
-        {
-            error("Missing url parameter to seturl");
-            return nullptr;
-        }
-
-        cmd = new CommandSetUrl(*url);
-    }
-    else if (commandName == "center")
-    {
-        auto t = paramList->getNumber<double>("time").value_or(1.0);
-        cmd = new CommandCenter(t);
-    }
-    else if (commandName == "follow")
-    {
-        cmd = new CommandFollow();
-    }
-    else if (commandName == "synchronous")
-    {
-        cmd = new CommandSynchronous();
-    }
-    else if (commandName == "lock")
-    {
-        cmd = new CommandLock();
-    }
-    else if (commandName == "chase")
-    {
-        cmd = new CommandChase();
-    }
-    else if (commandName == "track")
-    {
-        cmd = new CommandTrack();
-    }
-    else if (commandName == "cancel")
-    {
-        cmd = new CommandCancel();
-    }
-    else if (commandName == "exit")
-    {
-        cmd = new CommandExit();
-    }
-    else if (commandName == "print")
-    {
-        const std::string* text = paramList->getString("text");
-        if (text == nullptr)
-        {
-            error("Missing text parameter to print");
-            return nullptr;
-        }
-
-        auto duration = paramList->getNumber<double>("duration").value_or(1e9);
-        auto voff = paramList->getNumber<int>("row").value_or(0);
-        auto hoff = paramList->getNumber<int>("column").value_or(0);
-        int horig = -1;
-        int vorig = -1;
-        if (const std::string* origin = paramList->getString("origin"); origin != nullptr)
-        {
-            if (compareIgnoringCase(*origin, "left") == 0)
-            {
-                horig = -1;
-                vorig = 0;
-            }
-            else if (compareIgnoringCase(*origin, "right") == 0)
-            {
-                horig = 1;
-                vorig = 0;
-            }
-            else if (compareIgnoringCase(*origin, "center") == 0)
-            {
-                horig = 0;
-                vorig = 0;
-            }
-            else if (compareIgnoringCase(*origin, "left") == 0)
-            {
-                horig = -1;
-                vorig = 0;
-            }
-            else if (compareIgnoringCase(*origin, "top") == 0)
-            {
-                horig = 0;
-                vorig = 1;
-            }
-            else if (compareIgnoringCase(*origin, "bottom") == 0)
-            {
-                horig = 0;
-                vorig = -1;
-            }
-            else if (compareIgnoringCase(*origin, "topright") == 0)
-            {
-                horig = 1;
-                vorig = 1;
-            }
-            else if (compareIgnoringCase(*origin, "topleft") == 0)
-            {
-                horig = -1;
-                vorig = 1;
-            }
-            else if (compareIgnoringCase(*origin, "bottomleft") == 0)
-            {
-                horig = -1;
-                vorig = -1;
-            }
-            else if (compareIgnoringCase(*origin, "bottomright") == 0)
-            {
-                horig = 1;
-                vorig = -1;
-            }
-        }
-
-        cmd = new CommandPrint(*text,
-                               horig, vorig, hoff, -voff,
-                               duration);
-    }
-    else if (commandName == "cls")
-    {
-        cmd = new CommandClearScreen();
-    }
-    else if (commandName == "time")
-    {
-        double jd = 2451545.0;
-        if (auto jdVal = paramList->getNumber<double>("jd"); jdVal.has_value())
-        {
-            jd = *jdVal;
-        }
-        else
-        {
-            const std::string* utc = paramList->getString("utc");
-            if (utc == nullptr)
-            {
-                error("Missing either time or utc parameter to time");
-                return nullptr;
-            }
-
-            astro::Date date = astro::Date(0.0);
-            sscanf(utc->c_str(), "%d-%d-%dT%d:%d:%lf",
-                &date.year, &date.month, &date.day,
-                &date.hour, &date.minute, &date.seconds);
-            jd = (double)date;
-        }
-        cmd = new CommandSetTime(jd);
-    }
-    else if (commandName == "timerate")
-    {
-        auto rate = paramList->getNumber<double>("rate").value_or(1.0);
-        cmd = new CommandSetTimeRate(rate);
-    }
-    else if (commandName == "changedistance")
-    {
-        auto rate = paramList->getNumber<double>("rate").value_or(0.0);
-        auto duration = paramList->getNumber<double>("duration").value_or(1.0);
-        cmd = new CommandChangeDistance(duration, rate);
-    }
-    else if (commandName == "orbit")
-    {
-        auto duration = paramList->getNumber<double>("duration").value_or(1.0);
-        auto rate = paramList->getNumber<double>("rate").value_or(0.0);
-        auto axis = paramList->getVector3<double>("axis").value_or(Eigen::Vector3d::Zero());
-        cmd = new CommandOrbit(duration,
-                               axis.cast<float>(),
-                               (float) degToRad(rate));
-    }
-    else if (commandName == "rotate")
-    {
-        auto duration = paramList->getNumber<double>("duration").value_or(1.0);
-        auto rate = paramList->getNumber<double>("rate").value_or(0.0);
-        auto axis = paramList->getVector3<double>("axis").value_or(Eigen::Vector3d::Zero());
-        cmd = new CommandRotate(duration,
-                                axis.cast<float>(),
-                                (float) degToRad(rate));
-    }
-    else if (commandName == "move")
-    {
-        auto duration = paramList->getNumber<double>("duration").value_or(1.0);
-        auto velocity = paramList->getVector3<double>("velocity").value_or(Eigen::Vector3d::Zero());
-        cmd = new CommandMove(duration, velocity * astro::kilometersToMicroLightYears(1.0));
-    }
-    else if (commandName == "setposition")
-    {
-        // Base position in light years, offset in kilometers
-        if (auto base = paramList->getVector3<double>("base"); base.has_value())
-        {
-            auto offset = paramList->getVector3<double>("offset").value_or(Eigen::Vector3d::Zero());
-            Eigen::Vector3f basef = base->cast<float>();
-            UniversalCoord basePosition = UniversalCoord::CreateLy(basef.cast<double>());
-            cmd = new CommandSetPosition(basePosition.offsetKm(offset));
-        }
-        else
-        {
-            const std::string* x = paramList->getString("x");
-            const std::string* y = paramList->getString("y");
-            const std::string* z = paramList->getString("z");
-            if (x == nullptr || y == nullptr || z == nullptr)
-            {
-                error("Missing x, y, z or base, offset parameters to setposition");
-                return nullptr;
-            }
-            cmd = new CommandSetPosition(UniversalCoord(DecodeFromBase64(*x),
-                                                        DecodeFromBase64(*y),
-                                                        DecodeFromBase64(*z)));
-        }
-    }
-    else if (commandName == "setorientation")
-    {
-        if (auto angle = paramList->getNumber<double>("angle"); angle.has_value())
-        {
-            auto axis = paramList->getVector3<double>("axis").value_or(Eigen::Vector3d::Zero());
-            auto orientation = Eigen::Quaternionf(Eigen::AngleAxisf((float) degToRad(*angle),
-                                                                    axis.cast<float>().normalized()));
-            cmd = new CommandSetOrientation(orientation);
-        }
-        else
-        {
-            auto ow = paramList->getNumber<double>("ow").value_or(0.0);
-            auto ox = paramList->getNumber<double>("ox").value_or(0.0);
-            auto oy = paramList->getNumber<double>("oy").value_or(0.0);
-            auto oz = paramList->getNumber<double>("oz").value_or(0.0);
-            Eigen::Quaternionf orientation(ow, ox, oy, oz);
-            cmd = new CommandSetOrientation(orientation);
-        }
-    }
-    else if (commandName == "lookback")
-    {
-        cmd = new CommandLookBack();
-    }
-    else if (commandName == "renderflags")
-    {
-        uint64_t setFlags = 0;
-        uint64_t clearFlags = 0;
-
-        if (const std::string* s = paramList->getString("set"); s != nullptr)
-            setFlags = parseRenderFlags(*s, scriptMaps->RenderFlagMap);
-        if (const std::string* s = paramList->getString("clear"); s != nullptr)
-            clearFlags = parseRenderFlags(*s, scriptMaps->RenderFlagMap);
-
-        cmd = new CommandRenderFlags(setFlags, clearFlags);
-    }
-    else if (commandName == "labels")
-    {
-        int setFlags = 0;
-        int clearFlags = 0;
-
-        if (const std::string* s = paramList->getString("set"); s != nullptr)
-            setFlags = parseLabelFlags(*s, scriptMaps->LabelFlagMap);
-        if (const std::string* s = paramList->getString("clear"); s != nullptr)
-            clearFlags = parseLabelFlags(*s, scriptMaps->LabelFlagMap);
-
-        cmd = new CommandLabels(setFlags, clearFlags);
-    }
-    else if (commandName == "orbitflags")
-    {
-        int setFlags = 0;
-        int clearFlags = 0;
-
-        if (const std::string* s = paramList->getString("set"); s != nullptr)
-            setFlags = parseOrbitFlags(*s, scriptMaps->OrbitVisibilityMap);
-        if (const std::string* s = paramList->getString("clear"); s != nullptr)
-            clearFlags = parseOrbitFlags(*s, scriptMaps->OrbitVisibilityMap);
-
-        cmd = new CommandOrbitFlags(setFlags, clearFlags);
-    }
-    else if (commandName == "constellations")
-    {
-        CommandConstellations *cmdcons= new CommandConstellations();
-
-        if (const std::string* s = paramList->getString("set"); s != nullptr)
-            parseConstellations(cmdcons, *s, 1);
-        if (const std::string* s = paramList->getString("clear"); s != nullptr)
-            parseConstellations(cmdcons, *s, 0);
-        cmd = cmdcons;
-    }
-
-    else if (commandName == "constellationcolor")
-    {
-        CommandConstellationColor *cmdconcol= new CommandConstellationColor();
-
-        auto colorv = paramList->getVector3<double>("color").value_or(Eigen::Vector3d::UnitX());
-
-        if (const std::string* s = paramList->getString("set"); s != nullptr)
-            parseConstellationColor(cmdconcol, *s, &colorv, 1);
-        if (const std::string* s = paramList->getString("clear"); s != nullptr)
-            parseConstellationColor(cmdconcol, *s, &colorv, 0);
-        cmd = cmdconcol;
-    }
-    else if (commandName == "setvisibilitylimit")
-    {
-        auto mag = paramList->getNumber<double>("magnitude").value_or(6.0);
-        cmd = new CommandSetVisibilityLimit(mag);
-    }
-    else if (commandName == "setfaintestautomag45deg")
-    {
-        auto mag = paramList->getNumber<double>("magnitude").value_or(8.5);
-        cmd = new CommandSetFaintestAutoMag45deg(mag);
-    }
-    else if (commandName == "setambientlight")
-    {
-        auto brightness = paramList->getNumber<float>("brightness").value_or(0.0f);
-        cmd = new CommandSetAmbientLight(brightness);
-    }
-    else if (commandName == "setgalaxylightgain")
-    {
-        auto gain = paramList->getNumber<float>("gain").value_or(0.0f);
-        cmd = new CommandSetGalaxyLightGain(gain);
-    }
-    else if (commandName == "settextureresolution")
-    {
-        unsigned int res = 1;
-        if (const std::string* textureRes = paramList->getString("resolution"); textureRes != nullptr)
-        {
-            if (compareIgnoringCase(*textureRes, "low") == 0)
-                res = 0;
-            else if (compareIgnoringCase(*textureRes, "medium") == 0)
-                res = 1;
-            else if (compareIgnoringCase(*textureRes, "high") == 0)
-                res = 2;
-        }
-        cmd = new CommandSetTextureResolution(res);
-    }
-    else if (commandName == "preloadtex")
-    {
-        const std::string* object = paramList->getString("object");
-        if (object == nullptr)
-        {
-            error("Missing object parameter to preloadtex");
-            return nullptr;
-        }
-
-        cmd = new CommandPreloadTextures(*object);
-    }
-    else if (commandName == "mark")
-    {
-        const std::string* object = paramList->getString("object");
-        if (object == nullptr)
-        {
-            error("Missing object parameter to mark");
-            return nullptr;
-        }
-
-        auto size = paramList->getNumber<double>("size").value_or(10.0);
-        auto colorv = paramList->getVector3<float>("color").value_or(Eigen::Vector3f::UnitX());
-        auto alpha = paramList->getNumber<float>("alpha").value_or(0.9f);
-        Color color(colorv.x(), colorv.y(), colorv.z(), alpha);
-
-        using namespace celestia;
-
-        MarkerRepresentation rep(MarkerRepresentation::Diamond);
-        if (const std::string* symbolString = paramList->getString("symbol"); symbolString != nullptr)
-        {
-            if (compareIgnoringCase(*symbolString, "diamond") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::Diamond);
-            else if (compareIgnoringCase(*symbolString, "triangle") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::Triangle);
-            else if (compareIgnoringCase(*symbolString, "square") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::Square);
-            else if (compareIgnoringCase(*symbolString, "filledsquare") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::FilledSquare);
-            else if (compareIgnoringCase(*symbolString, "plus") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::Plus);
-            else if (compareIgnoringCase(*symbolString, "x") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::X);
-            else if (compareIgnoringCase(*symbolString, "leftarrow") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::LeftArrow);
-            else if (compareIgnoringCase(*symbolString, "rightarrow") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::RightArrow);
-            else if (compareIgnoringCase(*symbolString, "uparrow") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::UpArrow);
-            else if (compareIgnoringCase(*symbolString, "downarrow") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::DownArrow);
-            else if (compareIgnoringCase(*symbolString, "circle") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::Circle);
-            else if (compareIgnoringCase(*symbolString, "disk") == 0)
-                rep = MarkerRepresentation(MarkerRepresentation::Disk);
-        }
-
-        rep.setSize((float) size);
-        rep.setColor(color);
-        if (const std::string* label = paramList->getString("label"); label != nullptr)
-            rep.setLabel(*label);
-
-        bool occludable = paramList->getBoolean("occludable").value_or(true);
-
-        cmd = new CommandMark(*object, rep, occludable);
-    }
-    else if (commandName == "unmark")
-    {
-        const std::string* object = paramList->getString("object");
-        if (object == nullptr)
-        {
-            error("Missing object parameter to unmark");
-            return nullptr;
-        }
-
-        cmd = new CommandUnmark(*object);
-    }
-    else if (commandName == "unmarkall")
-    {
-        cmd = new CommandUnmarkAll();
-    }
-    else if (commandName == "capture")
-    {
-        const std::string* filename = paramList->getString("filename");
-        if (filename == nullptr)
-        {
-            error("Missing filename parameter to capture");
-            return nullptr;
-        }
-
-        std::string type;
-        if (const std::string* typeStr = paramList->getString("type"); typeStr != nullptr)
-        {
-            type = *typeStr;
-        }
-
-        cmd = new CommandCapture(type, *filename);
-    }
-    else if (commandName == "renderpath")
-    {
-        // ignore: renderpath not supported
-    }
-    else if (commandName == "splitview")
-    {
-        auto view = paramList->getNumber<unsigned int>("view").value_or(1u);
-        string splitType;
-        if (const std::string* splitVal = paramList->getString("type"); splitVal != nullptr)
-        {
-            splitType = *splitVal;
-        }
-
-        auto splitPos = paramList->getNumber<float>("position").value_or(0.5f);
-        cmd = new CommandSplitView(view, splitType, splitPos);
-    }
-    else if (commandName == "deleteview")
-    {
-        auto view = paramList->getNumber<unsigned int>("view").value_or(1u);
-        cmd = new CommandDeleteView(view);
-    }
-    else if (commandName == "singleview")
-    {
-        cmd = new CommandSingleView();
-    }
-    else if (commandName == "setactiveview")
-    {
-        auto view = paramList->getNumber<unsigned int>("view").value_or(1u);
-        cmd = new CommandSetActiveView(view);
-    }
-    else if (commandName == "setradius")
-    {
-        const std::string* object = paramList->getString("object");
-        if (object == nullptr)
-        {
-            error("Missing object parameter to setradius");
-            return nullptr;
-        }
-        auto radius = paramList->getNumber<float>("radius").value_or(1.0f);
-        cmd = new CommandSetRadius(*object, radius);
-    }
-    else if (commandName == "setlinecolor")
-    {
-        const std::string* item = paramList->getString("item");
-        if (item == nullptr)
-        {
-            error("Missing item parameter to setlinecolor");
-            return nullptr;
-        }
-
-        auto colorv = paramList->getVector3<float>("color").value_or(Eigen::Vector3f::UnitX());
-        Color color(colorv.x(), colorv.y(), colorv.z());
-        cmd = new CommandSetLineColor(*item, color);
-    }
-    else if (commandName == "setlabelcolor")
-    {
-        const std::string* item = paramList->getString("item");
-        if (item == nullptr)
-        {
-            error("Missing item parameter to setlabelcolor");
-            return nullptr;
-        }
-
-        auto colorv = paramList->getVector3<float>("color").value_or(Eigen::Vector3f::UnitX());
-        Color color(colorv.x(), colorv.y(), colorv.z());
-        cmd = new CommandSetLabelColor(*item, color);
-    }
-    else if (commandName == "settextcolor")
-    {
-        auto colorv = paramList->getVector3<float>("color").value_or(Eigen::Vector3f::Ones());
-        Color color(colorv.x(), colorv.y(), colorv.z());
-        cmd = new CommandSetTextColor(color);
-    }
-    else if (commandName == "play")
-    {
-#ifdef USE_MINIAUDIO
-        int channel = std::max(paramList->getNumber<int>("channel").value_or(defaultAudioChannel),
-                               minAudioChannel);
-
-        auto optionalVolume = paramList->getNumber<float>("volume");
-        if (optionalVolume.has_value())
-            optionalVolume = clamp(*optionalVolume, minAudioVolume, maxAudioVolume);
-        float pan = clamp(paramList->getNumber<float>("pan").value_or(defaultAudioPan),
-                          minAudioPan, maxAudioPan);
-        int nopause = paramList->getNumber<int>("nopause").value_or(0);
-        std::optional<bool> optionalLoop = std::nullopt;
-        if (auto loop = paramList->getNumber<int>("loop"); loop.has_value())
-            optionalLoop = *loop == 1;
-        std::optional<string> optionalFilename = std::nullopt;
-        if (auto filename = paramList->getString("filename"); filename != nullptr)
-            optionalFilename = *filename;
-
-        cmd = new CommandPlay(channel, optionalVolume, pan, optionalLoop, optionalFilename, nopause == 1);
-#else
-        cmd = new CommandWait(0);
-#endif
-    }
-    else if (commandName == "overlay")
-    {
-        auto duration = paramList->getNumber<float>("duration").value_or(3.0f);
-        auto xoffset = paramList->getNumber<float>("xoffset").value_or(0.0f);
-        auto yoffset = paramList->getNumber<float>("yoffset").value_or(0.0f);
-        std::optional<float> alpha = paramList->getNumber<float>("alpha");
-
-        const std::string* filename = paramList->getString("filename");
-        if (filename == nullptr)
-        {
-            error("Missing filename parameter to overlay");
-            return nullptr;
-        }
-
-        bool fitscreen = false;
-        if (auto fitscreenValue = paramList->getBoolean("fitscreen"); fitscreenValue.has_value())
-        {
-            fitscreen = *fitscreenValue;
-        }
-        else
-        {
-            fitscreen = paramList->getNumber<int>("fitscreen").value_or(0) != 0;
-        }
-
-        array<Color, 4> colors;
-        Color color = paramList->getColor("color").value_or(Color::White);
-        colors.fill(alpha.has_value() ? Color(color, *alpha) : color);
-
-        if (auto colorTop = paramList->getColor("colortop"); colorTop.has_value())
-            colors[0] = colors[1] = alpha.has_value() ? Color(*colorTop, *alpha) : *colorTop;
-        if (auto colorBottom = paramList->getColor("colorbottom"); colorBottom.has_value())
-            colors[2] = colors[3] = alpha.has_value() ? Color(*colorBottom, *alpha) : *colorBottom;
-        if (auto colorTopLeft = paramList->getColor("colortopleft"); colorTopLeft.has_value())
-            colors[0] = alpha.has_value() ? Color(*colorTopLeft, *alpha) : *colorTopLeft;
-        if (auto colorTopRight = paramList->getColor("colortopright"); colorTopRight.has_value())
-            colors[1] = alpha.has_value() ? Color(*colorTopRight, *alpha) : *colorTopRight;
-        if (auto colorBottomRight = paramList->getColor("colorbottomright"); colorBottomRight.has_value())
-            colors[2] = alpha.has_value() ? Color(*colorBottomRight, *alpha) : *colorBottomRight;
-        if (auto colorBottomLeft = paramList->getColor("colorbottomleft"); colorBottomLeft.has_value())
-            colors[3] = alpha.has_value() ? Color(*colorBottomLeft, *alpha) : *colorBottomLeft;
-
-        auto fadeafter = paramList->getNumber<float>("fadeafter").value_or(duration);
-
-        cmd = new CommandScriptImage(duration, fadeafter, xoffset, yoffset, *filename, fitscreen, colors);
-    }
-    else if (commandName == "verbosity")
-    {
-        int level = paramList->getNumber<int>("level").value_or(2);
-        cmd = new CommandVerbosity(level);
-    }
-    else if (commandName == "setwindowbordersvisible")
-    {
-        bool visible = paramList->getBoolean("visible").value_or(true);
-        cmd = new CommandSetWindowBordersVisible(visible);
-    }
-    else if (commandName == "setringstexture")
-    {
-        const std::string* object = paramList->getString("object");
-        if (object == nullptr)
-        {
-            error("Missing object parameter to setringstexture");
-            return nullptr;
-        }
-
-        const std::string* texture = paramList->getString("texture");
-        if (texture == nullptr)
-        {
-            error("Missing texture parameter to setringstexture");
-            return nullptr;
-        }
-
-        std::string path;
-        if (const std::string* pathStr = paramList->getString("path"); pathStr != nullptr)
-        {
-            path = *pathStr;
-        }
-
-        cmd = new CommandSetRingsTexture(*object, *texture, path);
-    }
-    else if (commandName == "loadfragment")
-    {
-        const std::string* type = paramList->getString("type");
-        if (type == nullptr)
-        {
-            error("Missing type parameter to loadfragment");
-            return nullptr;
-        }
-
-        const std::string* fragment = paramList->getString("fragment");
-        if (fragment == nullptr)
-        {
-            error("Missing fragment parameter to loadfragment");
-            return nullptr;
-        }
-
-        std::string dir;
-        if (const std::string* dirName = paramList->getString("dir"); dirName != nullptr)
-        {
-            dir = *dirName;
-        }
-
-        cmd = new CommandLoadFragment(*type, *fragment, dir);
-    }
-    else
-    {
-        error("Unknown command name '" + commandName + "'");
-        cmd = nullptr;
-    }
-
-    return cmd;
-}
-
-
-uint64_t parseRenderFlags(const string &s, const FlagMap64& RenderFlagMap)
-{
-    istringstream in(s);
+    std::istringstream in(s);
 
     Tokenizer tokenizer(&in);
-    uint64_t flags = 0;
-
+    std::uint64_t flags = 0;
 
     Tokenizer::TokenType ttype = tokenizer.nextToken();
     while (ttype != Tokenizer::TokenEnd)
@@ -954,9 +79,10 @@ uint64_t parseRenderFlags(const string &s, const FlagMap64& RenderFlagMap)
 }
 
 
-int parseLabelFlags(const string &s, const FlagMap &LabelFlagMap)
+int
+parseLabelFlags(const std::string &s, const celestia::scripts::FlagMap &LabelFlagMap)
 {
-    istringstream in(s);
+    std::istringstream in(s);
 
     Tokenizer tokenizer(&in);
     int flags = 0;
@@ -981,9 +107,10 @@ int parseLabelFlags(const string &s, const FlagMap &LabelFlagMap)
 }
 
 
-int parseOrbitFlags(const string &s, const FlagMap &BodyTypeMap)
+int
+parseOrbitFlags(const std::string &s, const celestia::scripts::FlagMap &BodyTypeMap)
 {
-    istringstream in(s);
+    std::istringstream in(s);
 
     Tokenizer tokenizer(&in);
     int flags = 0;
@@ -1011,9 +138,10 @@ int parseOrbitFlags(const string &s, const FlagMap &BodyTypeMap)
 }
 
 
-int parseConstellations(CommandConstellations* cmd, const string &s, int act)
+int
+parseConstellations(CommandConstellations& cmd, const std::string &s, bool act)
 {
-    istringstream in(s);
+    std::istringstream in(s);
 
     Tokenizer tokenizer(&in);
     int flags = 0;
@@ -1021,64 +149,1019 @@ int parseConstellations(CommandConstellations* cmd, const string &s, int act)
     Tokenizer::TokenType ttype = tokenizer.nextToken();
     while (ttype != Tokenizer::TokenEnd)
     {
-        if (auto tokenValue = tokenizer.getNameValue(); tokenValue.has_value())
-        {
-            if (compareIgnoringCase(*tokenValue, "all") == 0 && act==1)
-                cmd->flags.all = true;
-            else if (compareIgnoringCase(*tokenValue, "all") == 0 && act==0)
-                cmd->flags.none = true;
-            else
-                cmd->setValues(*tokenValue, act);
-
-            ttype = tokenizer.nextToken();
-            if (ttype == Tokenizer::TokenBar)
-                ttype = tokenizer.nextToken();
-        }
-        else
+        auto tokenValue = tokenizer.getNameValue();
+        if (!tokenValue.has_value())
         {
             GetLogger()->error("Command Parser: error parsing render flags\n");
             return 0;
         }
+
+        if (compareIgnoringCase(*tokenValue, "all"sv) == 0)
+        {
+            if (act)
+                cmd.flags.all = true;
+            else
+                cmd.flags.none = true;
+        }
+        else
+            cmd.setValues(*tokenValue, act);
+
+        ttype = tokenizer.nextToken();
+        if (ttype == Tokenizer::TokenBar)
+            ttype = tokenizer.nextToken();
     }
 
     return flags;
 }
 
 
-int parseConstellationColor(CommandConstellationColor* cmd, const string &s, Eigen::Vector3d *col, int act)
+int
+parseConstellationColor(CommandConstellationColor& cmd,
+                        const std::string &s,
+                        const Eigen::Vector3d &col,
+                        bool act)
 {
-    istringstream in(s);
+    std::istringstream in(s);
 
     Tokenizer tokenizer(&in);
     int flags = 0;
 
-    if(!act)
-        cmd->unsetColor();
+    if (act)
+        cmd.setColor(static_cast<float>(col.x()),
+                     static_cast<float>(col.y()),
+                     static_cast<float>(col.z()));
     else
-        cmd->setColor((float)col->x(), (float)col->y(), (float)col->z());
+        cmd.unsetColor();
 
     Tokenizer::TokenType ttype = tokenizer.nextToken();
     while (ttype != Tokenizer::TokenEnd)
     {
-        if (auto tokenValue = tokenizer.getNameValue(); tokenValue.has_value())
-        {
-            if (compareIgnoringCase(*tokenValue, "all") == 0 && act==1)
-                cmd->flags.all = true;
-            else if (compareIgnoringCase(*tokenValue, "all") == 0 && act==0)
-                cmd->flags.none = true;
-            else
-                cmd->setConstellations(*tokenValue);
-
-            ttype = tokenizer.nextToken();
-            if (ttype == Tokenizer::TokenBar)
-                ttype = tokenizer.nextToken();
-        }
-        else
+        auto tokenValue = tokenizer.getNameValue();
+        if (!tokenValue.has_value())
         {
             GetLogger()->error("Command Parser: error parsing render flags\n");
             return 0;
         }
+
+        if (compareIgnoringCase(*tokenValue, "all"sv) == 0)
+        {
+            if (act)
+                cmd.flags.all = true;
+            else
+                cmd.flags.none = true;
+        }
+        else
+            cmd.setConstellations(*tokenValue);
+
+        ttype = tokenizer.nextToken();
+        if (ttype == Tokenizer::TokenBar)
+            ttype = tokenizer.nextToken();
     }
 
     return flags;
 }
+
+
+ObserverFrame::CoordinateSystem parseCoordinateSystem(std::string_view name)
+{
+    if (compareIgnoringCase("observer"sv, name) == 0)
+        return ObserverFrame::ObserverLocal;
+    if (compareIgnoringCase("bodyfixed"sv, name) == 0 ||
+        // 'geographic' is a deprecated name for the bodyfixed coordinate
+        // system, maintained here for compatibility with older scripts.
+        compareIgnoringCase("geographic"sv, name) == 0)
+        return ObserverFrame::BodyFixed;
+    if (compareIgnoringCase("equatorial"sv, name) == 0)
+        return ObserverFrame::Equatorial;
+    if (compareIgnoringCase("ecliptical"sv, name) == 0)
+        return ObserverFrame::Ecliptical;
+    if (compareIgnoringCase("universal"sv, name) == 0)
+        return ObserverFrame::Universal;
+    if (compareIgnoringCase("lock"sv, name) == 0)
+        return ObserverFrame::PhaseLock;
+    if (compareIgnoringCase("chase"sv, name) == 0)
+        return ObserverFrame::Chase;
+    return ObserverFrame::ObserverLocal;
+}
+
+
+using ParseResult = std::variant<std::unique_ptr<Command>, std::string>;
+
+
+template<typename F>
+class ParseResultVisitor
+{
+ public:
+    explicit ParseResultVisitor(F _f) : f(_f) {}
+
+    std::unique_ptr<Command> operator()(std::unique_ptr<Command> p) const { return p; }
+    std::unique_ptr<Command> operator()(std::string&& s)
+    {
+        f(std::move(s));
+        return nullptr;
+    }
+
+ private:
+    F f;
+};
+
+
+inline ParseResult makeError(const char* message)
+{
+    return ParseResult{ std::in_place_type<std::string>, message };
+}
+
+
+template<typename T>
+ParseResult parseParameterlessCommand(const Hash&, const ScriptMaps&)
+{
+    return std::make_unique<T>();
+}
+
+
+ParseResult parseWaitCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto duration = paramList.getNumber<double>("duration").value_or(1.0);
+    return std::make_unique<CommandWait>(duration);
+}
+
+
+ParseResult parseSetCommand(const Hash& paramList, const ScriptMaps&)
+{
+    double value = 0.0;
+    const std::string* name = paramList.getString("name");
+    if (name == nullptr)
+        return makeError("Missing name");
+
+    if (auto valueOpt = paramList.getNumber<double>("value"); valueOpt.has_value())
+        value = *valueOpt;
+    else if (const std::string* valstr = paramList.getString("value"); valstr != nullptr)
+    {
+        // Some values may be specified via strings
+        if (compareIgnoringCase(*valstr, "fuzzypoints") == 0)
+            value = static_cast<double>(Renderer::FuzzyPointStars);
+        else if (compareIgnoringCase(*valstr, "points") == 0)
+            value = static_cast<double>(Renderer::PointStars);
+        else if (compareIgnoringCase(*valstr, "scaleddiscs") == 0)
+            value = static_cast<double>(Renderer::ScaledDiscStars);
+    }
+
+    return std::make_unique<CommandSet>(*name, value);
+}
+
+
+ParseResult parseSelectCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* objStr = paramList.getString("object");
+    return objStr == nullptr
+        ? makeError("Missing object parameter to select")
+        : std::make_unique<CommandSelect>(*objStr);
+}
+
+
+ParseResult parseSetFrameCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* refName = paramList.getString("ref");
+    if (refName == nullptr)
+        return makeError("Missing ref parameter to setframe");
+
+    const std::string* targetName = paramList.getString("target");
+    if (targetName == nullptr)
+        return makeError("Missing target parameter to setframe");
+
+    ObserverFrame::CoordinateSystem coordSys;
+    if (const std::string* coordSysName = paramList.getString("coordsys"); coordSysName == nullptr)
+        coordSys = ObserverFrame::Universal;
+    else
+        coordSys = parseCoordinateSystem(*coordSysName);
+
+    return std::make_unique<CommandSetFrame>(coordSys, *refName, *targetName);
+}
+
+
+ParseResult parseSetSurfaceCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* name = paramList.getString("name");
+    return name == nullptr
+        ? makeError("Missing name parameter to setsurface")
+        : std::make_unique<CommandSetSurface>(*name);
+}
+
+
+ParseResult parseGotoCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto t = paramList.getNumber<double>("time").value_or(1.0);
+    auto distance = paramList.getNumber<double>("distance").value_or(5.0);
+
+    ObserverFrame::CoordinateSystem upFrame = ObserverFrame::ObserverLocal;
+    if (const std::string* frameString = paramList.getString("upframe"); frameString != nullptr)
+        upFrame = parseCoordinateSystem(*frameString);
+
+    auto up = paramList.getVector3<double>("up").value_or(Eigen::Vector3d::UnitY());
+
+    return std::make_unique<CommandGoto>(t,
+                                         distance,
+                                         up.cast<float>(),
+                                         upFrame);
+}
+
+
+ParseResult parseGotoLongLatCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto t         = paramList.getNumber<double>("time").value_or(1.0);
+    auto distance  = paramList.getNumber<double>("distance").value_or(5.0);
+    auto up        = paramList.getVector3<double>("up").value_or(Eigen::Vector3d::UnitY());
+    auto longitude = paramList.getNumber<double>("longitude").value_or(0.0);
+    auto latitude  = paramList.getNumber<double>("latitude").value_or(0.0);
+
+    return std::make_unique<CommandGotoLongLat>(t,
+                                                distance,
+                                                static_cast<float>(celmath::degToRad(longitude)),
+                                                static_cast<float>(celmath::degToRad(latitude)),
+                                                up.cast<float>());
+}
+
+
+ParseResult parseGotoLocCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto t = paramList.getNumber<double>("time").value_or(1.0);
+
+    if (auto pos = paramList.getVector3<double>("position"); pos.has_value())
+    {
+        *pos *= astro::kilometersToMicroLightYears(1.0);
+        auto xrot = paramList.getNumber<double>("xrot").value_or(0.0);
+        auto yrot = paramList.getNumber<double>("yrot").value_or(0.0);
+        auto zrot = paramList.getNumber<double>("zrot").value_or(0.0);
+        auto rotation = Eigen::Quaterniond(Eigen::AngleAxisd(celmath::degToRad(xrot), Eigen::Vector3d::UnitX()) *
+                                           Eigen::AngleAxisd(celmath::degToRad(yrot), Eigen::Vector3d::UnitY()) *
+                                           Eigen::AngleAxisd(celmath::degToRad(zrot), Eigen::Vector3d::UnitZ()));
+        return std::make_unique<CommandGotoLocation>(t, *pos, rotation);
+    }
+
+    const std::string* x = paramList.getString("x");
+    const std::string* y = paramList.getString("y");
+    const std::string* z = paramList.getString("z");
+    double xpos = x == nullptr ? 0.0 : static_cast<double>(DecodeFromBase64(*x));
+    double ypos = y == nullptr ? 0.0 : static_cast<double>(DecodeFromBase64(*y));
+    double zpos = z == nullptr ? 0.0 : static_cast<double>(DecodeFromBase64(*z));
+    auto ow = paramList.getNumber<double>("ow").value_or(0.0);
+    auto ox = paramList.getNumber<double>("ox").value_or(0.0);
+    auto oy = paramList.getNumber<double>("oy").value_or(0.0);
+    auto oz = paramList.getNumber<double>("oz").value_or(0.0);
+    Eigen::Quaterniond orientation(ow, ox, oy, oz);
+    return std::make_unique<CommandGotoLocation>(t, Eigen::Vector3d(xpos, ypos, zpos), orientation);
+}
+
+
+ParseResult parseSetUrlCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* url = paramList.getString("url");
+    return url == nullptr
+        ? makeError("Missing url parameter to seturl")
+        : std::make_unique<CommandSetUrl>(*url);
+}
+
+
+ParseResult parseCenterCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto t = paramList.getNumber<double>("time").value_or(1.0);
+    return std::make_unique<CommandCenter>(t);
+}
+
+
+ParseResult parsePrintCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* text = paramList.getString("text");
+    if (text == nullptr)
+        return makeError("Missing text parameter to print");
+
+    auto duration = paramList.getNumber<double>("duration").value_or(1e9);
+    auto voff     = paramList.getNumber<int>("row").value_or(0);
+    auto hoff     = paramList.getNumber<int>("column").value_or(0);
+    int horig = -1;
+    int vorig = -1;
+    if (const std::string* origin = paramList.getString("origin"); origin != nullptr && !origin->empty())
+    {
+        constexpr std::string_view top    = "top"sv;
+        constexpr std::string_view bottom = "bottom"sv;
+        constexpr std::string_view left   = "left"sv;
+        constexpr std::string_view right  = "right"sv;
+        constexpr std::string_view center = "center"sv;
+
+        if (*origin == center)
+        {
+            horig = 0;
+            vorig = 0;
+        }
+        else
+        {
+            // (bottom|top)(left|right)? or (left|right)
+            std::string_view originSv = *origin;
+            if (compareIgnoringCase(originSv, bottom, bottom.size()) == 0)
+            {
+                vorig = -1;
+                originSv = originSv.substr(bottom.size());
+            }
+            else if (compareIgnoringCase(originSv, top, top.size()) == 0)
+            {
+                vorig = 1;
+                originSv = originSv.substr(top.size());
+            }
+            else
+                vorig = 0;
+
+            if (originSv.empty())
+                horig = 0; // was either "top" or "bottom" exactly
+            else if (compareIgnoringCase(originSv, right) == 0)
+                horig = 1;
+            else if (compareIgnoringCase(originSv, left) == 0)
+                horig = -1;
+            else
+            {
+                // Could not parse the origin
+                horig = -1;
+                vorig = -1;
+            }
+        }
+    }
+
+    return std::make_unique<CommandPrint>(*text,
+                                          horig, vorig, hoff, -voff,
+                                          duration);
+}
+
+
+ParseResult parseTimeCommand(const Hash& paramList, const ScriptMaps&)
+{
+    double jd = 2451545.0;
+    if (auto jdVal = paramList.getNumber<double>("jd"); jdVal.has_value())
+    {
+        jd = *jdVal;
+    }
+    else
+    {
+        const std::string* utc = paramList.getString("utc");
+        if (utc == nullptr)
+            return makeError("Missing either time or utc parameter to time");
+
+        astro::Date date = astro::Date(0.0);
+        std::sscanf(utc->c_str(), "%d-%d-%dT%d:%d:%lf",
+                    &date.year, &date.month, &date.day,
+                    &date.hour, &date.minute, &date.seconds);
+        jd = static_cast<double>(date);
+    }
+
+    return std::make_unique<CommandSetTime>(jd);
+}
+
+
+ParseResult parseTimeRateCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto rate = paramList.getNumber<double>("rate").value_or(1.0);
+    return std::make_unique<CommandSetTimeRate>(rate);
+}
+
+
+ParseResult parseChangeDistanceCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto rate     = paramList.getNumber<double>("rate").value_or(0.0);
+    auto duration = paramList.getNumber<double>("duration").value_or(1.0);
+    return std::make_unique<CommandChangeDistance>(duration, rate);
+}
+
+
+ParseResult parseOrbitCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto duration = paramList.getNumber<double>("duration").value_or(1.0);
+    auto rate     = paramList.getNumber<double>("rate").value_or(0.0);
+    auto axis     = paramList.getVector3<double>("axis").value_or(Eigen::Vector3d::Zero());
+    return std::make_unique<CommandOrbit>(duration,
+                                          axis.cast<float>(),
+                                          static_cast<float>(celmath::degToRad(rate)));
+}
+
+
+ParseResult parseRotateCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto duration = paramList.getNumber<double>("duration").value_or(1.0);
+    auto rate     = paramList.getNumber<double>("rate").value_or(0.0);
+    auto axis     = paramList.getVector3<double>("axis").value_or(Eigen::Vector3d::Zero());
+    return std::make_unique<CommandRotate>(duration,
+                                           axis.cast<float>(),
+                                           static_cast<float>(celmath::degToRad(rate)));
+}
+
+
+ParseResult parseMoveCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto duration = paramList.getNumber<double>("duration").value_or(1.0);
+    auto velocity = paramList.getVector3<double>("velocity").value_or(Eigen::Vector3d::Zero());
+    return std::make_unique<CommandMove>(duration, velocity * astro::kilometersToMicroLightYears(1.0));
+}
+
+
+ParseResult parseSetPositionCommand(const Hash& paramList, const ScriptMaps&)
+{
+    // Base position in light years, offset in kilometers
+    if (auto base = paramList.getVector3<float>("base"); base.has_value())
+    {
+        auto offset = paramList.getVector3<double>("offset").value_or(Eigen::Vector3d::Zero());
+        UniversalCoord basePosition = UniversalCoord::CreateLy(base->cast<double>());
+        return std::make_unique<CommandSetPosition>(basePosition.offsetKm(offset));
+    }
+
+    const std::string* x = paramList.getString("x");
+    const std::string* y = paramList.getString("y");
+    const std::string* z = paramList.getString("z");
+    return x == nullptr || y == nullptr || z == nullptr
+        ? makeError("Missing x, y, z or base, offset parameters to setposition")
+        : std::make_unique<CommandSetPosition>(UniversalCoord(DecodeFromBase64(*x),
+                                                              DecodeFromBase64(*y),
+                                                              DecodeFromBase64(*z)));
+}
+
+
+ParseResult parseSetOrientationCommand(const Hash& paramList, const ScriptMaps&)
+{
+    if (auto angle = paramList.getNumber<double>("angle"); angle.has_value())
+    {
+        auto axis = paramList.getVector3<double>("axis").value_or(Eigen::Vector3d::Zero());
+        auto orientation = Eigen::Quaternionf(Eigen::AngleAxisf(static_cast<float>(celmath::degToRad(*angle)),
+                                                                axis.cast<float>().normalized()));
+        return std::make_unique<CommandSetOrientation>(orientation);
+    }
+
+    auto ow = paramList.getNumber<double>("ow").value_or(0.0);
+    auto ox = paramList.getNumber<double>("ox").value_or(0.0);
+    auto oy = paramList.getNumber<double>("oy").value_or(0.0);
+    auto oz = paramList.getNumber<double>("oz").value_or(0.0);
+    Eigen::Quaternionf orientation(ow, ox, oy, oz);
+    return std::make_unique<CommandSetOrientation>(orientation);
+}
+
+
+ParseResult parseRenderFlagsCommand(const Hash& paramList, const ScriptMaps& scriptMaps)
+{
+    std::uint64_t setFlags = 0;
+    std::uint64_t clearFlags = 0;
+
+    if (const std::string* s = paramList.getString("set"); s != nullptr)
+        setFlags = parseRenderFlags(*s, scriptMaps.RenderFlagMap);
+    if (const std::string* s = paramList.getString("clear"); s != nullptr)
+        clearFlags = parseRenderFlags(*s, scriptMaps.RenderFlagMap);
+
+    return std::make_unique<CommandRenderFlags>(setFlags, clearFlags);
+}
+
+
+ParseResult parseLabelsCommand(const Hash& paramList, const ScriptMaps& scriptMaps)
+{
+    int setFlags = 0;
+    int clearFlags = 0;
+
+    if (const std::string* s = paramList.getString("set"); s != nullptr)
+        setFlags = parseLabelFlags(*s, scriptMaps.LabelFlagMap);
+    if (const std::string* s = paramList.getString("clear"); s != nullptr)
+        clearFlags = parseLabelFlags(*s, scriptMaps.LabelFlagMap);
+
+    return std::make_unique<CommandLabels>(setFlags, clearFlags);
+}
+
+
+ParseResult parseOrbitFlagsCommand(const Hash& paramList, const ScriptMaps& scriptMaps)
+{
+    int setFlags = 0;
+    int clearFlags = 0;
+
+    if (const std::string* s = paramList.getString("set"); s != nullptr)
+        setFlags = parseOrbitFlags(*s, scriptMaps.OrbitVisibilityMap);
+    if (const std::string* s = paramList.getString("clear"); s != nullptr)
+        clearFlags = parseOrbitFlags(*s, scriptMaps.OrbitVisibilityMap);
+
+    return std::make_unique<CommandOrbitFlags>(setFlags, clearFlags);
+}
+
+
+ParseResult parseConstellationsCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto cmdcons = std::make_unique<CommandConstellations>();
+
+    if (const std::string* s = paramList.getString("set"); s != nullptr)
+        parseConstellations(*cmdcons, *s, true);
+    if (const std::string* s = paramList.getString("clear"); s != nullptr)
+        parseConstellations(*cmdcons, *s, false);
+    return ParseResult(std::move(cmdcons));
+}
+
+
+ParseResult parseConstellationColorCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto cmdconcol = std::make_unique<CommandConstellationColor>();
+
+    auto colorv = paramList.getVector3<double>("color").value_or(Eigen::Vector3d::UnitX());
+
+    if (const std::string* s = paramList.getString("set"); s != nullptr)
+        parseConstellationColor(*cmdconcol, *s, colorv, true);
+    if (const std::string* s = paramList.getString("clear"); s != nullptr)
+        parseConstellationColor(*cmdconcol, *s, colorv, false);
+    return ParseResult(std::move(cmdconcol));
+}
+
+
+ParseResult parseSetVisibilityLimitCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto mag = paramList.getNumber<double>("magnitude").value_or(6.0);
+    return std::make_unique<CommandSetVisibilityLimit>(mag);
+}
+
+
+ParseResult parseSetFaintestAutoMag45DegCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto mag = paramList.getNumber<double>("magnitude").value_or(8.5);
+    return std::make_unique<CommandSetFaintestAutoMag45deg>(mag);
+}
+
+
+ParseResult parseSetAmbientLightCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto brightness = paramList.getNumber<float>("brightness").value_or(0.0f);
+    return std::make_unique<CommandSetAmbientLight>(brightness);
+}
+
+
+ParseResult parseSetGalaxyLightGainCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto gain = paramList.getNumber<float>("gain").value_or(0.0f);
+    return std::make_unique<CommandSetGalaxyLightGain>(gain);
+}
+
+
+ParseResult parseSetTextureResolutionCommand(const Hash& paramList, const ScriptMaps&)
+{
+    unsigned int res = 1;
+    if (const std::string* textureRes = paramList.getString("resolution"); textureRes != nullptr)
+    {
+        if (compareIgnoringCase(*textureRes, "low") == 0)
+            res = 0;
+        else if (compareIgnoringCase(*textureRes, "medium") == 0)
+            res = 1;
+        else if (compareIgnoringCase(*textureRes, "high") == 0)
+            res = 2;
+    }
+
+    return std::make_unique<CommandSetTextureResolution>(res);
+}
+
+
+ParseResult parsePreloadTexCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* object = paramList.getString("object");
+    return object == nullptr
+        ? makeError("Missing object parameter to preloadtex")
+        : std::make_unique<CommandPreloadTextures>(*object);
+}
+
+
+ParseResult parseMarkCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* object = paramList.getString("object");
+    if (object == nullptr)
+        return makeError("Missing object parameter to mark");
+
+    auto size   = paramList.getNumber<double>("size").value_or(10.0);
+    auto colorv = paramList.getVector3<float>("color").value_or(Eigen::Vector3f::UnitX());
+    auto alpha  = paramList.getNumber<float>("alpha").value_or(0.9f);
+    Color color(colorv.x(), colorv.y(), colorv.z(), alpha);
+
+    celestia::MarkerRepresentation::Symbol symbol = celestia::MarkerRepresentation::Diamond;
+    if (const std::string* symbolString = paramList.getString("symbol"); symbolString != nullptr)
+    {
+        if (compareIgnoringCase("diamond"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::Diamond;
+        else if (compareIgnoringCase("triangle"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::Triangle;
+        else if (compareIgnoringCase("square"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::Square;
+        else if (compareIgnoringCase("filledsquare"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::FilledSquare;
+        else if (compareIgnoringCase("plus"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::Plus;
+        else if (compareIgnoringCase("x"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::X;
+        else if (compareIgnoringCase("leftarrow"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::LeftArrow;
+        else if (compareIgnoringCase("rightarrow"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::RightArrow;
+        else if (compareIgnoringCase("uparrow"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::UpArrow;
+        else if (compareIgnoringCase("downarrow"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::DownArrow;
+        else if (compareIgnoringCase("circle"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::Circle;
+        else if (compareIgnoringCase("disk"sv, *symbolString) == 0)
+            symbol = celestia::MarkerRepresentation::Disk;
+    }
+
+    celestia::MarkerRepresentation rep{symbol};
+
+    rep.setSize(static_cast<float>(size));
+    rep.setColor(color);
+    if (const std::string* label = paramList.getString("label"); label != nullptr)
+        rep.setLabel(*label);
+
+    bool occludable = paramList.getBoolean("occludable").value_or(true);
+
+    return std::make_unique<CommandMark>(*object, rep, occludable);
+}
+
+
+ParseResult parseUnmarkCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* object = paramList.getString("object");
+    return object == nullptr
+        ? makeError("Missing object parameter to unmark")
+        : std::make_unique<CommandUnmark>(*object);
+}
+
+
+ParseResult parseCaptureCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* filename = paramList.getString("filename");
+    if (filename == nullptr)
+        return makeError("Missing filename parameter to capture");
+
+    std::string type;
+    if (const std::string* typeStr = paramList.getString("type"); typeStr != nullptr)
+    {
+        type = *typeStr;
+    }
+
+    return std::make_unique<CommandCapture>(type, *filename);
+}
+
+
+ParseResult parseSplitViewCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto view = paramList.getNumber<unsigned int>("view").value_or(1u);
+    std::string splitType;
+    if (const std::string* splitVal = paramList.getString("type"); splitVal != nullptr)
+    {
+        splitType = *splitVal;
+    }
+
+    auto splitPos = paramList.getNumber<float>("position").value_or(0.5f);
+    return std::make_unique<CommandSplitView>(view, splitType, splitPos);
+}
+
+
+ParseResult parseDeleteViewCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto view = paramList.getNumber<unsigned int>("view").value_or(1u);
+    return std::make_unique<CommandDeleteView>(view);
+}
+
+
+ParseResult parseSetActiveViewCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto view = paramList.getNumber<unsigned int>("view").value_or(1u);
+    return std::make_unique<CommandSetActiveView>(view);
+}
+
+
+ParseResult parseSetRadiusCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* object = paramList.getString("object");
+    if (object == nullptr)
+        return makeError("Missing object parameter to setradius");
+
+    auto radius = paramList.getNumber<float>("radius").value_or(1.0f);
+    return std::make_unique<CommandSetRadius>(*object, radius);
+}
+
+
+ParseResult parseSetLineColorCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* item = paramList.getString("item");
+    if (item == nullptr)
+        return makeError("Missing item parameter to setlinecolor");
+
+    auto colorv = paramList.getVector3<float>("color").value_or(Eigen::Vector3f::UnitX());
+    Color color(colorv.x(), colorv.y(), colorv.z());
+    return std::make_unique<CommandSetLineColor>(*item, color);
+}
+
+
+ParseResult parseSetLabelColorCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* item = paramList.getString("item");
+    if (item == nullptr)
+        return makeError("Missing item parameter to setlabelcolor");
+
+    auto colorv = paramList.getVector3<float>("color").value_or(Eigen::Vector3f::UnitX());
+    Color color(colorv.x(), colorv.y(), colorv.z());
+    return std::make_unique<CommandSetLabelColor>(*item, color);
+}
+
+
+ParseResult parseSetTextColorCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto colorv = paramList.getVector3<float>("color").value_or(Eigen::Vector3f::Ones());
+    Color color(colorv.x(), colorv.y(), colorv.z());
+    return std::make_unique<CommandSetTextColor>(color);
+}
+
+
+ParseResult parsePlayCommand(const Hash& paramList, const ScriptMaps&)
+{
+#ifdef USE_MINIAUDIO
+    int channel = std::max(paramList.getNumber<int>("channel").value_or(celestia::defaultAudioChannel),
+                           celestia::minAudioChannel);
+
+    auto optionalVolume = paramList.getNumber<float>("volume");
+    if (optionalVolume.has_value())
+        optionalVolume = std::clamp(*optionalVolume, celestia::minAudioVolume, celestia::maxAudioVolume);
+    float pan = std::clamp(paramList.getNumber<float>("pan").value_or(celestia::defaultAudioPan),
+                           celestia::minAudioPan, celestia::maxAudioPan);
+    int nopause = paramList.getNumber<int>("nopause").value_or(0);
+    std::optional<bool> optionalLoop = std::nullopt;
+    if (auto loop = paramList.getNumber<int>("loop"); loop.has_value())
+        optionalLoop = *loop == 1;
+    std::optional<std::string> optionalFilename = std::nullopt;
+    if (auto filename = paramList.getString("filename"); filename != nullptr)
+        optionalFilename = *filename;
+
+    return std::make_unique<CommandPlay>(channel, optionalVolume, pan, optionalLoop, optionalFilename, nopause == 1);
+#else
+    return std::make_unique<CommandNoOp>();
+#endif
+}
+
+
+ParseResult parseOverlayCommand(const Hash& paramList, const ScriptMaps&)
+{
+    auto duration = paramList.getNumber<float>("duration").value_or(3.0f);
+    auto xoffset  = paramList.getNumber<float>("xoffset").value_or(0.0f);
+    auto yoffset  = paramList.getNumber<float>("yoffset").value_or(0.0f);
+    std::optional<float> alpha = paramList.getNumber<float>("alpha");
+
+    const std::string* filename = paramList.getString("filename");
+    if (filename == nullptr)
+        return makeError("Missing filename parameter to overlay");
+
+    bool fitscreen = false;
+    // The below triggers a Sonar rule to use value_or in the outer condition,
+    // however this would be eagerly-evaluated and cause unnecessary map
+    // lookups in the case that the boolean lookup succeeds.
+    if (auto fitscreenValue = paramList.getBoolean("fitscreen"); fitscreenValue.has_value()) // NOSONAR
+        fitscreen = *fitscreenValue;
+    else
+        fitscreen = paramList.getNumber<int>("fitscreen").value_or(0) != 0;
+
+    std::array<Color, 4> colors;
+    Color color = paramList.getColor("color").value_or(Color::White);
+    colors.fill(alpha.has_value() ? Color(color, *alpha) : color);
+
+    if (auto colorTop = paramList.getColor("colortop"); colorTop.has_value())
+        colors[0] = colors[1] = alpha.has_value() ? Color(*colorTop, *alpha) : *colorTop;
+    if (auto colorBottom = paramList.getColor("colorbottom"); colorBottom.has_value())
+        colors[2] = colors[3] = alpha.has_value() ? Color(*colorBottom, *alpha) : *colorBottom;
+    if (auto colorTopLeft = paramList.getColor("colortopleft"); colorTopLeft.has_value())
+        colors[0] = alpha.has_value() ? Color(*colorTopLeft, *alpha) : *colorTopLeft;
+    if (auto colorTopRight = paramList.getColor("colortopright"); colorTopRight.has_value())
+        colors[1] = alpha.has_value() ? Color(*colorTopRight, *alpha) : *colorTopRight;
+    if (auto colorBottomRight = paramList.getColor("colorbottomright"); colorBottomRight.has_value())
+        colors[2] = alpha.has_value() ? Color(*colorBottomRight, *alpha) : *colorBottomRight;
+    if (auto colorBottomLeft = paramList.getColor("colorbottomleft"); colorBottomLeft.has_value())
+        colors[3] = alpha.has_value() ? Color(*colorBottomLeft, *alpha) : *colorBottomLeft;
+
+    auto fadeafter = paramList.getNumber<float>("fadeafter").value_or(duration);
+
+    return std::make_unique<CommandScriptImage>(duration,
+                                                fadeafter,
+                                                xoffset,
+                                                yoffset,
+                                                *filename,
+                                                fitscreen,
+                                                colors);
+}
+
+
+ParseResult parseVerbosityCommand(const Hash& paramList, const ScriptMaps&)
+{
+    int level = paramList.getNumber<int>("level").value_or(2);
+    return std::make_unique<CommandVerbosity>(level);
+}
+
+
+ParseResult parseSetWindowBordersVisibleCommand(const Hash& paramList, const ScriptMaps&)
+{
+    bool visible = paramList.getBoolean("visible").value_or(true);
+    return std::make_unique<CommandSetWindowBordersVisible>(visible);
+}
+
+
+ParseResult parseSetRingsTextureCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* object = paramList.getString("object");
+    if (object == nullptr)
+        return makeError("Missing object parameter to setringstexture");
+
+    const std::string* texture = paramList.getString("texture");
+    if (texture == nullptr)
+        return makeError("Missing texture parameter to setringstexture");
+
+    std::string path;
+    if (const std::string* pathStr = paramList.getString("path"); pathStr != nullptr)
+    {
+        path = *pathStr;
+    }
+
+    return std::make_unique<CommandSetRingsTexture>(*object, *texture, path);
+}
+
+
+ParseResult parseLoadFragmentCommand(const Hash& paramList, const ScriptMaps&)
+{
+    const std::string* type = paramList.getString("type");
+    if (type == nullptr)
+        return makeError("Missing type parameter to loadfragment");
+
+    const std::string* fragment = paramList.getString("fragment");
+    if (fragment == nullptr)
+        return makeError("Missing fragment parameter to loadfragment");
+
+    std::string dir;
+    if (const std::string* dirName = paramList.getString("dir"); dirName != nullptr)
+        dir = *dirName;
+
+    return std::make_unique<CommandLoadFragment>(*type, *fragment, dir);
+}
+
+
+using ParseCommandPtr = ParseResult (*)(const Hash&, const ScriptMaps&);
+using ParseCommandMap = std::map<std::string_view, ParseCommandPtr>;
+
+std::unique_ptr<ParseCommandMap> createParseCommandMap()
+{
+    return std::make_unique<ParseCommandMap>(
+        std::initializer_list<ParseCommandMap::value_type>
+        {
+            { "wait"sv,                    &parseWaitCommand                              },
+            { "set"sv,                     &parseSetCommand                               },
+            { "select"sv,                  &parseSelectCommand                            },
+            { "setframe"sv,                &parseSetFrameCommand                          },
+            { "setsurface"sv,              &parseSetSurfaceCommand                        },
+            { "goto"sv,                    &parseGotoCommand                              },
+            { "gotolonglat"sv,             &parseGotoLongLatCommand                       },
+            { "gotoloc"sv,                 &parseGotoLocCommand                           },
+            { "seturl"sv,                  &parseSetUrlCommand                            },
+            { "center"sv,                  &parseCenterCommand                            },
+            { "follow"sv,                  &parseParameterlessCommand<CommandFollow>      },
+            { "synchronous"sv,             &parseParameterlessCommand<CommandSynchronous> },
+            { "lock"sv,                    &parseParameterlessCommand<CommandLock>        },
+            { "chase"sv,                   &parseParameterlessCommand<CommandChase>       },
+            { "track"sv,                   &parseParameterlessCommand<CommandTrack>       },
+            { "cancel"sv,                  &parseParameterlessCommand<CommandCancel>      },
+            { "exit"sv,                    &parseParameterlessCommand<CommandExit>        },
+            { "print"sv,                   &parsePrintCommand                             },
+            { "cls"sv,                     &parseParameterlessCommand<CommandClearScreen> },
+            { "time"sv,                    &parseTimeCommand                              },
+            { "timerate"sv,                &parseTimeRateCommand                          },
+            { "changedistance"sv,          &parseChangeDistanceCommand                    },
+            { "orbit"sv,                   &parseOrbitCommand                             },
+            { "rotate"sv,                  &parseRotateCommand                            },
+            { "move"sv,                    &parseMoveCommand                              },
+            { "setposition"sv,             &parseSetPositionCommand                       },
+            { "setorientation"sv,          &parseSetOrientationCommand                    },
+            { "lookback"sv,                &parseParameterlessCommand<CommandLookBack>    },
+            { "renderflags"sv,             &parseRenderFlagsCommand                       },
+            { "labels"sv,                  &parseLabelsCommand                            },
+            { "orbitflags"sv,              &parseOrbitFlagsCommand                        },
+            { "constellations"sv,          &parseConstellationsCommand                    },
+            { "constellationcolor"sv,      &parseConstellationColorCommand                },
+            { "setvisibilitylimit"sv,      &parseSetVisibilityLimitCommand                },
+            { "setfaintestautomag45deg"sv, &parseSetFaintestAutoMag45DegCommand           },
+            { "setambientlight"sv,         &parseSetAmbientLightCommand                   },
+            { "setgalaxylightgain"sv,      &parseSetGalaxyLightGainCommand                },
+            { "settextureresolution"sv,    &parseSetTextureResolutionCommand              },
+            { "preloadtex"sv,              &parsePreloadTexCommand                        },
+            { "mark"sv,                    &parseMarkCommand                              },
+            { "unmark"sv,                  &parseUnmarkCommand                            },
+            { "unmarkall"sv,               &parseParameterlessCommand<CommandUnmarkAll>   },
+            { "capture"sv,                 &parseCaptureCommand                           },
+            { "renderpath"sv,              &parseParameterlessCommand<CommandNoOp>        },
+            { "splitview"sv,               &parseSplitViewCommand                         },
+            { "deleteview"sv,              &parseDeleteViewCommand                        },
+            { "singleview"sv,              &parseParameterlessCommand<CommandSingleView>  },
+            { "setactiveview"sv,           &parseSetActiveViewCommand                     },
+            { "setradius"sv,               &parseSetRadiusCommand                         },
+            { "setlinecolor"sv,            &parseSetLineColorCommand                      },
+            { "setlabelcolor"sv,           &parseSetLabelColorCommand                     },
+            { "settextcolor"sv,            &parseSetTextColorCommand                      },
+            { "play"sv,                    &parsePlayCommand                              },
+            { "overlay"sv,                 &parseOverlayCommand                           },
+            { "verbosity"sv,               &parseVerbosityCommand                         },
+            { "setwindowbordersvisible"sv, &parseSetWindowBordersVisibleCommand           },
+            { "setringstexture"sv,         &parseSetRingsTextureCommand                   },
+            { "loadfragment"sv,            &parseLoadFragmentCommand                      },
+        });
+}
+
+} // end unnamed namespace
+
+
+CommandParser::CommandParser(std::istream& in, const std::shared_ptr<ScriptMaps> &sm) :
+    tokenizer(std::make_unique<Tokenizer>(&in)),
+    scriptMaps(sm)
+{
+    parser = std::make_unique<Parser>(tokenizer.get());
+}
+
+
+CommandParser::~CommandParser() = default;
+
+
+CommandSequence CommandParser::parse()
+{
+    CommandSequence seq;
+
+    if (tokenizer->nextToken() != Tokenizer::TokenBeginGroup)
+    {
+        error("'{' expected at start of script.");
+        return {};
+    }
+
+    Tokenizer::TokenType ttype = tokenizer->nextToken();
+    while (ttype != Tokenizer::TokenEnd && ttype != Tokenizer::TokenEndGroup)
+    {
+        tokenizer->pushBack();
+        std::unique_ptr<Command> cmd = parseCommand();
+        if (cmd == nullptr)
+        {
+            return {};
+        }
+        else
+        {
+            seq.emplace_back(std::move(cmd));
+        }
+
+        ttype = tokenizer->nextToken();
+    }
+
+    if (ttype != Tokenizer::TokenEndGroup)
+    {
+        error("Missing '}' at end of script.");
+        return {};
+    }
+
+    return seq;
+}
+
+
+celestia::util::array_view<std::string> CommandParser::getErrors() const
+{
+    return errorList;
+}
+
+
+void CommandParser::error(std::string&& errMsg)
+{
+    errorList.emplace_back(std::move(errMsg));
+}
+
+
+std::unique_ptr<Command> CommandParser::parseCommand()
+{
+    tokenizer->nextToken();
+    std::string commandName;
+    if (auto tokenValue = tokenizer->getNameValue(); tokenValue.has_value())
+    {
+        commandName = *tokenValue;
+    }
+    else
+    {
+        error("Invalid command name");
+        return nullptr;
+    }
+
+    const Value paramListValue = parser->readValue();
+    const Hash* paramList = paramListValue.getHash();
+    if (paramList == nullptr)
+    {
+        error("Bad parameter list");
+        return nullptr;
+    }
+
+    static const ParseCommandMap* parseCommandMap = createParseCommandMap().release();
+    auto it = parseCommandMap->find(commandName);
+    if (it == parseCommandMap->end())
+    {
+        error(fmt::format("Unknown command name '{}'", commandName));
+        return nullptr;
+    }
+
+    return std::visit(ParseResultVisitor([this](std::string&& s) { error(std::move(s)); }),
+                      it->second(*paramList, *scriptMaps));
+}
+
+} // end namespace celestia::scripts

--- a/src/celscript/legacy/cmdparser.h
+++ b/src/celscript/legacy/cmdparser.h
@@ -9,39 +9,41 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CMDPARSER_H_
-#define _CMDPARSER_H_
+#pragma once
 
 #include <iosfwd>
-#include <string_view>
-#include <celscript/common/scriptmaps.h>
-#include <celutil/array_view.h>
-#include "command.h" // CommandSequence
+#include <memory>
+#include <string>
+#include <vector>
 
-class Command;
+#include <celutil/array_view.h>
+#include "command.h"
+
 class Parser;
 class Tokenizer;
 
+namespace celestia::scripts
+{
+
+class ScriptMaps;
 
 class CommandParser
 {
  public:
     CommandParser(std::istream&, const std::shared_ptr<celestia::scripts::ScriptMaps> &sm);
-    CommandParser(Tokenizer&, const std::shared_ptr<celestia::scripts::ScriptMaps> &sm);
     ~CommandParser();
 
-    CommandSequence* parse();
+    CommandSequence parse();
     celestia::util::array_view<std::string> getErrors() const;
 
  private:
-    Command* parseCommand();
-    void error(std::string);
+    std::unique_ptr<Command> parseCommand();
+    void error(std::string&&);
 
-    Parser* parser;
-    Tokenizer* tokenizer;
+    std::unique_ptr<Parser> parser;
+    std::unique_ptr<Tokenizer> tokenizer;
     std::vector<std::string> errorList;
     std::shared_ptr<celestia::scripts::ScriptMaps> scriptMaps;
 };
 
-#endif // _CMDPARSER_H_
-
+} // end namespace celestia::scripts

--- a/src/celscript/legacy/execenv.h
+++ b/src/celscript/legacy/execenv.h
@@ -7,14 +7,16 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _EXECENV_H_
-#define _EXECENV_H_
+#pragma once
 
-#include <celengine/render.h>
-#include <celengine/simulation.h>
-#include <string>
+#include <string_view>
 
 class CelestiaCore;
+class Renderer;
+class Simulation;
+
+namespace celestia::scripts
+{
 
 class ExecutionEnvironment
 {
@@ -29,7 +31,7 @@ class ExecutionEnvironment
     virtual Renderer* getRenderer() const = 0;
     virtual CelestiaCore* getCelestiaCore() const = 0;
 
-    virtual void showText(std::string, int, int, int, int, double) = 0;
+    virtual void showText(std::string_view, int, int, int, int, double) = 0;
 };
 
-#endif // _EXECENV_H_
+}

--- a/src/celscript/legacy/execution.cpp
+++ b/src/celscript/legacy/execution.cpp
@@ -9,14 +9,14 @@
 
 #include "execution.h"
 
-using namespace std;
+#include <utility>
 
+namespace celestia::scripts
+{
 
-Execution::Execution(CommandSequence& cmd, ExecutionEnvironment& _env) :
-    currentCommand(cmd.begin()),
-    finalCommand(cmd.end()),
-    env(_env),
-    commandTime(-1.0)
+Execution::Execution(CommandSequence&& cmd, ExecutionEnvironment& _env) :
+    commandSequence(std::move(cmd)),
+    env(_env)
 {
 }
 
@@ -32,9 +32,9 @@ bool Execution::tick(double dt)
         return false;
     }
 
-    while (dt > 0.0 && currentCommand != finalCommand)
+    while (dt > 0.0 && currentCommand < commandSequence.size())
     {
-        Command* cmd = *currentCommand;
+        Command* cmd = commandSequence[currentCommand].get();
 
         double timeLeft = cmd->getDuration() - commandTime;
         if (dt >= timeLeft)
@@ -52,15 +52,7 @@ bool Execution::tick(double dt)
         }
     }
 
-    return currentCommand == finalCommand;
+    return currentCommand == commandSequence.size();
 }
 
-
-void Execution::reset(CommandSequence& cmd)
-{
-    currentCommand = cmd.begin();
-    finalCommand = cmd.end();
-    commandTime = -1.0;
 }
-
-

--- a/src/celscript/legacy/execution.h
+++ b/src/celscript/legacy/execution.h
@@ -7,27 +7,29 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _EXECUTION_H_
-#define _EXECUTION_H_
+#pragma once
 
-#include "execenv.h"
+#include <cstddef>
+
 #include "command.h"
 
+namespace celestia::scripts
+{
+
+class ExecutionEnvironment;
 
 class Execution
 {
  public:
-    Execution(CommandSequence&, ExecutionEnvironment&);
+    Execution(CommandSequence&&, ExecutionEnvironment&);
 
     bool tick(double);
-    void reset(CommandSequence&);
 
  private:
-    CommandSequence::const_iterator currentCommand;
-    CommandSequence::const_iterator finalCommand;
+    CommandSequence commandSequence;
+    std::size_t currentCommand{ 0 };
     ExecutionEnvironment& env;
-    double commandTime;
+    double commandTime{ -1.0 };
 };
 
-#endif // _EXECUTION_H_
-
+} // end namespace celestia::scripts

--- a/src/celscript/legacy/legacyscript.h
+++ b/src/celscript/legacy/legacyscript.h
@@ -9,15 +9,21 @@
 
 #pragma once
 
-#include <celscript/common/script.h>
 #include <iosfwd>
+#include <memory>
+#include <string>
 
-class Execution;
-class ExecutionEnvironment;
+#include <celcompat/filesystem.h>
+#include <celscript/common/script.h>
+
+
 class CelestiaCore;
 
 namespace celestia::scripts
 {
+
+class Execution;
+class ExecutionEnvironment;
 
 class LegacyScript : public IScript
 {
@@ -25,7 +31,7 @@ class LegacyScript : public IScript
     LegacyScript(CelestiaCore*);
     ~LegacyScript() override = default;
 
-    bool load(std::ifstream&, const fs::path&, std::string&);
+    bool load(std::istream&, const fs::path&, std::string&);
 
     bool tick(double) override;
 


### PR DESCRIPTION
Refactoring of the legacy (.cel) scripts code. More use of smart pointers, break up some of the larger methods, move everything into the `celestia::scripts` namespace