### PR TITLE
Update lodspheremesh trigonometry calculations

### DIFF
--- a/src/celengine/lodspheremesh.h
+++ b/src/celengine/lodspheremesh.h
@@ -10,20 +10,34 @@
 
 #pragma once
 
-#include <Eigen/Geometry>
-#include <celengine/texture.h>
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include <Eigen/Core>
+
 #include <celengine/glsupport.h>
-#include <celmath/frustum.h>
 
+class Texture;
 
-#define MAX_SPHERE_MESH_TEXTURES 6
-#define NUM_SPHERE_VERTEX_BUFFERS 2
+namespace celmath
+{
+class Frustum;
+}
 
 class LODSphereMesh
 {
 public:
-    LODSphereMesh();
+    static constexpr std::size_t MAX_SPHERE_MESH_TEXTURES = 6;
+    static constexpr std::size_t NUM_SPHERE_VERTEX_BUFFERS = 2;
+
+    LODSphereMesh() = default;
     ~LODSphereMesh();
+
+    LODSphereMesh(const LODSphereMesh&) = delete;
+    LODSphereMesh& operator=(const LODSphereMesh&) = delete;
+    LODSphereMesh(LODSphereMesh&&) = delete;
+    LODSphereMesh& operator=(LODSphereMesh&&) = delete;
 
     void render(unsigned int attributes, const celmath::Frustum&, float pixWidth,
                 Texture** tex, int nTextures);
@@ -53,8 +67,8 @@ public:
         int step;
         unsigned int attributes;  // vertex attributes
         const celmath::Frustum& frustum;   // frustum, for culling
-        Eigen::Vector3f fp[8];    // frustum points, for culling
-        int texLOD[MAX_SPHERE_MESH_TEXTURES];
+        std::array<Eigen::Vector3f, 8> fp{};    // frustum points, for culling
+        std::array<int, MAX_SPHERE_MESH_TEXTURES> texLOD{};
     };
 
     void renderPatches(int phi0, int theta0,
@@ -64,20 +78,17 @@ public:
 
     void renderSection(int phi0, int theta0, int extent, const RenderInfo&);
 
-    float* vertices{ nullptr };
-
-    int maxVertices{ 0 };
     int vertexSize{ 0 };
 
-    int nIndices{ 0 };
-    unsigned short* indices{ nullptr };
+    std::vector<float> vertices{};
+    std::vector<unsigned short> indices{};
 
     int nTexturesUsed{ 0 };
-    Texture* textures[MAX_SPHERE_MESH_TEXTURES]{};
-    unsigned int subtextures[MAX_SPHERE_MESH_TEXTURES]{};
+    std::array<Texture*, MAX_SPHERE_MESH_TEXTURES> textures{};
+    std::array<unsigned int, MAX_SPHERE_MESH_TEXTURES> subtextures{};
 
     bool vertexBuffersInitialized{ false };
     GLuint currentVB{ 0 };
-    GLuint vertexBuffers[NUM_SPHERE_VERTEX_BUFFERS];
+    std::array<GLuint, NUM_SPHERE_VERTEX_BUFFERS> vertexBuffers{};
     GLuint indexBuffer{ 0 };
 };

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -61,6 +61,7 @@
 #include <celrender/eclipticlinerenderer.h>
 #include <celrender/linerenderer.h>
 #include <celrender/vertexobject.h>
+#include <celutil/arrayvector.h>
 #include <celutil/logger.h>
 #include <celutil/utf8.h>
 #include <celutil/timer.h>
