### PR TITLE
Require at least one argument for formatting

### DIFF
--- a/src/celengine/overlay.cpp
+++ b/src/celengine/overlay.cpp
@@ -76,7 +76,7 @@ void Overlay::endText()
     restorePos();
 }
 
-void Overlay::print_impl(const std::string& s)
+void Overlay::print(std::string_view s)
 {
     layout->render(s);
 }

--- a/src/celengine/overlay.h
+++ b/src/celengine/overlay.h
@@ -56,20 +56,24 @@ class Overlay
 
     void beginText();
     void endText();
+
+    void print(std::string_view);
+
     template <typename... T>
     void print(std::string_view format, const T&... args)
     {
-        print_impl(fmt::format(format, args...));
+        static_assert(sizeof...(args) > 0);
+        print(fmt::format(format, args...));
     }
+
     template <typename... T>
     void printf(std::string_view format, const T&... args)
     {
-        print_impl(fmt::sprintf(format, args...));
+        static_assert(sizeof...(args) > 0);
+        print(fmt::sprintf(format, args...));
     }
 
  private:
-    void print_impl(const std::string&);
-
     int windowWidth{ 1 };
     int windowHeight{ 1 };
 


### PR DESCRIPTION
There were some crashes about unmatched "}" but i was not able to find the string based on the stack trace

<img width="1263" alt="Screenshot 2023-07-30 at 11 33 56" src="https://github.com/CelestiaProject/Celestia/assets/17924287/5aa34d9a-ea43-49ed-a971-cadad21fd2bf">
