### PR TITLE
Replace include guards with #pragma once

### DIFF
--- a/src/celengine/atmosphere.h
+++ b/src/celengine/atmosphere.h
@@ -8,8 +8,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_ATMOSPHERE_H_
-#define _CELENGINE_ATMOSPHERE_H_
+#pragma once
 
 #include <celutil/reshandle.h>
 #include <celutil/color.h>
@@ -68,6 +67,3 @@ class Atmosphere
 // density of the atmosphere falls to the extinction threshold, i.e.
 // -H * ln(extinctionThreshold)
 constexpr inline float AtmosphereExtinctionThreshold = 0.05f;
-
-#endif // _CELENGINE_ATMOSPHERE_H_
-

--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_BODY_H_
-#define _CELENGINE_BODY_H_
+#pragma once
 
 #include <celengine/astroobj.h>
 #include <celengine/surface.h>
@@ -426,5 +425,3 @@ class Body
     bool secondaryIlluminator{ true };
     bool primaryNameLocalized { false };
 };
-
-#endif // _CELENGINE_BODY_H_

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -8,8 +8,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_FRAME_H_
-#define _CELENGINE_FRAME_H_
+#pragma once
 
 #include <celengine/astro.h>
 #include <celengine/selection.h>
@@ -256,5 +255,3 @@ class TwoVectorFrame : public CachingFrame
     int secondaryAxis;
     int tertiaryAxis;
 };
-
-#endif // _CELENGINE_FRAME_H_

--- a/src/celengine/frametree.h
+++ b/src/celengine/frametree.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_FRAMETREE_H_
-#define _CELENGINE_FRAMETREE_H_
+#pragma once
 
 #include <memory>
 #include <vector>
@@ -102,5 +101,3 @@ private:
 
     ReferenceFrame::SharedConstPtr defaultFrame;
 };
-
-#endif // _CELENGINE_FRAMETREE_H_

--- a/src/celengine/lightenv.h
+++ b/src/celengine/lightenv.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_LIGHTENV_H_
-#define _CELENGINE_LIGHTENV_H_
+#pragma once
 
 #include <celutil/color.h>
 #include <Eigen/Core>
@@ -91,5 +90,3 @@ public:
 
     Eigen::Vector3f ambientColor;
 };
-
-#endif // _CELENGINE_LIGHTENV_H_

--- a/src/celengine/location.h
+++ b/src/celengine/location.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_LOCATION_H_
-#define _CELENGINE_LOCATION_H_
+#pragma once
 
 #include <string>
 #include <celengine/astroobj.h>
@@ -136,5 +135,3 @@ public:
     Color labelColor{ 1.0f, 1.0f, 1.0f };
     std::string infoURL;
 };
-
-#endif // _CELENGINE_LOCATION_H_

--- a/src/celengine/marker.h
+++ b/src/celengine/marker.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef CELENGINE_MARKER_H_
-#define CELENGINE_MARKER_H_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -119,5 +118,3 @@ class Marker
 
 typedef std::vector<Marker> MarkerList;
 }
-
-#endif // CELENGINE_MARKER_H_

--- a/src/celengine/multitexture.h
+++ b/src/celengine/multitexture.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_MULTITEXTURE_H_
-#define _CELENGINE_MULTITEXTURE_H_
+#pragma once
 
 #include <string>
 #include "texture.h"
@@ -46,5 +45,3 @@ class MultiResTexture
  public:
     ResourceHandle tex[3];
 };
-
-#endif // _CELENGINE_MULTITEXTURE_H_

--- a/src/celengine/observer.h
+++ b/src/celengine/observer.h
@@ -15,8 +15,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_OBSERVER_H_
-#define _CELENGINE_OBSERVER_H_
+#pragma once
 
 #include <celcompat/numbers.h>
 #include <celmath/mathlib.h>
@@ -333,5 +332,3 @@ public:
     uint64_t locationFilter{ ~0ull };
     std::string displayedSurface;
 };
-
-#endif // _CELENGINE_OBSERVER_H_

--- a/src/celengine/octree.h
+++ b/src/celengine/octree.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_OCTREE_H_
-#define _CELENGINE_OCTREE_H_
+#pragma once
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -409,6 +408,3 @@ void StaticOctree<OBJ, PREC>::computeStatistics(std::vector<OctreeLevelStatistic
             _children[i]->computeStatistics(stats, level + 1);
     }
 }
-
-
-#endif // _OCTREE_H_

--- a/src/celengine/referencemark.h
+++ b/src/celengine/referencemark.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_REFERENCEMARK_H_
-#define _CELENGINE_REFERENCEMARK_H_
+#pragma once
 
 #include <string>
 #include <Eigen/Core>
