### PR TITLE
[celx] Implement object:setatmosphere with a table instead of 22 numbers

### DIFF
--- a/test/scripts/atmosphere.celx
+++ b/test/scripts/atmosphere.celx
@@ -1,0 +1,14 @@
+-- This snippet assigns Titan's atmosphere to Earth
+
+sel = celestia:find("Sol/Earth")
+
+t = {}
+
+t.height = 950
+t.miescaleheight = 130
+t.rayleigh = { 0.00125, 0.00176, 0.00274 }
+t.absorption = { 0.0001, 0.0005, 0.001 }
+t.mieasymmetry = 0
+t.mie = 0
+
+sel:setatmosphere(t)


### PR DESCRIPTION
\+ small cleanup in object:mark.

I doubt that anybody really used method with 22 arguments, so I hope it's safe to change API. 