### PR TITLE
Fix a couple of warnings in the tokenizer tests

### DIFF
--- a/test/unit/tokenizer_test.cpp
+++ b/test/unit/tokenizer_test.cpp
@@ -324,14 +324,14 @@ TEST_CASE("Tokenizer parses numbers", "[Tokenizer]")
         std::optional<double> numberValue = tok.getNumberValue();
         REQUIRE(numberValue.has_value());
         REQUIRE(numberValue.value() == -0.0);
-        REQUIRE(std::signbit(numberValue.value()) == 1);
+        REQUIRE(std::signbit(numberValue.value()));
         REQUIRE(!tok.getIntegerValue().has_value());
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenNumber);
         numberValue = tok.getNumberValue();
         REQUIRE(numberValue.has_value());
         REQUIRE(numberValue.value() == -0.0);
-        REQUIRE(std::signbit(numberValue.value()) == 1);
+        REQUIRE(std::signbit(numberValue.value()));
         REQUIRE(!tok.getIntegerValue().has_value());
 
         REQUIRE(tok.nextToken() == Tokenizer::TokenNumber);


### PR DESCRIPTION
Fixes some warnings with MSVC. `std::signbit` returns `bool` not `int`.