### PR TITLE
Create font atlas using Image class instead of glTexSubImage2D

### DIFF
--- a/shaders/text_frag.glsl
+++ b/shaders/text_frag.glsl
@@ -5,5 +5,5 @@ uniform sampler2D atlasTex;
 
 void main(void)
 {
-    gl_FragColor = vec4(color.rgb, texture2D(atlasTex, texCoord).a * color.a);
+    gl_FragColor = vec4(color.rgb, texture2D(atlasTex, texCoord).r * color.a);
 }


### PR DESCRIPTION
The new code
 * smaller
 * will work with core GL3 without any changes.
 * should be faster because it uploads only the final image