### PR TITLE
Remove custom date formatter

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -3199,12 +3199,7 @@ void CelestiaCore::renderOverlay()
         }
 
         double tdb = sim->getTime() + lt;
-        string dateStr;
-        if (customDateFormatter != nullptr)
-            dateStr = customDateFormatter(tdb);
-
-        if (dateStr.empty())
-            dateStr = dateFormatter->formatDate(tdb, timeZoneBias != 0, dateFormat);
+        auto dateStr = dateFormatter->formatDate(tdb, timeZoneBias != 0, dateFormat);
         int dateWidth = (TextLayout::getTextWidth(dateStr, font.get()) / (emWidth * 3) + 2) * emWidth * 3;
         if (dateWidth > dateStrWidth) dateStrWidth = dateWidth;
 

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -396,8 +396,6 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     void setContextMenuHandler(ContextMenuHandler*);
     ContextMenuHandler* getContextMenuHandler() const;
 
-    void setCustomDateFormatter(std::function<std::string(double)> df) { customDateFormatter = df; };
-
     bool setFont(const fs::path& fontPath, int collectionIndex, int fontSize);
     bool setTitleFont(const fs::path& fontPath, int collectionIndex, int fontSize);
     bool setRendererFont(const fs::path& fontPath, int collectionIndex, int fontSize, Renderer::FontStyle fontStyle);
@@ -568,7 +566,6 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     CursorShape defaultCursorShape{ CelestiaCore::CrossCursor };
     ContextMenuHandler* contextMenuHandler{ nullptr };
     std::unique_ptr<celestia::engine::DateFormatter> dateFormatter;
-    std::function<std::string(double)> customDateFormatter{ nullptr };
 
     std::vector<Url> history;
     std::vector<Url>::size_type historyCurrent{ 0 };


### PR DESCRIPTION
Custom date formatter was originally introduced to provide better localized date time strings via platform dependent implementation. Since we can use ICU to do this job now, this can be removed.