### PR TITLE
Remove the load fragment script commands

### DIFF
--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -980,24 +980,6 @@ ParseResult parseSetRingsTextureCommand(const Hash& paramList, const ScriptMaps&
 }
 
 
-ParseResult parseLoadFragmentCommand(const Hash& paramList, const ScriptMaps&)
-{
-    const std::string* type = paramList.getString("type");
-    if (type == nullptr)
-        return makeError("Missing type parameter to loadfragment");
-
-    const std::string* fragment = paramList.getString("fragment");
-    if (fragment == nullptr)
-        return makeError("Missing fragment parameter to loadfragment");
-
-    std::string dir;
-    if (const std::string* dirName = paramList.getString("dir"); dirName != nullptr)
-        dir = *dirName;
-
-    return std::make_unique<CommandLoadFragment>(*type, *fragment, dir);
-}
-
-
 using ParseCommandPtr = ParseResult (*)(const Hash&, const ScriptMaps&);
 using ParseCommandMap = std::map<std::string_view, ParseCommandPtr>;
 
@@ -1063,7 +1045,6 @@ std::unique_ptr<ParseCommandMap> createParseCommandMap()
             { "verbosity"sv,               &parseVerbosityCommand                         },
             { "setwindowbordersvisible"sv, &parseSetWindowBordersVisibleCommand           },
             { "setringstexture"sv,         &parseSetRingsTextureCommand                   },
-            { "loadfragment"sv,            &parseLoadFragmentCommand                      },
         });
 }
 

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -1106,35 +1106,4 @@ void CommandSetRingsTexture::processInstantaneous(ExecutionEnvironment& env)
     }
 }
 
-
-///////////////
-// LoadFragment command
-CommandLoadFragment::CommandLoadFragment(std::string _type, std::string _fragment, std::string _dir) :
-    type(std::move(_type)),
-    fragment(std::move(_fragment)),
-    dir(std::move(_dir))
-{
-}
-
-void CommandLoadFragment::processInstantaneous(ExecutionEnvironment& env)
-{
-    Universe* u = env.getSimulation()->getUniverse();
-    if (u == nullptr)
-        return;
-
-    std::istringstream in(fragment);
-    if (compareIgnoringCase(type, "ssc") == 0)
-    {
-        LoadSolarSystemObjects(in, *u, dir);
-    }
-    else if (compareIgnoringCase(type, "stc") == 0)
-    {
-        u->getStarCatalog()->load(in, dir);
-    }
-    else if (compareIgnoringCase(type, "dsc") == 0)
-    {
-        u->getDSOCatalog()->load(in, dir);
-    }
-}
-
 } // end namespace celestia::scripts

--- a/src/celscript/legacy/command.h
+++ b/src/celscript/legacy/command.h
@@ -803,17 +803,4 @@ class CommandSetRingsTexture : public InstantaneousCommand
     std::string object, textureName, path;
 };
 
-
-class CommandLoadFragment : public InstantaneousCommand
-{
- public:
-    CommandLoadFragment(std::string, std::string, std::string);
-
- protected:
-    void processInstantaneous(ExecutionEnvironment&) override;
-
- private:
-    std::string type, fragment, dir;
-};
-
 } // end namespace celestia::scripts

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -2533,41 +2533,6 @@ static int celestia_setaudionopause(lua_State* l)
     return 0;
 }
 
-static int celestia_loadfragment(lua_State* l)
-{
-    Celx_CheckArgs(l, 3, 4, "Function celestia:from_ssc requires two or three arguments");
-    CelestiaCore* appCore = this_celestia(l);
-    const char* type = Celx_SafeGetString(l, 2, AllErrors, "First argument to celestia:loadfragment must be a string");
-    const char* frag = Celx_SafeGetString(l, 3, AllErrors, "Second argument to celestia:loadfragment must be a string");
-    if (type == nullptr || frag == nullptr)
-    {
-        lua_pushboolean(l, false);
-        return 1;
-    }
-    const char* dir = Celx_SafeGetString(l, 3, WrongType, "Third argument to celestia:loadfragment must be a string");
-    if (dir == nullptr)
-        dir = "";
-
-    bool ret = false;
-    Universe *u = appCore->getSimulation()->getUniverse();
-    istringstream in(frag);
-    if (compareIgnoringCase(type, "ssc") == 0)
-    {
-        ret = LoadSolarSystemObjects(in, *u, dir);
-    }
-    else if (compareIgnoringCase(type, "stc") == 0)
-    {
-        ret = u->getStarCatalog()->load(in, dir);
-    }
-    else if (compareIgnoringCase(type, "dsc") == 0)
-    {
-        ret = u->getDSOCatalog()->load(in, dir);
-    }
-
-    lua_pushboolean(l, ret);
-    return 1;
-}
-
 static int celestia_version(lua_State* l)
 {
     lua_pushstring(l, VERSION);
@@ -2698,8 +2663,6 @@ void CreateCelestiaMetaTable(lua_State* l)
     Celx_RegisterMethod(l, "setaudiopan", celestia_setaudiopan);
     Celx_RegisterMethod(l, "setaudioloop", celestia_setaudioloop);
     Celx_RegisterMethod(l, "setaudionopause", celestia_setaudionopause);
-
-    Celx_RegisterMethod(l, "loadfragment", celestia_loadfragment);
 
     Celx_RegisterMethod(l, "version", celestia_version);
 


### PR DESCRIPTION
This does not play nicely with areas of the codebase that assume object pointers remain stable after the load phase is complete, e.g. the category system.

For now I think it's best to remove this functionality (which does not exist yet in any final release). It might make sense to re-add this if we allow script hooks to run during loading, if we want to support updating the databases after loading this will likely need more re-engineering.