### PR TITLE
Fix a couple of runtime errors

### DIFF
--- a/src/celengine/lodspheremesh.cpp
+++ b/src/celengine/lodspheremesh.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <cmath>
 #include <limits>
 
@@ -22,6 +23,8 @@
 #include <celmath/mathlib.h>
 #include <celutil/arrayvector.h>
 #include <celutil/array_view.h>
+
+#define PTR(p) (reinterpret_cast<const void*>(static_cast<std::uintptr_t>(p)))
 
 namespace
 {
@@ -630,30 +633,29 @@ LODSphereMesh::renderSection(int phi0, int theta0, int extent,
 {
     auto stride = static_cast<GLsizei>(vertexSize * sizeof(float));
     int texCoordOffset = ((ri.attributes & Tangents) != 0) ? 6 : 3;
-    float* vertexBase = nullptr;
 
     glVertexAttribPointer(CelestiaGLProgram::VertexCoordAttributeIndex,
                           3, GL_FLOAT, GL_FALSE,
-                          stride, vertexBase);
+                          stride, PTR(0));
     if ((ri.attributes & Normals) != 0)
     {
         glVertexAttribPointer(CelestiaGLProgram::NormalAttributeIndex,
                               3, GL_FLOAT, GL_FALSE,
-                              stride, vertexBase);
+                              stride, PTR(0));
     }
 
     for (int tc = 0; tc < nTexturesUsed; tc++)
     {
         glVertexAttribPointer(CelestiaGLProgram::TextureCoord0AttributeIndex + tc,
                               2, GL_FLOAT, GL_FALSE,
-                              stride, vertexBase + (tc * 2) + texCoordOffset);
+                              stride, PTR(((tc * 2) + texCoordOffset) * sizeof(float)));
     }
 
     if ((ri.attributes & Tangents) != 0)
     {
         glVertexAttribPointer(CelestiaGLProgram::TangentAttributeIndex,
                               3, GL_FLOAT, GL_FALSE,
-                              stride, vertexBase + 3); // 3 == tangentOffset
+                              stride, PTR(3 * sizeof(float))); // 3 == tangentOffset
     }
 
     // assert(ri.step >= minStep);

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4206,8 +4206,8 @@ Renderer::renderAnnotationLabel(const Annotation &a,
     glVertexAttrib(CelestiaGLProgram::ColorAttributeIndex, a.color);
 
     Matrix4f mv = celmath::translate(*m.modelview,
-                                     (int)a.position.x() + hOffset + PixelOffset,
-                                     (int)a.position.y() + vOffset + PixelOffset,
+                                     std::trunc(a.position.x()) + hOffset + PixelOffset,
+                                     std::trunc(a.position.y()) + vOffset + PixelOffset,
                                      depth);
 
     layout.begin(*m.projection, mv);


### PR DESCRIPTION
A couple of runtime UB errors reported while running debug build:

- render.cpp: large annotation positions overflow int
- lodspheremesh.cpp: pointer arithmetic on null pointer