### PR TITLE
Save some memory by moving texture coordinates transform to uniforms in lodsphere

### DIFF
--- a/src/celengine/glshader.cpp
+++ b/src/celengine/glshader.cpp
@@ -130,6 +130,25 @@ FloatShaderParameter::operator=(float f)
 }
 
 
+Vec2ShaderParameter::Vec2ShaderParameter() :
+    slot(-1)
+{
+}
+
+Vec2ShaderParameter::Vec2ShaderParameter(GLuint obj, const char* name)
+{
+    slot = glGetUniformLocation(obj, name);
+}
+
+Vec2ShaderParameter&
+Vec2ShaderParameter::operator=(const Eigen::Vector2f& v)
+{
+    if (slot != -1)
+        glUniform2fv(slot, 1, v.data());
+    return *this;
+}
+
+
 Vec3ShaderParameter::Vec3ShaderParameter() :
     slot(-1)
 {

--- a/src/celengine/glshader.h
+++ b/src/celengine/glshader.h
@@ -108,6 +108,19 @@ class FloatShaderParameter
 };
 
 
+class Vec2ShaderParameter
+{
+ public:
+    Vec2ShaderParameter();
+    Vec2ShaderParameter(GLuint obj, const char* name);
+
+    Vec2ShaderParameter& operator=(const Eigen::Vector2f&);
+
+ private:
+    int slot;
+};
+
+
 class Vec3ShaderParameter
 {
  public:

--- a/src/celengine/lodspheremesh.cpp
+++ b/src/celengine/lodspheremesh.cpp
@@ -268,7 +268,7 @@ createVertices(std::vector<float>& vertices,
                 vertices.push_back(-ctheta);
             }
 
-            for (int tex = 0; tex < tc.nTexturesUsed; tex++)
+            if (tc.nTexturesUsed > 0)
             {
                 vertices.push_back(static_cast<float>(theta));
                 vertices.push_back(static_cast<float>(phi));
@@ -464,7 +464,7 @@ void LODSphereMesh::render(unsigned int attributes,
     vertexSize = 3;
     if ((attributes & Tangents) != 0)
         vertexSize += 3;
-    for (int i = 0; i < nTextures; i++)
+    if (nTextures > 0)
         vertexSize += 2;
 
     glEnableVertexAttribArray(CelestiaGLProgram::VertexCoordAttributeIndex);
@@ -651,7 +651,7 @@ LODSphereMesh::renderSection(int phi0, int theta0, int extent,
     {
         glVertexAttribPointer(CelestiaGLProgram::TextureCoord0AttributeIndex + tc,
                               2, GL_FLOAT, GL_FALSE,
-                              stride, PTR(((tc * 2) + texCoordOffset) * sizeof(float)));
+                              stride, PTR(texCoordOffset * sizeof(float)));
     }
 
     if ((ri.attributes & Tangents) != 0)
@@ -731,7 +731,7 @@ LODSphereMesh::renderSection(int phi0, int theta0, int extent,
     vertices.clear();
     int perVertexFloats = (ri.attributes & Tangents) == 0 ? 3 : 6;
     int expectedVertices = ((phi1 - phi0) / ri.step + 1) *
-                           ((theta1 - theta0) / ri.step + 1) * (perVertexFloats + nTexturesUsed * 2);
+                           ((theta1 - theta0) / ri.step + 1) * (perVertexFloats + (nTexturesUsed > 0 ? 2 : 0));
     assert(expectedVertices <= maxVertices * MaxVertexSize);
     vertices.reserve(expectedVertices);
     if ((ri.attributes & Tangents) == 0)

--- a/src/celengine/lodspheremesh.h
+++ b/src/celengine/lodspheremesh.h
@@ -25,6 +25,8 @@ namespace celmath
 class Frustum;
 }
 
+class CelestiaGLProgram;
+
 class LODSphereMesh
 {
 public:
@@ -40,12 +42,12 @@ public:
     LODSphereMesh& operator=(LODSphereMesh&&) = delete;
 
     void render(unsigned int attributes, const celmath::Frustum&, float pixWidth,
-                Texture** tex, int nTextures);
-    void render(unsigned int attributes, const celmath::Frustum&, float pixWidth,
+                Texture** tex, int nTextures, CelestiaGLProgram *);
+    void render(unsigned int attributes, const celmath::Frustum&, float pixWidth, CelestiaGLProgram *,
                 Texture* tex0 = nullptr, Texture* tex1 = nullptr,
                 Texture* tex2 = nullptr, Texture* tex3 = nullptr);
     void render(const celmath::Frustum&, float pixWidth,
-                Texture** tex, int nTextures);
+                Texture** tex, int nTextures, CelestiaGLProgram *);
 
     enum
     {
@@ -74,9 +76,10 @@ public:
     void renderPatches(int phi0, int theta0,
                        int extent,
                        int level,
-                       const RenderInfo&);
+                       const RenderInfo&,
+                       CelestiaGLProgram *);
 
-    void renderSection(int phi0, int theta0, int extent, const RenderInfo&);
+    void renderSection(int phi0, int theta0, int extent, const RenderInfo&, CelestiaGLProgram *);
 
     int vertexSize{ 0 };
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1842,11 +1842,12 @@ static void renderSphereUnlit(const RenderInfo& ri,
     celestia::util::ArrayVector<Texture*, LODSphereMesh::MAX_SPHERE_MESH_TEXTURES> textures;
 
     ShaderProperties shadprop;
+    shadprop.texUsage = ShaderProperties::TextureCoordTransform;
 
     // Set up the textures used by this object
     if (ri.baseTex != nullptr)
     {
-        shadprop.texUsage = ShaderProperties::DiffuseTexture;
+        shadprop.texUsage |= ShaderProperties::DiffuseTexture;
         textures.try_push_back(ri.baseTex);
     }
     if (ri.nightTex != nullptr)
@@ -1877,7 +1878,7 @@ static void renderSphereUnlit(const RenderInfo& ri,
     r->setPipelineState(ps);
 
     g_lodSphere->render(frustum, ri.pixWidth,
-                        textures.data(), static_cast<int>(textures.size()));
+                        textures.data(), static_cast<int>(textures.size()), prog);
 }
 
 
@@ -1889,7 +1890,7 @@ static void renderCloudsUnlit(const RenderInfo& ri,
                               Renderer *r)
 {
     ShaderProperties shadprop;
-    shadprop.texUsage = ShaderProperties::DiffuseTexture;
+    shadprop.texUsage = ShaderProperties::DiffuseTexture | ShaderProperties::TextureCoordTransform;
     shadprop.lightModel = ShaderProperties::UnlitModel;
 
     // Get a shader for the current rendering configuration
@@ -1906,7 +1907,7 @@ static void renderCloudsUnlit(const RenderInfo& ri,
     ps.depthTest = true;
     r->setPipelineState(ps);
 
-    g_lodSphere->render(frustum, ri.pixWidth, &cloudTex, 1);
+    g_lodSphere->render(frustum, ri.pixWidth, &cloudTex, 1, prog);
 }
 
 void

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -222,12 +222,13 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
     celestia::util::ArrayVector<Texture*, LODSphereMesh::MAX_SPHERE_MESH_TEXTURES> textures;
 
     ShaderProperties shadprop;
+    shadprop.texUsage = ShaderProperties::TextureCoordTransform;
     shadprop.nLights = std::min(ls.nLights, MaxShaderLights);
 
     // Set up the textures used by this object
     if (ri.baseTex != nullptr)
     {
-        shadprop.texUsage = ShaderProperties::DiffuseTexture;
+        shadprop.texUsage |= ShaderProperties::DiffuseTexture;
         textures.try_push_back(ri.baseTex);
     }
 
@@ -435,7 +436,7 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
     textures.erase(endTextures, textures.end());
     g_lodSphere->render(attributes,
                         frustum, ri.pixWidth,
-                        textures.data(), static_cast<int>(textures.size()));
+                        textures.data(), static_cast<int>(textures.size()), prog);
 }
 
 
@@ -630,12 +631,13 @@ void renderClouds_GLSL(const RenderInfo& ri,
     celestia::util::ArrayVector<Texture*, LODSphereMesh::MAX_SPHERE_MESH_TEXTURES> textures;
 
     ShaderProperties shadprop;
+    shadprop.texUsage = ShaderProperties::TextureCoordTransform;
     shadprop.nLights = ls.nLights;
 
     // Set up the textures used by this object
     if (cloudTex != nullptr)
     {
-        shadprop.texUsage = ShaderProperties::DiffuseTexture;
+        shadprop.texUsage |= ShaderProperties::DiffuseTexture;
         textures.try_push_back(cloudTex);
     }
 
@@ -718,7 +720,7 @@ void renderClouds_GLSL(const RenderInfo& ri,
     textures.erase(endTextures, textures.end());
     g_lodSphere->render(attributes,
                         frustum, ri.pixWidth,
-                        textures.data(), static_cast<int>(textures.size()));
+                        textures.data(), static_cast<int>(textures.size()), prog);
 
     prog->textureOffset = 0.0f;
 }

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -171,6 +171,17 @@ attribute vec4 in_TexCoord3;
 attribute vec4 in_Color;
 )glsl"sv;
 
+constexpr std::string_view TextureTransformUniforms = R"glsl(
+uniform vec2 texCoordBase0;
+uniform vec2 texCoordBase1;
+uniform vec2 texCoordBase2;
+uniform vec2 texCoordBase3;
+uniform vec2 texCoordDelta0;
+uniform vec2 texCoordDelta1;
+uniform vec2 texCoordDelta2;
+uniform vec2 texCoordDelta3;
+)glsl"sv;
+
 std::string
 LightProperty(unsigned int i, std::string_view property)
 {
@@ -851,9 +862,12 @@ ShadowDepth(unsigned int i)
 
 
 std::string
-TexCoord2D(unsigned int i)
+TexCoord2D(unsigned int i, bool transform)
 {
-    return fmt::format("in_TexCoord{}.st", i);
+    auto str = fmt::format("in_TexCoord{}.st", i);
+    if (!transform)
+        return str;
+    return fmt::format("(texCoordBase{} + texCoordDelta{} * {})", i, i, str);
 }
 
 
@@ -1718,6 +1732,11 @@ ShaderProperties::hasSharedTextureCoords() const
     return (texUsage & SharedTextureCoords) != 0;
 }
 
