### PR TITLE
Add components to install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,11 +452,24 @@ set(BASE_DATA_SOURCES
   controls.txt
   COPYING
 )
-install(FILES ${BASE_DATA_SOURCES} DESTINATION ${DATADIR})
-install(FILES "splash.png" DESTINATION "${DATADIR}/splash")
+install(
+  FILES ${BASE_DATA_SOURCES}
+  DESTINATION ${DATADIR}
+  COMPONENT core
+)
+install(
+  FILES "splash.png"
+  DESTINATION "${DATADIR}/splash"
+  COMPONENT core
+)
 
 if(NOT WIN32)
-  install(FILES celestia-logo.png DESTINATION "${CMAKE_INSTALL_DATADIR}/pixmaps" RENAME celestia.png)
+  install(
+    FILES celestia-logo.png
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/pixmaps"
+    RENAME celestia.png
+    COMPONENT core
+  )
 endif()
 
 add_subdirectory(src)

--- a/cmake/FixGettext.cmake
+++ b/cmake/FixGettext.cmake
@@ -1,45 +1,50 @@
 macro(GETTEXT_CREATE_TRANSLATIONS2 _potFile _firstPoFileArg)
-   # make it a real variable, so we can modify it here
-   set(_firstPoFile "${_firstPoFileArg}")
+  # make it a real variable, so we can modify it here
+  set(_firstPoFile "${_firstPoFileArg}")
 
-   set(_gmoFiles)
-   get_filename_component(_potName ${_potFile} NAME)
-   string(REGEX REPLACE "^(.+)(\\.[^.]+)$" "\\1" _potBasename ${_potName})
-   get_filename_component(_absPotFile ${_potFile} ABSOLUTE)
+  set(_gmoFiles)
+  get_filename_component(_potName ${_potFile} NAME)
+  string(REGEX REPLACE "^(.+)(\\.[^.]+)$" "\\1" _potBasename ${_potName})
+  get_filename_component(_absPotFile ${_potFile} ABSOLUTE)
 
-   set(_addToAll)
-   if(${_firstPoFile} STREQUAL "ALL")
-      set(_addToAll "ALL")
-      set(_firstPoFile)
-   endif()
+  set(_addToAll)
+  if(${_firstPoFile} STREQUAL "ALL")
+    set(_addToAll "ALL")
+    set(_firstPoFile)
+  endif()
 
-   foreach (_currentPoFile ${_firstPoFile} ${ARGN})
-      get_filename_component(_absFile ${_currentPoFile} ABSOLUTE)
-      get_filename_component(_abs_PATH ${_absFile} PATH)
-      get_filename_component(_lang ${_absFile} NAME_WE)
-      set(_gmoFile ${CMAKE_CURRENT_BINARY_DIR}/${_lang}.gmo)
-      set(_poFile ${CMAKE_CURRENT_BINARY_DIR}/${_lang}.po)
+  foreach (_currentPoFile ${_firstPoFile} ${ARGN})
+    get_filename_component(_absFile ${_currentPoFile} ABSOLUTE)
+    get_filename_component(_abs_PATH ${_absFile} PATH)
+    get_filename_component(_lang ${_absFile} NAME_WE)
+    set(_gmoFile ${CMAKE_CURRENT_BINARY_DIR}/${_lang}.gmo)
+    set(_poFile ${CMAKE_CURRENT_BINARY_DIR}/${_lang}.po)
 
-      add_custom_command(
-         OUTPUT ${_gmoFile}
-         COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE} --quiet --output-file=${_poFile} --lang=${_lang} --sort-output ${_absFile} ${_absPotFile}
-         COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${_gmoFile} ${_poFile}
-         DEPENDS ${_absPotFile} ${_absFile}
-      )
+    add_custom_command(
+      OUTPUT ${_gmoFile}
+      COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE} --quiet --output-file=${_poFile} --lang=${_lang} --sort-output ${_absFile} ${_absPotFile}
+      COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${_gmoFile} ${_poFile}
+      DEPENDS ${_absPotFile} ${_absFile}
+    )
 
-      install(FILES ${_gmoFile} DESTINATION ${CMAKE_INSTALL_LOCALEDIR}/${_lang}/LC_MESSAGES RENAME ${_potBasename}.mo)
-      set(_gmoFiles ${_gmoFiles} ${_gmoFile})
+    install(
+      FILES ${_gmoFile}
+      DESTINATION ${CMAKE_INSTALL_LOCALEDIR}/${_lang}/LC_MESSAGES
+      RENAME ${_potBasename}.mo
+      COMPONENT core
+    )
+    set(_gmoFiles ${_gmoFiles} ${_gmoFile})
 
