### PR TITLE
Switch most non-Windows usages of wchar_t to char16_t

### DIFF
--- a/src/celengine/console.h
+++ b/src/celengine/console.h
@@ -17,6 +17,8 @@
 
 #include <Eigen/Core>
 
+#include <celutil/utf8.h>
+
 class Color;
 class Console;
 class TextureFont;
@@ -40,9 +42,7 @@ class ConsoleStreamBuf : public std::streambuf
     };
 
     Console* console{ nullptr };
-    UTF8DecodeState decodeState{ UTF8DecodeState::Start };
-    wchar_t decodedChar{ 0 };
-    unsigned int decodeShift{ 0 };
+    UTF8Validator validator{};
 };
 
 class Renderer;
@@ -73,7 +73,7 @@ class Console : public std::ostream
     void savePos();
     void restorePos();
 
-    void print(wchar_t);
+    void print(char16_t);
     void newline();
 
     int getWindowRow() const;
@@ -82,7 +82,7 @@ class Console : public std::ostream
     int getHeight() const;
     int getWidth() const;
 
-    std::wstring text{ };
+    std::u16string text{ };
     int nRows;
     int nColumns;
     int row{ 0 };
@@ -101,7 +101,6 @@ class Console : public std::ostream
 
     bool autoScroll{ true };
 
-    float xoffset { 0.0f };
     struct CursorPosition
     {
         void reset()

--- a/src/celengine/textlayout.h
+++ b/src/celengine/textlayout.h
@@ -10,6 +10,12 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <Eigen/Core>
+
 #include <celttf/truetypefont.h>
 
 namespace celestia::engine
@@ -113,7 +119,7 @@ class TextLayout
     float positionY{ 0.0f };
     float alignmentEdgeX{ 0.0f };
 
-    std::wstring currentLine;
+    std::u16string currentLine;
     Eigen::Matrix4f modelview{ Eigen::Matrix4f::Identity() };
     Eigen::Matrix4f projection{ Eigen::Matrix4f::Identity() };
 
@@ -122,10 +128,10 @@ class TextLayout
 
     float getPixelSize(float size, Unit unit) const;
 
-    void renderLine(std::wstring_view line);
+    void renderLine(std::u16string_view line);
     void flushInternal(bool flushFont);
 
-    static bool processString(std::string_view input, std::vector<std::wstring> &output);
+    static bool processString(std::string_view input, std::vector<std::u16string> &output);
 };
 
 }

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -58,6 +58,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <cctype>
+#include <cwctype>
 #include <cstring>
 #include <cassert>
 #include <ctime>