+bool
+ShaderProperties::hasTextureCoordTransform() const
+{
+    return (texUsage & TextureCoordTransform) != 0;
+}
 
 bool
 ShaderProperties::hasSpecular() const
@@ -1952,6 +1971,8 @@ R"glsl(
     source += CommonHeader;
     source += VertexHeader;
     source += CommonAttribs;
+    if (props.hasTextureCoordTransform())
+        source += TextureTransformUniforms;
 
     source += DeclareLights(props);
     source += TextureCoordDeclarations(props, Shader_Out);
@@ -2029,6 +2050,7 @@ R"glsl(
     // Output the texture coordinates. Use just a single texture coordinate if all textures are mapped
     // identically. The texture offset is added for cloud maps; specular and night texture are not offset
     // because cloud layers never have these textures.
+    bool hasTexCoordTransform = props.hasTextureCoordTransform();
     if (props.hasSharedTextureCoords())
     {
         if (props.texUsage & (ShaderProperties::DiffuseTexture  |
@@ -2038,7 +2060,7 @@ R"glsl(
                               ShaderProperties::EmissiveTexture |
                               ShaderProperties::OverlayTexture))
         {
-            source += "diffTexCoord = " + TexCoord2D(nTexCoords) + ";\n";
+            source += "diffTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + ";\n";
             source += "diffTexCoord.x += textureOffset;\n";
         }
     }
