### PR TITLE
Use glBlendFuncSeparate instead of glBlendFunc in celx scripts

### DIFF
--- a/src/celscript/lua/celx_gl.cpp
+++ b/src/celscript/lua/celx_gl.cpp
@@ -157,7 +157,7 @@ static int gl_BlendFunc(lua_State* l)
     celx.checkArgs(2, 2, "Two arguments expected for gl.BlendFunc()");
     int i = (int)celx.safeGetNumber(1, WrongType, "argument 1 to gl.BlendFunc must be a number", 0.0);
     int j = (int)celx.safeGetNumber(2, WrongType, "argument 2 to gl.BlendFunc must be a number", 0.0);
-    glBlendFunc(i,j);
+    glBlendFuncSeparate(i,j,GL_ZERO,GL_ONE);
     return 0;
 }
 


### PR DESCRIPTION
This would bring setting the blend functions from celx in line with the changes in #1616, but need to figure out a good way of testing it before we merge this.