### PR TITLE
Remove unnecessary const from getTile return type

### DIFF
--- a/src/celengine/texture.cpp
+++ b/src/celengine/texture.cpp
@@ -528,7 +528,7 @@ void ImageTexture::bind()
 }
 
 
-const TextureTile ImageTexture::getTile(int lod, int u, int v)
+TextureTile ImageTexture::getTile(int lod, int u, int v)
 {
     if (lod != 0 || u != 0 || v != 0)
         return TextureTile(0);
@@ -756,7 +756,7 @@ int TiledTexture::getVTileCount(int /*lod*/) const
 }
 
 
-const TextureTile TiledTexture::getTile(int lod, int u, int v)
+TextureTile TiledTexture::getTile(int lod, int u, int v)
 {
     if (lod != 0 || u >= uSplit || u < 0 || v >= vSplit || v < 0)
         return TextureTile(0);
@@ -846,7 +846,7 @@ void CubeMap::bind()
 }
 
 
-const TextureTile CubeMap::getTile(int lod, int u, int v)
+TextureTile CubeMap::getTile(int lod, int u, int v)
 {
     if (lod != 0 || u != 0 || v != 0)
         return TextureTile(0);

--- a/src/celengine/texture.h
+++ b/src/celengine/texture.h
@@ -53,7 +53,7 @@ class Texture
     Texture(int w, int h, int d = 1);
     virtual ~Texture() = default;
 
-    virtual const TextureTile getTile(int lod, int u, int v) = 0;
+    virtual TextureTile getTile(int lod, int u, int v) = 0;
     virtual void bind() = 0;
 
     virtual int getLODCount() const;
@@ -131,7 +131,7 @@ class ImageTexture : public Texture
     ImageTexture(const Image& img, AddressMode, MipMapMode);
     ~ImageTexture();
 
-    const TextureTile getTile(int lod, int u, int v) override;
+    TextureTile getTile(int lod, int u, int v) override;
     void bind() override;
     void setBorderColor(Color) override;
 
@@ -148,7 +148,7 @@ class TiledTexture : public Texture
     TiledTexture(const Image& img, int _uSplit, int _vSplit, MipMapMode);
     ~TiledTexture();
 
-    const TextureTile getTile(int lod, int u, int v) override;
+    TextureTile getTile(int lod, int u, int v) override;
     void bind() override;
     void setBorderColor(Color) override;
 
@@ -168,7 +168,7 @@ class CubeMap : public Texture
     explicit CubeMap(celestia::util::array_view<const Image*>);
     ~CubeMap();
 
-    const TextureTile getTile(int lod, int u, int v) override;
+    TextureTile getTile(int lod, int u, int v) override;
     void bind() override;
     void setBorderColor(Color) override;
 

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -81,7 +81,7 @@ VirtualTexture::VirtualTexture(const fs::path& _tilePath,
 }
 
 
-const TextureTile VirtualTexture::getTile(int lod, int u, int v)
+TextureTile VirtualTexture::getTile(int lod, int u, int v)
 {
     tilesRequested++;
 

--- a/src/celengine/virtualtex.h
+++ b/src/celengine/virtualtex.h
@@ -26,7 +26,7 @@ class VirtualTexture : public Texture
                    const std::string& _tileType);
     ~VirtualTexture() = default;
 
-    const TextureTile getTile(int lod, int u, int v) override;
+    TextureTile getTile(int lod, int u, int v) override;
     void bind() override;
 
     int getLODCount() const override;


### PR DESCRIPTION
Unnecessary use of const in value return.