@@ -2046,7 +2068,7 @@ R"glsl(
     {
         if (props.texUsage & ShaderProperties::DiffuseTexture)
         {
-            source += "diffTexCoord = " + TexCoord2D(nTexCoords) + " + vec2(textureOffset, 0.0);\n";
+            source += "diffTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + " + vec2(textureOffset, 0.0);\n";
             nTexCoords++;
         }
 
@@ -2054,25 +2076,25 @@ R"glsl(
         {
             if (props.texUsage & ShaderProperties::NormalTexture)
             {
-                source += "normTexCoord = " + TexCoord2D(nTexCoords) + " + vec2(textureOffset, 0.0);\n";
+                source += "normTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + " + vec2(textureOffset, 0.0);\n";
                 nTexCoords++;
             }
 
             if (props.texUsage & ShaderProperties::SpecularTexture)
             {
-                source += "specTexCoord = " + TexCoord2D(nTexCoords) + ";\n";
+                source += "specTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + ";\n";
                 nTexCoords++;
             }
 
             if (props.texUsage & ShaderProperties::NightTexture)
             {
-                source += "nightTexCoord = " + TexCoord2D(nTexCoords) + ";\n";
+                source += "nightTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + ";\n";
                 nTexCoords++;
             }
 
             if (props.texUsage & ShaderProperties::EmissiveTexture)
             {
-                source += "emissiveTexCoord = " + TexCoord2D(nTexCoords) + ";\n";
+                source += "emissiveTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + ";\n";
                 nTexCoords++;
             }
         }
@@ -2144,7 +2166,7 @@ R"glsl(
 
     if ((props.texUsage & ShaderProperties::OverlayTexture) && !props.hasSharedTextureCoords())
     {
-        source += "overlayTexCoord = " + TexCoord2D(nTexCoords) + ";\n";
+        source += "overlayTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + ";\n";
         nTexCoords++;
     }
 
@@ -2544,6 +2566,8 @@ ShaderManager::buildRingsVertexShader(const ShaderProperties& props)
     source += CommonHeader;
     source += VertexHeader;
     source += CommonAttribs;
+    if (props.hasTextureCoordTransform())
+        source += TextureTransformUniforms;
 
     source += DeclareLights(props);
     source += DeclareUniform("eyePosition", Shader_Vector3);
@@ -2684,6 +2708,8 @@ ShaderManager::buildRingsVertexShader(const ShaderProperties& props)
     source += CommonHeader;
     source += VertexHeader;
     source += CommonAttribs;
+    if (props.hasTextureCoordTransform())
+        source += TextureTransformUniforms;
 
     source += DeclareLights(props);
 
@@ -2704,7 +2730,7 @@ ShaderManager::buildRingsVertexShader(const ShaderProperties& props)
     source += "\nvoid main(void)\n{\n";
 
     if (props.texUsage & ShaderProperties::DiffuseTexture)
-        source += "diffTexCoord = " + TexCoord2D(0) + ";\n";
+        source += "diffTexCoord = " + TexCoord2D(0, props.hasTextureCoordTransform()) + ";\n";
 
     source += "position = in_Position.xyz;\n";
     if (props.hasEclipseShadows())
@@ -2842,6 +2868,8 @@ ShaderManager::buildAtmosphereVertexShader(const ShaderProperties& props)
     source += CommonHeader;
     source += VertexHeader;
     source += CommonAttribs;
+    if (props.hasTextureCoordTransform())
+        source += TextureTransformUniforms;
 
     source += DeclareLights(props);
     source += DeclareUniform("eyePosition", Shader_Vector3);
@@ -2928,6 +2956,8 @@ ShaderManager::buildEmissiveVertexShader(const ShaderProperties& props)
     source += CommonHeader;
     source += VertexHeader;
     source += CommonAttribs;
+    if (props.hasTextureCoordTransform())
+        source += TextureTransformUniforms;
 
     source += DeclareUniform("opacity", Shader_Float);
 
@@ -2956,7 +2986,7 @@ ShaderManager::buildEmissiveVertexShader(const ShaderProperties& props)
     // Optional texture coordinates (generated automatically for point
     // sprites.)
     if ((props.texUsage & ShaderProperties::DiffuseTexture) && !props.usePointSize())
-        source += "    v_TexCoord0.st = " + TexCoord2D(0) + ";\n";
+        source += "    v_TexCoord0.st = " + TexCoord2D(0, props.hasTextureCoordTransform()) + ";\n";
 
     // Set the color.
 
@@ -3043,6 +3073,8 @@ ShaderManager::buildParticleVertexShader(const ShaderProperties& props)
     source << CommonHeader;
     source << VertexHeader;
     source << CommonAttribs;
+    if (props.hasTextureCoordTransform())
+        source << TextureTransformUniforms;
 
     source << "// PARTICLE SHADER\n";
     source << "// shadow count: " << props.shadowCounts << std::endl;
@@ -3373,6 +3405,13 @@ CelestiaGLProgram::samplerParam(const char *paramName)
 }
 
 
