### PR TITLE
Split EllipticalOrbit and HyperbolicOrbit classes

### DIFF
--- a/src/celengine/astro.cpp
+++ b/src/celengine/astro.cpp
@@ -8,6 +8,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <algorithm>
 #include <cmath>
 #include <ostream>
 #include <utility>
@@ -89,6 +90,13 @@ static const astro::LeapSecondRecord LeapSeconds[] =
     { 36, 2457204.5 }, // 1 Jul 2015
     { 37, 2457754.5 }, // 1 Jan 2017
 };
+
+
+static inline void negateIf(double& d, bool condition)
+{
+    if (condition)
+        d = -d;
+}
 
 
 static celestia::util::array_view<astro::LeapSecondRecord> g_leapSeconds = LeapSeconds;
@@ -764,4 +772,96 @@ std::optional<double> astro::getMassScale(MassUnit unit)
 void astro::setLeapSeconds(celestia::util::array_view<astro::LeapSecondRecord> leapSeconds)
 {
     g_leapSeconds = leapSeconds;
+}
+
+
+astro::KeplerElements astro::StateVectorToElements(const Eigen::Vector3d& r,
+                                                   const Eigen::Vector3d& v,
+                                                   double mu)
+{
+    constexpr double tolerance = 1e-9;
+
+    Eigen::Vector3d h = r.cross(v);
+    double rNorm = r.norm();
+
+    KeplerElements result;
+
+    // Compute eccentricity
+    Eigen::Vector3d evec = v.cross(h) / mu - r / rNorm;
+    result.eccentricity = evec.norm();
+
+    // Compute inclination
+    result.inclination = std::acos(std::clamp(h.y() / h.norm(), -1.0, 1.0));
+
+    // Normal vector (UnitY x h)
+    Eigen::Vector3d nvec(h[2], 0, -h[0]);
+    double nNorm = nvec.norm();
+
+    // compute longAscendingNode and argPericenter
+    if (result.inclination < tolerance)
+    {
+        // handle face-on orbit: by convention Omega = 0.0
+        if (result.eccentricity >= tolerance)
+        {
+            result.argPericenter = std::acos(evec.x() / result.eccentricity);
+            negateIf(result.argPericenter, evec.z() >= 0.0);
+        }
+    }
+    else
+    {
+        result.longAscendingNode = std::acos(nvec.x() / nNorm);
+        negateIf(result.longAscendingNode, nvec.z() >= 0.0);
+        if (result.eccentricity >= tolerance)
+        {
+            result.argPericenter = std::acos(std::clamp(nvec.dot(evec) / (nNorm * result.eccentricity), -1.0, 1.0));
+            negateIf(result.argPericenter, evec.y() < 0.0);
+        }
+    }
+
+    // compute true anomaly
+    double nu;
+    if (result.eccentricity >= tolerance)
+    {
+        nu = std::acos(std::clamp(evec.dot(r) / (result.eccentricity * rNorm), -1.0, 1.0));
+        negateIf(nu, r.dot(v) < 0.0);
+    }
+    else
+    {
+        if (result.inclination < tolerance)
+        {
+            // circular face-on orbit
+            nu = std::acos(r.x() / rNorm);
+            negateIf(nu, v.x() > 0.0);
+        }
+        else
+        {
+            nu = std::acos(std::clamp(nvec.dot(r) / (nNorm * rNorm), -1.0, 1.0));
+            negateIf(nu, nvec.dot(v) > 0.0);
+        }
+    }
+
+    double s_nu;
+    double c_nu;
+    celmath::sincos(nu, s_nu, c_nu);
+
+    // compute mean anomaly
+    double e2 = celmath::square(result.eccentricity);
+    if (result.eccentricity < 1.0)
+    {
+        double E = std::atan2(std::sqrt(1.0 - e2) * s_nu,
+                              result.eccentricity + c_nu);
+        result.meanAnomaly = E - result.eccentricity * std::sin(E);
+    }
+    else
+    {
+        double sinhE = std::sqrt(e2 - 1.0) * s_nu / (1.0 + result.eccentricity * c_nu);
+        double E = std::asinh(sinhE);
+        result.meanAnomaly = result.eccentricity * sinhE - E;
+    }
+
+    // compute semimajor axis
+    result.semimajorAxis = 1.0 / (2.0 / rNorm - v.squaredNorm() / mu);
+    result.period = 2.0 * celestia::numbers::pi * std::sqrt(celmath::cube(std::abs(result.semimajorAxis)) / mu);
+
+    return result;
 }

--- a/src/celengine/astro.h
+++ b/src/celengine/astro.h
@@ -320,4 +320,19 @@ namespace astro
         return astro::speedOfLight * n;
     }
     }
