### PR TITLE
Use star color to tint atmospheres

### DIFF
--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -210,9 +210,6 @@ class CelestiaGLProgram
 
  public:
     CelestiaGLProgramLight lights[MaxShaderLights];
-    Vec3ShaderParameter fragLightColor[MaxShaderLights];
-    Vec3ShaderParameter fragLightSpecColor[MaxShaderLights];
-    FloatShaderParameter fragLightBrightness[MaxShaderLights];
     FloatShaderParameter ringShadowLOD[MaxShaderLights];
     Vec3ShaderParameter eyePosition;
     FloatShaderParameter shininess;

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -151,6 +151,7 @@ constexpr inline unsigned int MaxShaderEclipseShadows = 3;
 struct CelestiaGLProgramLight
 {
     Vec3ShaderParameter direction;
+    Vec3ShaderParameter color;
     Vec3ShaderParameter diffuse;
     Vec3ShaderParameter specular;
     Vec3ShaderParameter halfVector;


### PR DESCRIPTION
I merged the two sets of light parameters in the shaders (`FragLightParameter(i, "name")`/`LightParameter(i, "name")`) as they appeared to be doing the same thing (first commit).

The second commit wires up the light source color to the atmosphere scattering calculations.