@@ -68,5 +67,3 @@ class ReferenceMark
 private:
     std::string tag;
 };
-
-#endif // _CELENGINE_REFERENCEMARK_H_

--- a/src/celengine/starbrowser.h
+++ b/src/celengine/starbrowser.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_STARBROWSER_H_
-#define _CELENGINE_STARBROWSER_H_
+#pragma once
 
 #include "star.h"
 #include "stardb.h"
@@ -46,5 +45,3 @@ class StarBrowser
     Simulation *appSim;
     int predicate;
 };
-
-#endif // _CELENGINE_STARBROWSER_H_

--- a/src/celengine/staroctree.h
+++ b/src/celengine/staroctree.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_STAROCTREE_H_
-#define _CELENGINE_STAROCTREE_H_
+#pragma once
 
 #include <celengine/star.h>
 #include <celengine/octree.h>
@@ -20,5 +19,3 @@
 typedef DynamicOctree  <Star, float> DynamicStarOctree;
 typedef StaticOctree   <Star, float> StarOctree;
 typedef OctreeProcessor<Star, float> StarHandler;
-
-#endif  // _CELENGINE_STAROCTREE_H_

--- a/src/celengine/surface.h
+++ b/src/celengine/surface.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _SURFACE_H_
-#define _SURFACE_H_
+#pragma once
 
 #include <celutil/color.h>
 #include <celutil/reshandle.h>
@@ -55,6 +54,3 @@ class Surface
     float bumpHeight;               // scale of bump map relief
     float lunarLambert;             // mix between Lambertian and Lommel-Seeliger (lunar-like) photometric functions
 };
-
-#endif // _SURFACE_H_
-

--- a/src/celengine/timeline.h
+++ b/src/celengine/timeline.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_TIMELINE_H_
-#define _CELENGINE_TIMELINE_H_
+#pragma once
 
 #include <memory>
 #include <vector>
@@ -37,5 +36,3 @@ public:
 private:
     std::vector<TimelinePhase::SharedConstPtr> phases;
 };
-
-#endif // _CELENGINE_TIMELINE_H_

--- a/src/celengine/timelinephase.h
+++ b/src/celengine/timelinephase.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_TIMELINEPHASE_H_
-#define _CELENGINE_TIMELINEPHASE_H_
+#pragma once
 
 #include <memory>
 #include "frame.h"
@@ -119,5 +118,3 @@ private:
 
     FrameTree* m_owner;
 };
-
-#endif // _CELENGINE_TIMELINEPHASE_H_

--- a/src/celengine/visibleregion.h
+++ b/src/celengine/visibleregion.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELENGINE_VISIBLEREGION_H_
-#define _CELENGINE_VISIBLEREGION_H_
+#pragma once
 
 #include <celengine/referencemark.h>
 #include <celengine/selection.h>
@@ -48,6 +47,3 @@ private:
     Color m_color;
     float m_opacity;
 };
-
-#endif // _CELENGINE_TERMINATOR_H_
-

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELESTIACORE_H_
-#define _CELESTIACORE_H_
+#pragma once
 
 #include <array>
 #include <fstream>
@@ -622,5 +621,3 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     friend std::shared_ptr<TextureFont> getTitleFont(CelestiaCore*);
 #endif
 };
-
-#endif // _CELESTIACORE_H_

--- a/src/celestia/eclipsefinder.h
+++ b/src/celestia/eclipsefinder.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _ECLIPSEFINDER_H_
-#define _ECLIPSEFINDER_H_
+#pragma once
 
 #include <vector>
 #include "celestiacore.h"
@@ -57,5 +56,3 @@ class EclipseFinder
     Body* body;
     EclipseFinderWatcher* watcher;
 };
-#endif // _ECLIPSEFINDER_H_
-

--- a/src/celestia/gtk/actions.h
+++ b/src/celestia/gtk/actions.h
@@ -10,8 +10,7 @@
  *  $Id: actions.h,v 1.7 2008-01-21 04:55:19 suwalski Exp $
  */
 
-#ifndef GTK_ACTIONS_H
-#define GTK_ACTIONS_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -141,6 +140,3 @@ void resyncTextureResolutionActions(AppData* app);
 #else
 #define FRONTEND "GTK+"
 #endif
-
-
-#endif /* GTK_ACTIONS_H */

--- a/src/celestia/gtk/common.h
+++ b/src/celestia/gtk/common.h
@@ -10,8 +10,7 @@
  *  $Id: common.h,v 1.5 2008-01-18 04:36:11 suwalski Exp $
  */
 
