### PR TITLE
Use geodetic coordinates for locations

### DIFF
--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -302,6 +302,9 @@ class Body
     Eigen::Vector3d planetocentricToCartesian(const Eigen::Vector3d& lonLatAlt) const;
     Eigen::Vector3d cartesianToPlanetocentric(const Eigen::Vector3d& v) const;
 
+    Eigen::Vector3d geodeticToCartesian(double lon, double lat, double alt) const;
+    Eigen::Vector3d geodeticToCartesian(const Eigen::Vector3d& lonLatAlt) const;
+
     Eigen::Vector3d eclipticToPlanetocentric(const Eigen::Vector3d& ecl, double tdb) const;
 
     bool extant(double) const;

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -815,7 +815,11 @@ CreateOrbit(const Selection& centralObject,
         Body* centralBody = centralObject.body();
         if (centralBody != nullptr)
         {
+#if 0 // TODO: This should be enabled after #542 is fixed
+            Vector3d pos = centralBody->geodeticToCartesian(*longlat);
+#else
             Vector3d pos = centralBody->planetocentricToCartesian(longlat->x(), longlat->y(), longlat->z());
+#endif
             return new celestia::ephem::SynchronousOrbit(*centralBody, pos);
         }
         // TODO: Allow fixing objects to the surface of stars.

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -160,7 +160,7 @@ Location* CreateLocation(const Hash* locationData,
     Location* location = new Location();
 
     auto longlat = locationData->getSphericalTuple("LongLat").value_or(Eigen::Vector3d::Zero());
-    Eigen::Vector3f position = body->planetocentricToCartesian(longlat).cast<float>();
+    Eigen::Vector3f position = body->geodeticToCartesian(longlat).cast<float>();
     location->setPosition(position);
 
     auto size = locationData->getLength<float>("Size").value_or(1.0f);


### PR DESCRIPTION
Closes: #1557

For bodies attached to the surface it's disabled because #542 cuts planet too aggressively, see the screenshot in #1557.