### PR TITLE
Rename Nil SelectionType to None

### DIFF
--- a/src/celengine/selection.h
+++ b/src/celengine/selection.h
@@ -22,7 +22,7 @@ class DeepSkyObject;
 
 enum class SelectionType
 {
-    Nil,
+    None,
     Star,
     Body,
     DeepSky,
@@ -45,7 +45,7 @@ class Selection
     Selection(Selection&&) noexcept = default;
     Selection& operator=(Selection&&) noexcept = default;
 
-    bool empty() const { return type == SelectionType::Nil; }
+    bool empty() const { return type == SelectionType::None; }
     double radius() const;
     UniversalCoord getPosition(double t) const;
     Eigen::Vector3d getVelocity(double t) const;
@@ -77,10 +77,10 @@ class Selection
     SelectionType getType() const { return type; }
 
  private:
-    SelectionType type { SelectionType::Nil };
+    SelectionType type { SelectionType::None };
     void* obj { nullptr };
 
-    void checkNull() { if (obj == nullptr) type = SelectionType::Nil; }
+    void checkNull() { if (obj == nullptr) type = SelectionType::None; }
 
     friend bool operator==(const Selection& s0, const Selection& s1);
     friend bool operator!=(const Selection& s0, const Selection& s1);

--- a/src/celscript/lua/celx_frame.cpp
+++ b/src/celscript/lua/celx_frame.cpp
@@ -152,7 +152,7 @@ static int frame_getrefobject(lua_State* l)
     celx.checkArgs(1, 1, "No arguments expected for frame:getrefobject()");
 
     ObserverFrame* frame = this_frame(l);
-    if (frame->getRefObject().getType() == SelectionType::Nil)
+    if (frame->getRefObject().getType() == SelectionType::None)
     {
         celx.push(CelxValue());
     }
@@ -171,7 +171,7 @@ static int frame_gettargetobject(lua_State* l)
     celx.checkArgs(1, 1, "No arguments expected for frame:gettarget()");
 
     ObserverFrame* frame = this_frame(l);
-    if (frame->getTargetObject().getType() == SelectionType::Nil)
+    if (frame->getTargetObject().getType() == SelectionType::None)
     {
         lua_pushnil(l);
     }

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -500,7 +500,7 @@ static int object_type(lua_State* l)
     case SelectionType::Location:
         tname = "location";
         break;
-    case SelectionType::Nil:
+    case SelectionType::None:
         tname = "null";
         break;
     default:


### PR DESCRIPTION
`Nil` is used in Objective-C and it throws `error: expected identifier` when included in an Objective-C++ source file.