### PR TITLE
[gtk] Fix demo after commit 21f526

### DIFF
--- a/src/celestia/gtk/actions.cpp
+++ b/src/celestia/gtk/actions.cpp
@@ -346,6 +346,18 @@ void actionCaptureMovie(GtkAction*, AppData* app)
 }
 
 
+/* File -> Run Demo... */
+void actionRunDemo(GtkAction*, AppData* app)
+{
+    const auto& demoScriptFile = app->core->getConfig()->paths.demoScriptFile;    
+    if (!demoScriptFile.empty())
+    {
+        app->core->cancelScript();
+        app->core->runScript(demoScriptFile);
+    }
+}
+
+
 void actionQuit(GtkAction*, AppData* app)
 {
     #ifdef GNOME
@@ -688,12 +700,6 @@ void actionMultiShowActive(GtkToggleAction* action, AppData* app)
 void actionMultiSyncTime(GtkToggleAction* action, AppData* app)
 {
     app->simulation->setSyncTime(gtk_toggle_action_get_active(action));
-}
-
-
-void actionRunDemo(GtkAction*, AppData* app)
-{
-    app->core->charEntered('D');
 }
 
 

--- a/src/celestia/gtk/data/celestiaui.xml
+++ b/src/celestia/gtk/data/celestiaui.xml
@@ -8,6 +8,8 @@
       <menuitem action='CaptureImage'/>
       <menuitem action='CaptureMovie'/>
       <separator/>
+      <menuitem action='RunDemo'/>
+      <separator/>
       <menuitem action='Quit'/>
     </menu>
     <menu action='NavigationMenu'>
@@ -130,8 +132,6 @@
       <menuitem action='MultiSyncTime'/>
     </menu>
     <menu action='HelpMenu'>
-      <menuitem action='RunDemo'/>
-      <separator/>
       <menuitem action='HelpControls'/>
       <menuitem action='HelpOpenGL'/>
       <separator/>

--- a/src/celestia/gtk/ui.h
+++ b/src/celestia/gtk/ui.h
@@ -27,6 +27,7 @@ static const GtkActionEntry actionsPlain[] = {
     { "OpenScript", GTK_STOCK_OPEN, "_Open Script...", NULL, NULL, G_CALLBACK(actionOpenScript) },
     { "CaptureImage", GTK_STOCK_SAVE_AS, "_Capture Image...", NULL, NULL, G_CALLBACK(actionCaptureImage) },
     { "CaptureMovie", GTK_STOCK_SAVE_AS, "Capture _Movie...", NULL, NULL, G_CALLBACK(actionCaptureMovie) },
+    { "RunDemo", GTK_STOCK_EXECUTE, "Run _Demo", NULL, NULL, G_CALLBACK(actionRunDemo) },
     { "Quit", GTK_STOCK_QUIT, "_Quit", "<control>Q", NULL, G_CALLBACK(actionQuit) },
 
     { "NavigationMenu", NULL, "_Navigation", NULL, NULL, NULL },
@@ -79,7 +80,6 @@ static const GtkActionEntry actionsPlain[] = {
     /* "Synchronize Time" in toggle actions */
 
     { "HelpMenu", NULL, "_Help", NULL, NULL, NULL },
-    { "RunDemo", GTK_STOCK_EXECUTE, "Run _Demo", "D", NULL, G_CALLBACK(actionRunDemo) },
     { "HelpControls", GTK_STOCK_HELP, "_Controls", NULL, NULL, G_CALLBACK(actionHelpControls) },
     #if GTK_CHECK_VERSION(2, 7, 0)
     { "HelpOpenGL", GTK_STOCK_INFO, "OpenGL _Info", NULL, NULL, G_CALLBACK(actionHelpOpenGL) },


### PR DESCRIPTION
Commit 21f526 caused demo script not to run in GTK interface. This code calls demo script via action addition duplicating Qt action addition.

The commit also modified user information files to indicate to run demo script from entry in File menu. GTK runs script from entry in Help menu. This moves/updates submenu entry in GTK. (Win and Qt use File menu.)

This code also removes the D key indicator on the demo menu item.

(note: During testing, new celestiaui.xml file must replace version in main data directory in addition to compiling GTK executable.)