### PR TITLE
Refactor the Qt interface

### DIFF
--- a/src/celestia/eclipsefinder.cpp
+++ b/src/celestia/eclipsefinder.cpp
@@ -10,40 +10,34 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <cstring>
+#include "eclipsefinder.h"
+
 #include <cassert>
 
+#include <Eigen/Core>
 #include <Eigen/Geometry>
 
 #include <celengine/body.h>
+#include <celengine/star.h>
 #include <celmath/distance.h>
-#include <celmath/ray.h>
-#include "eclipsefinder.h"
-
-using namespace Eigen;
-using namespace std;
-using namespace celmath;
 
 
-constexpr const double dT = 1.0 / (24.0 * 60.0);
-constexpr const int EclipseObjectMask = Body::Planet      |
-                                        Body::Moon        |
-                                        Body::MinorMoon   |
-                                        Body::DwarfPlanet |
-                                        Body::Asteroid;
+namespace
+{
+
+constexpr double dT = 1.0 / (24.0 * 60.0);
+constexpr int EclipseObjectMask = Body::Planet      |
+                                  Body::Moon        |
+                                  Body::MinorMoon   |
+                                  Body::DwarfPlanet |
+                                  Body::Asteroid;
 
 // TODO: share this constant and function with render.cpp
-static const float MinRelativeOccluderRadius = 0.005f;
-
-EclipseFinder::EclipseFinder(Body* _body,
-                             EclipseFinderWatcher* _watcher) :
-    body(_body),
-    watcher(_watcher)
-{
-}
+constexpr float MinRelativeOccluderRadius = 0.005f;
 
 
-bool testEclipse(const Body& receiver, const Body& caster, double now)
+bool
+testEclipse(const Body& receiver, const Body& caster, double now)
 {
     // Ignore situations where the shadow casting body is much smaller than
     // the receiver, as these shadows aren't likely to be relevant.  Also,
@@ -60,15 +54,15 @@ bool testEclipse(const Body& receiver, const Body& caster, double now)
         // less than the distance between the sun and the receiver.  This
         // approximation works everywhere in the solar system, and likely
         // works for any orbitally stable pair of objects orbiting a star.
-        Vector3d posReceiver = receiver.getAstrocentricPosition(now);
-        Vector3d posCaster = caster.getAstrocentricPosition(now);
+        Eigen::Vector3d posReceiver = receiver.getAstrocentricPosition(now);
+        Eigen::Vector3d posCaster = caster.getAstrocentricPosition(now);
 
         const Star* sun = receiver.getSystem()->getStar();
         assert(sun != nullptr);
         double distToSun = posReceiver.norm();
         float appSunRadius = (float) (sun->getRadius() / distToSun);
 
-        Vector3d dir = posCaster - posReceiver;
+        Eigen::Vector3d dir = posCaster - posReceiver;
         double distToCaster = dir.norm() - receiver.getRadius();
         float appOccluderRadius = (float) (caster.getRadius() / distToCaster);
 
@@ -89,7 +83,7 @@ bool testEclipse(const Body& receiver, const Body& caster, double now)
         // If the distance is less than the sum of the caster's and receiver's
         // radii, then we have an eclipse.
         float R = receiver.getRadius() + shadowRadius;
-        double dist = distance(posReceiver, Eigen::ParametrizedLine<double, 3>(posCaster, posCaster));
+        double dist = celmath::distance(posReceiver, Eigen::ParametrizedLine<double, 3>(posCaster, posCaster));
         if (dist < R)
         {
             // Ignore "eclipses" where the caster and receiver have
@@ -102,9 +96,10 @@ bool testEclipse(const Body& receiver, const Body& caster, double now)
     return false;
 }
 
-#if 1
-double findEclipseSpan(const Body& receiver, const Body& caster,
-                       double now, double dt)
+
+double
+findEclipseSpan(const Body& receiver, const Body& caster,
+                double now, double dt)
 {
     double t = now;
     while (testEclipse(receiver, caster, t))
@@ -112,77 +107,14 @@ double findEclipseSpan(const Body& receiver, const Body& caster,
 
     return t;
 }
-#else
-// Given a time during an eclipse, find the start of the eclipse to
-// a precision of minStep.
-double findEclipseStart(const Body& receiver, const Body& occulter,
-                        double now,
-                        double startStep,
-                        double minStep)
-{
-    double step = startStep / 2;
-    double t = now - step;
-    bool eclipsed = true;
-
-    // Perform a binary search to find the end of the eclipse
-    while (step > minStep)
-    {
-        eclipsed = testEclipse(receiver, occulter, t);
-        step *= 0.5;
-        if (eclipsed)
-            t -= step;
-        else
-            t += step;
-    }
-
-    // Always return a time when the receiver is /not/ in eclipse
-    if (eclipsed)
-        t -= step;
-
-    return t;
-}
-
-// Given a time during an eclipse, find the end of the eclipse to
-// a precision of minStep.
-double findEclipseEnd(const Body& receiver, const Body& occulter,
-                      double now,
-                      double startStep,
-                      double minStep)
-{
-    // First do a coarse search to find the eclipse end to within the precision
-    // of startStep.
-    while (testEclipse(receiver, occulter, now + startStep))
-        now += startStep;
-
-    double step = startStep / 2;
-    double t = now + step;
-    bool eclipsed = true;
 
 
-    // Perform a binary search to find the end of the eclipse
-    while (step > minStep)
-    {
-        eclipsed = testEclipse(receiver, occulter, t);
-        step *= 0.5;
-        if (eclipsed)
-            t += step;
-        else
-            t -= step;
-    }
-
-    // Always return a time when the receiver is /not/ in eclipse
-    if (eclipsed)
-        t += step;
-
-    return t;
-}
-#endif
-
-void addEclipse(const Body& receiver, const Body& occulter,
-                double now,
-                double /*startStep*/, double /*minStep*/,
-                vector<Eclipse>& eclipses,
-                vector<double>& previousEclipseEndTimes, int i)
+void
+addEclipse(const Body& receiver, const Body& occulter,
+           double now,
+           double /*startStep*/, double /*minStep*/,
+           std::vector<Eclipse>& eclipses,
+           std::vector<double>& previousEclipseEndTimes, int i)
 {
     if (testEclipse(receiver, occulter, now))
     {
@@ -202,10 +134,21 @@ void addEclipse(const Body& receiver, const Body& occulter,
     }
 }
 
+} // end unnamed namespace
+
+
+EclipseFinder::EclipseFinder(Body* _body,
+                             EclipseFinderWatcher* _watcher) :
+    body(_body),
+    watcher(_watcher)
+{
+}
+
+
 void EclipseFinder::findEclipses(double startDate,
                                  double endDate,
                                  int eclipseTypeMask,
-                                 vector<Eclipse>& eclipses)
+                                 std::vector<Eclipse>& eclipses)
 {
     PlanetarySystem* satellites = body->getSatellites();
 
@@ -214,11 +157,11 @@ void EclipseFinder::findEclipses(double startDate,
         return;
 
     // For each body, we'll need to store the time when the last eclipse ended
-    vector<double> previousEclipseEndTimes;
+    std::vector<double> previousEclipseEndTimes;
 
     // Make a list of satellites that we'll actually test for eclipses; ignore
     // spacecraft and very small objects.
-    vector<Body*> testBodies;
+    std::vector<Body*> testBodies;
     for (int i = 0; i < satellites->getSystemSize(); i++)
     {
         Body* obj = satellites->getBody(i);

--- a/src/celestia/eclipsefinder.h
+++ b/src/celestia/eclipsefinder.h
@@ -13,7 +13,9 @@
 #pragma once
 
 #include <vector>
-#include "celestiacore.h"
+
+class Body;
+
 
 struct Eclipse
 {
@@ -30,6 +32,7 @@ struct Eclipse
     double endTime{ 0.0 };
 };
 
+
 class EclipseFinderWatcher
 {
  public:
@@ -42,6 +45,7 @@ class EclipseFinderWatcher
     virtual Status eclipseFinderProgressUpdate(double t) = 0;
     virtual ~EclipseFinderWatcher() = default;
 };
+
 
 class EclipseFinder
 {

--- a/src/celestia/qt/qtappwin.h
+++ b/src/celestia/qt/qtappwin.h
@@ -12,33 +12,40 @@
 
 #pragma once
 
-#include <celestia/celestiacore.h>
 #include <QImage>
 #include <QMainWindow>
-#include "qttimetoolbar.h"
+#include <QString>
+#include <QTimer>
 
+#include <celestia/celestiacore.h>
 
-class QMenu;
 class QCloseEvent;
+class QColor;
 class QDockWidget;
+class QMenu;
+class QPoint;
+class QToolBar;
+class QUrl;
+class QWidget;
+
+class Selection;
+
+class BookmarkManager;
+class BookmarkToolBar;
+class CelestiaActions;
 struct CelestiaCommandLineOptions;
 class CelestiaGlWidget;
 class CelestialBrowser;
-class InfoPanel;
 class EventFinder;
-class CelestiaActions;
-class FPSActionGroup;
-
+class InfoPanel;
 class PreferencesDialog;
-class BookmarkManager;
-class BookmarkToolBar;
-class QUrl;
+class TimeToolBar;
 
 class CelestiaAppWindow : public QMainWindow, public CelestiaCore::ContextMenuHandler
 {
- Q_OBJECT
+   Q_OBJECT
 
- public:
+public:
     CelestiaAppWindow(QWidget* parent = nullptr);
     ~CelestiaAppWindow();
 
@@ -49,11 +56,11 @@ class CelestiaAppWindow : public QMainWindow, public CelestiaCore::ContextMenuHa
     bool loadBookmarks();
     void saveBookmarks();
 
-    void requestContextMenu(float x, float y, Selection sel);
+    void requestContextMenu(float x, float y, Selection sel) override;
 
     void loadingProgressUpdate(const QString& s);
 
- public slots:
+public slots:
     void celestia_tick();
     void slotShowSelectionContextMenu(const QPoint& pos, Selection& sel);
     void slotManual();
@@ -62,7 +69,7 @@ class CelestiaAppWindow : public QMainWindow, public CelestiaCore::ContextMenuHa
     void setFPS(int);
     void setCustomFPS();
 
- private slots:
+private slots:
     void slotGrabImage();
     void slotCaptureVideo();
     void slotCopyImage();
@@ -110,10 +117,12 @@ class CelestiaAppWindow : public QMainWindow, public CelestiaCore::ContextMenuHa
     void copyTextOrURL();
     void pasteTextOrURL();
 
- signals:
+signals:
     void progressUpdate(const QString& s, int align, const QColor& c);
 
- private:
+private:
+    class FPSActionGroup;
+
     void initAppDataDirectory();
 
     void createActions();
@@ -121,14 +130,13 @@ class CelestiaAppWindow : public QMainWindow, public CelestiaCore::ContextMenuHa
     QMenu* buildScriptsMenu();
     void populateBookmarkMenu();
 
-    void closeEvent(QCloseEvent* event);
+    void closeEvent(QCloseEvent* event) override;
 
     void switchToNormal();
     void switchToFullscreen();
 
     QImage grabFramebuffer() const;
 
- private:
     CelestiaGlWidget* glWidget{ nullptr };
     QDockWidget* toolsDock{ nullptr };
     CelestialBrowser* celestialBrowser{ nullptr };

--- a/src/celestia/qt/qtappwin.h
+++ b/src/celestia/qt/qtappwin.h
@@ -43,7 +43,7 @@ class TimeToolBar;
 
 class CelestiaAppWindow : public QMainWindow, public CelestiaCore::ContextMenuHandler
 {
-   Q_OBJECT
+     Q_OBJECT
 
 public:
     CelestiaAppWindow(QWidget* parent = nullptr);

--- a/src/celestia/qt/qtbookmark.h
+++ b/src/celestia/qt/qtbookmark.h
@@ -12,19 +12,29 @@
 
 #pragma once
 
-#include <QString>
-#include <QList>
+#include <Qt>
 #include <QAbstractItemModel>
-#include <QToolBar>
+#include <QDialog>
 #include <QIcon>
 #include <QImage>
+#include <QList>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QToolBar>
 
 #include "ui_addbookmark.h"
 #include "ui_newbookmarkfolder.h"
 #include "ui_organizebookmarks.h"
 
-class QSortFilterProxyModel;
+class QIODevice;
 class QMenu;
+class QMimeData;
+class QModelIndex;
+class QSortFilterProxyModel;
+class QVariant;
+class QWidget;
+
 class CelestiaState;
 
 class BookmarkItem
@@ -38,7 +48,7 @@ public:
         None
     };
 
-    static const int ICON_SIZE = 24;
+    static constexpr int ICON_SIZE = 24;
 
     BookmarkItem() = default;
 
@@ -74,7 +84,6 @@ private:
     void setParent(BookmarkItem* parent);
     void reindex(int startIndex);
 
-private:
     Type m_type{ None };
     BookmarkItem* m_parent{ nullptr };
     QString m_title;
@@ -98,24 +107,24 @@ public:
         TypeRole = Qt::UserRole + 1
     };
 
-    QModelIndex index(int row, int /* column */, const QModelIndex& parent) const;
-    QModelIndex parent(const QModelIndex& index) const;
+    QModelIndex index(int row, int /* column */, const QModelIndex& parent) const override;
+    QModelIndex parent(const QModelIndex& index) const override;
 
-    int rowCount(const QModelIndex& parent = QModelIndex()) const;
-    int columnCount(const QModelIndex& /* parent */) const;
-    QVariant data(const QModelIndex& index, int role) const;
-    QVariant headerData(int /* section */, Qt::Orientation /* orientation */, int /* role */) const   ;
-    Qt::ItemFlags flags(const QModelIndex& index) const;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& /* parent */) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+    QVariant headerData(int /* section */, Qt::Orientation /* orientation */, int /* role */) const override;
+    Qt::ItemFlags flags(const QModelIndex& index) const override;
 
     // Modifying operations
-    bool setData(const QModelIndex& index, const QVariant& value, int role);
-    bool removeRows(int row, int count, const QModelIndex& parent);
+    bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+    bool removeRows(int row, int count, const QModelIndex& parent) override;
 
     // Drag and drop support
-    Qt::DropActions supportedDropActions() const;
-    bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent);
-    QStringList mimeTypes() const;
-    QMimeData* mimeData(const QModelIndexList& indexes) const;
+    Qt::DropActions supportedDropActions() const override;
+    bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) override;
+    QStringList mimeTypes() const override;
+    QMimeData* mimeData(const QModelIndexList& indexes) const override;
 
     QModelIndex itemIndex(BookmarkItem* item);
     const BookmarkItem* getItem(const QModelIndex& index) const;
@@ -123,7 +132,6 @@ public:
 
     void addItem(BookmarkItem* item, int position);
     void removeItem(BookmarkItem* item);
-    void modifyItem(BookmarkItem* item);
 
 public:
     BookmarkItem* m_root{ nullptr };

--- a/src/celestia/qt/qtcelestiaactions.cpp
+++ b/src/celestia/qt/qtcelestiaactions.cpp
@@ -10,14 +10,21 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include "qtcelestiaactions.h"
+
+#include <cstdint>
+
+#include <QtGlobal>
 #include <QAction>
 #include <QActionGroup>
+#include <QKeySequence>
 #include <QMenu>
+#include <QString>
 
 #include <celengine/body.h>
+#include <celengine/simulation.h>
 #include <celestia/celestiacore.h>
 #include <celutil/gettext.h>
-#include "qtcelestiaactions.h"
 
 
 CelestiaActions::CelestiaActions(QObject* parent,
@@ -228,7 +235,8 @@ CelestiaActions::~CelestiaActions()
 }
 
 
-void CelestiaActions::syncWithRenderer(const Renderer* renderer)
+void
+CelestiaActions::syncWithRenderer(const Renderer* renderer)
 {
     auto renderFlags = renderer->getRenderFlags();
     int labelMode   = renderer->getLabelMode();
@@ -302,30 +310,34 @@ void CelestiaActions::syncWithRenderer(const Renderer* renderer)
 }
 
 
-void CelestiaActions::syncWithAppCore()
+void
+CelestiaActions::syncWithAppCore()
 {
     lightTimeDelayAction->setChecked(appCore->getLightDelayActive());
 }
 
 
-void CelestiaActions::notifyRenderSettingsChanged(const Renderer* renderer)
+void
+CelestiaActions::notifyRenderSettingsChanged(const Renderer* renderer)
 {
     syncWithRenderer(renderer);
 }
 
 
-void CelestiaActions::slotToggleRenderFlag()
+void
+CelestiaActions::slotToggleRenderFlag()
 {
     QAction* act = qobject_cast<QAction*>(sender());
     if (act != nullptr)
     {
-        uint64_t renderFlag = act->data().toULongLong();
+        std::uint64_t renderFlag = act->data().toULongLong();
         appCore->getRenderer()->setRenderFlags(appCore->getRenderer()->getRenderFlags() ^ renderFlag);
     }
 }
 
 
-void CelestiaActions::slotToggleLabel()
+void
+CelestiaActions::slotToggleLabel()
 {
     QAction* act = qobject_cast<QAction*>(sender());
     if (act != nullptr)
@@ -336,7 +348,8 @@ void CelestiaActions::slotToggleLabel()
 }
 
 
-void CelestiaActions::slotToggleOrbit()
+void
+CelestiaActions::slotToggleOrbit()
 {
     QAction* act = qobject_cast<QAction*>(sender());
     if (act != nullptr)
@@ -347,7 +360,8 @@ void CelestiaActions::slotToggleOrbit()
 }
 
 
-void CelestiaActions::slotSetStarStyle()
+void
+CelestiaActions::slotSetStarStyle()
 {
     QAction* act = qobject_cast<QAction*>(sender());
     if (act != nullptr)
@@ -358,7 +372,8 @@ void CelestiaActions::slotSetStarStyle()
 }
 
 
-void CelestiaActions::slotSetTextureResolution()
+void
+CelestiaActions::slotSetTextureResolution()
 {
     QAction* act = qobject_cast<QAction*>(sender());
     if (act != nullptr)
@@ -369,7 +384,8 @@ void CelestiaActions::slotSetTextureResolution()
 }
 
 
-void CelestiaActions::slotAdjustLimitingMagnitude()
+void
+CelestiaActions::slotAdjustLimitingMagnitude()
 {
     QAction* act = qobject_cast<QAction*>(sender());
     if (act != nullptr)
@@ -408,7 +424,8 @@ void CelestiaActions::slotAdjustLimitingMagnitude()
 }
 
 
-void CelestiaActions::slotSetLightTimeDelay()
+void
+CelestiaActions::slotSetLightTimeDelay()
 {
     // TODO: CelestiaCore class should offer an API for enabling/disabling light
     // time delay.
@@ -418,7 +435,8 @@ void CelestiaActions::slotSetLightTimeDelay()
 
 // Convenience method to create a checkable action for a menu and set the data
 // to the specified integer value.
-QAction* CelestiaActions::createCheckableAction(const QString& text, QMenu* menu, int data)
+QAction*
+CelestiaActions::createCheckableAction(const QString& text, QMenu* menu, int data)
 {
     QAction* act = new QAction(text, menu);
     act->setCheckable(true);
@@ -431,7 +449,8 @@ QAction* CelestiaActions::createCheckableAction(const QString& text, QMenu* menu
 
 // Convenience method to create a checkable action and set the data
 // to the specified integer value.
-QAction* CelestiaActions::createCheckableAction(const QString& text, int data)
+QAction*
+CelestiaActions::createCheckableAction(const QString& text, int data)
 {
     QAction* act = new QAction(text, this);
     act->setCheckable(true);

--- a/src/celestia/qt/qtcelestiaactions.h
+++ b/src/celestia/qt/qtcelestiaactions.h
@@ -13,10 +13,14 @@
 #pragma once
 
 #include <QObject>
-#include "celengine/render.h"
 
-class QMenu;
+#include <celengine/render.h>
+
+
 class QAction;
+class QMenu;
+class QString;
+
 class CelestiaCore;
 
 

--- a/src/celestia/qt/qtcelestialbrowser.h
+++ b/src/celestia/qt/qtcelestialbrowser.h
@@ -13,32 +13,31 @@
 #pragma once
 
 #include <QWidget>
-#include <celengine/body.h>
-#include "qtselectionpopup.h"
 
-class QAbstractItemModel;
-class QItemSelection;
-class QTreeView;
-class QRadioButton;
-class QComboBox;
 class QCheckBox;
+class QComboBox;
+class QItemSelection;
 class QLabel;
 class QLineEdit;
-class ColorSwatchWidget;
-class CelestiaCore;
-class InfoPanel;
+class QPoint;
+class QRadioButton;
+class QTreeView;
 
-class StarTableModel;
+class CelestiaCore;
+class Selection;
+
+class ColorSwatchWidget;
+class InfoPanel;
 
 class CelestialBrowser : public QWidget
 {
-Q_OBJECT
+    Q_OBJECT
 
- public:
+public:
     CelestialBrowser(CelestiaCore* _appCore, QWidget* parent, InfoPanel* infoPanel);
     ~CelestialBrowser() = default;
 
- public slots:
+public slots:
     void slotUncheckMultipleFilterBox();
     void slotUncheckBarycentersFilterBox();
     void slotRefreshTable();
@@ -48,10 +47,12 @@ Q_OBJECT
     void slotClearMarkers();
     void slotSelectionChanged(const QItemSelection& newSel, const QItemSelection& oldSel);
 
- signals:
+signals:
     void selectionContextMenuRequested(const QPoint& pos, Selection& sel);
 
- private:
+private:
+    class StarTableModel;
+
     CelestiaCore* appCore;
 
     StarTableModel* starModel{nullptr};

--- a/src/celestia/qt/qtcolorswatchwidget.cpp
+++ b/src/celestia/qt/qtcolorswatchwidget.cpp
@@ -11,7 +11,9 @@
 // of the License, or (at your option) any later version.
 
 #include "qtcolorswatchwidget.h"
+
 #include <QColorDialog>
+#include <QPalette>
 
 
 ColorSwatchWidget::ColorSwatchWidget(const QColor& c, QWidget* /*parent*/) :
@@ -23,13 +25,15 @@ ColorSwatchWidget::ColorSwatchWidget(const QColor& c, QWidget* /*parent*/) :
 }
 
 
-QColor ColorSwatchWidget::color() const
+QColor
+ColorSwatchWidget::color() const
 {
     return m_color;
 }
 
 
-void ColorSwatchWidget::setColor(QColor c)
+void
+ColorSwatchWidget::setColor(QColor c)
 {
     m_color = c;
     setPalette(QPalette(m_color));
@@ -37,7 +41,8 @@ void ColorSwatchWidget::setColor(QColor c)
 }
 
 
-void ColorSwatchWidget::mouseReleaseEvent(QMouseEvent* /*unused*/)
+void
+ColorSwatchWidget::mouseReleaseEvent(QMouseEvent* /*unused*/)
 {
     QColor c = QColorDialog::getColor(m_color, this);
     if (c.isValid())

--- a/src/celestia/qt/qtcolorswatchwidget.h
+++ b/src/celestia/qt/qtcolorswatchwidget.h
@@ -12,8 +12,12 @@
 
 #pragma once
 
-#include <QLabel>
 #include <QColor>
+#include <QLabel>
+
+class QMouseEvent;
+class QWidget;
+
 
 class ColorSwatchWidget : public QLabel
 {

--- a/src/celestia/qt/qtcommandline.cpp
+++ b/src/celestia/qt/qtcommandline.cpp
@@ -5,6 +5,7 @@
 
 #include <celutil/gettext.h>
 
+
 CelestiaCommandLineOptions ParseCommandLine(const QCoreApplication& app)
 {
     QCommandLineParser parser;

--- a/src/celestia/qt/qtcommandline.h
+++ b/src/celestia/qt/qtcommandline.h
@@ -11,9 +11,11 @@
 
 #pragma once
 
-#include <QCoreApplication>
 #include <QString>
 #include <QStringList>
+
+class QCoreApplication;
+
 
 struct CelestiaCommandLineOptions
 {

--- a/src/celestia/qt/qtdeepskybrowser.h
+++ b/src/celestia/qt/qtdeepskybrowser.h
@@ -13,31 +13,32 @@
 #pragma once
 
 #include <QWidget>
-#include "celengine/selection.h"
 
-class QAbstractItemModel;
-class QItemSelection;
-class QTreeView;
-class QRadioButton;
-class QComboBox;
 class QCheckBox;
+class QComboBox;
+class QItemSelection;
 class QLabel;
 class QLineEdit;
-class ColorSwatchWidget;
+class QPoint;
+class QRadioButton;
+class QTreeView;
+
 class CelestiaCore;
+class Selection;
+
+class ColorSwatchWidget;
 class InfoPanel;
 
-class DSOTableModel;
 
 class DeepSkyBrowser : public QWidget
 {
-Q_OBJECT
+    Q_OBJECT
 
- public:
+public:
     DeepSkyBrowser(CelestiaCore* _appCore, QWidget* parent, InfoPanel* infoPanel);
     ~DeepSkyBrowser() = default;
 
- public slots:
+public slots:
     void slotRefreshTable();
     void slotContextMenu(const QPoint& pos);
     void slotMarkSelected();
@@ -45,10 +46,12 @@ Q_OBJECT
     void slotClearMarkers();
     void slotSelectionChanged(const QItemSelection& newSel, const QItemSelection& oldSel);
 
- signals:
+signals:
     void selectionContextMenuRequested(const QPoint& pos, Selection& sel);
 
- private:
+private:
+    class DSOTableModel;
+
     CelestiaCore* appCore;
 
     DSOTableModel* dsoModel{nullptr};

--- a/src/celestia/qt/qtdraghandler.cpp
+++ b/src/celestia/qt/qtdraghandler.cpp
@@ -2,9 +2,15 @@
 
 #include <QCursor>
 #include <QGuiApplication>
+#include <QMouseEvent>
+#include <QString>
+
+#include <celestia/celestiacore.h>
+
 #ifdef USE_WAYLAND
 #include "qtwaylanddraghandler.h"
 #endif
+
 
 void
 DragHandler::begin(const QMouseEvent &m, qreal s, int b)
@@ -13,6 +19,7 @@ DragHandler::begin(const QMouseEvent &m, qreal s, int b)
     scale         = s;
     buttons       = b;
 }
+
 
 void
 DragHandler::move(const QMouseEvent &m, qreal s)
@@ -27,17 +34,20 @@ DragHandler::move(const QMouseEvent &m, qreal s)
     saveCursorPos = m.globalPos();
 }
 
+
 void
 DragHandler::setButton(int button)
 {
     buttons |= button;
 }
 
+
 void
 DragHandler::clearButton(int button)
 {
     buttons &= ~button;
 }
+
 
 int
 DragHandler::effectiveButtons() const
@@ -67,11 +77,13 @@ WarpingDragHandler::move(const QMouseEvent &m, qreal s)
     QCursor::setPos(saveCursorPos);
 }
 
+
 void
 WarpingDragHandler::finish()
 {
     QCursor::setPos(saveCursorPos);
 }
+
 
 std::unique_ptr<DragHandler>
 createDragHandler([[maybe_unused]] QWidget *widget, CelestiaCore *appCore)

--- a/src/celestia/qt/qtdraghandler.h
+++ b/src/celestia/qt/qtdraghandler.h
@@ -11,14 +11,15 @@
 
 #pragma once
 
-#include <QMouseEvent>
-#include <QPoint>
 #include <memory>
-#ifdef USE_WAYLAND
-#include <QWidget>
-#endif
+
 #include <QtGlobal>
-#include <celestia/celestiacore.h>
+#include <QPoint>
+
+class QMouseEvent;
+class QWidget;
+
+class CelestiaCore;
 
 // The base version of DragHandler is the fallback implementation for
 // platforms which do not support pointer warping

--- a/src/celestia/qt/qteventfinder.cpp
+++ b/src/celestia/qt/qteventfinder.cpp
@@ -10,48 +10,80 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <algorithm>
-#include <array>
-#include <cassert>
-#include <vector>
-
-#include <QRadioButton>
-#include <QTreeView>
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QGroupBox>
-#include <QDateEdit>
-#include <QComboBox>
-#include <QPushButton>
-#include <QStandardItemModel>
-#include <QMessageBox>
-#include <QProgressDialog>
-#include <QApplication>
-#include <QMenu>
-
-#include <celengine/body.h>
-#include <celestia/celestiacore.h>
-#include <celestia/eclipsefinder.h>
-#include <celmath/distance.h>
-#include <celmath/intersect.h>
-#include <celmath/geomutil.h>
-#include <celutil/gettext.h>
 #include "qteventfinder.h"
 
-using namespace Eigen;
-using namespace std;
-using namespace celmath;
+#include <algorithm>
+#include <array>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <fmt/format.h>
+
+#include <Qt>
+#include <QAbstractTableModel>
+#include <QAction>
+#include <QApplication>
+#include <QComboBox>
+#include <QDate>
+#include <QDateEdit>
+#include <QDateTime>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLatin1Char>
+#include <QMenu>
+#include <QMessageBox>
+#include <QModelIndex>
+#include <QProgressDialog>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QString>
+#include <QTime>
+#include <QTreeView>
+#include <QVariant>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <celengine/astro.h>
+#include <celengine/body.h>
+#include <celengine/observer.h>
+#include <celengine/selection.h>
+#include <celengine/simulation.h>
+#include <celengine/univcoord.h>
+#include <celestia/celestiacore.h>
+#include <celmath/geomutil.h>
+#include <celmath/intersect.h>
+#include <celmath/sphere.h>
+#include <celutil/gettext.h>
+
+
+namespace
+{
+
+constexpr std::array planets =
+{
+    N_("Earth"),
+    N_("Jupiter"),
+    N_("Saturn"),
+    N_("Uranus"),
+    N_("Neptune"),
+    N_("Pluto"),
+};
 
 
 // Functions to convert between Qt dates and Celestia dates.
 // TODO: Qt's date class doesn't support leap seconds
-static double QDateToTDB(const QDate& date)
+double
+QDateToTDB(const QDate& date)
 {
     return astro::UTCtoTDB(astro::Date(date.year(), date.month(), date.day()));
 }
 
 
-static QDateTime TDBToQDate(double tdb)
+QDateTime
+TDBToQDate(double tdb)
 {
     astro::Date date = astro::TDBtoUTC(tdb);
 
@@ -64,7 +96,42 @@ static QDateTime TDBToQDate(double tdb)
 }
 
 
-class EventTableModel : public QAbstractTableModel
+// Find the point of maximum eclipse, either the intersection of the eclipsed body with the
+// ray from sun to occluder, or the nearest point to that ray if there is no intersection.
+// The returned point is relative to the center of the eclipsed body. Note that this function
+// assumes that the eclipsed body is spherical.
+Eigen::Vector3d
+findMaxEclipsePoint(const Eigen::Vector3d& toCasterDir,
+                    const Eigen::Vector3d& toReceiver,
+                    double eclipsedBodyRadius)
+{
+    double distance = 0.0;
+    bool intersect = celmath::testIntersection(Eigen::ParametrizedLine<double, 3>(Eigen::Vector3d::Zero(), toCasterDir),
+                                               celmath::Sphered(toReceiver, eclipsedBodyRadius),
+                                               distance);
+
+    Eigen::Vector3d maxEclipsePoint;
+    if (intersect)
+    {
+        maxEclipsePoint = (toCasterDir * distance) - toReceiver;
+    }
+    else
+    {
+        // If the center line doesn't actually intersect the occluder, find the point on the
+        // eclipsed body nearest to the line.
+        double t = toReceiver.dot(toCasterDir) / toCasterDir.squaredNorm();
+        Eigen::Vector3d closestPoint = t * toCasterDir;
+        maxEclipsePoint = closestPoint - toReceiver;
+        maxEclipsePoint *= eclipsedBodyRadius / maxEclipsePoint.norm();
+    }
+
+    return maxEclipsePoint;
+}
+
+} // end unnamed namespace
+
+
+class EventFinder::EventTableModel : public QAbstractTableModel
 {
 public:
     EventTableModel() = default;
@@ -78,7 +145,7 @@ public:
     int columnCount(const QModelIndex& index) const override;
     void sort(int column, Qt::SortOrder order) override;
 
-    void setEclipses(const vector<Eclipse>& _eclipses);
+    void setEclipses(const std::vector<Eclipse>& _eclipses);
 
     const Eclipse* eclipseAtIndex(const QModelIndex& index) const;
 
@@ -91,17 +158,19 @@ public:
     };
 
 private:
-    vector<Eclipse> eclipses;
+    std::vector<Eclipse> eclipses;
 };
 
 
-Qt::ItemFlags EventTableModel::flags(const QModelIndex& /*unused*/) const
+Qt::ItemFlags
+EventFinder::EventTableModel::flags(const QModelIndex& /*unused*/) const
 {
     return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
 }
 
 
-QVariant EventTableModel::data(const QModelIndex& index, int role) const
+QVariant
+EventFinder::EventTableModel::data(const QModelIndex& index, int role) const
 {
     if (index.row() < 0 || index.row() >= (int) eclipses.size())
     {
@@ -135,7 +204,8 @@ QVariant EventTableModel::data(const QModelIndex& index, int role) const
 }
 
 
-QVariant EventTableModel::headerData(int section, Qt::Orientation /*unused*/, int role) const
+QVariant
+EventFinder::EventTableModel::headerData(int section, Qt::Orientation /*unused*/, int role) const
 {
     if (role != Qt::DisplayRole)
         return QVariant();
@@ -156,19 +226,22 @@ QVariant EventTableModel::headerData(int section, Qt::Orientation /*unused*/, in
 }
 
 
-int EventTableModel::rowCount(const QModelIndex& /*unused*/) const
+int
+EventFinder::EventTableModel::rowCount(const QModelIndex& /*unused*/) const
 {
     return (int) eclipses.size();
 }
 
 
-int EventTableModel::columnCount(const QModelIndex& /*unused*/) const
+int
+EventFinder::EventTableModel::columnCount(const QModelIndex& /*unused*/) const
 {
     return 4;
 }
 
 
-void EventTableModel::sort(int column, Qt::SortOrder order)
+void
+EventFinder::EventTableModel::sort(int column, Qt::SortOrder order)
 {
     switch (column)
     {
@@ -191,13 +264,14 @@ void EventTableModel::sort(int column, Qt::SortOrder order)
     }
 
     if (order == Qt::DescendingOrder)
-        reverse(eclipses.begin(), eclipses.end());
+        std::reverse(eclipses.begin(), eclipses.end());
 
     dataChanged(index(0, 0), index(eclipses.size() - 1, columnCount(QModelIndex())));
 }
 
 
-void EventTableModel::setEclipses(const vector<Eclipse>& _eclipses)
+void
+EventFinder::EventTableModel::setEclipses(const std::vector<Eclipse>& _eclipses)
 {
     beginResetModel();
     eclipses = _eclipses;
@@ -205,7 +279,8 @@ void EventTableModel::setEclipses(const vector<Eclipse>& _eclipses)
 }
 
 
-const Eclipse* EventTableModel::eclipseAtIndex(const QModelIndex& index) const
+const Eclipse*
+EventFinder::EventTableModel::eclipseAtIndex(const QModelIndex& index) const
 {
     int row = index.row();
     if (row >= 0 && row < (int) eclipses.size())
@@ -213,17 +288,6 @@ const Eclipse* EventTableModel::eclipseAtIndex(const QModelIndex& index) const
     else
         return nullptr;
 }
-
-
-constexpr std::array planets =
-{
-    N_("Earth"),
-    N_("Jupiter"),
-    N_("Saturn"),
-    N_("Uranus"),
-    N_("Neptune"),
-    N_("Pluto"),
-};
 
 
 EventFinder::EventFinder(CelestiaCore* _appCore,
@@ -308,7 +372,8 @@ EventFinder::EventFinder(CelestiaCore* _appCore,
 }
 
 
-EclipseFinderWatcher::Status EventFinder::eclipseFinderProgressUpdate(double t)
+EclipseFinderWatcher::Status
+EventFinder::eclipseFinderProgressUpdate(double t)
 {
     if (progress != nullptr)
     {
@@ -329,7 +394,8 @@ EclipseFinderWatcher::Status EventFinder::eclipseFinderProgressUpdate(double t)
 }
 
 
-void EventFinder::slotFindEclipses()
+void
+EventFinder::slotFindEclipses()
 {
     int eclipseTypeMask = Eclipse::Solar;
     if (lunarOnlyButton->isChecked())
@@ -373,7 +439,7 @@ void EventFinder::slotFindEclipses()
     progress->show();
 
 
-    vector<Eclipse> eclipses;
+    std::vector<Eclipse> eclipses;
     finder.findEclipses(startTimeTDB, endTimeTDB,
                         eclipseTypeMask,
                         eclipses);
@@ -389,7 +455,8 @@ void EventFinder::slotFindEclipses()
 }
 
 
-void EventFinder::slotContextMenu(const QPoint& pos)
+void
+EventFinder::slotContextMenu(const QPoint& pos)
 {
     QModelIndex index = eventTable->indexAt(pos);
     activeEclipse = model->eclipseAtIndex(index);
@@ -425,48 +492,18 @@ void EventFinder::slotContextMenu(const QPoint& pos)
 }
 
 
-void EventFinder::slotSetEclipseTime()
+void
+EventFinder::slotSetEclipseTime()
 {
     double midEclipseTime = (activeEclipse->startTime + activeEclipse->endTime) / 2.0;
     appCore->getSimulation()->setTime(midEclipseTime);
 }
 
 
-// Find the point of maximum eclipse, either the intersection of the eclipsed body with the
-// ray from sun to occluder, or the nearest point to that ray if there is no intersection.
-// The returned point is relative to the center of the eclipsed body. Note that this function
-// assumes that the eclipsed body is spherical.
-static Vector3d findMaxEclipsePoint(const Vector3d& toCasterDir,
-                                    const Vector3d& toReceiver,
-                                    double eclipsedBodyRadius)
-{
-    double distance = 0.0;
-    bool intersect = testIntersection(Eigen::ParametrizedLine<double, 3>(Vector3d::Zero(), toCasterDir),
-                                      Sphered(toReceiver, eclipsedBodyRadius),
-                                      distance);
-
-    Vector3d maxEclipsePoint;
-    if (intersect)
-    {
-        maxEclipsePoint = (toCasterDir * distance) - toReceiver;
-    }
-    else
-    {
-        // If the center line doesn't actually intersect the occluder, find the point on the
-        // eclipsed body nearest to the line.
-        double t = toReceiver.dot(toCasterDir) / toCasterDir.squaredNorm();
-        Vector3d closestPoint = t * toCasterDir;
-        maxEclipsePoint = closestPoint - toReceiver;
-        maxEclipsePoint *= eclipsedBodyRadius / maxEclipsePoint.norm();
-    }
-
-    return maxEclipsePoint;
-}
-
-
 /*! Move the camera to a point 3 radii from the surface, aimed at the point of maximum eclipse.
  */
-void EventFinder::slotViewNearEclipsed()
+void
+EventFinder::slotViewNearEclipsed()
 {
     Simulation* sim = appCore->getSimulation();
 
@@ -480,13 +517,13 @@ void EventFinder::slotViewNearEclipsed()
     Selection caster(activeEclipse->occulter);
     Selection sun(activeEclipse->receiver->getSystem()->getStar());
 
-    Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Vector3d toReceiver = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Vector3d maxEclipsePoint = findMaxEclipsePoint(toCasterDir, toReceiver, receiver.radius());
+    Eigen::Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d toReceiver = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d maxEclipsePoint = findMaxEclipsePoint(toCasterDir, toReceiver, receiver.radius());
 
-    Vector3d up = activeEclipse->receiver->getEclipticToBodyFixed(now).conjugate() * Vector3d::UnitY();
-    Vector3d viewerPos = maxEclipsePoint * 4.0; // 4 radii from center
-    Quaterniond viewOrientation = LookAt(viewerPos, maxEclipsePoint, up);
+    Eigen::Vector3d up = activeEclipse->receiver->getEclipticToBodyFixed(now).conjugate() * Eigen::Vector3d::UnitY();
+    Eigen::Vector3d viewerPos = maxEclipsePoint * 4.0; // 4 radii from center
+    Eigen::Quaterniond viewOrientation = celmath::LookAt(viewerPos, maxEclipsePoint, up);
 
     sim->setFrame(ObserverFrame::Ecliptical, receiver);
     sim->gotoLocation(UniversalCoord::Zero().offsetKm(viewerPos), viewOrientation, 5.0);
@@ -495,7 +532,8 @@ void EventFinder::slotViewNearEclipsed()
 
 /*! Position the camera on the surface of the eclipsed body and pointing directly at the sun.
  */
-void EventFinder::slotViewEclipsedSurface()
+void
+EventFinder::slotViewEclipsedSurface()
 {
     Simulation* sim = appCore->getSimulation();
 
@@ -509,15 +547,15 @@ void EventFinder::slotViewEclipsedSurface()
     Selection caster(activeEclipse->occulter);
     Selection sun(activeEclipse->receiver->getSystem()->getStar());
 
-    Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Vector3d toReceiver = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Vector3d maxEclipsePoint = findMaxEclipsePoint(toCasterDir, toReceiver, receiver.radius());
+    Eigen::Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d toReceiver = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d maxEclipsePoint = findMaxEclipsePoint(toCasterDir, toReceiver, receiver.radius());
 
-    Vector3d up = maxEclipsePoint.normalized();
+    Eigen::Vector3d up = maxEclipsePoint.normalized();
     // TODO: Select alternate up direction when eclipse is directly overhead
 
-    Quaterniond viewOrientation = LookAt<double>(maxEclipsePoint, -toReceiver, up);
-    Vector3d v = maxEclipsePoint * 1.0001;
+    Eigen::Quaterniond viewOrientation = celmath::LookAt<double>(maxEclipsePoint, -toReceiver, up);
+    Eigen::Vector3d v = maxEclipsePoint * 1.0001;
 
     sim->setFrame(ObserverFrame::Ecliptical, receiver);
     sim->gotoLocation(UniversalCoord::Zero().offsetKm(v), viewOrientation, 5.0);
@@ -525,7 +563,8 @@ void EventFinder::slotViewEclipsedSurface()
 
 
 /*! Position the camera on the surface of the occluding body, aimed toward the eclipse. */
-void EventFinder::slotViewOccluderSurface()
+void
+EventFinder::slotViewOccluderSurface()
 {
     Simulation* sim = appCore->getSimulation();
 
@@ -539,12 +578,12 @@ void EventFinder::slotViewOccluderSurface()
     Selection caster(activeEclipse->occulter);
     Selection sun(activeEclipse->receiver->getSystem()->getStar());
 
-    Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Vector3d up = activeEclipse->receiver->getEclipticToBodyFixed(now).conjugate() * Vector3d::UnitY();
-    Vector3d toReceiverDir = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d up = activeEclipse->receiver->getEclipticToBodyFixed(now).conjugate() * Eigen::Vector3d::UnitY();
+    Eigen::Vector3d toReceiverDir = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
 
-    Vector3d surfacePoint = toCasterDir * caster.radius() / toCasterDir.norm() * 1.0001;
-    Quaterniond viewOrientation = LookAt<double>(surfacePoint, toReceiverDir, up);
+    Eigen::Vector3d surfacePoint = toCasterDir * caster.radius() / toCasterDir.norm() * 1.0001;
+    Eigen::Quaterniond viewOrientation = celmath::LookAt<double>(surfacePoint, toReceiverDir, up);
 
     sim->setFrame(ObserverFrame::Ecliptical, caster);
     sim->gotoLocation(UniversalCoord::Zero().offsetKm(surfacePoint), viewOrientation, 5.0);
@@ -554,7 +593,8 @@ void EventFinder::slotViewOccluderSurface()
 /*! Position the camera directly behind the occluding body in the direction
  *  of the sun.
  */
-void EventFinder::slotViewBehindOccluder()
+void
+EventFinder::slotViewBehindOccluder()
 {
     Simulation* sim = appCore->getSimulation();
 
@@ -568,12 +608,12 @@ void EventFinder::slotViewBehindOccluder()
     Selection caster(activeEclipse->occulter);
     Selection sun(activeEclipse->receiver->getSystem()->getStar());
 
-    Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Vector3d up = activeEclipse->receiver->getEclipticToBodyFixed(now).conjugate() * Vector3d::UnitY();
-    Vector3d toReceiverDir = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d up = activeEclipse->receiver->getEclipticToBodyFixed(now).conjugate() * Eigen::Vector3d::UnitY();
+    Eigen::Vector3d toReceiverDir = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
 
-    Vector3d surfacePoint = toCasterDir * caster.radius() / toCasterDir.norm() * 20.0;
-    Quaterniond viewOrientation = LookAt<double>(surfacePoint, toReceiverDir, up);
+    Eigen::Vector3d surfacePoint = toCasterDir * caster.radius() / toCasterDir.norm() * 20.0;
+    Eigen::Quaterniond viewOrientation = celmath::LookAt<double>(surfacePoint, toReceiverDir, up);
 
     sim->setFrame(ObserverFrame::Ecliptical, caster);
     sim->gotoLocation(UniversalCoord::Zero().offsetKm(surfacePoint), viewOrientation, 5.0);

--- a/src/celestia/qt/qteventfinder.h
+++ b/src/celestia/qt/qteventfinder.h
@@ -14,28 +14,33 @@
 
 #include <QDockWidget>
 #include <QElapsedTimer>
+
 #include <celestia/eclipsefinder.h>
 
-class QTreeView;
-class QRadioButton;
-class QDateEdit;
 class QComboBox;
-class QProgressDialog;
+class QDateEdit;
 class QMenu;
-class EventTableModel;
+class QPoint;
+class QProgressDialog;
+class QRadioButton;
+class QString;
+class QTreeView;
+class QWidget;
+
 class CelestiaCore;
+
 
 class EventFinder : public QDockWidget, EclipseFinderWatcher
 {
     Q_OBJECT
 
- public:
+public:
     EventFinder(CelestiaCore* _appCore, const QString& title, QWidget* parent);
     ~EventFinder() = default;
 
     EclipseFinderWatcher::Status eclipseFinderProgressUpdate(double t);
 
- public slots:
+public slots:
     void slotFindEclipses();
     void slotContextMenu(const QPoint&);
 
@@ -45,7 +50,9 @@ class EventFinder : public QDockWidget, EclipseFinderWatcher
     void slotViewOccluderSurface();
     void slotViewBehindOccluder();
 
- private:
+private:
+    class EventTableModel;
+
     CelestiaCore* appCore;
 
     QRadioButton* solarOnlyButton{ nullptr };

--- a/src/celestia/qt/qtgettext.h
+++ b/src/celestia/qt/qtgettext.h
@@ -8,7 +8,9 @@
  ***************************************************************************/
 
 
+#include <QString>
 #include <QTranslator>
+
 #include <celutil/gettext.h>
 
 class CelestiaQTranslator : public QTranslator

--- a/src/celestia/qt/qtglwidget.h
+++ b/src/celestia/qt/qtglwidget.h
@@ -13,15 +13,22 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
+#include <memory>
+
+#include <celengine/glsupport.h>
 
 #include <QOpenGLWidget>
 
-#include "celestia/celestiacore.h"
-#include "celengine/simulation.h"
-#include <celengine/starbrowser.h>
-#include "qtdraghandler.h"
+#include <celestia/celestiacore.h>
+
+class QKeyEvent;
+class QMouseEvent;
+class QWheelEvent;
+class QWidget;
+
+class Renderer;
+
+class DragHandler;
 
 /**
   *@author Christophe Teyssier
@@ -33,7 +40,7 @@ class CelestiaGlWidget : public QOpenGLWidget, public CelestiaCore::CursorHandle
 
 public:
     CelestiaGlWidget(QWidget* parent, const char* name, CelestiaCore* core);
-    ~CelestiaGlWidget() = default;
+    ~CelestiaGlWidget();
 
     void setCursorShape(CelestiaCore::CursorShape);
     CelestiaCore::CursorShape getCursorShape() const;
@@ -53,16 +60,11 @@ protected:
     virtual QSize sizeHint() const;
 
 private:
-
     CelestiaCore* appCore;
     Renderer* appRenderer;
-    Simulation* appSim;
     int lastX{ 0 };
     int lastY{ 0 };
     bool cursorVisible;
     std::unique_ptr<DragHandler> dragHandler;
     CelestiaCore::CursorShape currentCursor;
-
-    //KActionCollection* actionColl;
-
 };

--- a/src/celestia/qt/qtgotoobjectdialog.cpp
+++ b/src/celestia/qt/qtgotoobjectdialog.cpp
@@ -1,12 +1,22 @@
-#include <QPushButton>
-#include <QLocale>
-
-#include <celengine/body.h>
-#include <celestia/celestiacore.h>
 #include "qtgotoobjectdialog.h"
 
-using namespace Eigen;
-using namespace celmath;
+#include <string>
+
+#include <Eigen/Core>
+
+#include <QDialogButtonBox>
+#include <QLocale>
+#include <QPushButton>
+#include <QString>
+
+#include <celengine/astro.h>
+#include <celengine/body.h>
+#include <celengine/observer.h>
+#include <celengine/selection.h>
+#include <celengine/simulation.h>
+#include <celestia/celestiacore.h>
+#include <celmath/mathlib.h>
+
 
 GoToObjectDialog::GoToObjectDialog(QWidget *parent, CelestiaCore* _appCore) :
     QDialog(parent),
@@ -38,7 +48,9 @@ GoToObjectDialog::GoToObjectDialog(QWidget *parent, CelestiaCore* _appCore) :
     ui.kmButton->setChecked(true);
 }
 
-void GoToObjectDialog::on_buttonBox_accepted()
+
+void
+GoToObjectDialog::on_buttonBox_accepted()
 {
     QString objectName = ui.objectName->text();
 
@@ -76,20 +88,22 @@ void GoToObjectDialog::on_buttonBox_accepted()
     {
         simulation->gotoSelectionLongLat(5.0,
                                          distance,
-                                         degToRad(longitude),
-                                         degToRad(latitude),
-                                         Vector3f::UnitY());
+                                         celmath::degToRad(longitude),
+                                         celmath::degToRad(latitude),
+                                         Eigen::Vector3f::UnitY());
     }
     else
     {
         simulation->gotoSelection(5.0,
                                   distance,
-                                  Vector3f::UnitY(),
+                                  Eigen::Vector3f::UnitY(),
                                   ObserverFrame::ObserverLocal);
     }
 }
 
-void GoToObjectDialog::on_objectName_textChanged(const QString &objectName)
+
+void
+GoToObjectDialog::on_objectName_textChanged(const QString &objectName)
 {
     QPushButton *okButton = ui.buttonBox->button(QDialogButtonBox::Ok);
 

--- a/src/celestia/qt/qtgotoobjectdialog.h
+++ b/src/celestia/qt/qtgotoobjectdialog.h
@@ -1,9 +1,14 @@
 #pragma once
 
 #include <QDialog>
+
 #include "ui_gotoobjectdialog.h"
 
+class QString;
+class QWidget;
+
 class CelestiaCore;
+
 
 class GoToObjectDialog : public QDialog
 {

--- a/src/celestia/qt/qtinfopanel.h
+++ b/src/celestia/qt/qtinfopanel.h
@@ -13,15 +13,21 @@
 #pragma once
 
 #include <QDockWidget>
-#include <QTextStream>
-#include "celengine/selection.h"
 
-class QTextBrowser;
-class Universe;
-class QModelIndex;
-class Selection;
 class QItemSelection;
+class QModelIndex;
+class QString;
+class QTextBrowser;
+class QTextStream;
+class QWidget;
+
+class Body;
 class CelestiaCore;
+class DeepSkyObject;
+class Selection;
+class Star;
+class Universe;
+
 
 class ModelHelper
 {
@@ -29,6 +35,7 @@ class ModelHelper
     virtual ~ModelHelper() = default;
     virtual Selection itemForInfoPanel(const QModelIndex&) = 0;
 };
+
 
 class InfoPanel : public QDockWidget
 {

--- a/src/celestia/qt/qtpreferencesdialog.h
+++ b/src/celestia/qt/qtpreferencesdialog.h
@@ -14,7 +14,10 @@
 #include <QDialog>
 #include "ui_preferences.h"
 
+class QWidget;
+
 class CelestiaCore;
+
 
 class PreferencesDialog : public QDialog
 {

--- a/src/celestia/qt/qtselectionpopup.h
+++ b/src/celestia/qt/qtselectionpopup.h
@@ -13,10 +13,15 @@
 #pragma once
 
 #include <QMenu>
+
 #include <celengine/selection.h>
-#include <celengine/body.h>
+
+class QAction;
+class QPoint;
+class QWidget;
 
 class CelestiaCore;
+class PlanetarySystem;
 
 class SelectionPopup : public QMenu
 {

--- a/src/celestia/qt/qtsettimedialog.cpp
+++ b/src/celestia/qt/qtsettimedialog.cpp
@@ -10,19 +10,20 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <celestia/celestiacore.h>
-#include <celengine/astro.h>
-#include <celutil/gettext.h>
-#include <QPushButton>
-#include <QDialogButtonBox>
-#include <QSpinBox>
-#include <QDoubleSpinBox>
-#include <QComboBox>
-#include <QLabel>
-#include <QVBoxLayout>
-#include <QGroupBox>
-#include <QGridLayout>
 #include "qtsettimedialog.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QDoubleSpinBox>
+#include <QGridLayout>
+#include <QLabel>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+#include <celengine/astro.h>
+#include <celestia/celestiacore.h>
+#include <celutil/gettext.h>
+
 
 namespace
 {
@@ -42,6 +43,7 @@ void setValueNoSignal(TControl* target, TValue value)
 }
 
 } // end unnamed namespace
+
 
 SetTimeDialog::SetTimeDialog(double currentTimeTDB,
                              QWidget* parent,
@@ -167,14 +169,17 @@ SetTimeDialog::SetTimeDialog(double currentTimeTDB,
 }
 
 
-void SetTimeDialog::slotSetSimulationTime()
+void
+SetTimeDialog::slotSetSimulationTime()
 {
     double tdb = astro::TTtoTDB(astro::TAItoTT(astro::JDUTCtoTAI(julianDateSpin->value())));
 
     appCore->getSimulation()->setTime(tdb);
 }
 
-void SetTimeDialog::slotSetDateTime()
+
+void
+SetTimeDialog::slotSetDateTime()
 {
     double tdb = astro::TTtoTDB(astro::TAItoTT(astro::JDUTCtoTAI(julianDateSpin->value())));
     int tzb = appCore->getTimeZoneBias();
@@ -192,7 +197,9 @@ void SetTimeDialog::slotSetDateTime()
     setValueNoSignal(secSpin, static_cast<int>(date.seconds));
 }
 
-void SetTimeDialog::slotDateTimeChanged()
+
+void
+SetTimeDialog::slotDateTimeChanged()
 {
     int year = yearSpin->value();
     int month = monthSpin->value();
@@ -227,7 +234,9 @@ void SetTimeDialog::slotDateTimeChanged()
             timeZoneBox->setEnabled(true);
 }
 
-void SetTimeDialog::slotTimeZoneChanged()
+
+void
+SetTimeDialog::slotTimeZoneChanged()
 {
     int tzb = 0;
 
@@ -256,7 +265,8 @@ void SetTimeDialog::slotTimeZoneChanged()
 }
 
 
-void SetTimeDialog::accept()
+void
+SetTimeDialog::accept()
 {
     slotSetSimulationTime();
 

--- a/src/celestia/qt/qtsettimedialog.h
+++ b/src/celestia/qt/qtsettimedialog.h
@@ -15,10 +15,11 @@
 #include <QDialog>
 
 class QAbstractItemModel;
-
 class QComboBox;
-class QSpinBox;
 class QDoubleSpinBox;
+class QSpinBox;
+class QWidget;
+
 class CelestiaCore;
 
 

--- a/src/celestia/qt/qtsolarsystembrowser.h
+++ b/src/celestia/qt/qtsolarsystembrowser.h
@@ -13,43 +13,42 @@
 #pragma once
 
 #include <QWidget>
-#include "celengine/selection.h"
 
-class QAbstractItemModel;
-class QTreeView;
 class QCheckBox;
 class QComboBox;
 class QItemSelection;
-class ColorSwatchWidget;
+class QPoint;
+class QTreeView;
+
 class CelestiaCore;
+class Selection;
+
+class ColorSwatchWidget;
 class InfoPanel;
 
-class SolarSystemTreeModel;
 
 class SolarSystemBrowser : public QWidget
 {
-Q_OBJECT
+    Q_OBJECT
 
- public:
+public:
     SolarSystemBrowser(CelestiaCore* _appCore, QWidget* parent, InfoPanel* infoPanel);
     ~SolarSystemBrowser() = default;
 
- public slots:
+public slots:
     void slotRefreshTree();
     void slotContextMenu(const QPoint& pos);
     void slotMarkSelected();
     void slotUnmarkSelected();
-    //void slotChooseMarkerColor();
     void slotClearMarkers();
     void slotSelectionChanged(const QItemSelection& newSel, const QItemSelection& oldSel);
 
- signals:
+signals:
     void selectionContextMenuRequested(const QPoint& pos, Selection& sel);
 
- private:
-    void setMarkerColor(QColor color);
+private:
+    class SolarSystemTreeModel;
 
- private:
     CelestiaCore* appCore;
 
     SolarSystemTreeModel* solarSystemModel{nullptr};

--- a/src/celestia/qt/qttimetoolbar.cpp
+++ b/src/celestia/qt/qttimetoolbar.cpp
@@ -10,12 +10,18 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include "qttimetoolbar.h"
+
+#include <QAction>
+#include <QDate>
+#include <QDateTime>
+#include <QIcon>
+#include <QString>
+#include <QTime>
+
+#include <celengine/astro.h>
 #include <celestia/celestiacore.h>
 #include <celutil/gettext.h>
-#include "qttimetoolbar.h"
-#include <QAction>
-#include <QIcon>
-#include <QDateTime>
 
 
 TimeToolBar::TimeToolBar(CelestiaCore* _appCore,
@@ -24,26 +30,6 @@ TimeToolBar::TimeToolBar(CelestiaCore* _appCore,
     QToolBar(title, parent),
     appCore(_appCore)
 {
-#if 0
-    // Text-only buttons
-    setToolButtonStyle(Qt::ToolButtonTextOnly);
-    QAction* reverseTimeAction = new QAction(QString("< >"), this);
-    reverseTimeAction->setToolTip(_("Reverse time"));
-    QAction* slowTimeAction = new QAction(QString("<<<"), this);
-    slowTimeAction->setToolTip(_("10x slower"));
-    QAction* halfTimeAction = new QAction(QString("<<"), this);
-    halfTimeAction->setToolTip(_("2x slower"));
-    QAction* pauseAction = new QAction(QString("||"), this);
-    pauseAction->setToolTip(_("Pause time"));
-    QAction* doubleTimeAction = new QAction(QString(">>"), this);
-    doubleTimeAction->setToolTip(_("2x faster"));
-    QAction* fastTimeAction = new QAction(QString(">>>"), this);
-    fastTimeAction->setToolTip(_("10x faster"));
-    QAction* realTimeAction = new QAction(QString("|^|"), this);
-    realTimeAction->setToolTip(_("Real time"));
-    QAction* currentTimeAction = new QAction(QString("< ! >"), this);
-    currentTimeAction->setToolTip(_("Set to current time"));
-#else
     QAction* reverseTimeAction = new QAction(QIcon(":/icons/time-reverse.png"),
                                              _("Reverse time"), this);
     QAction* slowTimeAction = new QAction(QIcon(":/icons/time-slower.png"),
@@ -60,7 +46,7 @@ TimeToolBar::TimeToolBar(CelestiaCore* _appCore,
                                           _("Real time"), this);
     QAction* currentTimeAction = new QAction(QIcon(":icons/time-currenttime.png"),
                                              _("Set to current time"), this);
-#endif
+
     connect(reverseTimeAction, SIGNAL(triggered()), this, SLOT(slotReverseTime()));
     addAction(reverseTimeAction);
 
@@ -88,49 +74,57 @@ TimeToolBar::TimeToolBar(CelestiaCore* _appCore,
 }
 
 
-void TimeToolBar::slotPauseTime()
+void
+TimeToolBar::slotPauseTime()
 {
     appCore->getSimulation()->setPauseState(!appCore->getSimulation()->getPauseState());
 }
 
 
-void TimeToolBar::slotReverseTime()
+void
+TimeToolBar::slotReverseTime()
 {
     appCore->getSimulation()->setTimeScale(-appCore->getSimulation()->getTimeScale());
 }
 
 
-void TimeToolBar::slotRealTime()
+void
+TimeToolBar::slotRealTime()
 {
     appCore->getSimulation()->setTimeScale(1.0);
 }
 
 
-void TimeToolBar::slotDoubleTime()
+void
+TimeToolBar::slotDoubleTime()
 {
     appCore->getSimulation()->setTimeScale(2.0 * appCore->getSimulation()->getTimeScale());
 }
 
 
-void TimeToolBar::slotHalfTime()
+void
+TimeToolBar::slotHalfTime()
 {
     appCore->getSimulation()->setTimeScale(0.5 * appCore->getSimulation()->getTimeScale());
 }
 
 
-void TimeToolBar::slotFaster()
+void
+TimeToolBar::slotFaster()
 {
     appCore->getSimulation()->setTimeScale(10.0 * appCore->getSimulation()->getTimeScale());
 }
 
 
-void TimeToolBar::slotSlower()
+void
+TimeToolBar::slotSlower()
 {
     appCore->getSimulation()->setTimeScale(0.1 * appCore->getSimulation()->getTimeScale());
 }
 
 
-void TimeToolBar::slotCurrentTime()
+void
+TimeToolBar::slotCurrentTime()
 {
     QDateTime now = QDateTime::currentDateTime().toUTC();
     QDate d = now.date();

--- a/src/celestia/qt/qttimetoolbar.h
+++ b/src/celestia/qt/qttimetoolbar.h
@@ -14,19 +14,23 @@
 
 #include <QToolBar>
 
+class QString;
+class QWidget;
+
 class CelestiaCore;
+
 
 class TimeToolBar : public QToolBar
 {
-Q_OBJECT
+    Q_OBJECT
 
- public:
+public:
     TimeToolBar(CelestiaCore* _appCore,
                 const QString& title,
                 QWidget* parent = nullptr);
     ~TimeToolBar() = default;
 
- public slots:
+public slots:
     void slotPauseTime();
     void slotReverseTime();
     void slotRealTime();
@@ -36,6 +40,6 @@ Q_OBJECT
     void slotSlower();
     void slotCurrentTime();
 
- private:
+private:
     CelestiaCore* appCore;
 };

--- a/src/celestia/qt/qtwaylanddraghandler.cpp
+++ b/src/celestia/qt/qtwaylanddraghandler.cpp
@@ -1,10 +1,12 @@
 #include "qtwaylanddraghandler.h"
 
-#include <QGuiApplication>
-#include <cstdint>
 #include <cstring>
-#include <memory>
+
+#include <QGuiApplication>
+#include <QWidget>
 #include <qpa/qplatformnativeinterface.h>
+
+#include <celestia/celestiacore.h>
 
 namespace
 {
@@ -20,6 +22,7 @@ getPlatformNativeInterface()
 
     return pni;
 }
+
 
 void
 addRegistryItem(
@@ -45,11 +48,13 @@ addRegistryItem(
     }
 }
 
+
 void
 removeRegistryItem(void *data, wl_registry *registry, std::uint32_t name)
 {
     // not handled
 }
+
 
 std::shared_ptr<WaylandDragHandler::PointerInterfaces>
 getPointerInterfaces()
@@ -83,12 +88,15 @@ getPointerInterfaces()
 
 } // end unnamed namespace
 
+
 const zwp_relative_pointer_v1_listener WaylandDragHandler::listener{ processRelativePointer };
+
 
 WaylandDragHandler::WaylandDragHandler(QWidget *_widget, CelestiaCore *_appCore) :
     DragHandler(_appCore), widget(_widget)
 {
 }
+
 
 WaylandDragHandler::~WaylandDragHandler()
 {
@@ -97,6 +105,7 @@ WaylandDragHandler::~WaylandDragHandler()
     if (relativePointer)
         zwp_relative_pointer_v1_destroy(relativePointer);
 }
+
 
 void
 WaylandDragHandler::begin(const QMouseEvent &m, qreal s, int b)
@@ -150,6 +159,7 @@ WaylandDragHandler::begin(const QMouseEvent &m, qreal s, int b)
     }
 }
 
+
 void
 WaylandDragHandler::move(const QMouseEvent &m, qreal s)
 {
@@ -158,6 +168,7 @@ WaylandDragHandler::move(const QMouseEvent &m, qreal s)
         DragHandler::move(m, s);
     }
 }
+
 
 void
 WaylandDragHandler::finish()
@@ -173,6 +184,7 @@ WaylandDragHandler::finish()
     zwp_relative_pointer_v1_destroy(relativePointer);
     relativePointer = nullptr;
 }
+
 
 void
 WaylandDragHandler::processRelativePointer(
@@ -192,10 +204,12 @@ WaylandDragHandler::processRelativePointer(
         dragHandler->effectiveButtons());
 }
 
+
 WaylandDragHandler::PointerInterfaces::PointerInterfaces(wl_registry *_registry) :
     registry{ _registry }
 {
 }
+
 
 WaylandDragHandler::PointerInterfaces::~PointerInterfaces()
 {

--- a/src/celestia/qt/qtwaylanddraghandler.h
+++ b/src/celestia/qt/qtwaylanddraghandler.h
@@ -1,12 +1,21 @@
 #pragma once
 
-#include "qtdraghandler.h"
-
-#include <QWidget>
+#include <cstdint>
 #include <memory>
+
+#include <QtGlobal>
+
 #include <pointer-constraints-unstable-v1-client-protocol.h>
 #include <relative-pointer-unstable-v1-client-protocol.h>
 #include <wayland-client.h>
+
+#include "qtdraghandler.h"
+
+class QMouseEvent;
+class QWidget;
+
+class CelestiaCore;
+
 
 class WaylandDragHandler : public DragHandler
 {

--- a/src/celestia/qt/xbel.cpp
+++ b/src/celestia/qt/xbel.cpp
@@ -10,20 +10,23 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <celutil/gettext.h>
 #include "xbel.h"
-#include "qtbookmark.h"
+
 #include <QBuffer>
+#include <QByteArray>
+#include <QIcon>
+#include <QLatin1String>
+#include <QPixmap>
+#include <QString>
 
+#include <celutil/gettext.h>
+#include "qtbookmark.h"
 
-XbelReader::XbelReader(QIODevice* device) :
-    QXmlStreamReader(device)
+namespace
 {
-}
-
 
 // Read an PNG image from a base64 encoded string.
-static QIcon CreateBookmarkIcon(const QString& iconBase64Data)
+QIcon CreateBookmarkIcon(const QString& iconBase64Data)
 {
     QByteArray iconData = QByteArray::fromBase64(iconBase64Data.toLatin1());
     QPixmap iconPixmap;
@@ -33,13 +36,24 @@ static QIcon CreateBookmarkIcon(const QString& iconBase64Data)
 
 
 // Return a string with icon data as a base64 encoded PNG file.
-static QString BookmarkIconData(const QIcon& icon)
+QString BookmarkIconData(const QIcon& icon)
 {
     QBuffer buffer;
     buffer.open(QIODevice::WriteOnly);
     icon.pixmap(BookmarkItem::ICON_SIZE).save(&buffer, "PNG");
     return QLatin1String(buffer.buffer().toBase64().data());
 }
+
+} // end unnamed namespace
+
+
+XbelReader::XbelReader(QIODevice* device) :
+    QXmlStreamReader(device)
+{
+}
+
+
+
 
 
 // This code is based on QXmlStreamReader example from Qt 4.3.3
@@ -268,6 +282,3 @@ XbelWriter::writeItem(const BookmarkItem* item)
         break;
     }
 }
-
-
-

--- a/src/celestia/qt/xbel.h
+++ b/src/celestia/qt/xbel.h
@@ -15,6 +15,8 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
+class QIODevice;
+
 class BookmarkItem;
 
 


### PR DESCRIPTION
- Clean up includes
- Remove using namespace std
- Put local classes into unnamed namespace
- Nest abstract item classes in parents

Also fix includes for the eclipsefinder base class in src/celestia