-#ifndef GTK_COMMON_H
-#define GTK_COMMON_H
+#pragma once
 
 #include <config.h>
 #include <gtk/gtk.h>
@@ -138,5 +137,3 @@ static const int resolutions[] =
 
 /* This is the spacing used for widgets throughout the program */
 #define CELSPACING 8
-
-#endif /* GTK_COMMON_H */

--- a/src/celestia/gtk/dialog-eclipse.h
+++ b/src/celestia/gtk/dialog-eclipse.h
@@ -10,8 +10,7 @@
  *  $Id: dialog-eclipse.h,v 1.1 2005-12-06 03:19:35 suwalski Exp $
  */
 
-#ifndef GTK_DIALOG_ECLIPSE_H
-#define GTK_DIALOG_ECLIPSE_H
+#pragma once
 
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
@@ -80,5 +79,3 @@ const char * const eclipsePlanetTitles[] =
     "Pluto",
     NULL
 };
-
-#endif /* GTK_DIALOG_ECLIPSE_H */

--- a/src/celestia/gtk/dialog-goto.h
+++ b/src/celestia/gtk/dialog-goto.h
@@ -10,8 +10,7 @@
  *  $Id: dialog-goto.h,v 1.1 2005-12-06 03:19:35 suwalski Exp $
  */
 
-#ifndef GTK_DIALOG_GOTO_H
-#define GTK_DIALOG_GOTO_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -43,5 +42,3 @@ static const char * const unitLabels[] =
     "au",
     NULL
 };
-
-#endif /* GTK_DIALOG_GOTO_H */

--- a/src/celestia/gtk/dialog-options.h
+++ b/src/celestia/gtk/dialog-options.h
@@ -10,8 +10,7 @@
  *  $Id: dialog-options.h,v 1.1 2005-12-06 03:19:35 suwalski Exp $
  */
 
-#ifndef GTK_DIALOG_OPTIONS_H
-#define GTK_DIALOG_OPTIONS_H
+#pragma once
 
 #include "common.h"
 
@@ -35,5 +34,3 @@ static const char * const infoLabels[]=
     "Verbose",
     NULL
 };
-
-#endif /* GTK_DIALOG_OPTIONS_H */

--- a/src/celestia/gtk/dialog-solar.h
+++ b/src/celestia/gtk/dialog-solar.h
@@ -10,8 +10,7 @@
  *  $Id: dialog-solar.h,v 1.1 2005-12-06 03:19:35 suwalski Exp $
  */
 
-#ifndef GTK_DIALOG_SOLAR_H
-#define GTK_DIALOG_SOLAR_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -30,5 +29,3 @@ static const char * const ssTitles[] =
     "Name",
     "Type"
 };
-
-#endif /* GTK_DIALOG_SOLAR_H */

--- a/src/celestia/gtk/dialog-star.h
+++ b/src/celestia/gtk/dialog-star.h
@@ -10,8 +10,7 @@
  *  $Id: dialog-star.h,v 1.1 2005-12-06 03:19:35 suwalski Exp $
  */
 
-#ifndef GTK_DIALOG_STAR_H
-#define GTK_DIALOG_STAR_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -56,5 +55,3 @@ static const char * const sbRadioLabels[] =
     "With Planets",
     NULL
 };
-
-#endif /* GTK_DIALOG_STAR_H */

--- a/src/celestia/gtk/dialog-time.h
+++ b/src/celestia/gtk/dialog-time.h
@@ -10,8 +10,7 @@
  *  $Id: dialog-time.h,v 1.2 2005-12-12 06:08:11 suwalski Exp $
  */
 
-#ifndef GTK_DIALOG_TIME_H
-#define GTK_DIALOG_TIME_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -24,5 +23,3 @@ void dialogSetTime(AppData* app);
 
 /* Labels for TimeZone dropdown */
 static const char* timeOptions[] = { "UTC", "Local", NULL };
-
-#endif /* GTK_DIALOG_TIME_H */

--- a/src/celestia/gtk/dialog-tour.h
+++ b/src/celestia/gtk/dialog-tour.h
@@ -10,8 +10,7 @@
  *  $Id: dialog-tour.h,v 1.1 2005-12-06 03:19:35 suwalski Exp $
  */
 
-#ifndef GTK_DIALOG_TOUR_H
-#define GTK_DIALOG_TOUR_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -30,5 +29,3 @@ struct _TourData {
     Destination* selected;
     GtkWidget* descLabel;
 };
