### PR TITLE
Remove incorrect spelling of 'spacecraft' from render flag map

### DIFF
--- a/src/celscript/common/scriptmaps.cpp
+++ b/src/celscript/common/scriptmaps.cpp
@@ -25,8 +25,6 @@ void initRenderFlagMap(FlagMap64 &RenderFlagMap)
     RenderFlagMap["asteroids"sv]           = Renderer::ShowAsteroids;
     RenderFlagMap["comets"sv]              = Renderer::ShowComets;
     RenderFlagMap["spacecraft"sv]          = Renderer::ShowSpacecrafts;
-    // incorrect spelling retained for compatibility
-    RenderFlagMap["spasecrafts"sv]         = Renderer::ShowSpacecrafts;
     RenderFlagMap["stars"sv]               = Renderer::ShowStars;
     RenderFlagMap["nightmaps"sv]           = Renderer::ShowNightMaps;
     RenderFlagMap["eclipseshadows"sv]      = Renderer::ShowEclipseShadows;


### PR DESCRIPTION
Prevents both spellings being returned when getting render flags, which iterates all keys in the map.

Since this value was not present in 1.6.x, I think it should be less problematic to simply remove this.