@@ -1014,13 +1015,8 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
 
     if (textEnterMode & KbAutoComplete)
     {
-        wchar_t wc = 0; // Null wide character
-        UTF8Decode(c_p, 0, wc);
-#ifdef __APPLE__
-        if ( wc && (!iscntrl(wc)) )
-#else
-        if ( wc && (!iswcntrl(wc)) )
-#endif
+        if (std::int32_t uc = 0;
+            UTF8Decode(c_p, uc) && !(uc <= WCHAR_MAX && std::iswcntrl(static_cast<std::wint_t>(uc))))
         {
             setTypedText(c_p);
         }

--- a/src/celttf/truetypefont.h
+++ b/src/celttf/truetypefont.h
@@ -9,9 +9,13 @@
 
 #pragma once
 
-#include <Eigen/Core>
-#include <celcompat/filesystem.h>
+#include <memory>
 #include <string_view>
+
+#include <Eigen/Core>
+
+#include <celcompat/filesystem.h>
+
 
 class Renderer;
 class TextureFont;
@@ -39,11 +43,9 @@ public:
     void setMVPMatrices(const Eigen::Matrix4f &p,
                         const Eigen::Matrix4f &m = Eigen::Matrix4f::Identity());
 
-    std::pair<float, float> render(wchar_t c, float xoffset = 0.0f, float yoffset = 0.0f) const;
-    std::pair<float, float> render(std::wstring_view line, float xoffset = 0.0f, float yoffset = 0.0f) const;
+    std::pair<float, float> render(std::u16string_view line, float xoffset = 0.0f, float yoffset = 0.0f) const;
 
-    int getWidth(std::wstring_view) const;
-    int getWidth(int c) const;
+    int getWidth(std::u16string_view) const;
     int getMaxWidth() const;
     int getHeight() const;
 
@@ -51,8 +53,6 @@ public:
     void setMaxAscent(int);
     int  getMaxDescent() const;
     void setMaxDescent(int);
-
-    short getAdvance(wchar_t c) const;
 
     void bind();
     void unbind();

--- a/src/celutil/strnatcmp.cpp
+++ b/src/celutil/strnatcmp.cpp
@@ -31,11 +31,23 @@
 namespace
 {
 
-using MaybeChar = std::optional<wchar_t>;
+using MaybeChar = std::optional<std::int32_t>;
 
 
-bool isDigit(MaybeChar c) { return c.has_value() && std::iswdigit(*c); }
-bool isSpace(MaybeChar c) { return c.has_value() && std::iswspace(*c); }
+inline bool
+isDigit(MaybeChar c)
+{
+    return c.has_value() &&
+           c >= 0 && c <= WCHAR_MAX &&
+           std::iswdigit(static_cast<std::wint_t>(*c));
+}
+
+inline bool isSpace(MaybeChar c)
+{
+    return c.has_value() &&
+           c >= 0 && c<= WCHAR_MAX &&
+           std::iswspace(*c);
+}
 
 
 class CharMapper
@@ -45,23 +57,23 @@ public:
 
     MaybeChar next()
     {
-        if (offset >= sv.size())
+        auto svSize = static_cast<std::int32_t>(sv.size());
+        if (offset >= svSize)
             return std::nullopt;
 
-        wchar_t ch;
+        std::int32_t ch;
         if (!UTF8Decode(sv, offset, ch))
         {
-            offset = sv.size();
+            offset = svSize;
             return std::nullopt;
         }
 
-        offset += UTF8EncodedSize(ch);
         return ch;
     }
 
 private:
     std::string_view sv;
-    std::string_view::size_type offset{ 0 };
+    std::int32_t offset{ 0 };
 };
 
 

--- a/src/celutil/tokenizer.cpp
+++ b/src/celutil/tokenizer.cpp
@@ -95,10 +95,11 @@ struct StringState
 bool
 StringState::checkUTF8(char c, std::string_view run)
 {
-    auto utf8Status = validator.check(c);
-    if (utf8Status == UTF8Status::Ok) { return true; }
+    auto decodedChar = validator.check(c);
+    if (decodedChar >= 0 || decodedChar == UTF8Validator::PartialSequence)
+        return true;
 
-    if (utf8Status == UTF8Status::InvalidTrailingByte)
+    if (decodedChar == UTF8Validator::InvalidTrailing)
     {
         std::size_t pos = run.size();
         while (pos > 0)
@@ -574,7 +575,7 @@ TokenizerImpl::readString()
         std::string_view run(buffer.data() + position + state.runStart,
                              state.runEnd - state.runStart);
 
-        if (!state.checkUTF8(ch, run)) { continue; }
+        if (!state.checkUTF8(ch, run) && ch != '"') { continue; }
         if (ch == '"') { break; }
         if (!parseChar(state, ch, run)) { return false;}
     }

--- a/src/celutil/unicode.cpp
+++ b/src/celutil/unicode.cpp
@@ -7,65 +7,86 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include "unicode.h"
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
 #include <vector>
+
 #ifdef HAVE_WIN_ICU_COMBINED_HEADER
+#include <icu.h>
 #elif defined(HAVE_WIN_ICU_SEPARATE_HEADERS)
+#include <icucommon.h>
 #include <icui18n.h>
 #else
 #include <unicode/ubidi.h>
+#include <unicode/umachine.h>
 #include <unicode/ushape.h>
 #include <unicode/ustring.h>
 #endif
 
 #include "flag.h"
-#include "unicode.h"
+
+
+static_assert(std::is_same_v<UChar, char16_t>);
 
 namespace celestia::util
 {
 
-bool ApplyArabicShaping(const std::vector<UChar> &input, std::vector<UChar> &output)
+namespace
+{
+
+bool
+ApplyArabicShaping(std::u16string_view input, std::u16string &output)
 {
     UErrorCode error = U_ZERO_ERROR;
-    uint32_t options = U_SHAPE_LETTERS_SHAPE | U_SHAPE_TEXT_DIRECTION_LOGICAL | U_SHAPE_LENGTH_GROW_SHRINK;
-    auto requiredSize = u_shapeArabic(input.data(), static_cast<int32_t>(input.size()), nullptr, 0, options, &error);
-    if (error != U_BUFFER_OVERFLOW_ERROR)
+    std::uint32_t options = U_SHAPE_LETTERS_SHAPE | U_SHAPE_TEXT_DIRECTION_LOGICAL | U_SHAPE_LENGTH_GROW_SHRINK;
+    auto inputSize = static_cast<std::int32_t>(input.size());
+    auto requiredSize = u_shapeArabic(input.data(), inputSize, nullptr, 0, options, &error);
+    if (U_FAILURE(error) && error != U_BUFFER_OVERFLOW_ERROR)
         return false;
 
     // Clear the error to be reused
     error = U_ZERO_ERROR;
 
-    output.resize(requiredSize + 1);
-    u_shapeArabic(input.data(), static_cast<int32_t>(input.size()), output.data(), static_cast<int32_t>(output.size()), options, &error);
     output.resize(requiredSize);
-    return error == U_ZERO_ERROR;
+    u_shapeArabic(input.data(), inputSize, output.data(), requiredSize, options, &error);
+    return U_SUCCESS(error);
 }
 
-bool ApplyBidiReordering(const std::vector<UChar> &input, std::vector<UChar> &output)
+bool
+ApplyBidiReordering(std::u16string_view input, std::u16string &output)
 {
     auto ubidi = ubidi_open();
     UErrorCode error = U_ZERO_ERROR;
-    ubidi_setPara(ubidi, input.data(), static_cast<int32_t>(input.size()), UBIDI_DEFAULT_LTR, nullptr, &error);
+    auto inputSize = static_cast<std::int32_t>(input.size());
+    ubidi_setPara(ubidi, input.data(), inputSize, UBIDI_DEFAULT_LTR, nullptr, &error);
 
-    uint16_t options = UBIDI_DO_MIRRORING | UBIDI_REMOVE_BIDI_CONTROLS;
+    std::uint16_t options = UBIDI_DO_MIRRORING | UBIDI_REMOVE_BIDI_CONTROLS;
 
     auto requiredSize = ubidi_writeReordered(ubidi, nullptr, 0, options, &error);
-    if (error != U_BUFFER_OVERFLOW_ERROR)
+    if (U_FAILURE(error) && error != U_BUFFER_OVERFLOW_ERROR)
     {
         ubidi_close(ubidi);
         return false;
     }
 
+    output.resize(requiredSize);
+
     // Clear the error to be reused
     error = U_ZERO_ERROR;
 
-    output.resize(requiredSize + 1);
-    ubidi_writeReordered(ubidi, output.data(), static_cast<int32_t>(output.size()), options, &error);
+    ubidi_writeReordered(ubidi, output.data(), requiredSize, options, &error);
     ubidi_close(ubidi);
-    output.resize(requiredSize);
-    return error == U_ZERO_ERROR;
+    return U_SUCCESS(error);
 }
 
-bool UTF8StringToUnicodeString(std::string_view input, std::vector<UChar> &output)
+} // end unnamed namespace
+
+
+bool
+UTF8StringToUnicodeString(std::string_view input, std::u16string &output)
 {
     if (input.empty())
     {
@@ -73,73 +94,53 @@ bool UTF8StringToUnicodeString(std::string_view input, std::vector<UChar> &outpu
         return true;
     }
 
-    int32_t requiredSize;
+    std::int32_t requiredSize;
     UErrorCode error = U_ZERO_ERROR;
 
     // dry run to get the required size for unicode string
-    u_strFromUTF8(nullptr, 0, &requiredSize, input.data(), static_cast<int32_t>(input.size()), &error);
-    if (error != U_BUFFER_OVERFLOW_ERROR)
+    auto inputLength = static_cast<std::int32_t>(input.size());
+    u_strFromUTF8(nullptr, 0, &requiredSize, input.data(), inputLength, &error);
+    if (U_FAILURE(error) && error != U_BUFFER_OVERFLOW_ERROR)
         return false;
 
-    output.resize(requiredSize + 1);
+    output.resize(requiredSize);
 
     // Clear the error to be reused
     error = U_ZERO_ERROR;
 
     // Get the actual data
-    u_strFromUTF8(output.data(), static_cast<int32_t>(output.size()), nullptr, input.data(), static_cast<int32_t>(input.size()), &error);
-
-    // Removing the redundant \0 at the end
-    output.resize(requiredSize);
-    return error == U_ZERO_ERROR;
+    u_strFromUTF8(output.data(), requiredSize, nullptr, input.data(), inputLength, &error);
+    return U_SUCCESS(error);
 }
 
-bool UnicodeStringToWString(const std::vector<UChar> &input, std::wstring &output, ConversionOption options)
-{
-    if (input.empty())
-    {
-        output.clear();
-        return true;
-    }
 
-    auto current = input;
+bool
+ApplyBidiAndShaping(std::u16string_view input, std::u16string &output, ConversionOption options)
+{
+    output.clear();
+    if (input.empty())
+        return true;
+
+    output.append(input);
     if (is_set(options, ConversionOption::ArabicShaping))
     {
-        std::vector<UChar> result;
-        if (ApplyArabicShaping(current, result))
-            current.swap(result);
+        std::u16string result;
+        if (ApplyArabicShaping(output, result))
+            output = std::move(result);
         else
             return false;
     }
 
     if (is_set(options, ConversionOption::BidiReordering))
     {
-        std::vector<UChar> result;
-        if (ApplyBidiReordering(current, result))
-            current.swap(result);
+        std::u16string result;
+        if (ApplyBidiReordering(output, result))
+            output = std::move(result);
         else
             return false;
     }
 
-    int32_t requiredSize;
-    UErrorCode error = U_ZERO_ERROR;
-
-    // dry run to get the required size for wstring
-    u_strToWCS(nullptr, 0, &requiredSize, current.data(), static_cast<int32_t>(current.size()), &error);
-    if (error != U_BUFFER_OVERFLOW_ERROR)
-        return false;
-
-    output.resize(requiredSize + 1);
-
-    // Clear the error to be reused
-    error = U_ZERO_ERROR;
-
-    // Get the actual data
-    u_strToWCS(output.data(), static_cast<int32_t>(output.size()), nullptr, current.data(), static_cast<int32_t>(current.size()), &error);
-
-    // Removing the redundant \0 at the end
-    output.resize(requiredSize);
-    return error == U_ZERO_ERROR;
+    return true;
 }
 
 }

--- a/src/celutil/unicode.h
+++ b/src/celutil/unicode.h
@@ -9,15 +9,8 @@
 
 #pragma once
 
-#include <vector>
 #include <string>
-#ifdef HAVE_WIN_ICU_COMBINED_HEADER
-#include <icu.h>
-#elif defined(HAVE_WIN_ICU_SEPARATE_HEADERS)
-#include <icucommon.h>
-#else
-#include <unicode/umachine.h>
-#endif
+#include <string_view>
 
 namespace celestia::util
 {
@@ -29,7 +22,9 @@ enum class ConversionOption : unsigned int
     BidiReordering  = 0x02,
 };
 
-bool UTF8StringToUnicodeString(std::string_view input, std::vector<UChar> &output);
-bool UnicodeStringToWString(const std::vector<UChar> &input, std::wstring &output, ConversionOption options = ConversionOption::None);
+bool UTF8StringToUnicodeString(std::string_view input, std::u16string &output);
+bool ApplyBidiAndShaping(std::u16string_view input,
+                         std::u16string &output,
+                         ConversionOption options = ConversionOption::None);
 
 }

--- a/test/unit/unicode_test.cpp
+++ b/test/unit/unicode_test.cpp
@@ -9,27 +9,13 @@
 
 using namespace celestia::util;
 
-inline std::wstring ProcessWString(const std::wstring& str, ConversionOption options)
+std::u16string ProcessU16String(const std::u16string& str, ConversionOption options)
 {
-    std::vector<UChar> result;
-    int32_t requiredSize;
-    UErrorCode error = U_ZERO_ERROR;
-    u_strFromWCS(nullptr, 0, &requiredSize, str.c_str(), str.size(), &error);
-    if (error != U_BUFFER_OVERFLOW_ERROR)
-        return L"";
+    std::u16string result;
+    if (!ApplyBidiAndShaping(str, result, options))
+        return {};
 
-    result.resize(requiredSize + 1);
-    error = U_ZERO_ERROR;
-
-    u_strFromWCS(result.data(), result.size(), nullptr, str.c_str(), str.size(), &error);
-    result.resize(requiredSize);
-    if (error != U_ZERO_ERROR)
-        return L"";
-
-    std::wstring output;
-    if (!UnicodeStringToWString(result, output, options))
-        return L"";
-    return output;
+    return result;
 }
 
 TEST_SUITE_BEGIN("Unicode");
@@ -39,15 +25,15 @@ TEST_CASE("Unicode")
 {
     SUBCASE("ArabicShaping")
     {
-        REQUIRE(ProcessWString(L"\u0633\u0644\u0627\u0645\u06f3\u06f9", ConversionOption::ArabicShaping) == L"\ufeb3\ufefc\ufee1\u06f3\u06f9"); // Numbers and letters
-        REQUIRE(ProcessWString(L"\u0645\u0643\u062a\u0628\u0629\u0020\u0627\u0644\u0625\u0633\u0643\u0646\u062f\u0631\u064a\u0629\u200e\u200e Maktabat al-Iskandar\u012byah", ConversionOption::ArabicShaping) == L"\ufee3\ufedc\ufe98\ufe92\ufe94\u0020\ufe8d\ufef9\ufeb3\ufedc\ufee8\ufeaa\ufead\ufef3\ufe94\u200e\u200e Maktabat al-Iskandar\u012byah");
-        REQUIRE(ProcessWString(L"\u0627\u0644\u064a\u064e\u0645\u064e\u0646\u200e\u200e", ConversionOption::ArabicShaping) == L"\ufe8d\ufedf\ufef4\ufe77\ufee4\ufe77\ufee6\u200e\u200e"); // Tashkeel
+        REQUIRE(ProcessU16String(u"\u0633\u0644\u0627\u0645\u06f3\u06f9", ConversionOption::ArabicShaping) == u"\ufeb3\ufefc\ufee1\u06f3\u06f9"); // Numbers and letters
+        REQUIRE(ProcessU16String(u"\u0645\u0643\u062a\u0628\u0629\u0020\u0627\u0644\u0625\u0633\u0643\u0646\u062f\u0631\u064a\u0629\u200e\u200e Maktabat al-Iskandar\u012byah", ConversionOption::ArabicShaping) == u"\ufee3\ufedc\ufe98\ufe92\ufe94\u0020\ufe8d\ufef9\ufeb3\ufedc\ufee8\ufeaa\ufead\ufef3\ufe94\u200e\u200e Maktabat al-Iskandar\u012byah");
+        REQUIRE(ProcessU16String(u"\u0627\u0644\u064a\u064e\u0645\u064e\u0646\u200e\u200e", ConversionOption::ArabicShaping) == u"\ufe8d\ufedf\ufef4\ufe77\ufee4\ufe77\ufee6\u200e\u200e"); // Tashkeel
     }
 
     SUBCASE("ArabicShapingWithBidi")
     {
-        REQUIRE(ProcessWString(L"\u0633\u0644\u0627\u0645\u06f3\u06f9", ConversionOption::ArabicShaping | ConversionOption::BidiReordering) == L"\u06f3\u06f9\ufee1\ufefc\ufeb3"); // Numbers and letters
-        REQUIRE(ProcessWString(L"\u0645\u0643\u062a\u0628\u0629\u0020\u0627\u0644\u0625\u0633\u0643\u0646\u062f\u0631\u064a\u0629\u200e\u200e Maktabat al-Iskandar\u012byah", ConversionOption::ArabicShaping | ConversionOption::BidiReordering) == L" Maktabat al-Iskandar\u012byah\ufe94\ufef3\ufead\ufeaa\ufee8\ufedc\ufeb3\ufef9\ufe8d\u0020\ufe94\ufe92\ufe98\ufedc\ufee3");
+        REQUIRE(ProcessU16String(u"\u0633\u0644\u0627\u0645\u06f3\u06f9", ConversionOption::ArabicShaping | ConversionOption::BidiReordering) == u"\u06f3\u06f9\ufee1\ufefc\ufeb3"); // Numbers and letters
+        REQUIRE(ProcessU16String(u"\u0645\u0643\u062a\u0628\u0629\u0020\u0627\u0644\u0625\u0633\u0643\u0646\u062f\u0631\u064a\u0629\u200e\u200e Maktabat al-Iskandar\u012byah", ConversionOption::ArabicShaping | ConversionOption::BidiReordering) == u" Maktabat al-Iskandar\u012byah\ufe94\ufef3\ufead\ufeaa\ufee8\ufedc\ufeb3\ufef9\ufe8d\u0020\ufe94\ufe92\ufe98\ufedc\ufee3");
     }
 }
 


### PR DESCRIPTION
- Reduces the size of the console buffer on Linux
- char16_t better matches the ICU C APIs
- Simplify/remove some of the UTF-8 handling routines

Would like to go further to reduce dependency on the `<cwctype>` functions but will leave that for another pull request.