### PR TITLE
Add star color tables relative to the Sun and Vega

### DIFF
--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -285,8 +285,8 @@ class Renderer
     void drawRectangle(const celestia::Rect& r, int fishEyeOverrideMode, const Eigen::Matrix4f& p, const Eigen::Matrix4f& m = Eigen::Matrix4f::Identity());
     void setRenderRegion(int x, int y, int width, int height, bool withScissor = true);
 
-    const ColorTemperatureTable* getStarColorTable() const;
-    void setStarColorTable(const ColorTemperatureTable*);
+    ColorTableType getStarColorTable() const;
+    void setStarColorTable(ColorTableType);
     [[deprecated]] bool getVideoSync() const;
     [[deprecated]] void setVideoSync(bool);
     void setSolarSystemMaxDistance(float);
@@ -751,7 +751,8 @@ class Renderer
     float minFeatureSize;
     uint64_t locationFilter;
 
-    const ColorTemperatureTable* colorTemp;
+    ColorTemperatureTable starColors{ ColorTableType::Blackbody_D65 };
+    ColorTemperatureTable tintColors{ ColorTableType::SunWhite };
 
     Selection highlightObject;
 

--- a/src/celengine/starcolors.h
+++ b/src/celengine/starcolors.h
@@ -11,30 +11,31 @@
 
 #pragma once
 
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include <Eigen/Core>
+
 #include <celmath/vecgl.h>
 #include <celutil/color.h>
-#include <celutil/array_view.h>
 
 enum class ColorTableType
 {
-    Enhanced,
-    Blackbody_D65,
+    Enhanced = 0,
+    Blackbody_D65 = 1,
+    SunWhite = 2,
+    VegaWhite = 3,
 };
 
 class ColorTemperatureTable
 {
  public:
-    ColorTemperatureTable(celestia::util::array_view<const Color> _colors,
-                          float maxTemp,
-                          ColorTableType _type) :
-        colors(_colors),
-        tempScale(static_cast<float>(_colors.size() - 1) / maxTemp),
-        tableType(_type)
-    {};
+    explicit ColorTemperatureTable(ColorTableType _type);
 
     Color lookupColor(float temp) const
     {
-        auto colorTableIndex = static_cast<unsigned int>(temp * tempScale);
+        auto colorTableIndex = static_cast<std::size_t>(std::nearbyint(temp * tempScale));
         if (colorTableIndex >= colors.size())
             return colors.back();
         else
@@ -54,11 +55,10 @@ class ColorTemperatureTable
         return tableType;
     }
 
+    bool setType(ColorTableType _type);
+
  private:
-    celestia::util::array_view<const Color> colors;
+    std::vector<Color> colors{ };
     float tempScale;
     ColorTableType tableType;
 };
-
-const ColorTemperatureTable* GetStarColorTable(ColorTableType);
-const ColorTemperatureTable* GetTintColorTable();

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -1368,25 +1368,31 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
         break;
 
     case '%':
+        switch (renderer->getStarColorTable())
         {
-            const ColorTemperatureTable* current = renderer->getStarColorTable();
+        case ColorTableType::Enhanced:
+            renderer->setStarColorTable(ColorTableType::Blackbody_D65);
+            flash(_("Star color: Blackbody D65"));
+            notifyWatchers(RenderFlagsChanged);
+            break;
 
-            if (current->type() == ColorTableType::Enhanced)
-            {
-                renderer->setStarColorTable(GetStarColorTable(ColorTableType::Blackbody_D65));
-                flash(_("Star color: Blackbody D65"));
-                notifyWatchers(RenderFlagsChanged);
-            }
-            else if (current->type() == ColorTableType::Blackbody_D65)
-            {
-                renderer->setStarColorTable(GetStarColorTable(ColorTableType::Enhanced));
-                flash(_("Star color: Enhanced"));
-                notifyWatchers(RenderFlagsChanged);
-            }
-            else
-            {
-                // Unknown color table
-            }
+        case ColorTableType::Blackbody_D65:
+            renderer->setStarColorTable(ColorTableType::SunWhite);
+            flash(_("Star color: Blackbody (Solar Whitepoint)"));
+            notifyWatchers(RenderFlagsChanged);
+            break;
+
+        case ColorTableType::SunWhite:
+            renderer->setStarColorTable(ColorTableType::VegaWhite);
+            flash(_("Star color: Blackbody (Vega Whitepoint)"));
+            notifyWatchers(RenderFlagsChanged);
+            break;
+
+        case ColorTableType::VegaWhite:
+            renderer->setStarColorTable(ColorTableType::Enhanced);
+            flash(_("Star color: Classic"));
+            notifyWatchers(RenderFlagsChanged);
+            break;
         }
         break;
 

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -534,12 +534,7 @@ void CelestiaAppWindow::writeSettings()
     settings.setValue("TintSaturation", renderer->getTintSaturation());
     settings.setValue("StarStyle", renderer->getStarStyle());
     settings.setValue("TextureResolution", renderer->getResolution());
