### PR TITLE
Remove useless object creation in StarDatabase::find

### DIFF
--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -428,9 +428,6 @@ StarDatabase::~StarDatabase()
 Star*
 StarDatabase::find(AstroCatalog::IndexNumber catalogNumber) const
 {
-    Star refStar;
-    refStar.setIndex(catalogNumber);
-
     auto star = std::lower_bound(catalogNumberIndex.cbegin(), catalogNumberIndex.cend(),
                                  catalogNumber,
                                  [](const Star* star, AstroCatalog::IndexNumber catNum) { return star->getIndex() < catNum; });


### PR DESCRIPTION
Left over from when this was being passed into `std::lower_bound` without the lambda parameter.