-
-#endif /* GTK_DIALOG_TOUR_H */

--- a/src/celestia/gtk/glwidget.h
+++ b/src/celestia/gtk/glwidget.h
@@ -10,8 +10,7 @@
  *  $Id: glwidget.h,v 1.1 2005-12-06 03:19:35 suwalski Exp $
  */
 
-#ifndef GTK_GLWIDGET_H
-#define GTK_GLWIDGET_H
+#pragma once
 
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
@@ -21,5 +20,3 @@
 
 /* Initialization Functions */
 void initGLCallbacks(AppData* app);
-
-#endif /* GTK_GLWIDGET_H */

--- a/src/celestia/gtk/menu-context.h
+++ b/src/celestia/gtk/menu-context.h
@@ -10,8 +10,7 @@
  *  $Id: menu-context.h,v 1.1 2005-12-06 03:19:35 suwalski Exp $
  */
 
-#ifndef GTK_MENU_CONTEXT_H
-#define GTK_MENU_CONTEXT_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -28,5 +27,3 @@ class GTKContextMenuHandler : public CelestiaCore::ContextMenuHandler
 
     void requestContextMenu(float, float, Selection sel);
 };
-
-#endif /* GTK_MENU_CONTEXT_H */

--- a/src/celestia/gtk/settings-file.h
+++ b/src/celestia/gtk/settings-file.h
@@ -10,8 +10,7 @@
  *  $Id: settings-file.h,v 1.1 2005-12-06 03:19:35 suwalski Exp $
  */
 
-#ifndef GTK_SETTINGS_FILE_H
-#define GTK_SETTINGS_FILE_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -29,5 +28,3 @@ void applySettingsFileMain(AppData* app, GKeyFile* file);
 
 /* Save Settings to File */
 void saveSettingsFile(AppData* app);
-
-#endif /* GTK_SETTINGS_FILE_H */

--- a/src/celestia/gtk/settings-gconf.h
+++ b/src/celestia/gtk/settings-gconf.h
@@ -10,8 +10,7 @@
  *  $Id: settings-gconf.h,v 1.1 2005-12-06 03:19:36 suwalski Exp $
  */
 
-#ifndef GTK_SETTINGS_GCONF_H
-#define GTK_SETTINGS_GCONF_H
+#pragma once
 
 #include <gconf/gconf-client.h>
 
@@ -40,5 +39,3 @@ enum {
     Orbit = 1,
     Label = 2,
 };
-
-#endif /* GTK_SETTINGS_GCONF_H */

--- a/src/celestia/gtk/splash.h
+++ b/src/celestia/gtk/splash.h
@@ -10,8 +10,7 @@
  *  $Id: splash.h,v 1.1 2006-01-01 23:43:52 suwalski Exp $
  */
 
-#ifndef GTK_SPLASH_H
-#define GTK_SPLASH_H
+#pragma once
 
 #include "common.h"
 
@@ -50,6 +49,3 @@ struct _SplashData {
 SplashData* splashStart(AppData* app, gboolean showSplash, const gchar* installDir, const gchar* defaultDir);
 void splashEnd(SplashData* ss);
 void splashSetText(SplashData* ss, const char* text);
-
-
-#endif /* GTK_SPLASH_H */

--- a/src/celestia/gtk/ui.h
+++ b/src/celestia/gtk/ui.h
@@ -10,8 +10,7 @@
  *  $Id: ui.h,v 1.6 2006-12-12 00:31:01 suwalski Exp $
  */
 
-#ifndef GTK_UI_H
-#define GTK_UI_H
+#pragma once
 
 #include <gtk/gtk.h>
 
@@ -192,5 +191,3 @@ static const GtkToggleActionEntry actionsLabelFlags[] = {
     { "LabelsLatin", NULL, "Labels in Latin", NULL, NULL, NULL, FALSE },
     */
 };
-
-#endif /* GTK_UI_H */

--- a/src/celestia/helper.h
+++ b/src/celestia/helper.h
@@ -1,5 +1,4 @@
-#ifndef _HELPER_H_
-#define _HELPER_H_
+#pragma once
 
 #include <string>
 
@@ -20,5 +19,3 @@ class Helper
     static bool hasPrimaryBody(const Body* body, int classification);
     static bool hasBarycenter(const Body* body);
 };
-
-#endif

--- a/src/celestia/moviecapture.h
+++ b/src/celestia/moviecapture.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _MOVIECAPTURE_H_
-#define _MOVIECAPTURE_H_
+#pragma once
 
 #include <celcompat/filesystem.h>
 
