### PR TITLE
Update unit conversions

### DIFF
--- a/src/celastro/astro.h
+++ b/src/celastro/astro.h
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <cstdint>
 #include <optional>
+#include <type_traits>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -23,35 +24,47 @@ namespace celestia::astro
 {
 
 constexpr inline float SOLAR_ABSMAG = 4.83f;
-constexpr inline float LN_MAG = 1.085736f;
+constexpr inline float LN_MAG = 1.0857362f; // 5/ln(100)
+
+namespace detail
+{
+template<typename T>
+using enable_if_fp = std::enable_if_t<std::is_floating_point_v<T>, T>;
+}
+
+// calculated in Sollya with a precision of 128 bits
+// =648000*149597870700/(9460730472580800*pi)
+template<typename T>
+constexpr inline auto LY_PER_PARSEC = detail::enable_if_fp<T>(3.26156377716743356213863970704550837409L);
 
 template<typename T>
-constexpr inline T LY_PER_PARSEC = T(3.26167);
+constexpr inline auto KM_PER_LY = detail::enable_if_fp<T>(9460730472580.8L);
 
 template<typename T>
-constexpr inline T KM_PER_LY = T(9460730472580.8);
+constexpr inline auto KM_PER_AU = detail::enable_if_fp<T>(149597870.7L);
 
+// calculated in Sollya with a precision of 128 bits
+// =9460730472580800/149597870700
 template<typename T>
-constexpr inline T KM_PER_AU = T(149597870.7);
+constexpr inline auto AU_PER_LY = detail::enable_if_fp<T>(63241.077084266280268653583182317313558L);
 
+// calculated in Sollya with a precision of 128 bits
+// =648000*149597870700/pi
 template<typename T>
-constexpr inline T AU_PER_LY = KM_PER_LY<T> / KM_PER_AU<T>;
-
-template<typename T>
-constexpr inline T KM_PER_PARSEC = KM_PER_LY<T> * LY_PER_PARSEC<T>;
+constexpr inline auto KM_PER_PARSEC = detail::enable_if_fp<T>(3.08567758149136727891393795779647161073e16L);
 
 constexpr inline double MINUTES_PER_DEG = 60.0;
 constexpr inline double SECONDS_PER_DEG = 3600.0;
 constexpr inline double DEG_PER_HRA     = 15.0;
 
 template<typename T>
-constexpr inline T EARTH_RADIUS = T(6378.14);
+constexpr inline auto EARTH_RADIUS = detail::enable_if_fp<T>(6378.14L);
 
 template<typename T>
-constexpr inline T JUPITER_RADIUS = T(71492.0);
+constexpr inline auto JUPITER_RADIUS = detail::enable_if_fp<T>(71492.0L);
 
 template<typename T>
-constexpr inline T SOLAR_RADIUS = T(696000.0);
+constexpr inline auto SOLAR_RADIUS = detail::enable_if_fp<T>(696000.0L);
 
 // Magnitude conversions
 float lumToAbsMag(float lum);

--- a/src/celcompat/numbers_impl.h
+++ b/src/celcompat/numbers_impl.h
@@ -11,19 +11,19 @@ using enable_if_fp = std::enable_if_t<std::is_floating_point_v<T>, T>;
 }
 
 // constants are given to 128 bits of precision, computed with sollya