-   endforeach ()
+  endforeach ()
 
-   if(NOT TARGET translations)
-      add_custom_target(translations)
-   endif()
+  if(NOT TARGET translations)
+    add_custom_target(translations)
+  endif()
 
   _GETTEXT_GET_UNIQUE_TARGET_NAME(translations uniqueTargetName)
 
-   add_custom_target(${uniqueTargetName} ${_addToAll} DEPENDS ${_gmoFiles})
+  add_custom_target(${uniqueTargetName} ${_addToAll} DEPENDS ${_gmoFiles})
 
-   add_dependencies(translations ${uniqueTargetName})
+  add_dependencies(translations ${uniqueTargetName})
 
 endmacro()

--- a/cmake/windres.cmake
+++ b/cmake/windres.cmake
@@ -38,7 +38,11 @@ macro(WINDRES_CREATE_TRANSLATIONS _rcFile _firstPoFileArg)
       set_target_properties(${_dllFile} PROPERTIES LINK_FLAGS "/MANIFEST:NO /NODEFAULTLIB /NOENTRY")
     endif()
 
-    install(TARGETS ${_dllFile} LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}/locale)
+    install(
+      TARGETS ${_dllFile}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}/locale
+      COMPONENT core
+    )
     set(_dllFiles ${_dllFiles} ${_dllFile})
   endforeach()
 

--- a/fonts/CMakeLists.txt
+++ b/fonts/CMakeLists.txt
@@ -1,3 +1,7 @@
 file(GLOB FONTS_SOURCES "*.ttf")
 
-install(FILES ${FONTS_SOURCES} DESTINATION "${DATADIR}/fonts")
+install(
+  FILES ${FONTS_SOURCES}
+  DESTINATION "${DATADIR}/fonts"
+  COMPONENT core
+)

--- a/help/CMakeLists.txt
+++ b/help/CMakeLists.txt
@@ -1,5 +1,13 @@
 file(GLOB HELP_SOURCES "*.html")
 file(GLOB HELP2_SOURCES "CelestiaGuide/*.*")
 
-install(FILES ${HELP_SOURCES} DESTINATION "${DATADIR}/help")
-install(FILES ${HELP2_SOURCES} DESTINATION "${DATADIR}/help/CelestiaGuide")
+install(
+  FILES ${HELP_SOURCES}
+  DESTINATION "${DATADIR}/help"
+  COMPONENT core
+)
+install(
+  FILES ${HELP2_SOURCES}
+  DESTINATION "${DATADIR}/help/CelestiaGuide"
+  COMPONENT core
+)

--- a/images/CMakeLists.txt
+++ b/images/CMakeLists.txt
@@ -1,3 +1,7 @@
 file(GLOB IMAGES_SOURCES INFO.txt "*.jpg" "*.png" "*.dds")
 
-install(FILES ${IMAGES_SOURCES} DESTINATION "${DATADIR}/images")
+install(
+  FILES ${IMAGES_SOURCES}
+  DESTINATION "${DATADIR}/images"
+  COMPONENT core
+)

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -1,3 +1,7 @@
 file(GLOB LOCALE_SOURCES "controls_*.txt" "*.cel")
 
-install(FILES ${LOCALE_SOURCES} DESTINATION "${DATADIR}/locale")
+install(
+  FILES ${LOCALE_SOURCES}
+  DESTINATION "${DATADIR}/locale"
+  COMPONENT core
+)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,3 +1,7 @@
 file(GLOB SCRIPTS_SOURCES "*.cel" "*.celx" "overlay/*.cel" "overlay/*.celx")
 
-install(FILES ${SCRIPTS_SOURCES} DESTINATION "${DATADIR}/scripts")
+install(
+  FILES ${SCRIPTS_SOURCES}
+  DESTINATION "${DATADIR}/scripts"
+  COMPONENT core
+)

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -1,3 +1,7 @@
 file(GLOB SHADERS_SOURCES *.glsl)
 
-install(FILES ${SHADERS_SOURCES} DESTINATION "${DATADIR}/shaders")
+install(
+  FILES ${SHADERS_SOURCES}
+  DESTINATION "${DATADIR}/shaders"
+  COMPONENT core
+)

--- a/src/celestia/CMakeLists.txt
+++ b/src/celestia/CMakeLists.txt
@@ -106,13 +106,21 @@ if (HAVE_MESHOPTIMIZER)
 endif()
 
 if(WIN32)
