### PR TITLE
Add support for camera transforms in rendering

### DIFF
--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -114,7 +114,7 @@ Renderer::renderSelectionPointer(const Observer& observer,
     if (prog == nullptr)
         return;
 
-    Eigen::Matrix3f cameraMatrix = getCameraOrientation().conjugate().toRotationMatrix();
+    Eigen::Matrix3f cameraMatrix = getCameraOrientationf().conjugate().toRotationMatrix();
     Eigen::Vector3f u = cameraMatrix.col(0);
     Eigen::Vector3f v = cameraMatrix.col(1);
     double distance = position.norm();

--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -114,7 +114,7 @@ PlanetographicGrid::render(Renderer* renderer,
 
     // Calculate the view normal; this is used for placement of the long/lat
     // label text.
-    Eigen::Vector3f vn = renderer->getCameraOrientation().conjugate() * -Eigen::Vector3f::UnitZ();
+    Eigen::Vector3f vn = renderer->getCameraOrientationf().conjugate() * -Eigen::Vector3f::UnitZ();
     Eigen::Vector3d viewNormal = vn.cast<double>();
 
     Renderer::PipelineState ps;

--- a/src/celengine/pointstarrenderer.cpp
+++ b/src/celengine/pointstarrenderer.cpp
@@ -124,7 +124,7 @@ void PointStarRenderer::process(const Star& star, float distance, float appMag)
         }
         else
         {
-            Matrix3f viewMat = observer->getOrientationf().toRotationMatrix();
+            Matrix3f viewMat = renderer->getCameraOrientationf().toRotationMatrix();
             Vector3f viewMatZ = viewMat.row(2);
 
             RenderListEntry rle;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -412,7 +412,11 @@ class Renderer
     void beginObjectAnnotations();
     void addObjectAnnotation(const celestia::MarkerRepresentation* markerRep, const std::string& labelText, Color, const Eigen::Vector3f&, LabelHorizontalAlignment halign, LabelVerticalAlignment valign);
     void endObjectAnnotations();
-    const Eigen::Quaternionf& getCameraOrientation() const;
+    Eigen::Quaternionf getCameraOrientationf() const;
+    Eigen::Quaterniond getCameraOrientation() const;
+    Eigen::Matrix3d getCameraTransform() const;
+    void setCameraTransform(const Eigen::Matrix3d&);
+
     float getNearPlaneDistance() const;
 
     void invalidateOrbitCache();
@@ -696,7 +700,8 @@ class Renderer
     Color ambientColor;
     std::string displayedSurface;
 
-    Eigen::Quaternionf m_cameraOrientation;
+    Eigen::Quaterniond m_cameraOrientation;
+    Eigen::Matrix3d m_cameraTransform{ Eigen::Matrix3d::Identity() };
     PointStarVertexBuffer* pointStarVertexBuffer;
     PointStarVertexBuffer* glareVertexBuffer;
     std::vector<RenderListEntry> renderList;

--- a/src/celengine/skygrid.cpp
+++ b/src/celengine/skygrid.cpp
@@ -368,7 +368,7 @@ SkyGrid::render(Renderer& renderer,
     Vector3d c2(-w,  h, -1.0);
     Vector3d c3( w,  h, -1.0);
 
-    Quaterniond cameraOrientation = observer.getOrientation();
+    Quaterniond cameraOrientation = renderer.getCameraOrientation();
     Matrix3d r = (cameraOrientation * xrot90 * m_orientation.conjugate() * xrot90.conjugate()).toRotationMatrix().transpose();
 
     // Transform the frustum corners by the camera and grid
@@ -543,7 +543,7 @@ SkyGrid::render(Renderer& renderer,
                 glEnd();
 #endif
 
-                Matrix3f m = observer.getOrientationf().toRotationMatrix();
+                Matrix3f m = cameraOrientation.cast<float>().toRotationMatrix();
                 p0 = orientationf.conjugate() * p0;
                 p1 = orientationf.conjugate() * p1;
                 Renderer::LabelHorizontalAlignment hAlign = getCoordLabelHAlign(k);
@@ -618,7 +618,7 @@ SkyGrid::render(Renderer& renderer,
                 glEnd();
 #endif
 
-                Matrix3f m = observer.getOrientationf().toRotationMatrix();
+                Matrix3f m = cameraOrientation.cast<float>().toRotationMatrix();
                 p0 = orientationf.conjugate() * p0;
                 p1 = orientationf.conjugate() * p1;
                 Renderer::LabelHorizontalAlignment hAlign = getCoordLabelHAlign(k);


### PR DESCRIPTION
For rendering, always try to get orientation from render class instead of observer.

Closes #1739