-    ColorTableType colorsst;
-    if (renderer->getStarColorTable()->type() == ColorTableType::Blackbody_D65)
-        colorsst = ColorTableType::Blackbody_D65;
-    else // if (renderer->getStarColorTable()->type() == ColorTableType::Enhanced)
-        colorsst = ColorTableType::Enhanced;
-    settings.setValue("StarsColor", static_cast<int>(colorsst));
+    settings.setValue("StarsColor", static_cast<int>(renderer->getStarColorTable()));
 
     Simulation* simulation = m_appCore->getSimulation();
 
@@ -1678,4 +1673,3 @@ void CelestiaAppWindow::pasteTextOrURL()
     else
         slotPasteURL();
 }
-

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -133,10 +133,7 @@ void CelestiaGlWidget::initializeGL()
     appRenderer->setStarStyle((Renderer::StarStyle) settings.value("StarStyle", DEFAULT_STAR_STYLE).toInt());
     appRenderer->setResolution(settings.value("TextureResolution", DEFAULT_TEXTURE_RESOLUTION).toUInt());
 
-    if (settings.value("StarsColor", DEFAULT_STARS_COLOR).toInt() == static_cast<int>(ColorTableType::Enhanced))
-        appRenderer->setStarColorTable(GetStarColorTable(ColorTableType::Enhanced));
-    else
-        appRenderer->setStarColorTable(GetStarColorTable(ColorTableType::Blackbody_D65));
+    appRenderer->setStarColorTable(static_cast<ColorTableType>(settings.value("StarsColor", DEFAULT_STARS_COLOR).toInt()));
 
     appCore->getSimulation()->setFaintestVisible((float) settings.value("Preferences/VisualMagnitude", DEFAULT_VISUAL_MAGNITUDE).toDouble());
 

--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -75,17 +75,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
     uint64_t locationFlags = observer->getLocationFilter();
     int labelMode = renderer->getLabelMode();
 
-    ColorTableType colors;
-    const ColorTemperatureTable* current = renderer->getStarColorTable();
-    if (current->type() == ColorTableType::Blackbody_D65)
-    {
-        colors = ColorTableType::Blackbody_D65;
-    }
-    else // if (current->type() == ColorTableType::Enhanced)
-    {
-        // TODO: Figure out what we should do if we have an unknown color table
-        colors = ColorTableType::Enhanced;
-    }
+    ColorTableType colors = renderer->getStarColorTable();
 
     ui.starsCheck->setChecked((renderFlags & Renderer::ShowStars) != 0);
     ui.planetsCheck->setChecked((renderFlags & Renderer::ShowPlanets) != 0);
@@ -188,9 +178,9 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
 
     auto tint = static_cast<int>(renderer->getTintSaturation() * 100.0f);
     ui.tintSaturationSlider->setValue(tint);
-    ui.tintSaturationSlider->setEnabled(colors == ColorTableType::Blackbody_D65);
+    ui.tintSaturationSlider->setEnabled(colors != ColorTableType::Enhanced);
     ui.tintSaturationSpinBox->setValue(tint);
-    ui.tintSaturationSpinBox->setEnabled(colors == ColorTableType::Blackbody_D65);
+    ui.tintSaturationSpinBox->setEnabled(colors != ColorTableType::Enhanced);
 
     int starStyle = renderer->getStarStyle();
 
@@ -209,6 +199,8 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
     }
 
     ui.starColorBox->addItem(_("Blackbody D65"), static_cast<int>(ColorTableType::Blackbody_D65));
+    ui.starColorBox->addItem(_("Blackbody (Solar Whitepoint)"), static_cast<int>(ColorTableType::SunWhite));
+    ui.starColorBox->addItem(_("Blackbody (Vega Whitepoint)"), static_cast<int>(ColorTableType::VegaWhite));
     ui.starColorBox->addItem(_("Classic colors"), static_cast<int>(ColorTableType::Enhanced));
     SetComboBoxValue(ui.starColorBox, static_cast<int>(colors));
 
@@ -837,8 +829,8 @@ void PreferencesDialog::on_starColorBox_currentIndexChanged(int index)
     Renderer* renderer = appCore->getRenderer();
     QVariant itemData = ui.starColorBox->itemData(index, Qt::UserRole);
     ColorTableType value = static_cast<ColorTableType>(itemData.toInt());