@@ -38,6 +37,3 @@ class MovieCapture
  protected:
     const Renderer *renderer{ nullptr };
 };
-
-#endif // _MOVIECAPTURE_H_
-

--- a/src/celestia/qt/qtappwin.h
+++ b/src/celestia/qt/qtappwin.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _QTAPPWIN_H_
-#define _QTAPPWIN_H_
+#pragma once
 
 #include <celestia/celestiacore.h>
 #include <QImage>
@@ -161,6 +160,3 @@ class CelestiaAppWindow : public QMainWindow, public CelestiaCore::ContextMenuHa
 
     QTimer *timer;
 };
-
-
-#endif // _QTAPPWIN_H_

--- a/src/celestia/qt/qtbookmark.h
+++ b/src/celestia/qt/qtbookmark.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELESTIA_QTBOOKMARK_H_
-#define _CELESTIA_QTBOOKMARK_H_
+#pragma once
 
 #include <QString>
 #include <QList>
@@ -232,6 +231,3 @@ public slots:
 private:
     BookmarkManager* m_manager;
 };
-
-
-#endif // _CELESTIA_QT_BOOKMARK_H_

--- a/src/celestia/qt/qtcelestiaactions.h
+++ b/src/celestia/qt/qtcelestiaactions.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELESTIAACTIONS_H_
-#define _CELESTIAACTIONS_H_
+#pragma once
 
 #include <QObject>
 #include "celengine/render.h"
@@ -120,5 +119,3 @@ Q_OBJECT
  private:
     CelestiaCore* appCore;
 };
-
-#endif // _CELESTIAACTIONS_H_

--- a/src/celestia/qt/qtcelestialbrowser.h
+++ b/src/celestia/qt/qtcelestialbrowser.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _QTCELESTIALBROWSER_H_
-#define _QTCELESTIALBROWSER_H_
+#pragma once
 
 #include <QWidget>
 #include <celengine/body.h>
@@ -75,5 +74,3 @@ Q_OBJECT
     ColorSwatchWidget* colorSwatch{nullptr};
     InfoPanel* infoPanel{nullptr};
 };
-
-#endif // _QTCELESTIALBROWSER_H_

--- a/src/celestia/qt/qtcolorswatchwidget.h
+++ b/src/celestia/qt/qtcolorswatchwidget.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _QTCOLORSWATCHWIDGET_H_
-#define _QTCOLORSWATCHWIDGET_H_
+#pragma once
 
 #include <QLabel>
 #include <QColor>
@@ -33,5 +32,3 @@ Q_OBJECT
  private:
     QColor m_color;
 };
-
-#endif // _QTCOLORSWATCHWIDGET_H_

--- a/src/celestia/qt/qtdeepskybrowser.h
+++ b/src/celestia/qt/qtdeepskybrowser.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _QTDEEPSKYBROWSER_H_
-#define _QTDEEPSKYBROWSER_H_
+#pragma once
 
 #include <QWidget>
 #include "celengine/selection.h"
@@ -72,5 +71,3 @@ Q_OBJECT
 
     InfoPanel* infoPanel{nullptr};
 };
-
-#endif // _QTDEEPSKYBROWSER_H_

--- a/src/celestia/qt/qteventfinder.h
+++ b/src/celestia/qt/qteventfinder.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _QTEVENTFINDER_H_
-#define _QTEVENTFINDER_H_
+#pragma once
 
 #include <QDockWidget>
 #include <QElapsedTimer>
@@ -70,5 +69,3 @@ class EventFinder : public QDockWidget, EclipseFinderWatcher
 
     const Eclipse* activeEclipse{ nullptr };
 };
-
-#endif // _QTEVENTFINDER_H_

--- a/src/celestia/qt/qtglwidget.h
+++ b/src/celestia/qt/qtglwidget.h
@@ -11,8 +11,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef QTGLWIDGET_H
-#define QTGLWIDGET_H
+#pragma once
 
 #include <string>
 #include <vector>
@@ -67,5 +66,3 @@ private:
     //KActionCollection* actionColl;
 
 };
-
-#endif

--- a/src/celestia/qt/qtinfopanel.h
+++ b/src/celestia/qt/qtinfopanel.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _INFOPANEL_H_
-#define _INFOPANEL_H_
+#pragma once
 
 #include <QDockWidget>
 #include <QTextStream>
@@ -53,5 +52,3 @@ class InfoPanel : public QDockWidget
  public:
     QTextBrowser* textBrowser{nullptr};
 };
-
-#endif // _INFOPANEL_H_

