### PR TITLE
[sonar] Don't report the use of `new` in Qt code

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,3 +7,8 @@ sonar.test.exclusions=test/**
 sonar.cfamily.compile-commands=build/compile_commands.json
 sonar.sourceEncoding=UTF-8
 sonar.host.url=https://sonarcloud.io
+
+# Allow use of new in Qt-specific code
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=cpp:S5025
+sonar.issue.ignore.multicriteria.e1.resourceKey=src/celestia/qt/**


### PR DESCRIPTION
- Qt has its own memory management, use of smart pointers would lead to double-freeing