-    renderer->setStarColorTable(GetStarColorTable(value));
-    bool enableTintSaturation = value == ColorTableType::Blackbody_D65;
+    renderer->setStarColorTable(value);
+    bool enableTintSaturation = value != ColorTableType::Enhanced;
     ui.tintSaturationSlider->setEnabled(enableTintSaturation);
     ui.tintSaturationSpinBox->setEnabled(enableTintSaturation);
 }

--- a/src/celestia/win32/res/celestia.rc
+++ b/src/celestia/win32/res/celestia.rc
@@ -222,8 +222,10 @@ IDR_MAIN_MENU MENU
         }
         POPUP "Star &Color"
         {
-            MENUITEM "&Disabled", ID_STARCOLOR_DISABLED, CHECKED
-            MENUITEM "&Enabled", ID_STARCOLOR_ENABLED
+            MENUITEM "Blackbody D65", ID_STARCOLOR_D65, CHECKED
+            MENUITEM "Blackbody (Solar Whitepoint)", ID_STARCOLOR_SOLAR
+            MENUITEM "Blackbody (Vega Whitepoint)", ID_STARCOLOR_VEGA
+            MENUITEM "Classic colors", ID_STARCOLOR_CLASSIC
         }
         MENUITEM SEPARATOR
         POPUP "&Ambient Light"

--- a/src/celestia/win32/res/resource.h
+++ b/src/celestia/win32/res/resource.h
@@ -269,9 +269,11 @@
 #define ID_RENDER_VELOCITY_VECTOR       40086
 #define ID_RENDER_PLANETOGRAPHIC_GRID   40087
 #define ID_RENDER_TERMINATOR            40088
-#define ID_STARCOLOR_DISABLED           40089
-#define ID_STARCOLOR_ENABLED            40090
-#define ID_SELECT_PRIMARY_BODY          40091
+#define ID_STARCOLOR_CLASSIC            40089
+#define ID_STARCOLOR_D65                40090
+#define ID_STARCOLOR_SOLAR              40091
+#define ID_STARCOLOR_VEGA               40092
+#define ID_SELECT_PRIMARY_BODY          40093
 #define ID_BOOKMARKS_FIRSTBOOKMARK      41000
 #define ID_FIRST_SCRIPT                 42000
 

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -1718,12 +1718,24 @@ static int celestia_getstarcolor(lua_State* l)
         return 0;
     }
 
-    if (auto starColor = renderer->getStarColorTable()->type(); starColor == ColorTableType::Enhanced)
+    switch (renderer->getStarColorTable())
+    {
+    case ColorTableType::Enhanced:
         lua_pushstring(l, "enhanced");
-    else if (starColor == ColorTableType::Blackbody_D65)
+        break;
+    case ColorTableType::Blackbody_D65:
         lua_pushstring(l, "blackbody_d65");
-    else
+        break;
+    case ColorTableType::SunWhite:
+        lua_pushstring(l, "sunwhite");
+        break;
+    case ColorTableType::VegaWhite:
+        lua_pushstring(l, "vegawhite");
+        break;
+    default:
         lua_pushstring(l, "invalid starcolor");
+        break;
+    }
 
     return 1;
 }
@@ -1742,9 +1754,13 @@ static int celestia_setstarcolor(lua_State* l)
     }
 
     if (starColor == "blackbody_d65")
-        renderer->setStarColorTable(GetStarColorTable(ColorTableType::Blackbody_D65));
+        renderer->setStarColorTable(ColorTableType::Blackbody_D65);
     else if (starColor == "enhanced")
-        renderer->setStarColorTable(GetStarColorTable(ColorTableType::Enhanced));
+        renderer->setStarColorTable(ColorTableType::Enhanced);
+    else if (starColor == "sunwhite")
+        renderer->setStarColorTable(ColorTableType::SunWhite);
+    else if (starColor == "vegawhite")
+        renderer->setStarColorTable(ColorTableType::VegaWhite);
     else
         Celx_DoError(l, "Invalid starcolor");
     appCore->notifyWatchers(CelestiaCore::RenderFlagsChanged);


### PR DESCRIPTION
Some additional color palettes for the stars: blackbody colors relative to the Sun (already used for tinted illumination) and Vega. I chose Vega-relative colors as the additional palette due to the use of Vega as a standard star in optical astronomy. I've also adjusted the color bucketing to use rounding (using `nearbyint` to avoid the performance hit of using a non-default rounding mode) rather than truncation, so the Sun ends up with the 5800 K colors rather than 5700 K.

Related issue: #1637