### PR TITLE
r128util: include cstdint

### DIFF
--- a/src/celutil/r128util.cpp
+++ b/src/celutil/r128util.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 
 #define R128_IMPLEMENTATION
 #include "r128util.h"


### PR DESCRIPTION
This is needed with GCC13/glibc2.37 (Fedora 38 and above).