### PR TITLE
Remove unused default move constructors of Universe and DSODatabase

### DIFF
--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -39,6 +39,10 @@ class DSODatabase
     DSODatabase() = default;
     ~DSODatabase();
 
+    DSODatabase(const DSODatabase&) = delete;
+    DSODatabase& operator=(const DSODatabase&) = delete;
+    DSODatabase(DSODatabase&&) = delete;
+    DSODatabase& operator=(DSODatabase&&) = delete;
 
     inline DeepSkyObject* getDSO(const std::uint32_t) const;
     inline std::uint32_t size() const;

--- a/src/celengine/universe.h
+++ b/src/celengine/universe.h
@@ -35,6 +35,11 @@ class Universe
     Universe() = default;
     ~Universe();
 
+    Universe(const Universe&) = delete;
+    Universe& operator=(const Universe&) = delete;
+    Universe(Universe&&) = delete;
+    Universe& operator=(Universe&&) = delete;
+
     StarDatabase* getStarCatalog() const;
     void setStarCatalog(std::unique_ptr<StarDatabase>&&);
 


### PR DESCRIPTION
Possible fix for the build issues on Debian 10?