@@ -1837,8 +1838,7 @@ static void renderSphereUnlit(const RenderInfo& ri,
                               const Matrices &m,
                               Renderer *r)
 {
-    Texture* textures[MAX_SPHERE_MESH_TEXTURES];
-    int nTextures = 0;
+    celestia::util::ArrayVector<Texture*, LODSphereMesh::MAX_SPHERE_MESH_TEXTURES> textures;
 
     ShaderProperties shadprop;
 
@@ -1846,17 +1846,17 @@ static void renderSphereUnlit(const RenderInfo& ri,
     if (ri.baseTex != nullptr)
     {
         shadprop.texUsage = ShaderProperties::DiffuseTexture;
-        textures[nTextures++] = ri.baseTex;
+        textures.try_push_back(ri.baseTex);
     }
     if (ri.nightTex != nullptr)
     {
         shadprop.texUsage |= ShaderProperties::NightTexture;
-        textures[nTextures++] = ri.nightTex;
+        textures.try_push_back(ri.nightTex);
     }
     if (ri.overlayTex != nullptr)
     {
         shadprop.texUsage |= ShaderProperties::OverlayTexture;
-        textures[nTextures++] = ri.overlayTex;
+        textures.try_push_back(ri.overlayTex);
     }
 
     // Get a shader for the current rendering configuration
@@ -1875,7 +1875,8 @@ static void renderSphereUnlit(const RenderInfo& ri,
     ps.depthTest = true;
     r->setPipelineState(ps);
 
-    g_lodSphere->render(frustum, ri.pixWidth, textures, nTextures);
+    g_lodSphere->render(frustum, ri.pixWidth,
+                        textures.data(), static_cast<int>(textures.size()));
 }
 
 

--- a/src/celutil/arrayvector.h
+++ b/src/celutil/arrayvector.h
@@ -1,0 +1,209 @@
+// Copyright (C) 2023 The Celestia Development Team
+// Original version by Andrew Tribick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace celestia::util
+{
+
+template<typename T, std::size_t N,
+         std::enable_if_t<std::is_default_constructible_v<T>, int> = 0>
+class ArrayVector
+{
+public:
+    using value_type             = T;
+    using size_type              = std::size_t;
+    using difference_type        = std::ptrdiff_t;
+    using pointer                = T*;
+    using const_pointer          = const T*;
+    using reference              = T&;
+    using const_reference        = const T&;
+    using iterator               = typename std::array<T, N>::iterator;
+    using const_iterator         = typename std::array<T, N>::const_iterator;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    ArrayVector() = default;
+
+    iterator               begin()         noexcept { return m_data.begin(); }
+    const_iterator         begin()   const noexcept { return m_data.begin(); }
+    const_iterator         cbegin()  const noexcept { return m_data.cbegin(); }
+    iterator               end()           noexcept { return m_data.begin() + m_size; }
+    const_iterator         end()     const noexcept { return m_data.begin() + m_size; }
+    const_iterator         cend()    const noexcept { return m_data.cbegin() + m_size; }
+    reverse_iterator       rbegin()        noexcept { return std::reverse_iterator(end()); }
+    const_reverse_iterator rbegin()  const noexcept { return std::reverse_iterator(end()); }
+    const_reverse_iterator crbegin() const noexcept { return std::reverse_iterator(cend()); }
+    reverse_iterator       rend()          noexcept { return std::reverse_iterator(begin()); }
+    const_reverse_iterator rend()    const noexcept { return std::reverse_iterator(begin()); }
+    const_reverse_iterator crend()   const noexcept { return std::reverse_iterator(cbegin()); }
+
+    reference       operator[](size_type idx)       { return m_data[idx]; }
+    const_reference operator[](size_type idx) const { return m_data[idx]; }
+
+    reference       front()       { return m_data[0]; }
+    const_reference front() const { return m_data[0]; }
+    reference       back()        { return m_data[m_size - 1]; }
+    const_reference back()  const { return m_data[m_size - 1]; }
+
+    pointer       data()       noexcept { return m_data.data(); }
+    const_pointer data() const noexcept { return m_data.data(); }
+
+    bool      empty()    const noexcept { return m_size == 0; }
+    size_type size()     const noexcept { return m_size; }
+
+    constexpr size_type max_size() const noexcept { return N; }
+    constexpr size_type capacity() const noexcept { return N; }
+
+    void clear()
+    {
+        std::fill(begin(), end(), T());
+        m_size = 0;
+    }
+
+    bool try_push_back(const T& value)
+    {
+        if (m_size == N)
+            return false;
+
+        m_data[m_size] = value;
+        ++m_size;
+        return true;
+    }
+
+    bool try_push_back(T&& value)
+    {
+        if (m_size == N)
+            return false;
+
+        m_data[m_size] = std::move(value);
+        ++m_size;
+        return true;
+    }
+
+    void pop_back()
+    {
+        --m_size;
+        m_data[m_size] = T();
+    }
+
+    void resize(size_type count)
+    {
+        if (count < m_size)
+            std::fill(begin() + count, end(), T());
+        else if (count > m_size)
+            std::fill(end(), begin() + count, T());
+        m_size = count;
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        auto idx = static_cast<size_type>(pos - cbegin());
+        if (idx == m_size - 1)
+        {
+            pop_back();
+            return end();
+        }
+
+        auto dest = begin() + idx;
+        std::move(begin() + idx + 1, end(), dest);
+        --m_size;
+        return dest;
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        auto firstIdx = static_cast<size_type>(first - cbegin());
+        auto lastIdx = static_cast<size_type>(last - cbegin());
+        if (firstIdx == lastIdx)
+            return begin() + lastIdx;
+
+        if (lastIdx == m_size)
+        {
+            resize(firstIdx);
+            return end();
+        }
+
+        auto dest = begin() + firstIdx;
+        std::move(begin() + lastIdx, end(), begin() + firstIdx);
+        resize(m_size - (last - first));
+        return dest;
+    }
+
+    // insert not implemented so far
+
+    void swap(ArrayVector& other) noexcept
+    {
+        using std::swap;
+        swap(m_size, other.m_size);
+        swap(m_data, other.m_data);
+    }
+
+private:
+    size_type        m_size{ 0 };
+    std::array<T, N> m_data{};
+};
+
+
+template<typename T, std::size_t N1, std::size_t N2>
+inline bool operator==(const ArrayVector<T, N1>& lhs, const ArrayVector<T, N2>& rhs)
+{
+    return lhs.size() == rhs.size() &&
+           std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+
+template<typename T, std::size_t N1, std::size_t N2>
+inline bool operator!=(const ArrayVector<T, N1>& lhs, const ArrayVector<T, N2>& rhs)
+{
+    return !(lhs == rhs);
+}
+
+
+template<typename T, std::size_t N1, std::size_t N2>
+inline bool operator<(const ArrayVector<T, N1>& lhs, const ArrayVector<T, N2>& rhs)
+{
+    return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+
+template<typename T, std::size_t N1, std::size_t N2>
+inline bool operator>(const ArrayVector<T, N1>& lhs, const ArrayVector<T, N2>& rhs)
+{
+    return rhs < lhs;
+}
+
+
+template<typename T, std::size_t N1, std::size_t N2>
+inline bool operator<=(const ArrayVector<T, N1>& lhs, const ArrayVector<T, N2>& rhs)
+{
+    return !(rhs < lhs);
+}
+
+
+template<typename T, std::size_t N1, std::size_t N2>
+inline bool operator>=(const ArrayVector<T, N1>& lhs, const ArrayVector<T, N2>& rhs)
+{
+    return !(lhs < rhs);
+}
+
+
+template<typename T, std::size_t N>
+inline void swap(ArrayVector<T, N>& lhs, ArrayVector<T, N>& rhs) noexcept
+{
+    lhs.swap(rhs);
+}
+
+} // end namespace celestia::util

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,3 +1,4 @@
+test_case(arrayvector)
 if(NOT HAVE_FLOAT_CHARCONV)
   test_case(charconv_compat)
 endif()

--- a/test/unit/arrayvector_test.cpp
+++ b/test/unit/arrayvector_test.cpp
@@ -1,0 +1,362 @@
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+#include <celutil/arrayvector.h>
+
+#include <catch.hpp>
+
+namespace celutil = celestia::util;
+
+namespace
+{
+class InstanceTracker
+{
+public:
+    thread_local static int counter;
+    InstanceTracker() = default;
+    explicit InstanceTracker(int value);
+    ~InstanceTracker();
+
+    InstanceTracker(const InstanceTracker&);
+    InstanceTracker& operator=(const InstanceTracker&);
+    InstanceTracker(InstanceTracker&&) noexcept;
+    InstanceTracker& operator=(InstanceTracker&&) noexcept;
+
+    int value() const { return m_value; }
+
+private:
+    int m_value{ 0 };
+};
+
+thread_local int InstanceTracker::counter = 0;
+
+InstanceTracker::InstanceTracker(int value) : m_value(value)
+{
+    if (m_value != 0)
+        ++counter;
+}
+
+InstanceTracker::~InstanceTracker()
+{
+    if (m_value != 0)
+        --counter;
+}
+
+InstanceTracker::InstanceTracker(const InstanceTracker& other)
+    : m_value(other.m_value)
+{
+    if (m_value != 0)
+        ++counter;
+}
+
+InstanceTracker& InstanceTracker::operator=(const InstanceTracker& other)
+{
+    if (m_value != 0)
+        --counter;
+    m_value = other.m_value;
+    if (m_value != 0)
+        ++counter;
+    return *this;
+}
+
+InstanceTracker::InstanceTracker(InstanceTracker&& other) noexcept
+    : m_value(other.m_value)
+{
+    other.m_value = 0;
+}
+
+InstanceTracker& InstanceTracker::operator=(InstanceTracker&& other) noexcept
+{
+    if (m_value != 0)
+        --counter;
+    m_value = other.m_value;
+    other.m_value = 0;
+    return *this;
+}
+
+} // end unnamed namespace
+
+TEST_CASE("ArrayVector constructor", "[ArrayVector]")
+{
+    celutil::ArrayVector<int, 3> vec;
+    REQUIRE(vec.max_size() == 3);
+    REQUIRE(vec.capacity() == 3);
+    REQUIRE(vec.size() == 0);
+    REQUIRE(vec.empty());
+    REQUIRE(vec.begin() == vec.end());
+    REQUIRE(vec.cbegin() == vec.cend());
+    REQUIRE(vec.rbegin() == vec.rend());
+    REQUIRE(vec.crbegin() == vec.crend());
+}
+
+TEST_CASE("ArrayVector try_push_back", "[ArrayVector]")
+{
+    celutil::ArrayVector<int, 3> vec;
+    REQUIRE(vec.try_push_back(2));
+    REQUIRE(vec.size() == 1);
+    REQUIRE(!vec.empty());
+    REQUIRE(vec.front() == 2);
+    REQUIRE(vec.back() == 2);
+    REQUIRE(vec[0] == 2);
+    REQUIRE(*vec.data() == 2);
+
+    REQUIRE(vec.try_push_back(3));
+    REQUIRE(vec.try_push_back(5));
+    REQUIRE(!vec.try_push_back(7));
+
+    REQUIRE(vec.size() == 3);
+    REQUIRE(!vec.empty());
+    REQUIRE(vec.front() == 2);
+    REQUIRE(vec.back() == 5);
+    REQUIRE(vec[0] == 2);
+    REQUIRE(vec[1] == 3);
+    REQUIRE(vec[2] == 5);
+    REQUIRE(*vec.data() == 2);
+    REQUIRE(*(vec.data() + 1) == 3);
+    REQUIRE(*(vec.data() + 2) == 5);
+}
+
+TEST_CASE("ArrayVector modify value", "[ArrayVector]")
+{
+    celutil::ArrayVector<int, 3> vec;
+    vec.try_push_back(2);
+    vec.try_push_back(3);
+
+    vec[0] = 1;
+    REQUIRE(vec[0] == 1);
+    REQUIRE(vec.front() == 1);
+    REQUIRE(vec.size() == 2);
+}
+
+TEST_CASE("ArrayVector forward iterators", "[ArrayVector]")
+{
+    celutil::ArrayVector<int, 3> vec;
+    vec.try_push_back(2);
+    vec.try_push_back(3);
+
+    std::vector<int> result;
+    std::copy(vec.begin(), vec.end(), std::back_inserter(result));
+
+    REQUIRE(result.size() == vec.size());
+    REQUIRE(std::equal(vec.cbegin(), vec.cend(), result.cbegin(), result.cend()));
+}
+
+TEST_CASE("ArrayVector reverse iterators", "[ArrayVector]")
+{
+    celutil::ArrayVector<int, 3> vec;
+    vec.try_push_back(2);
+    vec.try_push_back(3);
+
+    std::vector<int> result;
+    std::copy(vec.rbegin(), vec.rend(), std::back_inserter(result));
+
+    REQUIRE(result.size() == vec.size());
+    REQUIRE(std::equal(vec.crbegin(), vec.crend(), result.cbegin(), result.cend()));
+}
+
+TEST_CASE("ArrayVector clear", "[ArrayVector]")
+{
+    celutil::ArrayVector<InstanceTracker, 5> vec;
+    REQUIRE(InstanceTracker::counter == 0);
+    vec.try_push_back(InstanceTracker(1));
+    vec.try_push_back(InstanceTracker(1));
+    REQUIRE(vec.size() == 2);
+    REQUIRE(InstanceTracker::counter == 2);
+
+    vec.clear();
+
+    REQUIRE(vec.empty());
+    REQUIRE(InstanceTracker::counter == 0);
+}
+
+TEST_CASE("ArrayVector pop_back", "[ArrayVector]")
+{
+    celutil::ArrayVector<InstanceTracker, 3> vec;
+    REQUIRE(InstanceTracker::counter == 0);
+    vec.try_push_back(InstanceTracker(1));
+    vec.try_push_back(InstanceTracker(1));
+    REQUIRE(vec.size() == 2);
+    REQUIRE(InstanceTracker::counter == 2);
+
+    vec.pop_back();
+    REQUIRE(vec.size() == 1);
+    REQUIRE(InstanceTracker::counter == 1);
+}
+
+TEST_CASE("ArrayVector resize", "[ArrayVector]")
+{
+    celutil::ArrayVector<InstanceTracker, 3> vec;
+    REQUIRE(InstanceTracker::counter == 0);
+    vec.try_push_back(InstanceTracker(1));
+    vec.try_push_back(InstanceTracker(1));
+    vec.try_push_back(InstanceTracker(1));
+    REQUIRE(vec.size() == 3);
+
+    vec.resize(1);
+    REQUIRE(vec.size() == 1);
+    REQUIRE(InstanceTracker::counter == 1);
+}
+
+TEST_CASE("ArrayVector erase", "[ArrayVector]")
+{
+    celutil::ArrayVector<InstanceTracker, 5> vec;
+    REQUIRE(InstanceTracker::counter == 0);
+    vec.try_push_back(InstanceTracker{ 2 });
+    vec.try_push_back(InstanceTracker{ 3 });
+    vec.try_push_back(InstanceTracker{ 5 });
+    vec.try_push_back(InstanceTracker{ 7 });
+    REQUIRE(vec.size() == 4);
+    REQUIRE(InstanceTracker::counter == 4);
+
+    SECTION("Single element erase at beginning")
+    {
+        auto it = vec.erase(vec.cbegin());
+        REQUIRE(it == vec.begin());
+        REQUIRE(vec.size() == 3);
+        REQUIRE(InstanceTracker::counter == 3);
+        REQUIRE(vec[0].value() == 3);
+        REQUIRE(vec[1].value() == 5);
+        REQUIRE(vec[2].value() == 7);
+    }
+
+    SECTION("Single element erase in middle")
+    {
+        auto it = vec.erase(vec.cbegin() + 2);
+        REQUIRE(it == vec.begin() + 2);
+        REQUIRE(vec.size() == 3);
+        REQUIRE(InstanceTracker::counter == 3);
+        REQUIRE(vec[0].value() == 2);
+        REQUIRE(vec[1].value() == 3);
+        REQUIRE(vec[2].value() == 7);
+    }
+
+    SECTION("Single element erase at end")
+    {
+        auto it = vec.erase(vec.cend() - 1);
+        REQUIRE(it == vec.end());
+        REQUIRE(vec.size() == 3);
+        REQUIRE(InstanceTracker::counter == 3);
+        REQUIRE(vec[0].value() == 2);
+        REQUIRE(vec[1].value() == 3);
+        REQUIRE(vec[2].value() == 5);
+    }
+
+    SECTION("Multiple element erase at beginning")
+    {
+         auto it = vec.erase(vec.cbegin(), vec.cbegin() + 2);
+         REQUIRE(it == vec.begin());
+         REQUIRE(vec.size() == 2);
+         REQUIRE(InstanceTracker::counter == 2);
+         REQUIRE(vec[0].value() == 5);
+         REQUIRE(vec[1].value() == 7);
+    }
+
+    SECTION("Multiple element erase in middle")
+    {
+        auto it = vec.erase(vec.cbegin() + 1, vec.cbegin() + 3);
+        REQUIRE(it == vec.begin() + 1);
+        REQUIRE(vec.size() == 2);
+        REQUIRE(InstanceTracker::counter == 2);
+        REQUIRE(vec[0].value() == 2);
+        REQUIRE(vec[1].value() == 7);
+    }
+
+    SECTION("Multiple element erase at end")
+    {
+        auto it = vec.erase(vec.cbegin() + 2, vec.cend());
+        REQUIRE(it == vec.begin() + 2);
+        REQUIRE(vec.size() == 2);
+        REQUIRE(InstanceTracker::counter == 2);
+        REQUIRE(vec[0].value() == 2);
+        REQUIRE(vec[1].value() == 3);
+    }
+
+    SECTION("Whole vector erase")
+    {
+        auto it = vec.erase(vec.cbegin(), vec.cend());
+        REQUIRE(it == vec.begin());
+        REQUIRE(it == vec.end());
+        REQUIRE(vec.size() == 0);
+        REQUIRE(vec.empty());
+        REQUIRE(InstanceTracker::counter == 0);
+    }
+
+    SECTION("Erase-remove idiom")
+    {
+        auto it = std::remove_if(vec.begin(), vec.end(),
+                                 [](const InstanceTracker& n) { return n.value() % 3 == 2; });
+        vec.erase(it, vec.end());
+        REQUIRE(vec.size() == 2);
+        REQUIRE(InstanceTracker::counter == 2);
+        REQUIRE(vec[0].value() == 3);
+        REQUIRE(vec[1].value() == 7);
+    }
+}
+
+TEST_CASE("ArrayVector member swap", "[ArrayVector]")
+{
+    celutil::ArrayVector<int, 3> a;
+    a.try_push_back(2);
+    a.try_push_back(3);
+    celutil::ArrayVector<int, 3> b;
+    b.try_push_back(1);
+    b.try_push_back(4);
+    b.try_push_back(9);
+
+    a.swap(b);
+
+    REQUIRE(a.size() == 3);
+    REQUIRE(a[0] == 1);
+    REQUIRE(a[1] == 4);
+    REQUIRE(a[2] == 9);
+
+    REQUIRE(b.size() == 2);
+    REQUIRE(b[0] == 2);
+    REQUIRE(b[1] == 3);
+}
+
+TEST_CASE("ArrayVector free function swap", "[ArrayVector]")
+{
+    celutil::ArrayVector<int, 3> a;
+    a.try_push_back(2);
+    a.try_push_back(3);
+    celutil::ArrayVector<int, 3> b;
+    b.try_push_back(1);
+    b.try_push_back(4);
+    b.try_push_back(9);
+
+    swap(a, b);
+
+    REQUIRE(a.size() == 3);
+    REQUIRE(a[0] == 1);
+    REQUIRE(a[1] == 4);
+    REQUIRE(a[2] == 9);
+
+    REQUIRE(b.size() == 2);
+    REQUIRE(b[0] == 2);
+    REQUIRE(b[1] == 3);
+}
+
+TEST_CASE("ArrayVector operators", "[ArrayVector]")
+{
+    celutil::ArrayVector<int, 3> a1;
+    a1.try_push_back(2);
+    a1.try_push_back(3);
+
+    celutil::ArrayVector<int, 5> a2;
+    a2.try_push_back(2);
+    a2.try_push_back(3);
+
+    celutil::ArrayVector<int, 3> b;
+    b.try_push_back(5);
+
+    REQUIRE(a1 == a2);
+    REQUIRE(a1 != b);
+    REQUIRE(a1 < b);
+    REQUIRE(b > a1);
+    REQUIRE(a1 <= b);
+    REQUIRE(a1 <= a2);
+    REQUIRE(b >= a1);
+    REQUIRE(a1 >= a2);
+}


### PR DESCRIPTION
- Add an ArrayVector class
- Ensure trigonometry arrays have exact values at multiples of 90°
- Use symmetry of sin/cos functions when populating trig arrays
- Use `glBufferSubData` to transfer index data
- Clean up buffers in LODSphereMesh destructor
- Reduce MaxVertexSize since normals just re-use the position data
