### PR TITLE
Replace DeepSkyObject::getObjTypeName with getObjType returning an enum

### DIFF
--- a/src/celengine/deepskyobj.h
+++ b/src/celengine/deepskyobj.h
@@ -31,6 +31,14 @@ class Galaxy;
 class Globular;
 class OpenCluster;
 
+enum class DeepSkyObjectType
+{
+    Galaxy,
+    Globular,
+    Nebula,
+    OpenCluster,
+};
+
 class DeepSkyObject
 {
 public:
@@ -72,8 +80,7 @@ public:
     bool isClickable() const { return clickable; }
     void setClickable(bool _clickable) { clickable = _clickable; }
 
-
-    virtual const char* getObjTypeName() const = 0;
+    virtual DeepSkyObjectType getObjType() const = 0;
 
     virtual bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
                       double& distanceToPicker,

--- a/src/celengine/dsorenderer.cpp
+++ b/src/celengine/dsorenderer.cpp
@@ -28,33 +28,6 @@ constexpr double enhance = 4.0;
 constexpr double pc10 = 32.6167; // 10 parsecs
 constexpr float CubeCornerToCenterDistance = 1.7320508075688772f;
 
-enum class DeepSkyObjectType
-{
-    Unknown,
-    Galaxy,
-    Globular,
-    Nebula,
-    OpenCluster
-};
-
-DeepSkyObjectType
-GetDSOType(const DeepSkyObject* dso)
-{
-    if (!strcmp(dso->getObjTypeName(), "galaxy"))
-        return DeepSkyObjectType::Galaxy;
-
-    if (!strcmp(dso->getObjTypeName(), "globular"))
-        return DeepSkyObjectType::Globular;
-
-    if (!strcmp(dso->getObjTypeName(), "nebula"))
-        return DeepSkyObjectType::Nebula;
-
-    if (!strcmp(dso->getObjTypeName(), "opencluster"))
-        return DeepSkyObjectType::OpenCluster;
-
-    return DeepSkyObjectType::Unknown;
-}
-
 float
 brightness(float avgAbsMag, float absMag, float appMag, float brightnessCorr, float faintestMag)
 {
@@ -126,7 +99,7 @@ void DSORenderer::process(DeepSkyObject* const &dso,
         }
 
         float b = 2.3f * (faintestMag - 4.75f) / renderer->getFaintestAM45deg(); // brightnesCorr
-        switch (GetDSOType(dso))
+        switch (dso->getObjType())
         {
         case DeepSkyObjectType::Galaxy:
             // -19.04f == average over 10937 galaxies in galaxies.dsc.

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -94,9 +94,9 @@ std::string Galaxy::getDescription() const
     return fmt::sprintf(_("Galaxy (Hubble type: %s)"), getType());
 }
 
-const char* Galaxy::getObjTypeName() const
+DeepSkyObjectType Galaxy::getObjType() const
 {
-    return "galaxy";
+    return DeepSkyObjectType::Galaxy;
 }
 
 int Galaxy::getFormId() const

--- a/src/celengine/galaxy.h
+++ b/src/celengine/galaxy.h
@@ -70,7 +70,7 @@ public:
     std::uint64_t getRenderMask() const override;
     unsigned int getLabelMask() const override;
 
-    const char* getObjTypeName() const override;
+    DeepSkyObjectType getObjType() const override;
 
     int getFormId() const;
 

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -67,9 +67,9 @@ std::string Globular::getDescription() const
    return fmt::sprintf(_("Globular (core radius: %4.2f', King concentration: %4.2f)"), r_c, c);
 }
 
-const char* Globular::getObjTypeName() const
+DeepSkyObjectType Globular::getObjType() const
 {
-    return "globular";
+    return DeepSkyObjectType::Globular;
 }
 
 bool Globular::pick(const Eigen::ParametrizedLine<double, 3>& ray,

--- a/src/celengine/globular.h
+++ b/src/celengine/globular.h
@@ -56,7 +56,7 @@ public:
 
     std::uint64_t getRenderMask() const override;
     unsigned int getLabelMask() const override;
-    const char* getObjTypeName() const override;
+    DeepSkyObjectType getObjType() const override;
 
     int getFormId() const;
 

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -46,9 +46,9 @@ void Nebula::setGeometry(ResourceHandle _geometry)
     geometry = _geometry;
 }
 
-const char* Nebula::getObjTypeName() const
+DeepSkyObjectType Nebula::getObjType() const
 {
-    return "nebula";
+    return DeepSkyObjectType::Nebula;
 }
 
 

--- a/src/celengine/nebula.h
+++ b/src/celengine/nebula.h
@@ -33,7 +33,7 @@ public:
     void setGeometry(ResourceHandle);
     ResourceHandle getGeometry() const;
 
-    const char* getObjTypeName() const override;
+    DeepSkyObjectType getObjType() const override;
 
     enum NebulaType
     {

--- a/src/celengine/opencluster.cpp
+++ b/src/celengine/opencluster.cpp
@@ -39,9 +39,9 @@ string OpenCluster::getDescription() const
 
 
 
-const char* OpenCluster::getObjTypeName() const
+DeepSkyObjectType OpenCluster::getObjType() const
 {
-    return "opencluster";
+    return DeepSkyObjectType::OpenCluster;
 }
 
 

--- a/src/celengine/opencluster.h
+++ b/src/celengine/opencluster.h
@@ -32,7 +32,7 @@ class OpenCluster : public DeepSkyObject
     uint64_t getRenderMask() const override;
     unsigned int getLabelMask() const override;
 
-    const char* getObjTypeName() const override;
+    DeepSkyObjectType getObjType() const override;
 
  public:
     enum ClusterType

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -63,6 +63,23 @@ static const char* bodyTypeName(int cl)
     return "unknown";
 }
 
+static const char* dsoTypeName(DeepSkyObjectType dsoType)
+{
+    switch (dsoType)
+    {
+    case DeepSkyObjectType::Galaxy:
+        return "galaxy";
+    case DeepSkyObjectType::Globular:
+        return "globular";
+    case DeepSkyObjectType::Nebula:
+        return "nebula";
+    case DeepSkyObjectType::OpenCluster:
+        return "opencluster";
+    default:
+        return "unknown";
+    }
+}
+
 static celestia::MarkerRepresentation::Symbol parseMarkerSymbol(const string& name)
 {
     using namespace celestia;
@@ -495,7 +512,7 @@ static int object_type(lua_State* l)
         tname = "star";
         break;
     case SelectionType::DeepSky:
-        tname = sel->deepsky()->getObjTypeName();
+        tname = dsoTypeName(sel->deepsky()->getObjType());
         break;
     case SelectionType::Location:
         tname = "location";
@@ -699,7 +716,7 @@ static int object_getinfo(lua_State* l)
     else if (sel->deepsky() != nullptr)
     {
         DeepSkyObject* deepsky = sel->deepsky();
-        const char* objTypeName = deepsky->getObjTypeName();
+        const char* objTypeName = dsoTypeName(deepsky->getObjType());
         celx.setTable("type", objTypeName);
 
         celx.setTable("name", celx.appCore(AllErrors)->getSimulation()->getUniverse()


### PR DESCRIPTION
Avoids a bunch of `strcmp` calls in the DSO renderer.