+Vec2ShaderParameter
+CelestiaGLProgram::vec2Param(const char *paramName)
+{
+    return Vec2ShaderParameter(program->getID(), paramName);
+}
+
+
 Vec3ShaderParameter
 CelestiaGLProgram::vec3Param(const char *paramName)
 {
@@ -3446,6 +3485,15 @@ CelestiaGLProgram::initParameters()
                 floatParam(IndexedParameter("shadowFalloff", i, j).c_str());
             shadows[i][j].maxDepth =
                 floatParam(IndexedParameter("shadowMaxDepth", i, j).c_str());
+        }
+    }
+
+    if (props.hasTextureCoordTransform())
+    {
+        for (unsigned int i = 0; i < maxTextureCount; ++i)
+        {
+            texCoordTransforms[i].base = vec2Param(fmt::format("texCoordBase{}", i).c_str());
+            texCoordTransforms[i].delta = vec2Param(fmt::format("texCoordDelta{}", i).c_str());
         }
     }
 

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -48,6 +48,7 @@ class ShaderProperties
 
     bool hasShadowsForLight(unsigned int) const;
     bool hasSharedTextureCoords() const;
+    bool hasTextureCoordTransform() const;
     bool hasSpecular() const;
     bool hasScattering() const;
     bool isViewDependent() const;
