### PR TITLE
[qt] Full screen toggle to common ALT + Enter  Issue #1771

### DIFF
--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -415,7 +415,12 @@ void CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
 
     QAction* fullScreenAction = new QAction(_("Full screen"), this);
     fullScreenAction->setCheckable(true);
-    fullScreenAction->setShortcut(QString(_("Shift+F11")));
+
+    // Qt defines Key_Return as enter key on keyboard and Key_Enter as enter key on numeric keypad
+    // Capture both keys
+    QList<QKeySequence> shortcuts;
+    shortcuts << QKeySequence(_("ALT+Enter")) << QKeySequence(_("ALT+Return"));
+    fullScreenAction->setShortcuts(shortcuts);
 
     // Set the full screen check state only after reading settings
     fullScreenAction->setChecked(isFullScreen());

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -415,7 +415,6 @@ void CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
 
     QAction* fullScreenAction = new QAction(_("Full screen"), this);
     fullScreenAction->setCheckable(true);
-
     // Qt defines Key_Return as enter key on keyboard and Key_Enter as enter key on numeric keypad
     // Capture both keys
     QList<QKeySequence> shortcuts;


### PR DESCRIPTION
Utilize the ALT + Enter key sequence to toggle full screen mode which is common among the Win32, SDL and Gtk interfaces, and specified in the Help manual and controls.txt file.

Closes: #1771