### PR TITLE
Move Android workaround to try_compile checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,9 @@ check_include_files(byteswap.h HAVE_BYTESWAP_H)
 
 try_compile(HAVE_SINCOS ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/checks/sincos.cpp")
 try_compile(HAVE_APPLE_SINCOS ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/checks/applesincos.cpp")
+# The libc++ headers in the latest stable NDK (r25) does not expose empty array methods as constexpr
+# https://github.com/android/ndk/issues/1530
+try_compile(HAVE_CONSTEXPR_EMPTY_ARRAY ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/checks/constexpremptyarray.cpp")
 
 find_package(Filesystem REQUIRED COMPONENTS Final Experimental)
 if(CXX_FILESYSTEM_IS_EXPERIMENTAL)

--- a/checks/constexpremptyarray.cpp
+++ b/checks/constexpremptyarray.cpp
@@ -1,0 +1,9 @@
+#include <array>
+
+constexpr std::array<int, 0> array {};
+constexpr const int *data = array.data();
+
+int main()
+{
+}
+

--- a/config.h.in
+++ b/config.h.in
@@ -6,4 +6,5 @@
 #cmakedefine HAVE_MESHOPTIMIZER
 #cmakedefine HAVE_SINCOS
 #cmakedefine HAVE_APPLE_SINCOS
+#cmakedefine HAVE_CONSTEXPR_EMPTY_ARRAY
 #cmakedefine WORDS_BIGENDIAN

--- a/src/celephem/vsop87.cpp
+++ b/src/celephem/vsop87.cpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <utility>
 
+#include <config.h>
+
 #include <celcompat/numbers.h>
 #include <celmath/mathlib.h>
 #include <celengine/astro.h>
@@ -43,9 +45,7 @@ struct VSOPSeries
     {
     }
 
-#ifdef __ANDROID__
-    // The libc++ headers in the latest stable NDK (r25) does not expose empty array methods as constexpr
-    // https://github.com/android/ndk/issues/1530
+#ifndef HAVE_CONSTEXPR_EMPTY_ARRAY
     explicit constexpr VSOPSeries(const std::array<VSOPTerm, 0>&)
         : terms(nullptr), nTerms(0)
     {


### PR DESCRIPTION
Since it is more of a cxx header issue (and might exist in earlier libc++ version), it is better to make this a try_compile check instead.