--- a/src/celestia/qt/qtselectionpopup.h
+++ b/src/celestia/qt/qtselectionpopup.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _QTSELECTIONPOPUP_H_
-#define _QTSELECTIONPOPUP_H_
+#pragma once
 
 #include <QMenu>
 #include <celengine/selection.h>
@@ -72,5 +71,3 @@ Q_OBJECT
     QAction* centerAction;
     QAction* gotoAction;
 };
-
-#endif // _QTSELECTIONPOPUP_H_

--- a/src/celestia/qt/qtsettimedialog.h
+++ b/src/celestia/qt/qtsettimedialog.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _QTSETTIMEDIALOG_H_
-#define _QTSETTIMEDIALOG_H_
+#pragma once
 
 #include <QDialog>
 
@@ -58,5 +57,3 @@ Q_OBJECT
 
     QDoubleSpinBox* julianDateSpin;
 };
-
-#endif // _QTSETTIMEDIALOG_H_

--- a/src/celestia/qt/qtsolarsystembrowser.h
+++ b/src/celestia/qt/qtsolarsystembrowser.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _QTSOLARSYSTEMBROWSER_H_
-#define _QTSOLARSYSTEMBROWSER_H_
+#pragma once
 
 #include <QWidget>
 #include "celengine/selection.h"
@@ -71,5 +70,3 @@ Q_OBJECT
 
     InfoPanel* infoPanel{nullptr};
 };
-
-#endif // _QTSOLARSYSTEMBROWSER_H_

--- a/src/celestia/qt/qttimetoolbar.h
+++ b/src/celestia/qt/qttimetoolbar.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _QTTIMETOOLBAR_H_
-#define _QTTIMETOOLBAR_H_
+#pragma once
 
 #include <QToolBar>
 
@@ -40,5 +39,3 @@ Q_OBJECT
  private:
     CelestiaCore* appCore;
 };
-
-#endif // _QTTIMETOOLBAR_H_

--- a/src/celestia/qt/xbel.h
+++ b/src/celestia/qt/xbel.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELESTIA_XBEL_H_
-#define _CELESTIA_XBEL_H_
+#pragma once
 
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
@@ -49,5 +48,3 @@ public:
 private:
     void writeItem(const BookmarkItem* item);
 };
-
-#endif // _CELESTIA_XBEL_H_

--- a/src/celestia/win32/odmenu.h
+++ b/src/celestia/win32/odmenu.h
@@ -1,5 +1,4 @@
-#ifndef _ODMENU_CLW
-#define _ODMENU_CLW
+#pragma once
 
 #include <windows.h>
 #include <map>
@@ -91,5 +90,3 @@ public:
     void AddItem(HMENU hMenu, int index, MENUITEMINFO* pItemInfo=NULL);
     void DeleteItem(HMENU hMenu, int index);
 };
-
-#endif

--- a/src/celestia/win32/wglext.h
+++ b/src/celestia/win32/wglext.h
@@ -1,5 +1,4 @@
-#ifndef __wglext_h_
-#define __wglext_h_
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -510,7 +509,3 @@ typedef BOOL (WINAPI * PFNWGLSETPBUFFERATTRIBARBPROC) (HPBUFFERARB hPbuffer, con
 #include <string>
 void InitWGLExtensions(HINSTANCE);
 bool WGLExtensionSupported(const std::string& extName);
-
-#endif
-
-

--- a/src/celestia/win32/winbookmarks.h
+++ b/src/celestia/win32/winbookmarks.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELESTIA_WINBOOKMARKS_H_
-#define _CELESTIA_WINBOOKMARKS_H_
+#pragma once
 
 
 #include <windows.h>
@@ -34,5 +33,3 @@ void OrganizeBookmarksOnMouseMove(HWND, LONG, LONG);
 void OrganizeBookmarksOnLButtonUp(HWND);
 void DragDropAutoScroll(HWND);
 //HTREEITEM GetTreeViewItemHandle(HWND, char*, HTREEITEM);
-
-#endif // _CELESTIA_WINBOOKMARKS_H_

--- a/src/celestia/win32/wineclipses.h
+++ b/src/celestia/win32/wineclipses.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _WINECLIPSES_H_
-#define _WINECLIPSES_H_
+#pragma once
 
 #include <vector>
 
@@ -33,6 +32,3 @@ class EclipseFinderDialog
     Body* BodytoSet_;
     int type;
 };
-
-#endif // _WINECLIPSES_H_
-

--- a/src/celestia/win32/wingotodlg.h
+++ b/src/celestia/win32/wingotodlg.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _WINGOTODLG_H_
-#define _WINGOTODLG_H_
+#pragma once
 
 #include "celestia/celestiacore.h"
 
