### PR TITLE
Prevent categories being scrambled by octree build process

### DIFF
--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -30,6 +30,7 @@
 
 
 class StarNameDatabase;
+class UserCategory;
 
 
 constexpr inline unsigned int MAX_STAR_NAMES = 10;
@@ -127,7 +128,7 @@ inline bool operator<(const StarDatabase::CrossIndexEntry& lhs, const StarDataba
 class StarDatabaseBuilder
 {
  public:
-    StarDatabaseBuilder();
+    StarDatabaseBuilder() = default;
     ~StarDatabaseBuilder() = default;
 
     StarDatabaseBuilder(const StarDatabaseBuilder&) = delete;
@@ -146,6 +147,12 @@ class StarDatabaseBuilder
     struct CustomStarDetails;
 
  private:
+    struct BarycenterUsage
+    {
+        AstroCatalog::IndexNumber catNo;
+        AstroCatalog::IndexNumber barycenterCatNo;
+    };
+
     bool createStar(Star* star,
                     DataDisposition disposition,
                     AstroCatalog::IndexNumber catalogNumber,
@@ -170,25 +177,27 @@ class StarDatabaseBuilder
                     StarDetails* details,
                     const CustomStarDetails& customDetails,
                     std::optional<Eigen::Vector3f>& barycenterPosition);
+    void loadCategories(AstroCatalog::IndexNumber catalogNumber,
+                        const Hash *starData,
+                        DataDisposition disposition,
+                        const std::string &domain);
+    void addCategory(AstroCatalog::IndexNumber catalogNumber,
+                     const std::string& name,
+                     const std::string& domain);
 
     void buildOctree();
     void buildIndexes();
     Star* findWhileLoading(AstroCatalog::IndexNumber catalogNumber) const;
 
-    std::unique_ptr<StarDatabase> starDB;
+    std::unique_ptr<StarDatabase> starDB{ std::make_unique<StarDatabase>() };
 
     AstroCatalog::IndexNumber nextAutoCatalogNumber{ 0xfffffffe };
 
-    BlockArray<Star> unsortedStars;
+    BlockArray<Star> unsortedStars{ };
     // List of stars loaded from binary file, sorted by catalog number
     std::vector<Star*> binFileCatalogNumberIndex{ nullptr };
     // Catalog number -> star mapping for stars loaded from stc files
-    std::map<AstroCatalog::IndexNumber, Star*> stcFileCatalogNumberIndex;
-
-    struct BarycenterUsage
-    {
-        AstroCatalog::IndexNumber catNo;
-        AstroCatalog::IndexNumber barycenterCatNo;
-    };
-    std::vector<BarycenterUsage> barycenters;
+    std::map<AstroCatalog::IndexNumber, Star*> stcFileCatalogNumberIndex{};
+    std::vector<BarycenterUsage> barycenters{};
+    std::multimap<AstroCatalog::IndexNumber, UserCategory*> categories{};
 };

--- a/src/celengine/starname.cpp
+++ b/src/celengine/starname.cpp
@@ -288,10 +288,11 @@ StarNameDatabase::findWithComponentSuffix(std::string_view name, bool i18n) cons
     return AstroCatalog::InvalidIndex;
 }
 
-StarNameDatabase*
+
+std::unique_ptr<StarNameDatabase>
 StarNameDatabase::readNames(std::istream& in)
 {
-    StarNameDatabase* db = new StarNameDatabase();
+    auto db = std::make_unique<StarNameDatabase>();
     bool failed = false;
     std::string s;
 
@@ -337,12 +338,7 @@ StarNameDatabase::readNames(std::istream& in)
     }
 
     if (failed)
-    {
-        delete db;
         return nullptr;
-    }
-    else
-    {
-        return db;
-    }
+
+    return db;
 }

--- a/src/celengine/starname.h
+++ b/src/celengine/starname.h
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <memory>
 #include <string_view>
 
 #include <celengine/name.h>
@@ -26,7 +27,7 @@ class StarNameDatabase: public NameDatabase
 
     std::uint32_t findCatalogNumberByName(std::string_view, bool i18n) const;
 
