### PR TITLE
Use smart pointers in SolarSystem/SolarSystemCatalog

### DIFF
--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -1303,19 +1303,13 @@ bool LoadSolarSystemObjects(std::istream& in,
 
 
 SolarSystem::SolarSystem(Star* _star) :
-    star(_star),
-    planets(nullptr),
-    frameTree(nullptr)
+    star(_star)
 {
-    planets = new PlanetarySystem(star);
-    frameTree = new FrameTree(star);
+    planets = std::make_unique<PlanetarySystem>(star);
+    frameTree = std::make_unique<FrameTree>(star);
 }
 
-SolarSystem::~SolarSystem()
-{
-    delete planets;
-    delete frameTree;
-}
+SolarSystem::~SolarSystem() = default;
 
 
 Star* SolarSystem::getStar() const
@@ -1333,10 +1327,10 @@ Eigen::Vector3f SolarSystem::getCenter() const
 
 PlanetarySystem* SolarSystem::getPlanets() const
 {
-    return planets;
+    return planets.get();
 }
 
 FrameTree* SolarSystem::getFrameTree() const
 {
-    return frameTree;
+    return frameTree.get();
 }

--- a/src/celengine/solarsys.h
+++ b/src/celengine/solarsys.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <map>
+#include <memory>
 
 #include <Eigen/Core>
 
@@ -36,11 +37,11 @@ class SolarSystem
 
  private:
     Star* star;
-    PlanetarySystem* planets;
-    FrameTree* frameTree;
+    std::unique_ptr<PlanetarySystem> planets;
+    std::unique_ptr<FrameTree> frameTree;
 };
 
-using SolarSystemCatalog = std::map<std::uint32_t, SolarSystem*>;
+using SolarSystemCatalog = std::map<std::uint32_t, std::unique_ptr<SolarSystem>>;
 
 bool LoadSolarSystemObjects(std::istream& in,
                             Universe& universe,

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -672,10 +672,9 @@ Universe::getSolarSystem(const Star* star) const
 
     auto starNum = star->getIndex();
     auto iter = solarSystemCatalog->find(starNum);
-    if (iter != solarSystemCatalog->end())
-        return iter->second;
-
-    return nullptr;
+    return iter == solarSystemCatalog->end()
+        ? nullptr
+        : iter->second.get();
 }
 
 
@@ -717,16 +716,13 @@ Universe::getSolarSystem(const Selection& sel) const
 SolarSystem*
 Universe::createSolarSystem(Star* star) const
 {
-    SolarSystem* solarSystem = getSolarSystem(star);
-    if (solarSystem != nullptr)
-        return solarSystem;
+    auto starNum = star->getIndex();
+    auto iter = solarSystemCatalog->lower_bound(starNum);
+    if (iter != solarSystemCatalog->end() && iter->first == starNum)
+        return iter->second.get();
 
-    solarSystem = new SolarSystem(star);
-    solarSystemCatalog->insert(SolarSystemCatalog::
-                               value_type(star->getIndex(),
-                                          solarSystem));
-
-    return solarSystem;
+    iter = solarSystemCatalog->emplace_hint(iter, starNum, std::make_unique<SolarSystem>(star));
+    return iter->second.get();
 }
 
 

--- a/src/celestia/gtk/menu-context.cpp
+++ b/src/celestia/gtk/menu-context.cpp
@@ -106,11 +106,9 @@ void GTKContextMenuHandler::requestContextMenu(float, float, Selection sel)
             /* Add info eventually:
              * AppendMenu(popup, NULL, "_Info", 0); */
 