-template<typename T> constexpr inline T e_v =          detail::enable_if_fp<T>{0x1.5bf0a8b1457695355fb8ac404e7a79e4p1};
-template<typename T> constexpr inline T log2e_v =      detail::enable_if_fp<T>{0x1.71547652b82fe1777d0ffda0d23a7d12p0};
-template<typename T> constexpr inline T log10e_v =     detail::enable_if_fp<T>{0x1.bcb7b1526e50e32a6ab7555f5a67b864p-2};
-template<typename T> constexpr inline T pi_v =         detail::enable_if_fp<T>{0x1.921fb54442d18469898cc51701b839a2p1};
-template<typename T> constexpr inline T inv_pi_v =     detail::enable_if_fp<T>{0x1.45f306dc9c882a53f84eafa3ea69bb82p-2};
-template<typename T> constexpr inline T inv_sqrtpi_v = detail::enable_if_fp<T>{0x1.20dd750429b6d11ae3a914fed7fd8688p-1};
-template<typename T> constexpr inline T ln2_v =        detail::enable_if_fp<T>{0x1.62e42fefa39ef35793c7673007e5ed5ep-1};
-template<typename T> constexpr inline T ln10_v =       detail::enable_if_fp<T>{0x1.26bb1bbb5551582dd4adac5705a61452p1};
-template<typename T> constexpr inline T sqrt2_v =      detail::enable_if_fp<T>{0x1.6a09e667f3bcc908b2fb1366ea957d3ep0};
-template<typename T> constexpr inline T sqrt3_v =      detail::enable_if_fp<T>{0x1.bb67ae8584caa73b25742d7078b83b8ap0};
-template<typename T> constexpr inline T inv_sqrt3_v =  detail::enable_if_fp<T>{0x1.279a74590331c4d218f81e4afb257d06p-1};
-template<typename T> constexpr inline T egamma_v =     detail::enable_if_fp<T>{0x1.2788cfc6fb618f49a37c7f0202a596aep-1};
-template<typename T> constexpr inline T phi_v =        detail::enable_if_fp<T>{0x1.9e3779b97f4a7c15f39cc0605cedc834p0};
+template<typename T> constexpr inline T e_v =          detail::enable_if_fp<T>(0x1.5bf0a8b1457695355fb8ac404e7a79e4p1L);
+template<typename T> constexpr inline T log2e_v =      detail::enable_if_fp<T>(0x1.71547652b82fe1777d0ffda0d23a7d12p0L);
+template<typename T> constexpr inline T log10e_v =     detail::enable_if_fp<T>(0x1.bcb7b1526e50e32a6ab7555f5a67b864p-2L);
+template<typename T> constexpr inline T pi_v =         detail::enable_if_fp<T>(0x1.921fb54442d18469898cc51701b839a2p1L);
+template<typename T> constexpr inline T inv_pi_v =     detail::enable_if_fp<T>(0x1.45f306dc9c882a53f84eafa3ea69bb82p-2L);
+template<typename T> constexpr inline T inv_sqrtpi_v = detail::enable_if_fp<T>(0x1.20dd750429b6d11ae3a914fed7fd8688p-1L);
+template<typename T> constexpr inline T ln2_v =        detail::enable_if_fp<T>(0x1.62e42fefa39ef35793c7673007e5ed5ep-1L);
+template<typename T> constexpr inline T ln10_v =       detail::enable_if_fp<T>(0x1.26bb1bbb5551582dd4adac5705a61452p1L);
+template<typename T> constexpr inline T sqrt2_v =      detail::enable_if_fp<T>(0x1.6a09e667f3bcc908b2fb1366ea957d3ep0L);
+template<typename T> constexpr inline T sqrt3_v =      detail::enable_if_fp<T>(0x1.bb67ae8584caa73b25742d7078b83b8ap0L);
+template<typename T> constexpr inline T inv_sqrt3_v =  detail::enable_if_fp<T>(0x1.279a74590331c4d218f81e4afb257d06p-1L);
+template<typename T> constexpr inline T egamma_v =     detail::enable_if_fp<T>(0x1.2788cfc6fb618f49a37c7f0202a596aep-1L);
+template<typename T> constexpr inline T phi_v =        detail::enable_if_fp<T>(0x1.9e3779b97f4a7c15f39cc0605cedc834p0L);
 
 constexpr inline double e          = e_v<double>;
 constexpr inline double log2e      = log2e_v<double>;


### PR DESCRIPTION
- Template-typed values are given to 128 bits (calculated with Sollya)
- Shortest representation of the LN_MAG constant has an additional decimal place

Resolves #1825