### PR TITLE
[win] Use getName(true) instead of gettext when loading eclipsing body names

### DIFF
--- a/src/celestia/win32/wineclipses.cpp
+++ b/src/celestia/win32/wineclipses.cpp
@@ -123,12 +123,12 @@ void EclipseFinderDisplayItem(LPNMLVDISPINFOA nm)
     switch (nm->item.iSubItem)
     {
     case 0:
-        strncpy(callbackScratch, UTF8ToCurrentCP(D_(eclipse->receiver->getName().c_str())).c_str(), sizeof(callbackScratch) - 1);
+        strncpy(callbackScratch, UTF8ToCurrentCP(eclipse->receiver->getName(true)).c_str(), sizeof(callbackScratch) - 1);
         nm->item.pszText = callbackScratch;
         break;
 
     case 1:
-        strncpy(callbackScratch, UTF8ToCurrentCP(D_(eclipse->occulter->getName().c_str())).c_str(), sizeof(callbackScratch) - 1);
+        strncpy(callbackScratch, UTF8ToCurrentCP(eclipse->occulter->getName(true)).c_str(), sizeof(callbackScratch) - 1);
         nm->item.pszText = callbackScratch;
         break;
 


### PR DESCRIPTION
Body already stores the localized name so use that rather than translating it again.