-    static StarNameDatabase* readNames(std::istream&);
+    static std::unique_ptr<StarNameDatabase> readNames(std::istream&);
 
  private:
     std::uint32_t findFlamsteedOrVariable(std::string_view, std::string_view, bool) const;

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -11,6 +11,7 @@
 // of the License, or (at your option) any later version.
 
 #include <cassert>
+#include <utility>
 
 #include <celcompat/numbers.h>
 #include <celmath/mathlib.h>
@@ -57,12 +58,12 @@ Universe::~Universe()
 
 StarDatabase* Universe::getStarCatalog() const
 {
-    return starCatalog;
+    return starCatalog.get();
 }
 
-void Universe::setStarCatalog(StarDatabase* catalog)
+void Universe::setStarCatalog(std::unique_ptr<StarDatabase>&& catalog)
 {
-    starCatalog = catalog;
+    starCatalog = std::move(catalog);
 }
 
 

--- a/src/celengine/universe.h
+++ b/src/celengine/universe.h
@@ -11,10 +11,10 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
-
 
 #include <celengine/univcoord.h>
 #include <celengine/stardb.h>
@@ -36,7 +36,7 @@ class Universe
     ~Universe();
 
     StarDatabase* getStarCatalog() const;
-    void setStarCatalog(StarDatabase*);
+    void setStarCatalog(std::unique_ptr<StarDatabase>&&);
 
     SolarSystemCatalog* getSolarSystemCatalog() const;
     void setSolarSystemCatalog(SolarSystemCatalog*);
@@ -125,7 +125,7 @@ class Universe
                                 float tolerance = 0.0f);
 
  private:
-    StarDatabase* starCatalog{nullptr};
+    std::unique_ptr<StarDatabase> starCatalog{nullptr};
     DSODatabase* dsoCatalog{nullptr};
     SolarSystemCatalog* solarSystemCatalog{nullptr};
     AsterismList* asterisms{nullptr};

--- a/src/celestia/qt/qtcelestialbrowser.cpp
+++ b/src/celestia/qt/qtcelestialbrowser.cpp
@@ -193,7 +193,7 @@ QVariant StarTableModel::data(const QModelIndex& index, int role) const
         case NameColumn:
             {
                 auto hipCatNo = star->getIndex();
-                auto hdCatNo  = universe->getStarCatalog()->crossIndex(StarDatabase::HenryDraper, hipCatNo);
+                auto hdCatNo  = universe->getStarCatalog()->crossIndex(StarCatalog::HenryDraper, hipCatNo);
                 if (hdCatNo != AstroCatalog::InvalidIndex)
                     return QString("HD %1").arg(hdCatNo);
                 else

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -940,17 +940,17 @@ static int object_catalognumber(lua_State* l)
     // The argument is a string indicating the catalog.
     bool validCatalog = false;
     bool useHIPPARCOS = false;
-    StarDatabase::Catalog catalog = StarDatabase::HenryDraper;
+    StarCatalog catalog = StarCatalog::HenryDraper;
     if (catalogName != nullptr)
     {
         if (compareIgnoringCase(catalogName, "HD") == 0)
         {
-            catalog = StarDatabase::HenryDraper;
+            catalog = StarCatalog::HenryDraper;
             validCatalog = true;
         }
         else if (compareIgnoringCase(catalogName, "SAO") == 0)
         {
-            catalog = StarDatabase::SAO;
+            catalog = StarCatalog::SAO;
             validCatalog = true;
         }
         else if (compareIgnoringCase(catalogName, "HIP") == 0)


### PR DESCRIPTION
Applying a category to a star from an stc file results in nonsense when the category is queried for objects, this is because the category system assumes pointer stability but the octree process moves the stars around. The fix is to defer applying categories until after the octree is built.

Also I split out the star database loader functions into their own class to avoid re-organizing the database after the load phase.

Note this is not an issue for DSOs since the octree stores pointers rather than the objects themselves.