-  install(TARGETS celestia RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-  install(TARGETS celestia RUNTIME_DEPENDENCIES
-    PRE_EXCLUDE_REGEXES "^api-ms" "^ext-ms-"
-    POST_EXCLUDE_REGEXES ".*system32/.*\\.dll$"
+  install(
+    TARGETS celestia
+    RUNTIME_DEPENDENCIES
+      PRE_EXCLUDE_REGEXES "^api-ms" "^ext-ms-"
+      POST_EXCLUDE_REGEXES ".*system32/.*\\.dll$"
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT core
   )
 else()
-  install(TARGETS celestia LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} NAMELINK_SKIP)
+  install(
+    TARGETS celestia
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    NAMELINK_SKIP
+    COMPONENT core
+  )
 endif()
 
 add_subdirectory(gtk)

--- a/src/celestia/gtk/CMakeLists.txt
+++ b/src/celestia/gtk/CMakeLists.txt
@@ -97,6 +97,10 @@ if (ENABLE_GLES)
   target_link_libraries(celestia-gtk celestia ${GLESv2_LIBRARIES})
 endif()
 
-install(TARGETS celestia-gtk RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  TARGETS celestia-gtk
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT gtkgui
+)
 
 add_subdirectory(data)

--- a/src/celestia/gtk/data/CMakeLists.txt
+++ b/src/celestia/gtk/data/CMakeLists.txt
@@ -1,8 +1,20 @@
-install(FILES celestiaui.xml celestia-logo.png
-        DESTINATION "${DATADIR}")
-install(FILES celestia-gtk.desktop
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/applications")
-install(FILES space.celestia.celestia_gtk.metainfo.xml
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo")
-install(FILES celestia-gtk.1
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/man/man1")
+install(
+  FILES celestiaui.xml celestia-logo.png
+  DESTINATION "${DATADIR}"
+  COMPONENT gtkgui
+)
+install(
+  FILES celestia-gtk.desktop
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/applications"
+  COMPONENT gtkgui
+)
+install(
+  FILES space.celestia.celestia_gtk.metainfo.xml
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo"
+  COMPONENT gtkgui
+)
+install(
+  FILES celestia-gtk.1
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/man/man1"
+  COMPONENT gtkgui
+)

--- a/src/celestia/qt5/CMakeLists.txt
+++ b/src/celestia/qt5/CMakeLists.txt
@@ -46,6 +46,10 @@ if(APPLE)
   set_property(TARGET celestia-qt5 APPEND_STRING PROPERTY LINK_FLAGS " -framework CoreServices")
 endif()
 
-install(TARGETS celestia-qt5 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  TARGETS celestia-qt5
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT qt5gui
+)
 
 add_subdirectory(data)

--- a/src/celestia/qt5/data/CMakeLists.txt
+++ b/src/celestia/qt5/data/CMakeLists.txt
@@ -1,6 +1,15 @@
-install(FILES celestia-qt5.desktop
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/applications")
-install(FILES space.celestia.celestia_qt5.metainfo.xml
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo")
-install(FILES celestia-qt5.1
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/man/man1")
+install(
+  FILES celestia-qt5.desktop
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/applications"
+  COMPONENT qt5gui
+)
+install(
+  FILES space.celestia.celestia_qt5.metainfo.xml
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo"
+  COMPONENT qt5gui
+)
+install(
+  FILES celestia-qt5.1
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/man/man1"
+  COMPONENT qt5gui
+)

--- a/src/celestia/qt6/CMakeLists.txt
+++ b/src/celestia/qt6/CMakeLists.txt
@@ -39,7 +39,11 @@ if(APPLE)
   set_property(TARGET celestia-qt6 APPEND_STRING PROPERTY LINK_FLAGS " -framework CoreServices")
 endif()
 
-install(TARGETS celestia-qt6 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  TARGETS celestia-qt6
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT qt6gui
+)
 
 if(WIN32)
   qt6_generate_deploy_app_script(TARGET celestia-qt6
@@ -47,7 +51,10 @@ if(WIN32)
     NO_UNSUPPORTED_PLATFORM_ERROR
     NO_TRANSLATIONS
   )
-  install(SCRIPT "${deploy-celestia-qt6}")
+  install(
+    SCRIPT "${deploy-celestia-qt6}"
+    COMPONENT qt6gui
+  )
 endif()
 
 add_subdirectory(data)

--- a/src/celestia/qt6/data/CMakeLists.txt
+++ b/src/celestia/qt6/data/CMakeLists.txt
@@ -1,6 +1,15 @@
-install(FILES celestia-qt6.desktop
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/applications")
-install(FILES space.celestia.celestia_qt6.metainfo.xml
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo")
-install(FILES celestia-qt6.1
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/man/man1")
+install(
+  FILES celestia-qt6.desktop
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/applications"
+  COMPONENT qt6gui
+)
+install(
+  FILES space.celestia.celestia_qt6.metainfo.xml
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo"
+  COMPONENT qt6gui
+)
+install(
+  FILES celestia-qt6.1
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/man/man1"
+  COMPONENT qt6gui
+)

--- a/src/celestia/sdl/CMakeLists.txt
+++ b/src/celestia/sdl/CMakeLists.txt
@@ -17,4 +17,8 @@ else()
   target_include_directories(celestia-sdl PRIVATE ${SDL2_INCLUDE_DIRS})
   target_link_libraries(celestia-sdl PRIVATE ${SDL2_LIBRARIES})
 endif()
-install(TARGETS celestia-sdl RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  TARGETS celestia-sdl
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT sdlgui
+)

--- a/src/celestia/win32/CMakeLists.txt
+++ b/src/celestia/win32/CMakeLists.txt
@@ -49,6 +49,10 @@ add_executable(celestia-win WIN32 ${WIN32_SOURCES} ${RESOURCES})
 add_dependencies(celestia-win celestia)
 target_link_libraries(celestia-win celestia ${OPENGL_LIBRARIES})
 target_include_directories(celestia-win PRIVATE ${OPENGL_INCLUDE_DIRS})
-install(TARGETS celestia-win RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  TARGETS celestia-win
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT wingui
+)
 
 add_subdirectory(res)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -5,7 +5,11 @@ macro(install_perl_tools)
 
   set(__sources ${ARGV})
 
-  install(PROGRAMS ${__sources} DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(
+    PROGRAMS ${__sources}
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT tools
+  )
 endmacro()
 
 add_subdirectory(atmosphere)

--- a/src/tools/atmosphere/CMakeLists.txt
+++ b/src/tools/atmosphere/CMakeLists.txt
@@ -1,4 +1,8 @@
 foreach(tool scattersim scattertable)
   add_executable(${tool} "${tool}.cpp")
-  install(TARGETS ${tool} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(
+    TARGETS ${tool}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT tools
+  )
 endforeach()

--- a/src/tools/cmod/CMakeLists.txt
+++ b/src/tools/cmod/CMakeLists.txt
@@ -25,7 +25,11 @@ macro(build_cmod_tool)
   target_link_libraries(${__target} celestia cmodcommon)
   add_dependencies(${__target} celestia cmodcommon)
 
-  install(TARGETS ${__target} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(
+    TARGETS ${__target}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT tools
+  )
 endmacro()
 
 add_subdirectory(common)

--- a/src/tools/spice2xyzv/CMakeLists.txt
+++ b/src/tools/spice2xyzv/CMakeLists.txt
@@ -5,4 +5,8 @@ endif()
 add_executable(spice2xyzv "spice2xyzv.cpp")
 target_link_libraries(spice2xyzv CSPICE::CSPICE)
 
-install(FILES naif0012.tls DESTINATION "${DATADIR}")
+install(
+  FILES naif0012.tls
+  DESTINATION "${DATADIR}"
+  COMPONENT tools
+)

--- a/src/tools/stardb/CMakeLists.txt
+++ b/src/tools/stardb/CMakeLists.txt
@@ -1,5 +1,9 @@
 foreach(tool makestardb makexindex startextdump)
   add_executable(${tool} "${tool}.cpp")
   target_link_libraries(${tool} celestia)
-  install(TARGETS ${tool} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(
+    TARGETS ${tool}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT tools
+  )
 endforeach()

--- a/src/tools/vsop/CMakeLists.txt
+++ b/src/tools/vsop/CMakeLists.txt
@@ -7,5 +7,9 @@ endif()
 foreach(tool vsoptrunc-rect vsoptrunc-sph)
   add_executable(${tool} "${tool}.c")
   target_link_libraries(${tool} PUBLIC ${LIBM})
-  install(TARGETS ${tool} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(
+    TARGETS ${tool}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT tools
+  )
 endforeach()

--- a/src/tools/xyzv2bin/CMakeLists.txt
+++ b/src/tools/xyzv2bin/CMakeLists.txt
@@ -1,6 +1,10 @@
 foreach(tool xyzv2bin bin2xyzv)
   add_executable(${tool} "${tool}.cpp")
-  install(TARGETS ${tool} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(
+    TARGETS ${tool}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT tools
+  )
 endforeach()
 
 install_perl_tools(xyzv2bin.pl)


### PR DESCRIPTION
Allows installing specific parts of the application via `cmake --install <dir> --component <component>`.
Components: core, tools, gtkgui, qt5gui, qt6gui, sdlgui, wingui

The eventual aim of this is to simplify generation of the Windows installers, by collecting files via `cmake --install` before running the Inno Setup compiler on the result.