### PR TITLE
Remove unneeded namespace aliases

### DIFF
--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -26,8 +26,6 @@ using namespace celmath;
 using namespace celestia;
 using celestia::render::LineRenderer;
 
-namespace astro = celestia::astro;
-
 LineRenderer *PlanetographicGrid::latitudeRenderer = nullptr;
 LineRenderer *PlanetographicGrid::equatorRenderer = nullptr;
 LineRenderer *PlanetographicGrid::longitudeRenderer = nullptr;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -95,8 +95,6 @@ using namespace celestia::engine;
 using namespace celestia::render;
 using celestia::util::GetLogger;
 
-namespace astro = celestia::astro;
-
 #define NEAR_DIST      0.5f
 #define FAR_DIST       1.0e9f
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -84,8 +84,6 @@ using namespace celestia::engine;
 using namespace celestia::scripts;
 using namespace celestia::util;
 
-namespace astro = celestia::astro;
-
 static const int DragThreshold = 3;
 
 // Perhaps you'll want to put this stuff in configuration file.


### PR DESCRIPTION
In this files we have `using namespace celestia` so with older g++ there is a conflict between two namespaces.