### PR TITLE
Move zoom to observer class

### DIFF
--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -82,6 +82,8 @@ Observer::Observer(const Observer& o) :
     trackObject(o.trackObject),
     trackingOrientation(o.trackingOrientation),
     fov(o.fov),
+    zoom(o.zoom),
+    alternateZoom(o.alternateZoom),
     reverseFlag(o.reverseFlag),
     locationFilter(o.locationFilter),
     displayedSurface(o.displayedSurface)
@@ -107,6 +109,8 @@ Observer& Observer::operator=(const Observer& o)
     trackObject = o.trackObject;
     trackingOrientation = o.trackingOrientation;
     fov = o.fov;
+    zoom = o.zoom;
+    alternateZoom = o.alternateZoom;
     reverseFlag = o.reverseFlag;
     locationFilter = o.locationFilter;
     displayedSurface = o.displayedSurface;
@@ -1348,6 +1352,25 @@ void Observer::setFOV(float _fov)
     fov = _fov;
 }
 
+float Observer::getZoom() const
+{
+    return zoom;
+}
+
+void Observer::setZoom(float _zoom)
+{
+    zoom = _zoom;
+}
+
+float Observer::getAlternateZoom() const
+{
+    return alternateZoom;
+}
+
+void Observer::setAlternateZoom(float _alternateZoom)
+{
+    alternateZoom = _alternateZoom;
+}
 
 Vector3f Observer::getPickRay(float x, float y) const
 {

--- a/src/celengine/observer.h
+++ b/src/celengine/observer.h
@@ -136,6 +136,11 @@ public:
     float          getFOV() const;
     void           setFOV(float);
 
+    float          getZoom() const;
+    void           setZoom(float);
+    float          getAlternateZoom() const;
+    void           setAlternateZoom(float);
+
     void           update(double dt, double timeScale);
 
     Eigen::Vector3f getPickRay(float x, float y) const;
@@ -314,6 +319,9 @@ public:
     Eigen::Quaterniond 	trackingOrientation{ Eigen::Quaternionf::Identity() };   // orientation prior to selecting tracking
 
     float fov{ static_cast<float>(celestia::numbers::pi / 4.0) };
+    float zoom{ 1.0f };
+    float alternateZoom{ 1.0f };
+
     bool reverseFlag{ false };
 
     uint64_t locationFilter{ ~0ull };

--- a/src/celestia/view.cpp
+++ b/src/celestia/view.cpp
@@ -209,7 +209,6 @@ void View::split(Type type, Observer *o, float splitPos, View **split, View **vi
                      x1, y1, w2, h2);
     (*split)->child2 = *view;
     (*view)->parent = *split;
-    (*view)->zoom = zoom;
 }
 
 View* View::remove(View* v)

--- a/src/celestia/view.h
+++ b/src/celestia/view.h
@@ -62,8 +62,6 @@ class View
     float     height;
     uint64_t  renderFlags     { 0 };
     int       labelMode       { 0 };
-    float     zoom            { 1.0f };
-    float     alternateZoom   { 1.0f };
 
 private:
     std::unique_ptr<FramebufferObject> fbo;

--- a/src/celmath/geomutil.h
+++ b/src/celmath/geomutil.h
@@ -138,6 +138,14 @@ ProjectFisheye(const Eigen::Matrix<T, 3, 1>& from,
     return true;
 }
 
+/*! Return vertical FOV for perspective projection based on screen dpi, number of vertical
+ *  pixels, and screen distance
+ */
+template<class T>
+T PerspectiveFOV(T height, int screenDpi, int distanceToScreen)
+{
+    return static_cast<T>(2.0) * std::atan(height / (static_cast<T>(screenDpi) / static_cast<T>(25.4)) / static_cast<T>(2.0) / static_cast<T>(distanceToScreen));
+}
 
 /*! Return an perspective projection matrix
  */


### PR DESCRIPTION
moving zoom to Observer so that renderer class can access this information to support more flexible projection mode