-            SolarSystemCatalog* solarSystemCatalog = sim->getUniverse()->getSolarSystemCatalog();
-            SolarSystemCatalog::iterator iter = solarSystemCatalog->find(sel.star()->getIndex());
-            if (iter != solarSystemCatalog->end())
+            const SolarSystem* solarSys = sim->getUniverse()->getSolarSystem(sel.star());
+            if (solarSys != nullptr)
             {
-                SolarSystem* solarSys = iter->second;
                 GtkMenu* planetsMenu = CreatePlanetarySystemMenu(name, solarSys->getPlanets());
                 if (name == "Sol")
                     gtk_menu_item_set_submenu(AppendMenu(popup, NULL, "Orbiting Bodies", 0), GTK_WIDGET(planetsMenu));

--- a/src/celestia/qt/qtselectionpopup.h
+++ b/src/celestia/qt/qtselectionpopup.h
@@ -67,8 +67,8 @@ Q_OBJECT
     QMenu* createMarkMenu();
     QMenu* createReferenceVectorMenu();
     QMenu* createAlternateSurfacesMenu();
-    QMenu* createObjectMenu(PlanetarySystem* sys, unsigned int classification);
-    void addObjectMenus(PlanetarySystem* sys);
+    QMenu* createObjectMenu(const PlanetarySystem* sys, unsigned int classification);
+    void addObjectMenus(const PlanetarySystem* sys);
 
  private:
     Selection selection;

--- a/src/celestia/qt/qtsolarsystembrowser.cpp
+++ b/src/celestia/qt/qtsolarsystembrowser.cpp
@@ -265,11 +265,10 @@ SolarSystemBrowser::SolarSystemTreeModel::createTreeItem(Selection sel,
     {
         // Stars may have both a solar system and other stars orbiting
         // them.
-        SolarSystemCatalog* solarSystems = universe->getSolarSystemCatalog();
-        auto iter = solarSystems->find(sel.star()->getIndex());
-        if (iter != solarSystems->end())
+        if (const SolarSystem* solarSys = universe->getSolarSystem(sel.star());
+            solarSys != nullptr)
         {
-            sys = iter->second->getPlanets();
+            sys = solarSys->getPlanets();
         }
 
         orbitingStars = sel.star()->getOrbitingStars();

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -1685,11 +1685,9 @@ VOID APIENTRY handlePopupMenu(HWND hwnd,
             AppendMenu(hMenu, MF_STRING, ID_NAVIGATION_GOTO, UTF8ToCurrentCP(_("&Goto")).c_str());
             AppendMenu(hMenu, MF_STRING, ID_INFO, UTF8ToCurrentCP(_("&Info")).c_str());
 
-            SolarSystemCatalog* solarSystemCatalog = sim->getUniverse()->getSolarSystemCatalog();
-            SolarSystemCatalog::iterator iter = solarSystemCatalog->find(sel.star()->getIndex());
-            if (iter != solarSystemCatalog->end())
+            const SolarSystem* solarSys = sim->getUniverse()->getSolarSystem(sel.star());
+            if (solarSys != nullptr)
             {
-                SolarSystem* solarSys = iter->second;
                 HMENU planetsMenu = CreatePlanetarySystemMenu(name, solarSys->getPlanets());
                 if (name == "Sol")
                     AppendMenu(hMenu, MF_POPUP | MF_STRING, (UINT_PTR) planetsMenu, UTF8ToCurrentCP(_("Orbiting Bodies")).c_str());

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -872,11 +872,9 @@ static int object_getchildren(lua_State* l)
     lua_newtable(l);
     if (sel->star() != nullptr)
     {
-        SolarSystemCatalog* solarSystemCatalog = sim->getUniverse()->getSolarSystemCatalog();
-        SolarSystemCatalog::iterator iter = solarSystemCatalog->find(sel->star()->getIndex());
-        if (iter != solarSystemCatalog->end())
+        const SolarSystem* solarSys = sim->getUniverse()->getSolarSystem(sel->star());
+        if (solarSys != nullptr)
         {
-            SolarSystem* solarSys = iter->second;
             for (int i = 0; i < solarSys->getPlanets()->getSystemSize(); i++)
             {
                 Body* body = solarSys->getPlanets()->getBody(i);


### PR DESCRIPTION
- Clarify ownership of solar system objects
- Prefer using the getSolarSystem(const Star*) overload
- Use lower_bound/emplace_hint when creating solar systems to avoid duplicate lookup