### PR TITLE
Fallback to default date formatter when custom date formatter returns empty

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3199,11 +3199,10 @@ void CelestiaCore::renderOverlay()
 
         double tdb = sim->getTime() + lt;
         string dateStr;
-        if (customDateFormatter)
-        {
+        if (customDateFormatter != nullptr)
             dateStr = customDateFormatter(tdb);
-        }
-        else
+
+        if (dateStr.empty())
         {
             astro::Date d = timeZoneBias != 0 ? astro::TDBtoLocal(tdb) : astro::TDBtoUTC(tdb);
             dateStr = d.toCStr(dateFormat);


### PR DESCRIPTION
If we provide custom date formatter backed by platform APIs, it might not be able to handle distant dates.