### PR TITLE
Process only triangle lists in Mesh::optimize()

### DIFF
--- a/src/celmodel/mesh.cpp
+++ b/src/celmodel/mesh.cpp
@@ -361,6 +361,9 @@ Mesh::optimize()
 
     auto &g = groups.front();
 
+    if (g.prim != PrimitiveGroupType::TriList)
+        return;
+
     meshopt_optimizeVertexCache(g.indices.data(), g.indices.data(), g.indices.size(), nVertices);
     meshopt_optimizeOverdraw(g.indices.data(), g.indices.data(), g.indices.size(), reinterpret_cast<float*>(vertices.data()), nVertices, vertexDesc.strideBytes, 1.05f);
     meshopt_optimizeVertexFetch(vertices.data(), g.indices.data(), g.indices.size(), vertices.data(), nVertices, vertexDesc.strideBytes);


### PR DESCRIPTION
meshoptimizer doesn't support other primitives

Closes: #1445 