### PR TITLE
Remove i18n from getCompletion methods as it is always true

### DIFF
--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -1305,7 +1305,6 @@ Body* PlanetarySystem::find(std::string_view _name, bool deepSearch, bool i18n) 
 
 void PlanetarySystem::getCompletion(std::vector<std::string>& completion,
                                     std::string_view _name,
-                                    bool i18n,
                                     bool deepSearch) const
 {
     // Search through all names in this planetary system.
@@ -1314,8 +1313,10 @@ void PlanetarySystem::getCompletion(std::vector<std::string>& completion,
         const string& alias = index.first;
 
         if (UTF8StartsWith(alias, _name))
+        {
             completion.push_back(alias);
-        else if (i18n)
+        }
+        else
         {
             std::string lname = D_(alias.c_str());
             if (lname != alias && UTF8StartsWith(lname, _name))
@@ -1331,6 +1332,6 @@ void PlanetarySystem::getCompletion(std::vector<std::string>& completion,
     {
         const PlanetarySystem* satelliteSystem = sat->getSatellites();
         if (satelliteSystem != nullptr)
-            satelliteSystem->getCompletion(completion, _name, i18n);
+            satelliteSystem->getCompletion(completion, _name);
     }
 }

--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -59,7 +59,7 @@ class PlanetarySystem
     };
 
     Body* find(std::string_view, bool deepSearch = false, bool i18n = false) const;
-    void getCompletion(std::vector<std::string>& completion, std::string_view _name, bool i18n, bool rec = true) const;
+    void getCompletion(std::vector<std::string>& completion, std::string_view _name, bool rec = true) const;
 
  private:
     void addBodyToNameIndex(Body* body);

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -73,11 +73,11 @@ DeepSkyObject* DSODatabase::find(std::string_view name, bool i18n) const
 }
 
 
-void DSODatabase::getCompletion(std::vector<std::string>& completion, std::string_view name, bool i18n) const
+void DSODatabase::getCompletion(std::vector<std::string>& completion, std::string_view name) const
 {
     // only named DSOs are supported by completion.
     if (!name.empty() && namesDB != nullptr)
-        namesDB->getCompletion(completion, name, i18n);
+        namesDB->getCompletion(completion, name);
 }
 
 

--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -45,7 +45,7 @@ class DSODatabase
     DeepSkyObject* find(const AstroCatalog::IndexNumber catalogNumber) const;
     DeepSkyObject* find(std::string_view, bool i18n) const;
 
-    void getCompletion(std::vector<std::string>&, std::string_view, bool i18n) const;
+    void getCompletion(std::vector<std::string>&, std::string_view) const;
 
     void findVisibleDSOs(DSOHandler& dsoHandler,
                          const Eigen::Vector3d& obsPosition,

--- a/src/celengine/name.cpp
+++ b/src/celengine/name.cpp
@@ -101,21 +101,18 @@ NameDatabase::NumberIndex::const_iterator NameDatabase::getFinalNameIter() const
     return numberIndex.end();
 }
 
-void NameDatabase::getCompletion(std::vector<std::string>& completion, std::string_view name, bool i18n) const
+void NameDatabase::getCompletion(std::vector<std::string>& completion, std::string_view name) const
 {
     std::string name2 = ReplaceGreekLetter(name);
-
     for (const auto &[n, _] : nameIndex)
     {
         if (UTF8StartsWith(n, name2, true))
             completion.push_back(n);
     }
-    if (i18n)
+
+    for (const auto &[n, _] : localizedNameIndex)
     {
-        for (const auto &[n, _] : localizedNameIndex)
-        {
-            if (UTF8StartsWith(n, name2, true))
-                completion.push_back(n);
-        }
+        if (UTF8StartsWith(n, name2, true))
+            completion.push_back(n);
     }
 }

--- a/src/celengine/name.h
+++ b/src/celengine/name.h
@@ -46,7 +46,7 @@ class NameDatabase
     NumberIndex::const_iterator getFirstNameIter(const AstroCatalog::IndexNumber catalogNumber) const;
     NumberIndex::const_iterator getFinalNameIter() const;
 
-    void getCompletion(std::vector<std::string>& completion, std::string_view name, bool i18n) const;
+    void getCompletion(std::vector<std::string>& completion, std::string_view name) const;
 
  protected:
     NameIndex   nameIndex;

--- a/src/celengine/simulation.cpp
+++ b/src/celengine/simulation.cpp
@@ -449,7 +449,6 @@ Selection Simulation::findObjectFromPath(std::string_view s, bool i18n) const
 
 void Simulation::getObjectCompletion(std::vector<std::string>& completion,
                                      std::string_view s,
-                                     bool i18n,
                                      bool withLocations) const
 {
     Selection path[2];
@@ -473,7 +472,7 @@ void Simulation::getObjectCompletion(std::vector<std::string>& completion,
         path[nPathEntries++] = Selection(nearestSolarSystem->getStar());
     }
 
-    universe->getCompletionPath(completion, s, i18n, {path, nPathEntries}, withLocations);
+    universe->getCompletionPath(completion, s, {path, nPathEntries}, withLocations);
 
     std::sort(completion.begin(), completion.end(),
               [](const std::string &s1, const std::string &s2) { return strnatcmp(s1, s2) < 0; });

--- a/src/celengine/simulation.h
+++ b/src/celengine/simulation.h
@@ -68,7 +68,6 @@ class Simulation
     Selection findObjectFromPath(std::string_view s, bool i18n = false) const;
     void getObjectCompletion(std::vector<std::string>& completion,
                              std::string_view s,
-                             bool i18n,
                              bool withLocations = false) const;
     void gotoSelection(double gotoTime,
                        const Eigen::Vector3f& up,

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -529,11 +529,11 @@ StarDatabase::searchCrossIndex(StarCatalog catalog, AstroCatalog::IndexNumber nu
 
 
 void
-StarDatabase::getCompletion(std::vector<std::string>& completion, std::string_view name, bool i18n) const
+StarDatabase::getCompletion(std::vector<std::string>& completion, std::string_view name) const
 {
     // only named stars are supported by completion.
     if (!name.empty() && namesDB != nullptr)
-        namesDB->getCompletion(completion, name, i18n);
+        namesDB->getCompletion(completion, name);
 }
 
 

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -61,7 +61,7 @@ class StarDatabase
     Star* find(std::string_view, bool i18n) const;
     AstroCatalog::IndexNumber findCatalogNumberByName(std::string_view, bool i18n) const;
 
-    void getCompletion(std::vector<std::string>&, std::string_view, bool i18n) const;
+    void getCompletion(std::vector<std::string>&, std::string_view) const;
 
     void findVisibleStars(StarHandler& starHandler,
                           const Eigen::Vector3f& obsPosition,

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -541,7 +541,6 @@ CloseDSOPicker::process(DeepSkyObject* const & dso,
 void
 getLocationsCompletion(std::vector<std::string>& completion,
                        std::string_view s,
-                       bool i18n,
                        const Body& body)
 {
     auto locations = body.getLocations();
@@ -555,7 +554,7 @@ getLocationsCompletion(std::vector<std::string>& completion,
         {
             completion.push_back(name);
         }
-        else if (i18n)
+        else
         {
             const std::string& lname = location->getName(true);
             if (lname != name && UTF8StartsWith(lname, s))
@@ -568,7 +567,6 @@ getLocationsCompletion(std::vector<std::string>& completion,
 void
 getLocationsCompletionPath(std::vector<std::string>& completion,
                            std::string_view search,
-                           bool i18n,
                            const Body& body)
 {
     auto locations = body.getLocations();
@@ -579,8 +577,10 @@ getLocationsCompletionPath(std::vector<std::string>& completion,
     {
         const std::string& name = location->getName(false);
         if (UTF8StartsWith(name, search))
+        {
             completion.push_back(name);
-        else if (i18n)
+        }
+        else
         {
             const std::string& lname = location->getName(true);
             if (lname != name && UTF8StartsWith(lname, search))
@@ -1161,7 +1161,6 @@ Universe::findPath(std::string_view s,
 void
 Universe::getCompletion(std::vector<std::string>& completion,
                         std::string_view s,
-                        bool i18n,
                         celutil::array_view<const Selection> contexts,
                         bool withLocations) const
 {
@@ -1170,8 +1169,7 @@ Universe::getCompletion(std::vector<std::string>& completion,
     {
         if (withLocations && context.getType() == SelectionType::Body)
         {
-            getLocationsCompletion(completion, s, i18n,
-                                   *context.body());
+            getLocationsCompletion(completion, s, *context.body());
         }
 
         const SolarSystem* sys = getSolarSystem(context);
@@ -1179,24 +1177,23 @@ Universe::getCompletion(std::vector<std::string>& completion,
         {
             const PlanetarySystem* planets = sys->getPlanets();
             if (planets != nullptr)
-                planets->getCompletion(completion, s, i18n);
+                planets->getCompletion(completion, s);
         }
     }
 
     // Deep sky objects:
     if (dsoCatalog != nullptr)
-        dsoCatalog->getCompletion(completion, s, i18n);
+        dsoCatalog->getCompletion(completion, s);
 
     // and finally stars;
     if (starCatalog != nullptr)
-        starCatalog->getCompletion(completion, s, i18n);
+        starCatalog->getCompletion(completion, s);
 }
 
 
 void
 Universe::getCompletionPath(std::vector<std::string>& completion,
                             std::string_view s,
-                            bool i18n,
                             celutil::array_view<const Selection> contexts,
                             bool withLocations) const
 {
@@ -1204,12 +1201,12 @@ Universe::getCompletionPath(std::vector<std::string>& completion,
 
     if (pos == std::string_view::npos)
     {
-        getCompletion(completion, s, i18n, contexts, withLocations);
+        getCompletion(completion, s, contexts, withLocations);
         return;
     }
 
     auto base = s.substr(0, pos);
-    Selection sel = findPath(base, contexts, i18n);
+    Selection sel = findPath(base, contexts, true);
 
     if (sel.empty())
     {
@@ -1235,13 +1232,12 @@ Universe::getCompletionPath(std::vector<std::string>& completion,
     }
 
     if (worlds != nullptr)
-        worlds->getCompletion(completion, s.substr(pos + 1), i18n, false);
+        worlds->getCompletion(completion, s.substr(pos + 1), false);
 
     if (sel.getType() == SelectionType::Body && withLocations)
     {
         getLocationsCompletionPath(completion,
                                    s.substr(pos + 1),
-                                   i18n,
                                    *sel.body());
     }
 }

--- a/src/celengine/universe.h
+++ b/src/celengine/universe.h
@@ -66,7 +66,6 @@ class Universe
 
     void getCompletionPath(std::vector<std::string>& completion,
                            std::string_view s,
-                           bool i18n,
                            celestia::util::array_view<const Selection> contexts,
                            bool withLocations = false) const;
 
@@ -93,7 +92,6 @@ class Universe
  private:
     void getCompletion(std::vector<std::string>& completion,
                        std::string_view s,
-                       bool i18n,
                        celestia::util::array_view<const Selection> contexts,
                        bool withLocations = false) const;
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -1043,7 +1043,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
 
                     typedTextCompletion.clear();
                     if (!typedText.empty())
-                         sim->getObjectCompletion(typedTextCompletion, typedText, true, (renderer->getLabelMode() & Renderer::LocationLabels) != 0);
+                         sim->getObjectCompletion(typedTextCompletion, typedText, (renderer->getLabelMode() & Renderer::LocationLabels) != 0);
 #ifdef AUTO_COMPLETION
                 } while (!typedText.empty() && typedTextCompletion.size() == 1);
 #endif
@@ -4778,7 +4778,7 @@ void CelestiaCore::setTypedText(const char *c_p)
 {
     typedText.append(c_p);
     typedTextCompletion.clear();
-    sim->getObjectCompletion(typedTextCompletion, typedText, true, (renderer->getLabelMode() & Renderer::LocationLabels) != 0);
+    sim->getObjectCompletion(typedTextCompletion, typedText, (renderer->getLabelMode() & Renderer::LocationLabels) != 0);
     typedTextCompletionIdx = -1;
 #ifdef AUTO_COMPLETION
     if (typedTextCompletion.size() == 1)


### PR DESCRIPTION
Simplifies the lookup code a bit - the methods handling completions always operate with localized names, so no need to pass the boolean.