-}
+
+    struct KeplerElements
+    {
+        double semimajorAxis{ 0.0 };
+        double eccentricity{ 0.0 };
+        double inclination{ 0.0 };
+        double longAscendingNode{ 0.0 };
+        double argPericenter{ 0.0 };
+        double meanAnomaly{ 0.0 };
+        double period{ 0.0 };
+    };
+
+    KeplerElements StateVectorToElements(const Eigen::Vector3d&,
+                                         const Eigen::Vector3d&,
+                                         double);
+} // end namespace astro

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1090,15 +1090,16 @@ void Renderer::renderOrbit(const OrbitPathListEntry& orbitPath,
     if (cachedOrbit == nullptr)
     {
         double startTime = t;
-#if 0
-        int nSamples = detailOptions.orbitPathSamplePoints;
-#endif
 
         // Adjust the number of samples used for aperiodic orbits--these aren't
         // true orbits, but are sampled trajectories, generally of spacecraft.
         // Better control is really needed--some sort of adaptive sampling would
         // be ideal.
-        if (!orbit->isPeriodic())
+        if (orbit->isPeriodic())
+        {
+            startTime = t - orbit->getPeriod();
+        }
+        else
         {
             double begin = 0.0, end = 0.0;
             orbit->getValidRange(begin, end);
@@ -1106,26 +1107,7 @@ void Renderer::renderOrbit(const OrbitPathListEntry& orbitPath,
             if (begin != end)
             {
                 startTime = begin;
-#if 0
-                nSamples = (int) (orbit->getPeriod() * 100.0);
-                nSamples = std::clamp(nSamples, 100, 1000);
-#endif
             }
-#if 0
-            else
-            {
-                // If the orbit is aperiodic and doesn't have a
-                // finite duration, we don't render it. A compromise
-                // would be to pick some time window centered at the
-                // current time, but we'd have to pick some arbitrary
-                // duration.
-                nSamples = 0;
-            }
-#endif
-        }
-        else
-        {
-            startTime = t - orbit->getPeriod();
         }
 
         cachedOrbit = new CurvePlot(*this);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ macro(test_case)
   endif()
   target_compile_definitions(${tgt} PRIVATE
     DOCTEST_CONFIG_USE_STD_HEADERS
-    DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS)
+  )
   target_include_directories(${tgt} PRIVATE "${_CELESTIA_TESTS_BASE_DIR}/doctest")
   if(WIN32)
     # Need to copy the dlls before test discovery

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ set(UNIT_TEST_SOURCES
   greek_test.cpp
   hash_test.cpp
   intrusiveptr_test.cpp
+  kepler_test.cpp
   logger_test.cpp
   ranges_test.cpp
   stellarclass_test.cpp

--- a/test/unit/kepler_test.cpp
+++ b/test/unit/kepler_test.cpp
@@ -1,0 +1,136 @@
+#include <array>
+#include <cmath>
+
+#include <celcompat/numbers.h>
+#include <celengine/astro.h>
+#include <celephem/orbit.h>
+#include <celmath/mathlib.h>
+#include <celutil/array_view.h>
+
+#include <doctest.h>
+
+namespace
+{
+constexpr double GMsun = 0.000296014912;
+constexpr double fourpi2 = 4.0 * celmath::square(celestia::numbers::pi);
+constexpr double tau = 2.0 * celestia::numbers::pi;
+
+constexpr std::array testPeriods{
+    50.0, 1200.0
+};
+
+constexpr std::array testInclinations{
+    0.0, 30.0, 90.0, 150.0, 180.0
+};
+
+constexpr std::array testAngles{
+    -180.0, -150.0, -90.0, -40.0, 0.0, 40.0, 90.0, 150.0, 180.0
+};
+
+constexpr std::array fixedZero{ 0.0 };
+
+constexpr double tolerance = 1e-3;
+
+bool ApproxAngle(double lhs, double rhs)
+{
+    return std::abs(lhs - rhs) < tolerance ||
+           std::abs(lhs + tau - rhs) < tolerance ||
+           std::abs(lhs - tau - rhs) < tolerance;
+}
+
+void TestElements(const astro::KeplerElements& expected,
+                  const astro::KeplerElements& actual)
+{
+    REQUIRE(expected.period == doctest::Approx(actual.period).epsilon(tolerance));
+    REQUIRE(expected.semimajorAxis == doctest::Approx(actual.semimajorAxis).epsilon(tolerance));
+    REQUIRE(expected.eccentricity == doctest::Approx(actual.eccentricity).epsilon(tolerance));
+    REQUIRE(ApproxAngle(expected.inclination, actual.inclination));
+    REQUIRE(ApproxAngle(expected.longAscendingNode, actual.longAscendingNode));
+    REQUIRE(ApproxAngle(expected.argPericenter, actual.argPericenter));
+    REQUIRE(ApproxAngle(expected.meanAnomaly, actual.meanAnomaly));
+}
+
+}
+
+TEST_SUITE_BEGIN("Keplerian orbits");
+
+TEST_CASE("Elliptical orbits")
+{
+    constexpr std::array testEccentricities{ 0.0, 0.2, 0.6 };
+
+    for (double period : testPeriods)
+    {
+        double semimajor = std::cbrt(GMsun * celmath::square(period) / fourpi2);
+        for (double meanAnomalyDeg : testAngles)
+        for (double inclinationDeg : testInclinations)
+        {
+            auto testNodes = inclinationDeg == 0.0 || inclinationDeg == 180.0
+                ? celestia::util::array_view<double>(fixedZero)
+                : celestia::util::array_view<double>(testAngles);
+            for (double nodeDeg : testNodes)
+            for (double eccentricity : testEccentricities)
+            {
+                auto testPericenters = eccentricity == 0.0
+                    ? celestia::util::array_view<double>(fixedZero)
+                    : celestia::util::array_view<double>(testAngles);
+                for (double pericenterDeg : testPericenters)
+                {
+                    astro::KeplerElements expected;
+                    expected.period = period;
+                    expected.semimajorAxis = semimajor;
+                    expected.eccentricity = eccentricity;
+                    expected.inclination = celmath::degToRad(inclinationDeg);
+                    expected.longAscendingNode = celmath::degToRad(nodeDeg);
+                    expected.argPericenter = celmath::degToRad(pericenterDeg);
+                    expected.meanAnomaly = celmath::degToRad(meanAnomalyDeg);
+                    auto orbit = celestia::ephem::EllipticalOrbit(expected, 0.0);
+                    auto position = orbit.positionAtTime(0.0);
+                    auto velocity = orbit.velocityAtTime(0.0);
+
+                    auto actual = astro::StateVectorToElements(position, velocity, GMsun);
+
+                    TestElements(expected, actual);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Hyperbolic orbits")
+{
+    constexpr std::array testEccentricities{ 1.5, 2.4 };
+
+    for (double period : testPeriods)
+    {
+        double semimajor = -std::cbrt(GMsun * celmath::square(period) / fourpi2);
+        for (double meanAnomalyDeg : testAngles)
+        for (double inclinationDeg : testInclinations)
+        {
+            auto testNodes = inclinationDeg == 0.0 || inclinationDeg == 180.0
+                ? celestia::util::array_view<double>(fixedZero)
+                : celestia::util::array_view<double>(testAngles);
+            for (double nodeDeg : testNodes)
+            for (double eccentricity : testEccentricities)
+            for (double pericenterDeg : testAngles)
+            {
+                astro::KeplerElements expected;
+                expected.period = period;
+                expected.semimajorAxis = semimajor;
+                expected.eccentricity = eccentricity;
+                expected.inclination = celmath::degToRad(inclinationDeg);
+                expected.longAscendingNode = celmath::degToRad(nodeDeg);
+                expected.argPericenter = celmath::degToRad(pericenterDeg);
+                expected.meanAnomaly = celmath::degToRad(meanAnomalyDeg);
+                auto orbit = celestia::ephem::HyperbolicOrbit(expected, 0.0);
+                auto position = orbit.positionAtTime(0.0);
+                auto velocity = orbit.velocityAtTime(0.0);
+
+                auto actual = astro::StateVectorToElements(position, velocity, GMsun);
+
+                TestElements(expected, actual);
+            }
+        }
+    }
+}
+
+TEST_SUITE_END();

--- a/test/unit/ranges_test.cpp
+++ b/test/unit/ranges_test.cpp
@@ -11,6 +11,9 @@
 
 using namespace std::string_view_literals;
 
+namespace
+{
+
 class UniqueString
 {
 public:
@@ -38,6 +41,8 @@ bool operator==(const UniqueString& lhs, std::string_view rhs)
 {
     return lhs.value() == rhs;
 }
+
+} // end unnamed namespace
 
 TEST_SUITE_BEGIN("Ranges");
 


### PR DESCRIPTION
- Store semimajor axis instead of pericenterDistance in EllipticalOrbit
- Store semiminor axis to avoid some sqrt calls during evaluation
- Support zero and negative mean anomaly in hyperbolic orbits
- Fix velocity calculation for hyperbolic orbits
- Consolidate state vector to orbital elements calculations
- Extend orbital elements calculation to support hyperbolic orbits
- Add tests for orbital elements calculations
- Fix hyperbolic orbital elements display in Qt info panel

Hyperbolic orbits now have the orbit line plotted (currently out to 1000 au or twice the pericenter distance, whichever is further). The eccentric anomaly calculation no longer attempts to take the logarithm of negative mean anomaly angles.