### PR TITLE
Ensure leap seconds are sorted by JD

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -188,6 +188,8 @@ bool ReadLeapSecondsFile(const fs::path& path, std::vector<astro::LeapSecondReco
         leapSeconds.push_back({seconds, jd});
     }
 
+    std::sort(leapSeconds.begin(), leapSeconds.end(), [](const auto& a, const auto& b) { return a.t < b.t; });
+
     astro::setLeapSeconds(leapSeconds);
     return true;
 }


### PR DESCRIPTION
Matches assumed ordering in astro.cpp