### PR TITLE
Use v2 of sonarcloud-github-c-cpp action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
     - name: 'Install sonar'
-      uses: SonarSource/sonarcloud-github-c-cpp@v1
+      uses: SonarSource/sonarcloud-github-c-cpp@v2
 
     - name: 'Install dependencies'
       run: |


### PR DESCRIPTION
I hope this fixes the file path issue with trying to find the sonar-scanner executable