@@ -25,6 +24,3 @@ class GotoObjectDialog
     HWND parent;
     HWND hwnd;
 };
-
-
-#endif // _WINGOTODLG_H_

--- a/src/celestia/win32/winhyperlinks.h
+++ b/src/celestia/win32/winhyperlinks.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELESTIA_WINHYPERLINKS_H_
-#define _CELESTIA_WINHYPERLINKS_H_
+#pragma once
 
 #include <windows.h>
 
@@ -22,5 +21,3 @@
 #define IDC_HAND            MAKEINTRESOURCE(32649)
 
 BOOL MakeHyperlinkFromStaticCtrl(HWND hDlg, UINT ctrlID);
-
-#endif

--- a/src/celestia/win32/winlocations.h
+++ b/src/celestia/win32/winlocations.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELESTIA_WINLOCATIONS_H_
-#define _CELESTIA_WINLOCATIONS_H_
+#pragma once
 
 #include <windows.h>
 #include <commctrl.h>
@@ -33,6 +32,3 @@ class LocationsDialog : public CelestiaWatcher
     uint64_t initialLocationFlags;
     float initialFeatureSize;
 };
-
-#endif // _CELESTIA_WINLOCATIONS_H_
-

--- a/src/celestia/win32/winssbrowser.h
+++ b/src/celestia/win32/winssbrowser.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _WINSSBROWSER_H_
-#define _WINSSBROWSER_H_
+#pragma once
 
 #include "celestia/celestiacore.h"
 
@@ -26,6 +25,3 @@ class SolarSystemBrowser
     HWND parent;
     HWND hwnd;
 };
-
-
-#endif // _WINSTARBROWSER_H_

--- a/src/celestia/win32/winstarbrowser.h
+++ b/src/celestia/win32/winstarbrowser.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _WINSTARBROWSER_H_
-#define _WINSTARBROWSER_H_
+#pragma once
 
 #include "celestia/celestiacore.h"
 
@@ -35,6 +34,3 @@ class StarBrowser
     int predicate;
     int nStars;
 };
-
-
-#endif // _WINSTARBROWSER_H_

--- a/src/celestia/win32/wintourguide.h
+++ b/src/celestia/win32/wintourguide.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _WINTOURGUIDE_H_
-#define _WINTOURGUIDE_H_
+#pragma once
 
 #include "celestia/celestiacore.h"
 
@@ -26,7 +25,3 @@ class TourGuide
     HWND parent;
     HWND hwnd;
 };
-
-
-#endif // _TOURGUIDE_H_
-

--- a/src/celestia/win32/winviewoptsdlg.h
+++ b/src/celestia/win32/winviewoptsdlg.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _WINVIEWOPTSDLG_H_
-#define _WINVIEWOPTSDLG_H_
+#pragma once
 
 #include "celestia/celestiacore.h"
 
@@ -32,6 +31,3 @@ class ViewOptionsDialog : public CelestiaWatcher
     int initialLabelMode;
     int initialHudDetail;
 };
-
-
-#endif // _WINVIEWOPTSDLG_H_

--- a/src/celscript/lua/celx_celestia.h
+++ b/src/celscript/lua/celx_celestia.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_CELESTIA_H_
-#define _CELX_CELESTIA_H_
+#pragma once
 
 struct lua_State;
 
@@ -19,5 +18,3 @@ CelestiaCore* to_celestia(lua_State*, int);
 CelestiaCore* this_celestia(lua_State*);
 void CreateCelestiaMetaTable(lua_State*);
 void ExtendCelestiaMetaTable(lua_State*);
-
-#endif // _CELX_CELESTIA_H_

--- a/src/celscript/lua/celx_frame.h
+++ b/src/celscript/lua/celx_frame.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_FRAME_H_
-#define _CELX_FRAME_H_
+#pragma once
 
 struct lua_State;
 class ObserverFrame;
@@ -18,5 +17,3 @@ class ObserverFrame;
 extern void CreateFrameMetaTable(lua_State* l);
 extern int frame_new(lua_State* l, const ObserverFrame& frame);
 extern ObserverFrame* to_frame(lua_State* l, int index);
-
-#endif // _CELX_FRAME_H_

--- a/src/celscript/lua/celx_gl.h
+++ b/src/celscript/lua/celx_gl.h
@@ -9,11 +9,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_GL_H_
-#define _CELX_GL_H_
+#pragma once
 
 struct lua_State;
 
 extern void LoadLuaGraphicsLibrary(lua_State* l);
-
-#endif // _CELX_GL_H_