@@ -72,6 +73,7 @@ class ShaderProperties
      SharedTextureCoords     =  0x8000,
      StaticPointSize         = 0x10000,
      LineAsTriangles         = 0x20000,
+     TextureCoordTransform   = 0x40000,
  };
 
  enum
@@ -161,6 +163,12 @@ struct CelestiaGLProgramShadow
     FloatShaderParameter maxDepth;
 };
 
+struct CelestiaGLProgramTextureTransform
+{
+    Vec2ShaderParameter base;
+    Vec2ShaderParameter delta;
+};
+
 class CelestiaGLProgram
 {
  public:
@@ -226,6 +234,9 @@ class CelestiaGLProgram
     FloatShaderParameter cloudHeight;
     FloatShaderParameter shadowTextureOffset;
 
+    static constexpr std::size_t maxTextureCount = 4;
+    CelestiaGLProgramTextureTransform texCoordTransforms[maxTextureCount];
+
     // Parameters for atmospheric scattering; all distances are normalized for
     // a unit sphere.
     FloatShaderParameter mieCoeff;
@@ -274,6 +285,7 @@ class CelestiaGLProgram
     FloatShaderParameter floatParam(const char*);
     IntegerShaderParameter intParam(const char*);
     IntegerShaderParameter samplerParam(const char*);
+    Vec2ShaderParameter vec2Param(const char*);
     Vec3ShaderParameter vec3Param(const char*);
     Vec4ShaderParameter vec4Param(const char*);
     Mat3ShaderParameter mat3Param(const char*);


### PR DESCRIPTION
Some memory will be saved when multiple texture is used since this only passes the original texture coordinate (regardless of tile/virtual texture) now