### PR TITLE
Remove trailing \0

### DIFF
--- a/src/celutil/unicode.cpp
+++ b/src/celutil/unicode.cpp
@@ -38,6 +38,9 @@ bool UnicodeStringToWString(const icu::UnicodeString &input, std::wstring &outpu
 
     // Get the actual data
     u_strToWCS(output.data(), static_cast<int32_t>(output.size()), nullptr, input.getBuffer(), input.length(), &error);
+
+    // Removing the redundant \0 at the end
+    output.resize(requiredSize);
     return error == U_ZERO_ERROR;
 }
 


### PR DESCRIPTION
we reserved an element for \0 to avoid error U_STRING_NOT_TERMINATED_WARNING, remove that redundant \0 in wstring.