--- a/src/celscript/lua/celx_internal.h
+++ b/src/celscript/lua/celx_internal.h
@@ -10,8 +10,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_INTERNAL_H_
-#define _CELX_INTERNAL_H_
+#pragma once
 
 #include <iterator>
 #include <memory>
@@ -360,5 +359,3 @@ lua_Number Celx_SafeGetNumber(lua_State* l, int index, FatalErrors fatalErrors =
 bool Celx_SafeGetBoolean(lua_State* l, int index, FatalErrors fatalErrors = AllErrors,
                               const char* errorMsg = "Boolean argument expected",
                               bool defaultValue = false);
-
-#endif // _CELX_INTERNAL_H_

--- a/src/celscript/lua/celx_object.h
+++ b/src/celscript/lua/celx_object.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_OBJECT_H_
-#define _CELX_OBJECT_H_
+#pragma once
 
 struct lua_State;
 class Selection;
@@ -24,5 +23,3 @@ extern void CreateObjectMetaTable(lua_State* l);
 extern void ExtendObjectMetaTable(lua_State* l);
 extern Selection* to_object(lua_State* l, int index);
 extern int object_new(lua_State* l, const Selection& sel);
-
-#endif // _CELX_OBJECT_H_

--- a/src/celscript/lua/celx_observer.h
+++ b/src/celscript/lua/celx_observer.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_OBSERVER_H_
-#define _CELX_OBSERVER_H_
+#pragma once
 
 struct lua_State;
 class Observer;
@@ -18,5 +17,3 @@ class Observer;
 extern void CreateObserverMetaTable(lua_State* l);
 extern int observer_new(lua_State* l, Observer* obs);
 extern Observer* to_observer(lua_State* l, int index);
-
-#endif // _CELX_OBSERVER_H_

--- a/src/celscript/lua/celx_phase.h
+++ b/src/celscript/lua/celx_phase.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_PHASE_H_
-#define _CELX_PHASE_H_
+#pragma once
 
 #include <memory>
 
@@ -24,5 +23,3 @@ inline int celxClassId(const TimelinePhase::SharedConstPtr&)
 
 extern void CreatePhaseMetaTable(lua_State* l);
 extern int phase_new(lua_State* l, const TimelinePhase::SharedConstPtr& phase);
-
-#endif // _CELX_PHASE_H_

--- a/src/celscript/lua/celx_position.h
+++ b/src/celscript/lua/celx_position.h
@@ -9,13 +9,10 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_POSITION_H_
-#define _CELX_POSITION_H_
+#pragma once
 
 struct lua_State;
 
 extern void CreatePositionMetaTable(lua_State* l);
 extern int position_new(lua_State* l, const UniversalCoord& uc);
 extern UniversalCoord* to_position(lua_State* l, int index);
-
-#endif // _CELX_POSITION_H_

--- a/src/celscript/lua/celx_rotation.h
+++ b/src/celscript/lua/celx_rotation.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_ROTATION_H_
-#define _CELX_ROTATION_H_
+#pragma once
 
 #include <Eigen/Geometry>
 
@@ -19,5 +18,3 @@ struct lua_State;
 extern void CreateRotationMetaTable(lua_State* l);
 extern int rotation_new(lua_State* l, const Eigen::Quaterniond& qd);
 extern Eigen::Quaterniond* to_rotation(lua_State* l, int index);
-
-#endif // _CELX_ROTATION_H_

--- a/src/celscript/lua/celx_vector.h
+++ b/src/celscript/lua/celx_vector.h
@@ -9,8 +9,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELX_VECTOR_H_
-#define _CELX_VECTOR_H_
+#pragma once
 
 #include <Eigen/Geometry>
 
@@ -19,5 +18,3 @@ struct lua_State;
 extern void CreateVectorMetaTable(lua_State* l);
 extern int vector_new(lua_State* l, const Eigen::Vector3d& v);
 extern Eigen::Vector3d* to_vector(lua_State* l, int index);
-
-#endif // _CELX_VECTOR_H_

--- a/src/celutil/watcher.h
+++ b/src/celutil/watcher.h
@@ -7,8 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#ifndef _CELUTIL_WATCHER_H_
-#define _CELUTIL_WATCHER_H_
+#pragma once
 
 template<class T> class Watcher
 {
@@ -28,5 +27,3 @@ template<class T> class Watcher
 
     virtual void notifyChange(T*, int) = 0;
 };
-
-#endif // _CELUTIL_WATCHER_H_


### PR DESCRIPTION
For consistency, and to avoid defining reserved identifiers starting with underscores.