### PR TITLE
Disable the FFMPEG support on FreeBSD due to undefined symbol in libtasn1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,8 +10,7 @@ task:
                    eigen            \
                    libepoxy         \
                    gettext          \
-                   ffmpeg           \
-                   libjpeg-turbo    \
+                   jpeg-turbo       \
                    png              \
                    mesa-libs        \
                    meshoptimizer    \
@@ -34,8 +33,8 @@ task:
           -DENABLE_TESTS=ON         \
           -DENABLE_SDL=ON           \
           -DENABLE_GTK=OFF          \
-          -DENABLE_QT5=OFF           \
-          -DENABLE_FFMPEG=ON        \
+          -DENABLE_QT5=OFF          \
+          -DENABLE_FFMPEG=OFF       \
           -DENABLE_LIBAVIF=OFF      \
           -DENABLE_MINIAUDIO=ON     \
           -DUSE_ICU=OFF # tests fail on freebsd


### PR DESCRIPTION
Seems there's an issue with libtasn1 pulled in by ffmpeg that the undefined symbol sanitizer doesn't like.

Disabling ffmpeg also revealed that the install stage was installing the wrong JPEG library: we need jpeg-turbo not libjpeg-turbo (which is actually libTurboJPEG).