### PR TITLE
Split (some parts of) celestiacore

### DIFF
--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -979,9 +979,9 @@ void Observer::setTargetSpeed(float s)
 }
 
 
-float Observer::getTargetSpeed()
+float Observer::getTargetSpeed() const
 {
-    return (float) targetSpeed;
+    return static_cast<float>(targetSpeed);
 }
 
 

--- a/src/celengine/observer.h
+++ b/src/celengine/observer.h
@@ -151,7 +151,7 @@ public:
     void rotate(const Eigen::Quaternionf &q);
     void changeOrbitDistance(const Selection&, float d);
     void setTargetSpeed(float s);
-    float getTargetSpeed();
+    float getTargetSpeed() const;
 
     Selection getTrackedObject() const;
     void setTrackedObject(const Selection&);

--- a/src/celengine/overlay.cpp
+++ b/src/celengine/overlay.cpp
@@ -99,6 +99,13 @@ void Overlay::setColor(const Color& c)
                      c.red(), c.green(), c.blue(), c.alpha());
 }
 
+void Overlay::setColor(const Color& c, float a)
+{
+    layout->flush();
+    glVertexAttrib4f(CelestiaGLProgram::ColorAttributeIndex,
+                     c.red(), c.green(), c.blue(), a);
+}
+
 void Overlay::moveBy(float dx, float dy)
 {
     layout->moveRelative(dx, dy);

--- a/src/celengine/overlay.h
+++ b/src/celengine/overlay.h
@@ -41,6 +41,7 @@ class Overlay
 
     void setColor(float r, float g, float b, float a);
     void setColor(const Color& c);
+    void setColor(const Color& c, float a);
 
     void moveBy(float dx, float dy);
     void moveBy(int dx, int dy);

--- a/src/celengine/simulation.cpp
+++ b/src/celengine/simulation.cpp
@@ -166,11 +166,15 @@ Observer& Simulation::getObserver()
 }
 
 
-Observer* Simulation::addObserver()
+const Observer& Simulation::getObserver() const
 {
-    Observer* o = new Observer();
-    observers.push_back(o);
-    return o;
+    return *activeObserver;
+}
+
+
+Observer* Simulation::duplicateActiveObserver()
+{
+    return observers.emplace_back(new Observer(*getActiveObserver()));
 }
 
 
@@ -183,6 +187,12 @@ void Simulation::removeObserver(Observer* o)
 
 
 Observer* Simulation::getActiveObserver()
+{
+    return activeObserver;
+}
+
+
+const Observer* Simulation::getActiveObserver() const
 {
     return activeObserver;
 }
@@ -262,7 +272,7 @@ void Simulation::setTargetSpeed(float s)
     activeObserver->setTargetSpeed(s);
 }
 
-float Simulation::getTargetSpeed()
+float Simulation::getTargetSpeed() const
 {
     return activeObserver->getTargetSpeed();
 }

--- a/src/celengine/simulation.h
+++ b/src/celengine/simulation.h
@@ -55,7 +55,7 @@ class Simulation
     void rotate(const Eigen::Quaternionf& q);
     void changeOrbitDistance(float d);
     void setTargetSpeed(float s);
-    float getTargetSpeed();
+    float getTargetSpeed() const;
 
     Selection getSelection() const;
     void setSelection(const Selection&);
@@ -94,13 +94,15 @@ class Simulation
     void cancelMotion();
 
     Observer& getObserver();
+    const Observer& getObserver() const;
     void setObserverPosition(const UniversalCoord&);
     void setObserverOrientation(const Eigen::Quaternionf&);
     void reverseObserverOrientation();
 
-    Observer* addObserver();
+    Observer* duplicateActiveObserver();
     void removeObserver(Observer*);
     Observer* getActiveObserver();
+    const Observer* getActiveObserver() const;
     void setActiveObserver(Observer*);
 
     SolarSystem* getNearestSolarSystem() const;

--- a/src/celestia/CMakeLists.txt
+++ b/src/celestia/CMakeLists.txt
@@ -13,15 +13,24 @@ set(CELESTIA_SOURCES
   favorites.h
   helper.cpp
   helper.h
+  hud.cpp
+  hud.h
   moviecapture.h
   scriptmenu.cpp
   scriptmenu.h
+  textinput.cpp
+  textinput.h
   textprintposition.cpp
   textprintposition.h
+  timeinfo.h
   url.cpp
   url.h
   view.cpp
   view.h
+  viewmanager.cpp
+  viewmanager.h
+  windowmetrics.cpp
+  windowmetrics.h
 )
 
 if(ENABLE_FFMPEG)

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -425,7 +425,7 @@ void CelestiaCore::mouseButtonDown(float x, float y, int button)
         return;
 
     // To select the clicked into view before a drag.
-    if (viewManager->pickView(sim, metrics, x, y) && hud->showActiveViewFrame)
+    if (viewManager->pickView(sim, metrics, x, y) && viewManager->showActiveViewFrame)
         viewManager->flashFrameStart(timeInfo.currentTime);
 
     if (button == LeftButton) // look if click is near a view border
@@ -459,7 +459,7 @@ void CelestiaCore::mouseButtonUp(float x, float y, int button)
     {
         if (button == LeftButton)
         {
-            if (viewManager->pickView(sim, metrics, x, y) && hud->showActiveViewFrame)
+            if (viewManager->pickView(sim, metrics, x, y) && viewManager->showActiveViewFrame)
                 viewManager->flashFrameStart(timeInfo.currentTime);
 
             float pickX, pickY;
@@ -981,7 +981,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
 
     case '\011': // TAB
         viewManager->nextView(sim);
-        if (!hud->showActiveViewFrame)
+        if (!viewManager->showActiveViewFrame)
             viewManager->flashFrameStart(timeInfo.currentTime);
         break;
 
@@ -2164,31 +2164,31 @@ void CelestiaCore::deleteView(View* v)
     if (!viewManager->deleteView(sim, v))
         return;
 
-    if (!hud->showActiveViewFrame)
+    if (!viewManager->showActiveViewFrame)
         viewManager->flashFrameStart(timeInfo.currentTime);
     setFOVFromZoom();
 }
 
 bool CelestiaCore::getFramesVisible() const
 {
-    return hud->showViewFrames;
+    return viewManager->showViewFrames;
 }
 
 void CelestiaCore::setFramesVisible(bool visible)
 {
     setViewChanged();
-    hud->showViewFrames = visible;
+    viewManager->showViewFrames = visible;
 }
 
 bool CelestiaCore::getActiveFrameVisible() const
 {
-    return hud->showActiveViewFrame;
+    return viewManager->showActiveViewFrame;
 }
 
 void CelestiaCore::setActiveFrameVisible(bool visible)
 {
     setViewChanged();
-    hud->showActiveViewFrame = visible;
+    viewManager->showActiveViewFrame = visible;
 }
 
 
@@ -2208,13 +2208,13 @@ void CelestiaCore::showText(std::string_view s,
                             double duration)
 {
     auto [emWidth, height] = hud->getTitleMetrics();
-    hud->showText<RelativeTextPrintPosition>(s, duration, timeInfo.currentTime,
-                                             horig, vorig, hoff, voff, emWidth, height);
+    hud->showText(TextPrintPosition::relative(horig, vorig, hoff, voff, emWidth, height),
+                  s, duration, timeInfo.currentTime);
 }
 
 void CelestiaCore::showTextAtPixel(std::string_view s, int x, int y, double duration)
 {
-    hud->showText<AbsoluteTextPrintPosition>(s, duration, timeInfo.currentTime, x, y);
+    hud->showText(TextPrintPosition::absolute(x, y), s, duration, timeInfo.currentTime);
 }
 
 
@@ -2938,22 +2938,6 @@ bool CelestiaCore::setRendererFont(const fs::path& fontPath, int collectionIndex
         return true;
     }
     return false;
-}
-
-void CelestiaCore::clearFonts()
-{
-    hud->clearFonts();
-
-    if (console)
-        console->setFont(nullptr);
-
-    if (renderer)
-    {
-        for (int i = Renderer::FontNormal; i < Renderer::FontCount; i += 1)
-        {
-            renderer->setFont((Renderer::FontStyle)i, nullptr);
-        }
-    }
 }
 
 int CelestiaCore::getTimeZoneBias() const

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -17,6 +17,7 @@
 #include "favorites.h"
 #include "textprintposition.h"
 #include "url.h"
+#include "viewmanager.h"
 #include <celcompat/numbers.h>
 #include <celengine/astro.h>
 #include <celengine/asterism.h>
@@ -93,55 +94,12 @@ static const double fMaxKeyAccel = 20.0;
 static const float RotationBraking = 10.0f;
 static const float RotationDecay = 2.0f;
 static const double MaximumTimeRate = 1.0e15;
-static const double MinimumTimeRate = 1.0e-15;
 static const float stdFOV = degToRad(45.0f);
 static float KeyRotationAccel = degToRad(120.0f);
 static float MouseRotationSensitivity = degToRad(1.0f);
-static const double OneMiInKm = 1.609344;
-static const double OneFtInKm = 0.0003048;
-static const double OneLbInKg = 0.45359237;
-static const double OneLbPerFt3InKgPerM3 = OneLbInKg / pow(OneFtInKm * 1000.0, 3);
 
 namespace
 {
-float KelvinToCelsius(float kelvin)
-{
-    return kelvin - 273.15f;
-}
-
-float KelvinToFahrenheit(float kelvin)
-{
-    return kelvin * 1.8f - 459.67f;
-}
-
-FormattedNumber SigDigitNum(double v, int digits)
-{
-    return FormattedNumber(v, digits,
-                           FormattedNumber::GroupThousands |
-                           FormattedNumber::SignificantDigits);
-}
-
-string KelvinToStr(float value, int digits, CelestiaCore::TemperatureScale temperatureScale)
-{
-    const char* unitTemplate = "";
-
-    switch (temperatureScale)
-    {
-        case CelestiaCore::Celsius:
-            value = KelvinToCelsius(value);
-            unitTemplate = "{} °C";
-            break;
-        case CelestiaCore::Fahrenheit:
-            value = KelvinToFahrenheit(value);
-            unitTemplate = "{} °F";
-            break;
-        case CelestiaCore::Kelvin:
-        default:
-            unitTemplate = "{} K";
-            break;
-    }
-    return fmt::format(unitTemplate, SigDigitNum(value, digits));
-}
 
 bool is_valid_directory(const fs::path& dir)
 {
@@ -236,7 +194,6 @@ CelestiaCore::CelestiaCore() :
 #endif
     m_scriptMaps(new ScriptMaps()),
     oldFOV(stdFOV),
-    dateFormatter(std::make_unique<celestia::engine::DateFormatter>()),
     console(new Console(*renderer, 200, 120)),
     m_tee(std::cout, std::cerr)
 {
@@ -409,8 +366,8 @@ void CelestiaCore::cancelScript()
 {
     if (m_script != nullptr)
     {
-        if (textEnterMode & KbPassToScript)
-            setTextEnterMode(textEnterMode & ~KbPassToScript);
+        if ((hud->getTextEnterMode() & Hud::TextEnterPassToScript) != 0)
+            setTextEnterMode(hud->getTextEnterMode() & ~Hud::TextEnterPassToScript);
         scriptState = ScriptCompleted;
         m_script = nullptr;
     }
@@ -464,56 +421,15 @@ void CelestiaCore::mouseButtonDown(float x, float y, int button)
    if (m_scriptHook != nullptr && m_scriptHook->call("mousebuttondown", x, y, button))
         return;
 
-    if (views.size() > 1)
-    {
-        // To select the clicked into view before a drag.
-        pickView(x, y);
-    }
+    if (viewManager->views().size() < 2)
+        return;
 
-    if (views.size() > 1 && button == LeftButton) // look if click is near a view border
-    {
-        View *v1 = nullptr, *v2 = nullptr;
-        for (const auto v : views)
-        {
-            if (v->type == View::ViewWindow)
-            {
-                float vx, vy, vxp, vyp;
-                vx = ( x / width - v->x ) / v->width;
-                vy = ( (1 - y / height ) - v->y ) / v->height;
-                vxp = vx * v->width * width;
-                vyp = vy * v->height * height;
-                if ( (vx >=0 && vx <= 1 && ( abs(vyp) <= 2 || abs(vyp - v->height * height) <= 2))
-                  || (vy >=0 && vy <= 1 && ( abs(vxp) <= 2 || abs(vxp - v->width * width) <= 2)) )
-                {
-                    if (v1 == 0)
-                    {
-                        v1 = v;
-                    }
-                    else
-                    {
-                        v2 = v;
-                        break;
-                    }
-                }
-            }
-        }
-        if (v2 != nullptr)
-        {
-             // Look for common ancestor to v1 & v2 = split being draged.
-             View *p1 = v1, *p2 = v2;
-             while ( (p1 = p1->parent) != nullptr )
-             {
-                 p2 = v2;
-                 while ( ((p2 = p2->parent) != nullptr) && p1 != p2) ;
-                 if (p2 != nullptr) break;
-             }
-             if (p2 != nullptr)
-             {
-                 resizeSplit = p1;
-             }
-        }
-    }
+    // To select the clicked into view before a drag.
+    if (viewManager->pickView(sim, metrics, x, y) && hud->showActiveViewFrame)
+        viewManager->flashFrameStart(timeInfo.currentTime);
 
+    if (button == LeftButton) // look if click is near a view border
+        viewManager->tryStartResizing(metrics, x, y);
 }
 
 void CelestiaCore::mouseButtonUp(float x, float y, int button)
@@ -521,13 +437,10 @@ void CelestiaCore::mouseButtonUp(float x, float y, int button)
     setViewChanged();
 
     // Four pixel tolerance for picking
-    float pickTolerance = sim->getActiveObserver()->getFOV() / height * this->pickTolerance;
+    float pickTolerance = sim->getActiveObserver()->getFOV() / metrics.height * this->pickTolerance;
 
-    if (resizeSplit != nullptr)
-    {
-        resizeSplit = nullptr;
+    if (viewManager->stopResizing())
         return;
-    }
 
 #ifdef CELX
     if (m_script != nullptr)
@@ -546,18 +459,19 @@ void CelestiaCore::mouseButtonUp(float x, float y, int button)
     {
         if (button == LeftButton)
         {
-            pickView(x, y);
+            if (viewManager->pickView(sim, metrics, x, y) && hud->showActiveViewFrame)
+                viewManager->flashFrameStart(timeInfo.currentTime);
 
             float pickX, pickY;
-            float aspectRatio = ((float) width / (float) height);
-            (*activeView)->mapWindowToView((float) x / (float) width,
-                                           (float) y / (float) height,
-                                           pickX, pickY);
+            float aspectRatio = ((float) metrics.width / (float) metrics.height);
+            viewManager->activeView()->mapWindowToView((float) x / (float) metrics.width,
+                                                       (float) y / (float) metrics.height,
+                                                       pickX, pickY);
             pickX *= aspectRatio;
             if (isViewportEffectUsed)
                 viewportEffect->distortXY(pickX, pickY);
 
-            Vector3f pickRay = renderer->getProjectionMode()->getPickRay(pickX, pickY, (*activeView)->getObserver()->getZoom());
+            Vector3f pickRay = renderer->getProjectionMode()->getPickRay(pickX, pickY, viewManager->activeView()->getObserver()->getZoom());
 
             Selection oldSel = sim->getSelection();
             Selection newSel = sim->pickObject(pickRay, renderer->getRenderFlags(), pickTolerance);
@@ -569,15 +483,15 @@ void CelestiaCore::mouseButtonUp(float x, float y, int button)
         else if (button == RightButton)
         {
             float pickX, pickY;
-            float aspectRatio = ((float) width / (float) height);
-            (*activeView)->mapWindowToView((float) x / (float) width,
-                                           (float) y / (float) height,
-                                           pickX, pickY);
+            float aspectRatio = ((float) metrics.width / (float) metrics.height);
+            viewManager->activeView()->mapWindowToView((float) x / (float) metrics.width,
+                                                       (float) y / (float) metrics.height,
+                                                       pickX, pickY);
             pickX *= aspectRatio;
             if (isViewportEffectUsed)
                 viewportEffect->distortXY(pickX, pickY);
 
-            Vector3f pickRay = renderer->getProjectionMode()->getPickRay(pickX, pickY, (*activeView)->getObserver()->getZoom());
+            Vector3f pickRay = renderer->getProjectionMode()->getPickRay(pickX, pickY, viewManager->activeView()->getObserver()->getZoom());
 
             Selection sel = sim->pickObject(pickRay, renderer->getRenderFlags(), pickTolerance);
             if (!sel.empty())
@@ -588,7 +502,7 @@ void CelestiaCore::mouseButtonUp(float x, float y, int button)
         }
         else if (button == MiddleButton)
         {
-            auto observer = (*activeView)->getObserver();
+            auto observer = viewManager->activeView()->getObserver();
             auto currentZoom = observer->getZoom();
             if (currentZoom != 1.0f)
             {
@@ -617,12 +531,12 @@ void CelestiaCore::mouseWheel(float motion, int modifiers)
     {
         if ((modifiers & ShiftKey) != 0)
         {
-            zoomTime = currentTime;
+            zoomTime = timeInfo.currentTime;
             zoomMotion = 0.25f * motion;
         }
         else
         {
-            dollyTime = currentTime;
+            dollyTime = timeInfo.currentTime;
             dollyMotion = 0.25f * motion;
         }
     }
@@ -636,31 +550,20 @@ void CelestiaCore::mouseMove(float x, float y)
     if (m_scriptHook != nullptr && m_scriptHook->call("mousemove", x, y))
         return;
 
-    if (views.size() > 1 && cursorHandler != nullptr)
-    {
-        for (const auto v : views)
-        {
-            if (v->type == View::ViewWindow)
-            {
-                float vx, vy, vxp, vyp;
-                vx = (x / width - v->x) / v->width;
-                vy = ((1 - y / height) - v->y ) / v->height;
-                vxp = vx * v->width * width;
-                vyp = vy * v->height * height;
+    if (viewManager->views().size() < 2 || cursorHandler == nullptr)
+        return;
 
-                if (vx >=0 && vx <= 1 && (abs(vyp) <= 2 || abs(vyp - v->height * height) <= 2))
-                {
-                    cursorHandler->setCursorShape(CelestiaCore::SizeVerCursor);
-                    return;
-                }
-                if (vy >=0 && vy <= 1 && (abs(vxp) <= 2 || abs(vxp - v->width * width) <= 2))
-                {
-                    cursorHandler->setCursorShape(CelestiaCore::SizeHorCursor);
-                    return;
-                }
-            }
-        }
+    switch (viewManager->checkViewBorder(metrics, x, y))
+    {
+    case ViewBorderType::SizeHorizontal:
+        cursorHandler->setCursorShape(CelestiaCore::SizeHorCursor);
+        break;
+    case ViewBorderType::SizeVertical:
+        cursorHandler->setCursorShape(CelestiaCore::SizeVerCursor);
+        break;
+    default:
         cursorHandler->setCursorShape(defaultCursorShape);
+        break;
     }
 }
 
@@ -669,29 +572,8 @@ void CelestiaCore::mouseMove(float dx, float dy, int modifiers)
     if (modifiers != 0)
         setViewChanged();
 
-    if (resizeSplit != nullptr)
+    if (viewManager->resizeViews(metrics, dx, dy))
     {
-        switch(resizeSplit->type) {
-        case View::HorizontalSplit:
-            if (   resizeSplit->walkTreeResizeDelta(resizeSplit->child1, dy / height, true)
-                && resizeSplit->walkTreeResizeDelta(resizeSplit->child2, dy / height, true))
-            {
-                resizeSplit->walkTreeResizeDelta(resizeSplit->child1, dy / height, false);
-                resizeSplit->walkTreeResizeDelta(resizeSplit->child2, dy / height, false);
-            }
-            break;
-        case View::VerticalSplit:
-            if (   resizeSplit->walkTreeResizeDelta(resizeSplit->child1, dx / width, true)
-                && resizeSplit->walkTreeResizeDelta(resizeSplit->child2, dx / width, true)
-            )
-            {
-                resizeSplit->walkTreeResizeDelta(resizeSplit->child1, dx / width, false);
-                resizeSplit->walkTreeResizeDelta(resizeSplit->child2, dx / width, false);
-            }
-            break;
-        case View::ViewWindow:
-            break;
-        }
         setFOVFromZoom();
         return;
     }
@@ -712,7 +594,7 @@ void CelestiaCore::mouseMove(float dx, float dy, int modifiers)
             else if (sel.getType() == SelectionType::Body)
                 q = sel.body()->getGeometryOrientation();
 
-            q = XRotation(dy / height) * YRotation(dx / width) * q;
+            q = XRotation(dy / metrics.height) * YRotation(dx / metrics.width) * q;
 
             if (sel.getType() == SelectionType::DeepSky)
                 sel.deepsky()->setOrientation(q);
@@ -730,7 +612,7 @@ void CelestiaCore::mouseMove(float dx, float dy, int modifiers)
                 Vector3d v = sel.getPosition(t).offsetFromKm(sim->getObserver().getPosition());
                 Vector3f axis = v.cast<float>().normalized();
 
-                Quaternionf r(AngleAxisf(dx / width, axis));
+                Quaternionf r(AngleAxisf(dx / metrics.width, axis));
 
                 Quaternionf q = sel.deepsky()->getOrientation();
                 sel.deepsky()->setOrientation(r * q);
@@ -741,7 +623,7 @@ void CelestiaCore::mouseMove(float dx, float dy, int modifiers)
         {
             // Y-axis controls distance (exponentially), and x-axis motion
             // rotates the camera about the view normal.
-            float amount = dy / height;
+            float amount = dy / metrics.height;
             sim->changeOrbitDistance(amount * 5);
             if (dx * dx > dy * dy)
             {
@@ -759,7 +641,7 @@ void CelestiaCore::mouseMove(float dx, float dy, int modifiers)
         else if (checkMask(modifiers, LeftButton | ShiftKey))
         {
             // Mouse zoom control
-            float amount = dy / height;
+            float amount = dy / metrics.height;
             float minFOV = renderer->getProjectionMode()->getMinimumFOV();
             float maxFOV = renderer->getProjectionMode()->getMaximumFOV();
             float fov = sim->getActiveObserver()->getFOV();
@@ -796,7 +678,7 @@ void CelestiaCore::mouseMove(float dx, float dy, int modifiers)
                 coarseness = ComputeRotationCoarseness(*sim);
             }
 
-            Quaternionf q = XRotation(dy / height * coarseness) * YRotation(dx / width * coarseness);
+            Quaternionf q = XRotation(dy / metrics.height * coarseness) * YRotation(dx / metrics.width * coarseness);
             if ((modifiers & RightButton) != 0)
                 sim->orbit(q);
             else
@@ -807,36 +689,6 @@ void CelestiaCore::mouseMove(float dx, float dy, int modifiers)
     }
 }
 
-/// Makes the view under x, y the active view.
-void CelestiaCore::pickView(float x, float y)
-{
-    if (x+2 < (*activeView)->x * width || x-2 > ((*activeView)->x + (*activeView)->width) * width
-        || (height - y)+2 < (*activeView)->y * height ||  (height - y)-2 > ((*activeView)->y + (*activeView)->height) * height)
-    {
-        activeView = views.begin();
-        while ( (activeView != views.end())
-                &&
-                ( (x+2 < (*activeView)->x * width || x-2 > ((*activeView)->x + (*activeView)->width) * width || (height - y)+2 < (*activeView)->y * height ||  (height - y)-2 > ((*activeView)->y + (*activeView)->height) * height)
-                  ||
-                  ((*activeView)->type != View::ViewWindow)
-                )
-              )
-        {
-                activeView++;
-        }
-
-        // Make sure that we're left with a valid view
-        if (activeView == views.end())
-        {
-            activeView = views.begin();
-        }
-
-        sim->setActiveObserver((*activeView)->observer);
-        if (!showActiveViewFrame)
-            flashFrameStart = currentTime;
-        return;
-    }
-}
 
 void CelestiaCore::joystickAxis(int axis, float amount)
 {
@@ -950,7 +802,7 @@ void CelestiaCore::keyDown(int key, int modifiers)
     // Only process alphanumeric keys if we're not in text enter mode
     if (std::islower(key))
         key = std::toupper(key);
-    if (!(key >= 'A' && key <= 'Z' && (textEnterMode != KbNormal) ))
+    if (!(key >= 'A' && key <= 'Z' && (hud->getTextEnterMode() != Hud::TextEnterNormal) ))
     {
         if (modifiers & ShiftKey)
             shiftKeysPressed[key] = true;
@@ -1006,7 +858,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
 
 
 #ifdef CELX
-    if (m_script != nullptr && (textEnterMode & KbPassToScript))
+    if (m_script != nullptr && (hud->getTextEnterMode() & Hud::TextEnterPassToScript) != 0)
     {
         if (c != '\033' && m_script->charEntered(c_p))
         {
@@ -1016,94 +868,36 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
 
 #endif
 
-    if (textEnterMode & KbAutoComplete)
+    if ((hud->getTextEnterMode() & Hud::TextEnterAutoComplete) != 0)
     {
-        if (std::int32_t uc = 0;
-            UTF8Decode(c_p, uc) && !(uc <= WCHAR_MAX && std::iswcntrl(static_cast<std::wint_t>(uc))))
+        switch (hud->textInput().charEntered(sim, c_p, (renderer->getLabelMode() & Renderer::LocationLabels) != 0))
         {
-            setTypedText(c_p);
-        }
-        else if (c == '\b')
-        {
-            typedTextCompletionIdx = -1;
-            if (!typedText.empty())
-            {
-#ifdef AUTO_COMPLETION
-                do
-                {
-#endif
-                    for (;;)
-                    {
-                        auto ch = static_cast<std::byte>(typedText.back());
-                        typedText.pop_back();
-                        // If the string is empty, or the removed character was
-                        // not a UTF-8 continuation byte 0b10xx_xxxx then we're
-                        // done.
-                        if (typedText.empty() || (ch & std::byte(0xc0)) != std::byte(0x80))
-                            break;
-                    }
-
-                    typedTextCompletion.clear();
-                    if (!typedText.empty())
-                         sim->getObjectCompletion(typedTextCompletion, typedText, (renderer->getLabelMode() & Renderer::LocationLabels) != 0);
-#ifdef AUTO_COMPLETION
-                } while (!typedText.empty() && typedTextCompletion.size() == 1);
-#endif
-            }
-        }
-        else if (c == '\011') // TAB
-        {
-            if (typedTextCompletionIdx + 1 < (int) typedTextCompletion.size())
-                typedTextCompletionIdx++;
-            else if ((int) typedTextCompletion.size() > 0 && typedTextCompletionIdx + 1 == (int) typedTextCompletion.size())
-                typedTextCompletionIdx = 0;
-            if (typedTextCompletionIdx >= 0) {
-                string::size_type pos = typedText.rfind('/', typedText.length());
-                if (pos != string::npos)
-                    typedText = typedText.substr(0, pos + 1) + typedTextCompletion[typedTextCompletionIdx];
-                else
-                    typedText = typedTextCompletion[typedTextCompletionIdx];
-            }
-        }
-        else if (c == Key_BackTab)
-        {
-            if (typedTextCompletionIdx > 0)
-                typedTextCompletionIdx--;
-            else if (typedTextCompletionIdx == 0)
-                typedTextCompletionIdx = typedTextCompletion.size() - 1;
-            else if (typedTextCompletion.size() > 0)
-                typedTextCompletionIdx = typedTextCompletion.size() - 1;
-            if (typedTextCompletionIdx >= 0) {
-                string::size_type pos = typedText.rfind('/', typedText.length());
-                if (pos != string::npos)
-                    typedText = typedText.substr(0, pos + 1) + typedTextCompletion[typedTextCompletionIdx];
-                else
-                    typedText = typedTextCompletion[typedTextCompletionIdx];
-            }
-        }
-        else if (c == '\033') // ESC
-        {
-            setTextEnterMode(textEnterMode & ~KbAutoComplete);
-        }
-        else if (c == '\n' || c == '\r')
-        {
-            if (typedText != "")
+        case CharEnteredResult::Finished:
+            if (auto typedText = hud->textInput().getTypedText(); !typedText.empty())
             {
                 Selection sel = sim->findObjectFromPath(typedText, true);
-                if (sel.empty() && typedTextCompletion.size() > 0)
+                if (sel.empty())
                 {
-                    sel = sim->findObjectFromPath(typedTextCompletion[0], true);
+                    auto completion = hud->textInput().getCompletion();
+                    if (!completion.empty())
+                        sel = sim->findObjectFromPath(completion.front(), true);
                 }
+
                 if (!sel.empty())
                 {
                     addToHistory();
                     sim->setSelection(sel);
                 }
-                typedText = "";
             }
-            setTextEnterMode(textEnterMode & ~KbAutoComplete);
+            [[fallthrough]];
+
+        case CharEnteredResult::Cancelled:
+            setTextEnterMode(hud->getTextEnterMode() & ~Hud::TextEnterAutoComplete);
+            [[fallthrough]];
+
+        default: // CharEnteredResult::Normal
+            return;
         }
-        return;
     }
 
 #ifdef CELX
@@ -1135,7 +929,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
 
     case '\n':
     case '\r':
-        setTextEnterMode(textEnterMode | KbAutoComplete);
+        setTextEnterMode(hud->getTextEnterMode() | Hud::TextEnterAutoComplete);
         break;
 
     case '\b':
@@ -1186,15 +980,9 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
         break;
 
     case '\011': // TAB
-        do
-        {
-            activeView++;
-            if (activeView == views.end())
-                activeView = views.begin();
-        } while ((*activeView)->type != View::ViewWindow);
-        sim->setActiveObserver((*activeView)->observer);
-        if (!showActiveViewFrame)
-            flashFrameStart = currentTime;
+        viewManager->nextView(sim);
+        if (!hud->showActiveViewFrame)
+            viewManager->flashFrameStart(timeInfo.currentTime);
         break;
 
     case '\020':  // Ctrl+P
@@ -1296,9 +1084,9 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
     case '\033': // Escape
         cancelScript();
         addToHistory();
-        if (textEnterMode != KbNormal)
+        if (hud->getTextEnterMode() != Hud::TextEnterNormal)
         {
-            setTextEnterMode(KbNormal);
+            setTextEnterMode(Hud::TextEnterNormal);
         }
         else
         {
@@ -1455,8 +1243,8 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
             (sim->getTargetSpeed() < 0.99_c))
         {
             Vector3d v = sim->getSelection().getPosition(sim->getTime()).offsetFromKm(sim->getObserver().getPosition());
-            lightTravelFlag = !lightTravelFlag;
-            if (lightTravelFlag)
+            timeInfo.lightTravelFlag = !timeInfo.lightTravelFlag;
+            if (timeInfo.lightTravelFlag)
             {
                 flash(_("Light travel delay included"), 2.0);
                 setLightTravelDelay(v.norm());
@@ -1610,7 +1398,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
 
     case 'K':
         addToHistory();
-        if (abs(sim->getTimeScale()) > MinimumTimeRate)
+        if (abs(sim->getTimeScale()) > TimeInfo::MinimumTimeRate)
         {
             if (c == 'k')
                 sim->setTimeScale(sim->getTimeScale() / CoarseTimeScaleFactor);
@@ -1800,7 +1588,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
         break;
 
     case '`':
-        showFPSCounter = !showFPSCounter;
+        hud->showFPSCounter = !hud->showFPSCounter;
         break;
 
     case '{':
@@ -1957,7 +1745,7 @@ void CelestiaCore::tick(double dt)
     if (scriptState == ScriptPaused)
         dt = 0.0;
 
-    currentTime += dt;
+    timeInfo.currentTime += dt;
 
     // Mouse wheel zoom
     if (zoomMotion != 0.0f)
@@ -1973,7 +1761,7 @@ void CelestiaCore::tick(double dt)
 #endif
 
         // sim->changeOrbitDistance(zoomMotion * (float) fraction);
-        if (currentTime - zoomTime >= span)
+        if (timeInfo.currentTime - zoomTime >= span)
             zoomMotion = 0.0f;
     }
 
@@ -1983,13 +1771,13 @@ void CelestiaCore::tick(double dt)
         double span = 0.1;
         double fraction;
 
-        if (currentTime - dollyTime >= span)
-            fraction = (dollyTime + span) - (currentTime - dt);
+        if (timeInfo.currentTime - dollyTime >= span)
+            fraction = (dollyTime + span) - (timeInfo.currentTime - dt);
         else
             fraction = dt / span;
 
         sim->changeOrbitDistance((float) (dollyMotion * fraction));
-        if (currentTime - dollyTime >= span)
+        if (timeInfo.currentTime - dollyTime >= span)
             dollyMotion = 0.0f;
     }
 
@@ -2141,12 +1929,12 @@ void CelestiaCore::draw()
     viewChanged = false;
 
     // Render each view
-    for (const auto view : views)
+    for (const auto view : viewManager->views())
         draw(view);
 
     // Reset to render to the main window
-    if (views.size() > 1)
-        renderer->setRenderRegion(0, 0, width, height, false);
+    if (viewManager->views().size() > 1)
+        renderer->setRenderRegion(0, 0, metrics.width, metrics.height, false);
 
     bool toggleAA = renderer->isMSAAEnabled();
     if (toggleAA && (renderer->getRenderFlags() & Renderer::ShowCloudMaps))
@@ -2155,10 +1943,10 @@ void CelestiaCore::draw()
     renderOverlay();
     if (showConsole)
     {
-        console->setFont(font);
+        console->setFont(hud->getFont());
         console->setColor(1.0f, 1.0f, 1.0f, 1.0f);
         console->begin();
-        console->moveBy(safeAreaInsets.left, screenDpi / 25.4f * 53.0f);
+        console->moveBy(metrics.insetLeft, metrics.screenDpi / 25.4f * 53.0f);
         console->render(Console::PageRows);
         console->end();
     }
@@ -2173,18 +1961,10 @@ void CelestiaCore::draw()
     nFrames++;
     if (nFrames == 100 || sysTime - fpsCounterStartTime > 10.0)
     {
-        fps = (double) nFrames / (sysTime - fpsCounterStartTime);
+        timeInfo.fps = (float) nFrames / (sysTime - fpsCounterStartTime);
         nFrames = 0;
         fpsCounterStartTime = sysTime;
     }
-
-#if 0
-    GLenum err = glGetError();
-    if (err != GL_NO_ERROR)
-    {
-        cout << _("GL error: ") << gluErrorString(err) << '\n';
-    }
-#endif
 }
 
 
@@ -2198,11 +1978,10 @@ void CelestiaCore::resize(GLsizei w, GLsizei h)
         renderer->setViewport(0, 0, w, h);
         renderer->resize(w, h);
     }
-    if (overlay != nullptr)
-        overlay->setWindowSize(w, h);
+    hud->setWindowSize(w, h);
     console->setScale(w, h);
-    width = w;
-    height = h;
+    metrics.width = w;
+    metrics.height = h;
 
     setFOVFromZoom();
     if (m_scriptHook != nullptr && m_scriptHook->call("resize", float(w), float(h)))
@@ -2219,15 +1998,15 @@ void CelestiaCore::draw(View* view)
     if (viewportEffect != nullptr)
     {
         // create/update FBO for viewport effect
-        view->updateFBO(width, height);
+        view->updateFBO(metrics.width, metrics.height);
         fbo = view->getFBO();
     }
     bool process = fbo != nullptr && viewportEffect->preprocess(renderer, fbo);
 
-    int x = view->x * width;
-    int y = view->y * height;
-    int viewWidth = view->width * width;
-    int viewHeight = view->height * height;
+    int x = view->x * metrics.width;
+    int y = view->y * metrics.height;
+    int viewWidth = view->width * metrics.width;
+    int viewHeight = view->height * metrics.height;
     // If we need to process, we draw to the FBO which starts at point zero
     renderer->setRenderRegion(process ? 0 : x, process ? 0 : y, viewWidth, viewHeight, !view->isRootView());
 
@@ -2250,63 +2029,22 @@ void CelestiaCore::draw(View* view)
     isViewportEffectUsed = viewportEffectUsed;
 }
 
-int CelestiaCore::getSafeAreaWidth() const
-{
-    return width - safeAreaInsets.left - safeAreaInsets.right;
-}
-
-int CelestiaCore::getSafeAreaHeight() const
-{
-    return height - safeAreaInsets.top - safeAreaInsets.bottom;
-}
-
-int CelestiaCore::getSafeAreaStart(int offset) const
-{
-    if (layoutDirection == LayoutDirection::RightToLeft)
-        return width - safeAreaInsets.right - offset;
-    return safeAreaInsets.left + offset;
-}
-
-int CelestiaCore::getSafeAreaEnd(int offset) const
-{
-    if (layoutDirection == LayoutDirection::RightToLeft)
-        return safeAreaInsets.left + offset;
-    return width - safeAreaInsets.right - offset;
-}
-
-int CelestiaCore::getSafeAreaTop(int offset) const
-{
-    return height - safeAreaInsets.top - offset;
-}
-
-int CelestiaCore::getSafeAreaBottom(int offset) const
-{
-    return safeAreaInsets.bottom + offset;
-}
-
 void CelestiaCore::setSafeAreaInsets(int left, int top, int right, int bottom)
 {
-    safeAreaInsets = { left, top, right, bottom };
+    metrics.insetLeft = left;
+    metrics.insetTop = top;
+    metrics.insetRight = right;
+    metrics.insetBottom = bottom;
 }
 
 std::tuple<int, int, int, int> CelestiaCore::getSafeAreaInsets() const
 {
-    return make_tuple(safeAreaInsets.left, safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom);
+    return std::make_tuple(metrics.insetLeft, metrics.insetTop, metrics.insetRight, metrics.insetBottom);
 }
 
 std::tuple<int, int> CelestiaCore::getWindowDimension() const
 {
-    return make_tuple(width, height);
-}
-
-float CelestiaCore::getPickTolerance() const
-{
-    return pickTolerance;
-}
-
-void CelestiaCore::setPickTolerance(float newPickTolerance)
-{
-    pickTolerance = newPickTolerance;
+    return std::make_tuple(metrics.width, metrics.height);
 }
 
 void CelestiaCore::setAccelerationCoefficient(float coefficient)
@@ -2367,151 +2105,90 @@ void CelestiaCore::setViewChanged()
 
 void CelestiaCore::splitView(View::Type type, View* av, float splitPos)
 {
-    if (type == View::ViewWindow)
-        return;
-
-    if (av == nullptr)
-        av = *activeView;
-
-    if (!av->isSplittable(type))
+    switch (viewManager->splitView(sim, type, av, splitPos))
     {
+    case ViewSplitResult::Ignored:
+        return;
+    case ViewSplitResult::NotSplittable:
         flash(_("View too small to be split"));
         return;
+    default: // ViewSplitResult::SplitOk
+        setViewChanged();
+        setFOVFromZoom();
+        flash(_("Added view"));
+        break;
     }
-
-    setViewChanged();
-
-    Observer* o = sim->addObserver();
-
-    // Make the new observer a copy of the old one
-    // TODO: This works, but an assignment operator for Observer
-    // should be defined.
-    *o = *(sim->getActiveObserver());
-
-    View* split, *view;
-    av->split(type, o, splitPos, &split, &view);
-    views.push_back(split);
-    views.push_back(view);
-
-    setFOVFromZoom();
-
-    flash(_("Added view"));
 }
+
 
 void CelestiaCore::setFOVFromZoom()
 {
     auto projectionMode = renderer->getProjectionMode();
-    for (const auto v : views)
+    for (const auto v : viewManager->views())
     {
-        if (v->type == View::ViewWindow)
-        {
-            projectionMode->setSize(v->width * static_cast<float>(width), v->height * static_cast<float>(height));
-            v->observer->setFOV(projectionMode->getFOV(v->observer->getZoom()));
-        }
+        if (v->type != View::ViewWindow)
+            continue;
+
+        projectionMode->setSize(v->width * static_cast<float>(metrics.width), v->height * static_cast<float>(metrics.height));
+        v->observer->setFOV(projectionMode->getFOV(v->observer->getZoom()));
     }
 }
 
 void CelestiaCore::setZoomFromFOV()
 {
     auto projectionMode = renderer->getProjectionMode();
-    for (auto v : views)
+    for (auto v : viewManager->views())
     {
-        if (v->type == View::ViewWindow)
-        {
-            projectionMode->setSize(v->width * static_cast<float>(width), v->height * static_cast<float>(height));
-            v->observer->setZoom(projectionMode->getZoom(v->observer->getFOV()));
-        }
+        if (v-> type != View::ViewWindow)
+            continue;
+
+        projectionMode->setSize(v->width * static_cast<float>(metrics.width), v->height * static_cast<float>(metrics.height));
+        v->observer->setZoom(projectionMode->getZoom(v->observer->getFOV()));
     }
 }
 
 void CelestiaCore::singleView(View* av)
 {
+    viewManager->singleView(sim, av);
     setViewChanged();
-
-    if (av == nullptr)
-        av = *activeView;
-
-    list<View*>::iterator i = views.begin();
-    while(i != views.end())
-    {
-        if ((*i) != av)
-        {
-            sim->removeObserver((*i)->getObserver());
-            delete (*i)->getObserver();
-            delete (*i);
-            i = views.erase(i);
-        }
-        else
-            ++i;
-    }
-
-    av->reset();
-
-    activeView = views.begin();
-    sim->setActiveObserver((*activeView)->observer);
     setFOVFromZoom();
 }
 
 void CelestiaCore::setActiveView(View* v)
 {
-    activeView = find(views.begin(), views.end(), v);
-    sim->setActiveObserver((*activeView)->observer);
+    viewManager->setActiveView(sim, v);
 }
 
 void CelestiaCore::deleteView(View* v)
 {
-    if (v == nullptr)
-        v = *activeView;
-
-    if (v->isRootView())
+    if (!viewManager->deleteView(sim, v))
         return;
 
-    //Erase view and parent view from views
-    for (auto i = views.begin(); i != views.end(); )
-    {
-        if ((*i == v) || (*i == v->parent))
-            i = views.erase(i);
-        else
-            ++i;
-    }
-
-    sim->removeObserver(v->getObserver());
-    delete(v->getObserver());
-    auto sibling = View::remove(v);
-
-    View* nextActiveView = sibling;
-    while (nextActiveView->type != View::ViewWindow)
-        nextActiveView = nextActiveView->child1;
-    activeView = find(views.begin(), views.end(), nextActiveView);
-    sim->setActiveObserver((*activeView)->observer);
-
-    if (!showActiveViewFrame)
-        flashFrameStart = currentTime;
+    if (!hud->showActiveViewFrame)
+        viewManager->flashFrameStart(timeInfo.currentTime);
     setFOVFromZoom();
 }
 
 bool CelestiaCore::getFramesVisible() const
 {
-    return showViewFrames;
+    return hud->showViewFrames;
 }
 
 void CelestiaCore::setFramesVisible(bool visible)
 {
     setViewChanged();
-
-    showViewFrames = visible;
+    hud->showViewFrames = visible;
 }
 
 bool CelestiaCore::getActiveFrameVisible() const
 {
-    return showActiveViewFrame;
+    return hud->showActiveViewFrame;
 }
 
 void CelestiaCore::setActiveFrameVisible(bool visible)
 {
     setViewChanged();
-
-    showActiveViewFrame = visible;
+    hud->showActiveViewFrame = visible;
 }
 
 
@@ -2530,1130 +2207,35 @@ void CelestiaCore::showText(std::string_view s,
                             int hoff, int voff,
                             double duration)
 {
-    if (!titleFont)
-        return;
-
-    messageText.replace(messageText.begin(), messageText.end(), s);
-    messageTextPosition = std::make_unique<RelativeTextPrintPosition>(horig, vorig, hoff, voff, TextLayout::getTextWidth("M", titleFont.get()), titleFont->getHeight());
-    messageStart = currentTime;
-    messageDuration = duration;
+    auto [emWidth, height] = hud->getTitleMetrics();
+    hud->showText<RelativeTextPrintPosition>(s, duration, timeInfo.currentTime,
+                                             horig, vorig, hoff, voff, emWidth, height);
 }
 
 void CelestiaCore::showTextAtPixel(std::string_view s, int x, int y, double duration)
 {
-    if (!titleFont)
-        return;
-
-    messageText.replace(messageText.begin(), messageText.end(), s);
-    messageTextPosition = std::make_unique<AbsoluteTextPrintPosition>(x, y);
-    messageStart = currentTime;
-    messageDuration = duration;
+    hud->showText<AbsoluteTextPrintPosition>(s, duration, timeInfo.currentTime, x, y);
 }
 
-int CelestiaCore::getTextWidth(const std::string &s) const
+
+int CelestiaCore::getTextWidth(std::string_view s) const
 {
-    return TextLayout::getTextWidth(s, titleFont.get());
+    return hud->getTextWidth(s);
 }
 
 
-static string DistanceLyToStr(double distance, int digits, CelestiaCore::MeasurementSystem measurement)
+void CelestiaCore::setScriptImage(std::unique_ptr<OverlayImage>&& _image)
 {
-    const char* units = "";
-
-    if (abs(distance) >= astro::parsecsToLightYears(1e+6))
-    {
-        units = _("Mpc");
-        distance = astro::lightYearsToParsecs(distance) / 1e+6;
-    }
-    else if (abs(distance) >= 0.5 * astro::parsecsToLightYears(1e+3))
-    {
-        units = _("kpc");
-        distance = astro::lightYearsToParsecs(distance) / 1e+3;
-    }
-    else if (abs(distance) >= astro::AUtoLightYears(1000.0f))
-    {
-        units = _("ly");
-    }
-    else if (abs(distance) >= astro::kilometersToLightYears(10000000.0))
-    {
-        units = _("au");
-        distance = astro::lightYearsToAU(distance);
-    }
-    else if (measurement == CelestiaCore::Imperial)
-    {
-        if (abs(distance) > astro::kilometersToLightYears(OneMiInKm))
-        {
-            units = _("mi");
-            distance = astro::lightYearsToKilometers(distance) / OneMiInKm;
-        }
-        else
-        {
-            units = _("ft");
-            distance = astro::lightYearsToKilometers(distance) / OneFtInKm;
-        }
-    }
-    else
-    {
-        if (abs(distance) > astro::kilometersToLightYears(1.0f))
-        {
-            units = _("km");
-            distance = astro::lightYearsToKilometers(distance);
-        }
-        else
-        {
-            units = _("m");
-            distance = astro::lightYearsToKilometers(distance) * 1000.0f;
-        }
-    }
-
-    return fmt::format("{} {}", SigDigitNum(distance, digits), units);
+    hud->setImage(std::move(_image), timeInfo.currentTime);
 }
 
-
-static string DistanceKmToStr(double distance, int digits, CelestiaCore::MeasurementSystem measurement)
-{
-    return DistanceLyToStr(astro::kilometersToLightYears(distance), digits, measurement);
-}
-
-
-static void displayRotationPeriod(Overlay& overlay, double days)
-{
-    FormattedNumber n;
-    const char *p;
-
-    if (days > 1.0)
-    {
-        n = FormattedNumber(days, 3, FormattedNumber::GroupThousands);
-        p = _("days");
-    }
-    else if (days > 1.0 / 24.0)
-    {
-        n = FormattedNumber(days * 24.0, 3, FormattedNumber::GroupThousands);
-        p = _("hours");
-    }
-    else if (days > 1.0 / (24.0 * 60.0))
-    {
-        n = FormattedNumber(days * 24.0 * 60.0, 3, FormattedNumber::GroupThousands);
-        p = _("minutes");
-    }
-    else
-    {
-        n = FormattedNumber(days * 24.0 * 60.0 * 60.0, 3, FormattedNumber::GroupThousands);
-        p = _("seconds");
-    }
-
-    overlay.print(_("Rotation period: {} {}\n"), n, p);
-}
-
-static void displayMass(Overlay& overlay, float mass, CelestiaCore::MeasurementSystem measurement)
-{
-    if (mass < 0.001f)
-    {
-        if (measurement == CelestiaCore::Imperial)
-            overlay.printf(_("Mass: %.6g lb\n"), mass * astro::EarthMass / (float) OneLbInKg);
-        else
-            overlay.printf(_("Mass: %.6g kg\n"), mass * astro::EarthMass);
-    }
-    else if (mass > 50)
-        overlay.printf(_("Mass: %.2f Mj\n"), mass * astro::EarthMass / astro::JupiterMass);
-    else
-        overlay.printf(_("Mass: %.2f Me\n"), mass);
-}
-
-static void displaySpeed(Overlay& overlay, float speed, CelestiaCore::MeasurementSystem measurement)
-{
-    FormattedNumber n;
-    const char *u;
-
-    if (speed >= (float) 1000.0_au)
-    {
-        n = SigDigitNum(astro::kilometersToLightYears(speed), 3);
-        u = _("ly/s");
-    }
-    else if (speed >= (float) 100.0_c)
-    {
-        n = SigDigitNum(astro::kilometersToAU(speed), 3);
-        u = _("AU/s");
-    }
-    else if (speed >= 10000.0f)
-    {
-        n = SigDigitNum(speed / astro::speedOfLight, 3);
-        u = "c";
-    }
-    else if (measurement == CelestiaCore::Imperial)
-    {
-        if (speed >= (float) OneMiInKm)
-        {
-            n = SigDigitNum(speed / (float) OneMiInKm, 3);
-            u = _("mi/s");
-        }
-        else
-        {
-            n = SigDigitNum(speed / (float) OneFtInKm, 3);
-            u = _("ft/s");
-        }
-    }
-    else
-    {
-        if (speed >= 1.0f)
-        {
-            n = SigDigitNum(speed, 3);
-            u = _("km/s");
-        }
-        else
-        {
-            n = SigDigitNum(speed * 1000.0f, 3);
-            u = _("m/s");
-        }
-    }
-    overlay.print(_("Speed: {} {}\n"), n, u);
-}
-
-// Display a positive angle as degrees, minutes, and seconds. If the angle is less than one
-// degree, only minutes and seconds are shown; if the angle is less than one minute, only
-// seconds are displayed.
-static string angleToStr(double angle)
-{
-    int degrees, minutes;
-    double seconds;
-    astro::decimalToDegMinSec(angle, degrees, minutes, seconds);
-
-    if (degrees > 0)
-    {
-        return fmt::format("{}" UTF8_DEGREE_SIGN "{:02d}' {:.1f}\"",
-                           degrees, abs(minutes), abs(seconds));
-    }
-
-    if (minutes > 0)
-    {
-        return fmt::format("{:02d}' {:.1f}\"", abs(minutes), abs(seconds));
-    }
-
-    return fmt::format("{:.2f}\"", abs(seconds));
-}
-
-static void displayDeclination(Overlay& overlay, double angle)
-{
-    int degrees, minutes;
-    double seconds;
-    astro::decimalToDegMinSec(angle, degrees, minutes, seconds);
-
-    overlay.printf(_("Dec: %+d%s %02d' %.1f\"\n"),
-                          abs(degrees), UTF8_DEGREE_SIGN,
-                          abs(minutes), abs(seconds));
-}
-
-
-static void displayRightAscension(Overlay& overlay, double angle)
-{
-    int hours, minutes;
-    double seconds;
-    astro::decimalToHourMinSec(angle, hours, minutes, seconds);
-
-    overlay.printf(_("RA: %dh %02dm %.1fs\n"),
-                          hours, abs(minutes), abs(seconds));
-}
-
-static void displayApparentDiameter(Overlay& overlay,
-                                    double radius,
-                                    double distance)
-{
-    if (distance > radius)
-    {
-        double arcSize = radToDeg(asin(radius / distance) * 2.0);
-
-        // Only display the arc size if it's less than 160 degrees and greater
-        // than one second--otherwise, it's probably not interesting data.
-        if (arcSize < 160.0 && arcSize > 1.0 / 3600.0)
-        {
-            overlay.printf(_("Apparent diameter: %s\n"),
-                                 angleToStr(arcSize));
-        }
-    }
-}
-
-static void displayApparentMagnitude(Overlay& overlay,
-                                     float absMag,
-                                     double distance)
-{
-    if (distance > 32.6167)
-    {
-        float appMag = astro::absToAppMag(absMag, (float) distance);
-        overlay.printf(_("Apparent magnitude: %.1f\n"), appMag);
-    }
-    else
-    {
-        overlay.printf(_("Absolute magnitude: %.1f\n"), absMag);
-    }
-}
-
-
-static void displayRADec(Overlay& overlay, const Vector3d& v)
-{
-    double phi = atan2(v.x(), v.z()) - celestia::numbers::pi / 2;
-    if (phi < 0)
-        phi = phi + 2 * celestia::numbers::pi;
-
-    double theta = atan2(sqrt(v.x() * v.x() + v.z() * v.z()), v.y());
-    if (theta > 0)
-        theta = celestia::numbers::pi / 2 - theta;
-    else
-        theta = -celestia::numbers::pi / 2 - theta;
-
-
-    displayRightAscension(overlay, radToDeg(phi));
-    displayDeclination(overlay, radToDeg(theta));
-}
-
-
-// Display nicely formatted planetocentric/planetographic coordinates.
-// The latitude and longitude parameters are angles in radians, altitude
-// is in kilometers.
-static void displayPlanetocentricCoords(Overlay& overlay,
-                                        const Body& body,
-                                        double longitude,
-                                        double latitude,
-                                        double altitude,
-                                        bool showAltitude,
-                                        CelestiaCore::MeasurementSystem measurement)
-{
-    char ewHemi = ' ';
-    char nsHemi = ' ';
-    double lon = 0.0;
-    double lat = 0.0;
-
-    // Terrible hack for Earth and Moon longitude conventions.  Fix by
-    // adding a field to specify the longitude convention in .ssc files.
-    if (body.getName() == "Earth" || body.getName() == "Moon")
-    {
-        if (latitude < 0.0)
-            nsHemi = 'S';
-        else if (latitude > 0.0)
-            nsHemi = 'N';
-
-        if (longitude < 0.0)
-            ewHemi = 'W';
-        else if (longitude > 0.0f)
-            ewHemi = 'E';
-
-        lon = (float) abs(radToDeg(longitude));
-        lat = (float) abs(radToDeg(latitude));
-    }
-    else
-    {
-        // Swap hemispheres if the object is a retrograde rotator
-        Quaterniond q = body.getEclipticToEquatorial(astro::J2000);
-        bool retrograde = (q * Vector3d::UnitY()).y() < 0.0;
-
-        if ((latitude < 0.0) ^ retrograde)
-            nsHemi = 'S';
-        else if ((latitude > 0.0) ^ retrograde)
-            nsHemi = 'N';
-
-        if (retrograde)
-            ewHemi = 'E';
-        else
-            ewHemi = 'W';
-
-        lon = -radToDeg(longitude);
-        if (lon < 0.0)
-            lon += 360.0;
-        lat = abs(radToDeg(latitude));
-    }
-
-    if (showAltitude)
-        overlay.printf("%.6f%c %.6f%c", lat, nsHemi, lon, ewHemi);
-    else
-        overlay.printf(_("%.6f%c %.6f%c %s"), lat, nsHemi, lon, ewHemi, DistanceKmToStr(altitude, 5, measurement));
-}
-
-
-#if 0
-// Show the planetocentric latitude, longitude, and altitude of a
-// observer.
-static void displayObserverPlanetocentricCoords(Overlay& overlay,
-                                                Body& body,
-                                                const UniversalCoord& observerPos,
-                                                double tdb)
-{
-    Vector3d ecl = observerPos.offsetFromKm(Selection(&body).getPosition(tdb));
-    Vector3d pc = body.eclipticToPlanetocentric(ecl, tdb);
-
-    displayPlanetocentricCoords(overlay, body, pc.x(), pc.y(), pc.z(), true);
-}
-#endif
-
-
-static void displayStarInfo(Overlay& overlay,
-                            int detail,
-                            Star& star,
-                            const Universe& universe,
-                            double distance,
-                            CelestiaCore::MeasurementSystem measurement,
-                            CelestiaCore::TemperatureScale temperatureScale)
-{
-    overlay.printf(_("Distance: %s\n"), DistanceLyToStr(distance, 5, measurement));
-
-    if (!star.getVisibility())
-    {
-        overlay.print(_("Star system barycenter\n"));
-    }
-    else
-    {
-        overlay.printf(_("Abs (app) mag: %.2f (%.2f)\n"),
-                                star.getAbsoluteMagnitude(),
-                                star.getApparentMagnitude(float(distance)));
-
-        if (star.getLuminosity() > 1.0e-10f)
-            overlay.print(_("Luminosity: {}x Sun\n"), SigDigitNum(star.getLuminosity(), 3));
-
-        const char* star_class;
-        switch (star.getSpectralType()[0])
-        {
-        case 'Q':
-            star_class = _("Neutron star");
-            break;
-        case 'X':
-            star_class = _("Black hole");
-            break;
-        default:
-            star_class = star.getSpectralType();
-        };
-        overlay.printf(_("Class: %s\n"), star_class);
-
-        displayApparentDiameter(overlay, star.getRadius(),
-                                astro::lightYearsToKilometers(distance));
-
-        if (detail > 1)
-        {
-            overlay.printf(_("Surface temp: %s\n"), KelvinToStr(star.getTemperature(), 3, temperatureScale));
-            float solarRadii = star.getRadius() / 6.96e5f;
-
-            if (solarRadii > 0.01f)
-            {
-                overlay.print(_("Radius: {} Rsun  ({})\n"),
-                              SigDigitNum(star.getRadius() / 696000.0f, 2),
-                              DistanceKmToStr(star.getRadius(), 3, measurement));
-            }
-            else
-            {
-                overlay.print(_("Radius: {}\n"),
-                              DistanceKmToStr(star.getRadius(), 3, measurement));
-            }
-
-            if (star.getRotationModel()->isPeriodic())
-            {
-                float period = (float) star.getRotationModel()->getPeriod();
-                displayRotationPeriod(overlay, period);
-            }
-        }
-    }
-
-    if (detail > 1)
-    {
-        SolarSystem* sys = universe.getSolarSystem(&star);
-        if (sys != nullptr && sys->getPlanets()->getSystemSize() != 0)
-            overlay.print(_("Planetary companions present\n"));
-    }
-}
-
-
-static void displayDSOinfo(Overlay& overlay, const DeepSkyObject& dso, double distance, CelestiaCore::MeasurementSystem measurement)
-{
-    overlay.print(dso.getDescription());
-    overlay.print("\n");
-
-    if (distance >= 0)
-    {
-        overlay.printf(_("Distance: %s\n"),
-                     DistanceLyToStr(distance, 5, measurement));
-    }
-    else
-    {
-        overlay.printf(_("Distance from center: %s\n"),
-                     DistanceLyToStr(distance + dso.getRadius(), 5, measurement));
-     }
-    overlay.printf(_("Radius: %s\n"),
-                 DistanceLyToStr(dso.getRadius(), 5, measurement));
-
-    displayApparentDiameter(overlay, dso.getRadius(), distance);
-    if (dso.getAbsoluteMagnitude() > DSO_DEFAULT_ABS_MAGNITUDE)
-    {
-        displayApparentMagnitude(overlay,
-                                 dso.getAbsoluteMagnitude(),
-                                 distance);
-    }
-}
-
-
-static void displayPlanetInfo(Overlay& overlay,
-                              int detail,
-                              Body& body,
-                              double t,
-                              double distanceKm,
-                              const Vector3d& viewVec,
-                              CelestiaCore::MeasurementSystem measurement,
-                              CelestiaCore::TemperatureScale temperatureScale)
-{
-    double distance = distanceKm - body.getRadius();
-    overlay.printf(_("Distance: %s\n"), DistanceKmToStr(distance, 5, measurement));
-
-    if (body.getClassification() == Body::Invisible)
-    {
-        return;
-    }
-
-    overlay.printf(_("Radius: %s\n"), DistanceKmToStr(body.getRadius(), 5, measurement));
-
-    displayApparentDiameter(overlay, body.getRadius(), distanceKm);
-
-    // Display the phase angle
-
-    // Find the parent star of the body. This can be slightly complicated if
-    // the body orbits a barycenter instead of a star.
-    Selection parent = Selection(&body).parent();
-    while (parent.body() != nullptr)
-        parent = parent.parent();
-
-    if (parent.star() != nullptr)
-    {
-        bool showPhaseAngle = false;
-
-        Star* sun = parent.star();
-        if (sun->getVisibility())
-        {
-            showPhaseAngle = true;
-        }
-        else if (const auto* orbitingStars = sun->getOrbitingStars(); orbitingStars != nullptr && orbitingStars->size() == 1)
-        {
-            // The planet's orbit is defined with respect to a barycenter. If there's
-            // a single star orbiting the barycenter, we'll compute the phase angle
-            // for the planet with respect to that star. If there are no stars, the
-            // planet is an orphan, drifting through space with no star. We also skip
-            // displaying the phase angle when there are multiple stars (for now.)
-            sun = orbitingStars->front();
-            showPhaseAngle = sun->getVisibility();
-        }
-
-        if (showPhaseAngle)
-        {
-            Vector3d sunVec = Selection(&body).getPosition(t).offsetFromKm(Selection(sun).getPosition(t));
-            sunVec.normalize();
-            double cosPhaseAngle = std::clamp(sunVec.dot(viewVec.normalized()), -1.0, 1.0);
-            double phaseAngle = acos(cosPhaseAngle);
-            overlay.printf(_("Phase angle: %.1f%s\n"), radToDeg(phaseAngle), UTF8_DEGREE_SIGN);
-        }
-    }
-
-    if (detail > 1)
-    {
-        if (body.getRotationModel(t)->isPeriodic())
-            displayRotationPeriod(overlay, body.getRotationModel(t)->getPeriod());
-
-        if (body.getName() != "Earth" && body.getMass() > 0)
-            displayMass(overlay, body.getMass(), measurement);
-
-        float density = body.getDensity();
-        if (density > 0)
-        {
-            if (measurement == CelestiaCore::Imperial)
-                overlay.printf(_("Density: %.2f x 1000 lb/ft^3\n"), density / (float) OneLbPerFt3InKgPerM3 / 1000.0f);
-            else
-                overlay.printf(_("Density: %.2f x 1000 kg/m^3\n"), density / 1000.0f);
-        }
-
-        float planetTemp = body.getTemperature(t);
-        if (planetTemp > 0)
-            overlay.printf(_("Temperature: %s\n"), KelvinToStr(planetTemp, 3, temperatureScale));
-    }
-}
-
-
-static void displayLocationInfo(Overlay& overlay,
-                                Location& location,
-                                double distanceKm,
-                                CelestiaCore::MeasurementSystem measurement)
-{
-    overlay.printf(_("Distance: %s\n"), DistanceKmToStr(distanceKm, 5, measurement));
-
-    Body* body = location.getParentBody();
-    if (body != nullptr)
-    {
-        Vector3f locPos = location.getPosition();
-        Vector3d lonLatAlt = body->cartesianToPlanetocentric(locPos.cast<double>());
-        displayPlanetocentricCoords(overlay, *body,
-                                    lonLatAlt.x(), lonLatAlt.y(), lonLatAlt.z(), false, measurement);
-    }
-}
-
-static string getSelectionName(const Selection& sel, const Universe& univ)
-{
-    switch (sel.getType())
-    {
-    case SelectionType::Body:
-        return sel.body()->getName(true);
-    case SelectionType::DeepSky:
-        return univ.getDSOCatalog()->getDSOName(sel.deepsky(), true);
-    case SelectionType::Star:
-        return univ.getStarCatalog()->getStarName(*sel.star(), true);
-    case SelectionType::Location:
-        return sel.location()->getName(true);
-    default:
-        return {};
-    }
-}
-
-#if 0
-static void displaySelectionName(Overlay& overlay,
-                                 const Selection& sel,
-                                 const Universe& univ)
-{
-    switch (sel.getType())
-    {
-    case SelectionType::Body:
-        overlay.print(sel.body()->getName(true));
-        break;
-    case SelectionType::DeepSky:
-        overlay.print(univ.getDSOCatalog()->getDSOName(sel.deepsky(), true));
-        break;
-    case SelectionType::Star:
-        //displayStarName(overlay, *(sel.star()), *univ.getStarCatalog());
-        overlay.print(univ.getStarCatalog()->getStarName(*sel.star(), true));
-        break;
-    case SelectionType::Location:
-        overlay.print(sel.location()->getName(true));
-        break;
-    default:
-        break;
-    }
-}
-#endif
-
-
-void CelestiaCore::setScriptImage(std::unique_ptr<OverlayImage> &&_image)
-{
-    image = std::move(_image);
-    image->setStartTime((float) currentTime);
-}
 
 void CelestiaCore::renderOverlay()
 {
     if (m_scriptHook != nullptr)
         m_scriptHook->call("renderoverlay");
 
-    if (font == nullptr)
-        return;
-
-    overlay->setFont(font);
-
-    int fontHeight = font->getHeight();
-    int titleFontHeight = titleFont->getHeight();
-    int emWidth = TextLayout::getTextWidth("M", font.get());
-    assert(emWidth > 0);
-
-    overlay->begin();
-
-    if (showOverlayImage && m_script != nullptr && image != nullptr)
-        image->render(static_cast<float>(currentTime), width, height);
-
-    if (views.size() > 1)
-    {
-        // Render a thin border arround all views
-        if (showViewFrames || resizeSplit)
-        {
-            for(const auto v : views)
-            {
-                if (v->type == View::ViewWindow)
-                    v->drawBorder(width, height, frameColor);
-            }
-        }
-
-        // Render a very simple border around the active view
-        View* av = *activeView;
-
-        if (showActiveViewFrame)
-        {
-            av->drawBorder(width, height, activeFrameColor, 2);
-        }
-
-        if (currentTime < flashFrameStart + 0.5)
-        {
-            float alpha = (float) (1.0 - (currentTime - flashFrameStart) / 0.5);
-            av->drawBorder(width, height, {activeFrameColor, alpha}, 8);
-        }
-    }
-
-    setlocale(LC_NUMERIC, "");
-
-    if (hudDetail > 0 && (overlayElements & ShowTime))
-    {
-        double lt = 0.0;
-
-        if (sim->getSelection().getType() == SelectionType::Body &&
-            (sim->getTargetSpeed() < 0.99_c))
-        {
-            if (lightTravelFlag)
-            {
-                Vector3d v = sim->getSelection().getPosition(sim->getTime()).offsetFromKm(sim->getObserver().getPosition());
-                // light travel time in days
-                lt = v.norm() / (86400.0_c);
-            }
-        }
-
-        double tdb = sim->getTime() + lt;
-        auto dateStr = dateFormatter->formatDate(tdb, timeZoneBias != 0, dateFormat);
-        int dateWidth = (TextLayout::getTextWidth(dateStr, font.get()) / (emWidth * 3) + 2) * emWidth * 3;
-        if (dateWidth > dateStrWidth) dateStrWidth = dateWidth;
-
-        // Time and date
-        overlay->savePos();
-        overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
-        overlay->moveBy(getSafeAreaEnd(dateStrWidth), getSafeAreaTop(fontHeight));
-        overlay->beginText();
-
-        overlay->print(dateStr);
-
-        if (lightTravelFlag && lt > 0.0)
-        {
-            overlay->setColor(0.42f, 1.0f, 1.0f, 1.0f);
-            overlay->print(_("  LT"));
-            overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
-        }
-        overlay->print("\n");
-
-        {
-            if (abs(abs(sim->getTimeScale()) - 1) < 1e-6)
-            {
-                if (sign(sim->getTimeScale()) == 1)
-                    overlay->print(_("Real time"));
-                else
-                    overlay->print(_("-Real time"));
-            }
-            else if (abs(sim->getTimeScale()) < MinimumTimeRate)
-            {
-                overlay->print(_("Time stopped"));
-            }
-            else if (abs(sim->getTimeScale()) > 1.0)
-            {
-                overlay->printf(_("%.6g x faster"), sim->getTimeScale()); // XXX: %'.12g
-            }
-            else
-            {
-                overlay->printf(_("%.6g x slower"), 1.0 / sim->getTimeScale()); // XXX: %'.12g
-            }
-
-            if (sim->getPauseState() == true)
-            {
-                overlay->setColor(1.0f, 0.0f, 0.0f, 1.0f);
-                overlay->print(_(" (Paused)"));
-            }
-        }
-
-        overlay->endText();
-        overlay->restorePos();
-    }
-
-    if (hudDetail > 0 && (overlayElements & ShowVelocity))
-    {
-        // Speed
-        overlay->savePos();
-        overlay->moveBy(getSafeAreaStart(), getSafeAreaBottom(fontHeight * 2 + static_cast<int>(static_cast<float>(screenDpi) / 25.4f * 1.3f)));
-        overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
-
-        overlay->beginText();
-        overlay->print("\n");
-        if (showFPSCounter)
-            overlay->printf(_("FPS: %.1f\n"), fps);
-        else
-            overlay->print("\n");
-
-        displaySpeed(*overlay, sim->getObserver().getVelocity().norm(), measurement);
-
-        overlay->endText();
-        overlay->restorePos();
-    }
-
-    Universe *u = sim->getUniverse();
-
-    if (hudDetail > 0 && (overlayElements & ShowFrame))
-    {
-        // Field of view and camera mode in lower right corner
-        overlay->savePos();
-        overlay->moveBy(getSafeAreaEnd(emWidth * 15), getSafeAreaBottom(fontHeight * 3 + static_cast<int>(static_cast<float>(screenDpi) / 25.4f * 1.3f)));
-        overlay->beginText();
-        overlay->setColor(0.6f, 0.6f, 1.0f, 1);
-
-        if (sim->getObserverMode() == Observer::Travelling)
-        {
-            double timeLeft = sim->getArrivalTime() - sim->getRealTime();
-            if (timeLeft >= 1)
-                overlay->print(_("Travelling ({})\n"),
-                               FormattedNumber(timeLeft, 0, FormattedNumber::GroupThousands));
-            else
-                overlay->print(_("Travelling\n"));
-        }
-        else
-        {
-            overlay->print("\n");
-        }
-
-        if (!sim->getTrackedObject().empty())
-        {
-            overlay->printf(_("Track %s\n"),
-                         CX_("Track", getSelectionName(sim->getTrackedObject(), *u)));
-        }
-        else
-        {
-            overlay->print("\n");
-        }
-
-        {
-            //FrameOfReference frame = sim->getFrame();
-            Selection refObject = sim->getFrame()->getRefObject();
-            ObserverFrame::CoordinateSystem coordSys = sim->getFrame()->getCoordinateSystem();
-
-            switch (coordSys)
-            {
-            case ObserverFrame::Ecliptical:
-                overlay->printf(_("Follow %s\n"),
-                             CX_("Follow", getSelectionName(refObject, *u)));
-                break;
-            case ObserverFrame::BodyFixed:
-                overlay->printf(_("Sync Orbit %s\n"),
-                             CX_("Sync", getSelectionName(refObject, *u)));
-                break;
-            case ObserverFrame::PhaseLock:
-                overlay->printf(_("Lock %s -> %s\n"),
-                             CX_("Lock", getSelectionName(refObject, *u)),
-                             CX_("LockTo", getSelectionName(sim->getFrame()->getTargetObject(), *u)));
-                break;
-
-            case ObserverFrame::Chase:
-                overlay->printf(_("Chase %s\n"),
-                             CX_("Chase", getSelectionName(refObject, *u)));
-                break;
-
-            default:
-                overlay->print("\n");
-                break;
-            }
-        }
-
-        overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
-
-        // Field of view
-        auto activeObserver = sim->getActiveObserver();
-        float fov = radToDeg(activeObserver->getFOV());
-        overlay->printf(_("FOV: %s (%.2fx)\n"), angleToStr(fov), activeObserver->getZoom());
-        overlay->endText();
-        overlay->restorePos();
-    }
-
-    // Selection info
-    Selection sel = sim->getSelection();
-    if (!sel.empty() && hudDetail > 0 && (overlayElements & ShowSelection))
-    {
-        overlay->savePos();
-        overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
-        overlay->moveBy(getSafeAreaStart(), getSafeAreaTop(titleFont->getHeight()));
-
-        overlay->beginText();
-        Vector3d v = sel.getPosition(sim->getTime()).offsetFromKm(sim->getObserver().getPosition());
-
-        switch (sel.getType())
-        {
-        case SelectionType::Star:
-            {
-                if (sel != lastSelection)
-                {
-                    lastSelection = sel;
-                    selectionNames = sim->getUniverse()->getStarCatalog()->getStarNameList(*sel.star());
-                }
-
-                overlay->setFont(titleFont);
-                overlay->print(selectionNames);
-                overlay->setFont(font);
-                overlay->print("\n");
-                displayStarInfo(*overlay,
-                                hudDetail,
-                                *(sel.star()),
-                                *(sim->getUniverse()),
-                                astro::kilometersToLightYears(v.norm()),
-                                measurement,
-                                temperatureScale);
-            }
-            break;
-
-        case SelectionType::DeepSky:
-            {
-                if (sel != lastSelection)
-                {
-                    lastSelection = sel;
-                    selectionNames = sim->getUniverse()->getDSOCatalog()->getDSONameList(sel.deepsky());
-                }
-
-                overlay->setFont(titleFont);
-                overlay->print(selectionNames);
-                overlay->setFont(font);
-                overlay->print("\n");
-                displayDSOinfo(*overlay,
-                               *sel.deepsky(),
-                               astro::kilometersToLightYears(v.norm()) - sel.deepsky()->getRadius(),
-                               measurement);
-            }
-            break;
-
-        case SelectionType::Body:
-            {
-                // Show all names for the body
-                if (sel != lastSelection)
-                {
-                    lastSelection = sel;
-                    auto body = sel.body();
-                    selectionNames = body->getLocalizedName(); // Primary name, might be localized
-                    const vector<string>& names = body->getNames();
-
-                    // Start from the second one because primary name is already in the string
-                    auto secondName = names.begin() + 1;
-
-                    for (auto iter = secondName; iter != names.end(); ++iter)
-                    {
-                        selectionNames += " / ";
-
-                        // Use localized version of parent name in alternative names.
-                        string alias = *iter;
-                        Selection parent = sel.parent();
-                        if (parent.body() != nullptr)
-                        {
-                            string parentName = parent.body()->getName();
-                            string locParentName = parent.body()->getName(true);
-                            string::size_type startPos = alias.find(parentName);
-                            if (startPos != string::npos)
-                                alias.replace(startPos, parentName.length(), locParentName);
-                        }
-
-                        selectionNames += alias;
-                    }
-                }
-
-                overlay->setFont(titleFont);
-                overlay->print(selectionNames);
-                overlay->setFont(font);
-                overlay->print("\n");
-                displayPlanetInfo(*overlay,
-                                  hudDetail,
-                                  *(sel.body()),
-                                  sim->getTime(),
-                                  v.norm(),
-                                  v,
-                                  measurement,
-                                  temperatureScale);
-            }
-            break;
-
-        case SelectionType::Location:
-            overlay->setFont(titleFont);
-            overlay->print(sel.location()->getName(true).c_str());
-            overlay->setFont(font);
-            overlay->print("\n");
-            displayLocationInfo(*overlay, *(sel.location()), v.norm(), measurement);
-            break;
-
-        default:
-            break;
-        }
-
-
-        // Display RA/Dec for the selection, but only when the observer is near
-        // the Earth.
-        Selection refObject = sim->getFrame()->getRefObject();
-        if (refObject.body() && refObject.body()->getName() == "Earth")
-        {
-            Body* earth = refObject.body();
-
-            UniversalCoord observerPos = sim->getObserver().getPosition();
-            double distToEarthCenter = observerPos.offsetFromKm(refObject.getPosition(sim->getTime())).norm();
-            double altitude = distToEarthCenter - earth->getRadius();
-            if (altitude < 1000.0)
-            {
-#if 1
-                // Code to show the geocentric RA/Dec
-
-                // Only show the coordinates for stars and deep sky objects, where
-                // the geocentric values will match the apparent values for observers
-                // near the Earth.
-                if (sel.star() != nullptr || sel.deepsky() != nullptr)
-                {
-                    Vector3d v = sel.getPosition(sim->getTime()).offsetFromKm(Selection(earth).getPosition(sim->getTime()));
-                    v = XRotation(astro::J2000Obliquity) * v;
-                    displayRADec(*overlay, v);
-                }
-#else
-                // Code to display the apparent RA/Dec for the observer
-
-                // Don't show RA/Dec for the Earth itself
-                if (sel.body() != earth)
-                {
-                    Vector3d vect = sel.getPosition(sim->getTime()).offsetFromKm(observerPos);
-                    vect = XRotation(astro::J2000Obliquity) * vect;
-                    displayRADec(*overlay, vect);
-                }
-
-                // Show the geocentric coordinates of the observer, required for
-                // converting the selection RA/Dec from observer-centric to some
-                // other coordinate system.
-                // TODO: We should really show the planetographic (for Earth, geodetic)
-                // coordinates.
-                displayObserverPlanetocentricCoords(*overlay,
-                                                    *earth,
-                                                    observerPos,
-                                                    sim->getTime());
-#endif
-            }
-        }
-
-        overlay->endText();
-        overlay->restorePos();
-    }
-
-    // Text input
-    if (textEnterMode & KbAutoComplete)
-    {
-        overlay->setFont(titleFont);
-        overlay->savePos();
-        int rectHeight = fontHeight * 3.0f + screenDpi / 25.4f * 9.3f + titleFontHeight;
-        celestia::Rect r(0, 0, width, safeAreaInsets.bottom + rectHeight);
-        r.setColor(consoleColor);
-        overlay->drawRectangle(r);
-        overlay->moveBy(getSafeAreaStart(), getSafeAreaBottom(rectHeight - titleFontHeight));
-        overlay->setColor(0.6f, 0.6f, 1.0f, 1.0f);
-        overlay->beginText();
-        overlay->printf(_("Target name: %s"), typedText);
-        overlay->endText();
-        overlay->setFont(font);
-        if (typedTextCompletion.size() >= 1)
-        {
-            int nb_cols = 4;
-            int nb_lines = 3;
-            int start = 0;
-            overlay->moveBy(3, -font->getHeight() - 3);
-            vector<std::string>::const_iterator iter = typedTextCompletion.begin();
-            if (typedTextCompletionIdx >= nb_cols * nb_lines)
-            {
-               start = (typedTextCompletionIdx / nb_lines + 1 - nb_cols) * nb_lines;
-               iter += start;
-            }
-            int columnWidth = getSafeAreaWidth() / nb_cols;
-            for (int i = 0; iter < typedTextCompletion.end() && i < nb_cols; i++)
-            {
-                overlay->savePos();
-                overlay->beginText();
-                for (int j = 0; iter < typedTextCompletion.end() && j < nb_lines; iter++, j++)
-                {
-                    if (i * nb_lines + j == typedTextCompletionIdx - start)
-                        overlay->setColor(1.0f, 0.6f, 0.6f, 1);
-                    else
-                        overlay->setColor(0.6f, 0.6f, 1.0f, 1);
-                    overlay->print(*iter);
-                    overlay->print("\n");
-                }
-                overlay->endText();
-                overlay->restorePos();
-                overlay->moveBy(layoutDirection == LayoutDirection::RightToLeft ? -columnWidth : columnWidth, 0);
-           }
-        }
-        overlay->restorePos();
-        overlay->setFont(font);
-    }
-
-    // Text messages
-    if (showMessage)
-    {
-        if (auto text = getCurrentMessage(); !text.empty())
-        {
-            int x = 0;
-            int y = 0;
-
-            messageTextPosition->resolvePixelPosition(this, x, y);
-
-            overlay->setFont(titleFont);
-            overlay->savePos();
-
-            float alpha = 1.0f;
-            if (currentTime > messageStart + messageDuration - 0.5)
-                alpha = static_cast<float>((messageStart + messageDuration - currentTime) / 0.5);
-            overlay->setColor(textColor.red(), textColor.green(), textColor.blue(), alpha);
-            overlay->moveBy(x, y);
-            overlay->beginText();
-            overlay->print(messageText);
-            overlay->endText();
-            overlay->restorePos();
-            overlay->setFont(font);
-        }
-    }
-
-    if (movieCapture != nullptr)
-    {
-        int movieWidth = movieCapture->getWidth();
-        int movieHeight = movieCapture->getHeight();
-        overlay->savePos();
-        Color color(1.0f, 0.0f, 0.0f, 1.0f);
-        overlay->setColor(color);
-        celestia::Rect r((width - movieWidth) / 2 - 1,
-               (height - movieHeight) / 2 - 1,
-               movieWidth + 1,
-               movieHeight + 1);
-        r.setColor(color);
-        r.setType(celestia::Rect::Type::BorderOnly);
-        overlay->drawRectangle(r);
-        overlay->moveBy((float) ((width - movieWidth) / 2),
-                        (float) ((height + movieHeight) / 2 + 2));
-        overlay->beginText();
-        overlay->printf(_("%dx%d at %.2f fps  %s"),
-                              movieWidth, movieHeight,
-                              movieCapture->getFrameRate(),
-                              recording ? _("Recording") : _("Paused"));
-
-        overlay->endText();
-        overlay->restorePos();
-
-        overlay->savePos();
-        overlay->moveBy((float) ((width + movieWidth) / 2 - emWidth * 5),
-                        (float) ((height + movieHeight) / 2 + 2));
-        float sec = movieCapture->getFrameCount() /
-            movieCapture->getFrameRate();
-        auto min = (int) (sec / 60);
-        sec -= min * 60.0f;
-        overlay->beginText();
-        overlay->print("{:3d}:{:05.2f}", min, sec);
-        overlay->endText();
-        overlay->restorePos();
-
-        overlay->savePos();
-        overlay->moveBy((float) ((width - movieWidth) / 2),
-                        (float) ((height - movieHeight) / 2 - fontHeight - 2));
-        overlay->beginText();
-        overlay->print(_("F11 Start/Pause    F12 Stop"));
-        overlay->endText();
-        overlay->restorePos();
-
-        overlay->restorePos();
-    }
-
-    if (editMode)
-    {
-        overlay->savePos();
-        overlay->beginText();
-        int x = (getSafeAreaWidth() - TextLayout::getTextWidth(_("Edit Mode"), font.get())) / 2;
-        overlay->moveBy(getSafeAreaStart(x), getSafeAreaTop(fontHeight));
-        overlay->setColor(1, 0, 1, 1);
-        overlay->print(_("Edit Mode"));
-        overlay->endText();
-        overlay->restorePos();
-    }
-
-    overlay->end();
-    setlocale(LC_NUMERIC, "C");
+    hud->renderOverlay(metrics, sim, *viewManager, movieCapture, timeInfo, m_script != nullptr, editMode);
 }
 
 
@@ -3964,7 +2546,9 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
     std::shared_ptr<ProjectionMode> projectionMode = nullptr;
     if (compareIgnoringCase(config->projectionMode, "fisheye") == 0)
     {
-        projectionMode = make_shared<FisheyeProjectionMode>(static_cast<float>(width), static_cast<float>(height), screenDpi);
+        projectionMode = std::make_shared<FisheyeProjectionMode>(static_cast<float>(metrics.width),
+                                                                 static_cast<float>(metrics.height),
+                                                                 metrics.screenDpi);
     }
     else
     {
@@ -3972,7 +2556,10 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
         {
             GetLogger()->warn("Unknown projection mode {}\n", config->projectionMode);
         }
-        projectionMode = make_shared<PerspectiveProjectionMode>(static_cast<float>(width), static_cast<float>(height), distanceToScreen, screenDpi);
+        projectionMode = std::make_shared<PerspectiveProjectionMode>(static_cast<float>(metrics.width),
+                                                                     static_cast<float>(metrics.height),
+                                                                     distanceToScreen,
+                                                                     metrics.screenDpi);
     }
     renderer->setProjectionMode(projectionMode);
 
@@ -4005,9 +2592,9 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
     if (!config->measurementSystem.empty())
     {
         if (compareIgnoringCase(config->measurementSystem, "imperial") == 0)
-            measurement = Imperial;
+            hud->measurementSystem = MeasurementSystem::Imperial;
         else if (compareIgnoringCase(config->measurementSystem, "metric") == 0)
-            measurement = Metric;
+            hud->measurementSystem = MeasurementSystem::Metric;
         else
             GetLogger()->warn("Unknown measurement system {}\n", config->measurementSystem);
     }
@@ -4015,11 +2602,11 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
     if (!config->temperatureScale.empty())
     {
         if (compareIgnoringCase(config->temperatureScale, "kelvin") == 0)
-            temperatureScale = Kelvin;
+            hud->temperatureScale = TemperatureScale::Kelvin;
         else if (compareIgnoringCase(config->temperatureScale, "celsius") == 0)
-            temperatureScale = Celsius;
+            hud->temperatureScale = TemperatureScale::Celsius;
         else if (compareIgnoringCase(config->temperatureScale, "fahrenheit") == 0)
-            temperatureScale = Fahrenheit;
+            hud->temperatureScale = TemperatureScale::Fahrenheit;
         else
             GetLogger()->warn("Unknown temperature scale {}\n", config->temperatureScale);
     }
@@ -4039,9 +2626,9 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
     if (!config->layoutDirection.empty())
     {
         if (compareIgnoringCase(config->layoutDirection, "ltr") == 0)
-            layoutDirection = LayoutDirection::LeftToRight;
+            metrics.layoutDirection = LayoutDirection::LeftToRight;
         else if (compareIgnoringCase(config->layoutDirection, "rtl") == 0)
-            layoutDirection = LayoutDirection::RightToLeft;
+            metrics.layoutDirection = LayoutDirection::RightToLeft;
         else
             GetLogger()->warn("Unknown layout direction {}\n", config->layoutDirection);
     }
@@ -4052,9 +2639,7 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
         sim->setFaintestVisible(config->renderDetails.faintestVisible);
     }
 
-    View* view = new View(View::ViewWindow, renderer, sim->getActiveObserver(), 0.0f, 0.0f, 1.0f, 1.0f);
-    views.push_back(view);
-    activeView = views.begin();
+    viewManager = std::make_unique<ViewManager>(new View(View::ViewWindow, renderer, sim->getActiveObserver(), 0.0f, 0.0f, 1.0f, 1.0f));
 
     if (!compareIgnoringCase(getConfig()->mouse.cursor, "inverting crosshair"))
     {
@@ -4070,6 +2655,8 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
     {
         cursorHandler->setCursorShape(defaultCursorShape);
     }
+
+    hud = std::make_unique<Hud>();
 
     return true;
 }
@@ -4106,7 +2693,7 @@ bool CelestiaCore::initRenderer([[maybe_unused]] bool useMesaPackInvert)
 #endif
 
     // Prepare the scene for rendering.
-    if (!renderer->init((int) width, (int) height, detailOptions))
+    if (!renderer->init(metrics.width, metrics.height, detailOptions))
     {
         fatalError(_("Failed to initialize renderer"), false);
         return false;
@@ -4118,36 +2705,38 @@ bool CelestiaCore::initRenderer([[maybe_unused]] bool useMesaPackInvert)
         setFaintestAutoMag();
     }
 
-    if (config->fonts.mainFont.empty())
-        font = LoadFontHelper(renderer, "DejaVuSans.ttf,12");
-    else
-        font = LoadFontHelper(renderer, config->fonts.mainFont);
+    hud->setFont(config->fonts.mainFont.empty()
+        ? LoadFontHelper(renderer, "DejaVuSans.ttf,12")
+        : LoadFontHelper(renderer, config->fonts.mainFont));
 
-    if (font == nullptr)
+    if (hud->getFont() == nullptr)
         cout << _("Error loading font; text will not be visible.\n");
 
-    if (!config->fonts.titleFont.empty())
-        titleFont = LoadFontHelper(renderer, config->fonts.titleFont);
-    if (titleFont == nullptr)
-        titleFont = font;
+    if (config->fonts.titleFont.empty() || !hud->setTitleFont(LoadFontHelper(renderer, config->fonts.titleFont)))
+        hud->setTitleFont(hud->getFont());
 
     // Set up the overlay
-    overlay = new Overlay(*renderer);
-    overlay->setTextAlignment(layoutDirection == LayoutDirection::RightToLeft ? TextLayout::HorizontalAlignment::Right : TextLayout::HorizontalAlignment::Left);
-    overlay->setWindowSize(width, height);
+    {
+    auto overlay = std::make_unique<Overlay>(*renderer);
+    overlay->setTextAlignment(metrics.layoutDirection == LayoutDirection::RightToLeft
+                                  ? TextLayout::HorizontalAlignment::Right
+                                  : TextLayout::HorizontalAlignment::Left);
+    overlay->setWindowSize(metrics.width, metrics.height);
+    hud->setOverlay(std::move(overlay));
+    }
 
     if (config->fonts.labelFont.empty())
     {
-        renderer->setFont(Renderer::FontNormal, font);
+        renderer->setFont(Renderer::FontNormal, hud->getFont());
     }
     else
     {
         auto labelFont = LoadFontHelper(renderer, config->fonts.labelFont);
-        renderer->setFont(Renderer::FontNormal, labelFont == nullptr ? font : labelFont);
+        renderer->setFont(Renderer::FontNormal, labelFont == nullptr ? hud->getFont() : labelFont);
     }
 
-    renderer->setFont(Renderer::FontLarge, titleFont);
-    renderer->setRTL(layoutDirection == LayoutDirection::RightToLeft);
+    renderer->setFont(Renderer::FontLarge, hud->getTitleFont());
+    renderer->setRTL(metrics.layoutDirection == LayoutDirection::RightToLeft);
     return true;
 }
 
@@ -4333,22 +2922,12 @@ CelestiaCore::ContextMenuHandler* CelestiaCore::getContextMenuHandler() const
 
 bool CelestiaCore::setFont(const fs::path& fontPath, int collectionIndex, int fontSize)
 {
-    if (auto f = LoadTextureFont(renderer, fontPath, collectionIndex, fontSize); f != nullptr)
-    {
-        font = f;
-        return true;
-    }
-    return false;
+    return hud->setFont(LoadTextureFont(renderer, fontPath, collectionIndex, fontSize));
 }
 
 bool CelestiaCore::setTitleFont(const fs::path& fontPath, int collectionIndex, int fontSize)
 {
-    if (auto f = LoadTextureFont(renderer, fontPath, collectionIndex, fontSize); f != nullptr)
-    {
-        titleFont = f;
-        return true;
-    }
-    return false;
+    return hud->setTitleFont(LoadTextureFont(renderer, fontPath, collectionIndex, fontSize));
 }
 
 bool CelestiaCore::setRendererFont(const fs::path& fontPath, int collectionIndex, int fontSize, Renderer::FontStyle fontStyle)
@@ -4363,15 +2942,10 @@ bool CelestiaCore::setRendererFont(const fs::path& fontPath, int collectionIndex
 
 void CelestiaCore::clearFonts()
 {
-    dateStrWidth = 0;
+    hud->clearFonts();
 
-    if (overlay)
-        overlay->setFont(nullptr);
     if (console)
         console->setFont(nullptr);
-
-    titleFont = nullptr;
-    font = nullptr;
 
     if (renderer)
     {
@@ -4384,49 +2958,43 @@ void CelestiaCore::clearFonts()
 
 int CelestiaCore::getTimeZoneBias() const
 {
-    return timeZoneBias;
+    return timeInfo.timeZoneBias;
 }
 
 bool CelestiaCore::getLightDelayActive() const
 {
-    return lightTravelFlag;
+    return timeInfo.lightTravelFlag;
 }
 
 void CelestiaCore::setLightDelayActive(bool lightDelayActive)
 {
-    lightTravelFlag = lightDelayActive;
+    timeInfo.lightTravelFlag = lightDelayActive;
 }
 
-void CelestiaCore::setTextEnterMode(int mode)
+void CelestiaCore::setTextEnterMode(unsigned int mode)
 {
-    if (mode != textEnterMode)
+    if (mode != hud->getTextEnterMode())
     {
-        if ((mode & KbAutoComplete) != (textEnterMode & KbAutoComplete))
-        {
-            typedText = "";
-            typedTextCompletion.clear();
-            typedTextCompletionIdx = -1;
-        }
-        textEnterMode = mode;
+        hud->setTextEnterMode(mode);
         notifyWatchers(TextEnterModeChanged);
     }
 }
 
-int CelestiaCore::getTextEnterMode() const
+unsigned int CelestiaCore::getTextEnterMode() const
 {
-    return textEnterMode;
+    return hud->getTextEnterMode();
 }
 
 void CelestiaCore::setScreenDpi(int dpi)
 {
-    screenDpi = dpi;
+    metrics.screenDpi = dpi;
     renderer->setScreenDpi(dpi);
     setFOVFromZoom();
 }
 
 int CelestiaCore::getScreenDpi() const
 {
-    return screenDpi;
+    return metrics.screenDpi;
 }
 
 void CelestiaCore::setDistanceToScreen(int dts)
@@ -4443,7 +3011,7 @@ int CelestiaCore::getDistanceToScreen() const
 
 void CelestiaCore::setTimeZoneBias(int bias)
 {
-    timeZoneBias = bias;
+    timeInfo.timeZoneBias = bias;
     notifyWatchers(TimeZoneChanged);
 }
 
@@ -4462,46 +3030,45 @@ void CelestiaCore::setTimeZoneName(const string& zone)
 
 int CelestiaCore::getHudDetail()
 {
-    return hudDetail;
+    return hud->getDetail();
 }
 
 void CelestiaCore::setHudDetail(int newHudDetail)
 {
-    hudDetail = newHudDetail%3;
+    hud->setDetail(newHudDetail);
     notifyWatchers(VerbosityLevelChanged);
 }
 
 
 Color CelestiaCore::getTextColor()
 {
-    return textColor;
+    return hud->textColor;
 }
 
 void CelestiaCore::setTextColor(Color newTextColor)
 {
-    textColor = newTextColor;
+    hud->textColor = newTextColor;
 }
 
 
 astro::Date::Format CelestiaCore::getDateFormat() const
 {
-    return dateFormat;
+    return hud->getDateFormat();
 }
 
 void CelestiaCore::setDateFormat(astro::Date::Format format)
 {
-    dateStrWidth = 0;
-    dateFormat = format;
+    hud->setDateFormat(format);
 }
 
 int CelestiaCore::getOverlayElements() const
 {
-    return overlayElements;
+    return hud->overlayElements;
 }
 
 void CelestiaCore::setOverlayElements(int _overlayElements)
 {
-    overlayElements = _overlayElements;
+    hud->overlayElements = static_cast<Hud::OverlayElements>(_overlayElements);
 }
 
 void CelestiaCore::initMovieCapture(MovieCapture* mc)
@@ -4548,7 +3115,7 @@ bool CelestiaCore::isRecording()
 
 void CelestiaCore::flash(const string& s, double duration)
 {
-    if (hudDetail > 0)
+    if (hud->getDetail() > 0)
         showText(s, -1, -1, 0, 5, duration);
 }
 
@@ -4765,28 +3332,20 @@ bool CelestiaCore::initLuaHook(ProgressNotifier* progressNotifier)
 }
 #endif
 
+std::string_view CelestiaCore::getTypedText() const
+{
+    return hud->textInput().getTypedText();
+}
+
 void CelestiaCore::setTypedText(const char *c_p)
 {
-    typedText.append(c_p);
-    typedTextCompletion.clear();
-    sim->getObjectCompletion(typedTextCompletion, typedText, (renderer->getLabelMode() & Renderer::LocationLabels) != 0);
-    typedTextCompletionIdx = -1;
-#ifdef AUTO_COMPLETION
-    if (typedTextCompletion.size() == 1)
-    {
-        string::size_type pos = typedText.rfind('/', typedText.length());
-        if (pos != string::npos)
-            typedText = typedText.substr(0, pos + 1) + typedTextCompletion[0];
-        else
-            typedText = typedTextCompletion[0];
-    }
-#endif
+    hud->textInput().appendText(sim, c_p, (renderer->getLabelMode() & Renderer::LocationLabels) != 0);
 }
 
 vector<Observer*> CelestiaCore::getObservers() const
 {
     vector<Observer*> observerList;
-    for (const auto view : views)
+    for (const auto view : viewManager->views())
         if (view->type == View::ViewWindow)
             observerList.push_back(view->observer);
     return observerList;
@@ -4794,10 +3353,10 @@ vector<Observer*> CelestiaCore::getObservers() const
 
 View* CelestiaCore::getViewByObserver(const Observer *obs) const
 {
-    for (const auto view : views)
-         if (view->observer == obs)
-             return view;
-    return nullptr;
+    auto end = viewManager->views().end();
+    auto it = std::find_if(viewManager->views().begin(), end,
+                           [obs](View* view) { return view->observer == obs; });
+    return it == end ? nullptr : *it;
 }
 
 void CelestiaCore::getCaptureInfo(std::array<int, 4>& viewport, celestia::PixelFormat& format) const
@@ -4944,32 +3503,32 @@ void CelestiaCore::resumeAudioIfNeeded()
 }
 #endif
 
-void CelestiaCore::setMeasurementSystem(CelestiaCore::MeasurementSystem newMeasurement)
+void CelestiaCore::setMeasurementSystem(MeasurementSystem newMeasurement)
 {
-    if (measurement != newMeasurement)
+    if (hud->measurementSystem != newMeasurement)
     {
-        measurement = newMeasurement;
+        hud->measurementSystem = newMeasurement;
         notifyWatchers(MeasurementSystemChanged);
     }
 }
 
-CelestiaCore::MeasurementSystem CelestiaCore::getMeasurementSystem() const
+MeasurementSystem CelestiaCore::getMeasurementSystem() const
 {
-    return measurement;
+    return hud->measurementSystem;
 }
 
-void CelestiaCore::setTemperatureScale(CelestiaCore::TemperatureScale newScale)
+void CelestiaCore::setTemperatureScale(TemperatureScale newScale)
 {
-    if (temperatureScale != newScale)
+    if (hud->temperatureScale != newScale)
     {
-        temperatureScale = newScale;
+        hud->temperatureScale = newScale;
         notifyWatchers(TemperatureScaleChanged);
     }
 }
 
-CelestiaCore::TemperatureScale CelestiaCore::getTemperatureScale() const
+TemperatureScale CelestiaCore::getTemperatureScale() const
 {
-    return temperatureScale;
+    return hud->temperatureScale;
 }
 
 void CelestiaCore::setScriptSystemAccessPolicy(ScriptSystemAccessPolicy newPolicy)
@@ -4982,43 +3541,16 @@ CelestiaCore::ScriptSystemAccessPolicy CelestiaCore::getScriptSystemAccessPolicy
     return scriptSystemAccessPolicy;
 }
 
-CelestiaCore::LayoutDirection CelestiaCore::getLayoutDirection() const
+celestia::LayoutDirection CelestiaCore::getLayoutDirection() const
 {
-    return layoutDirection;
+    return metrics.layoutDirection;
 }
 
-void CelestiaCore::setLayoutDirection(LayoutDirection value)
+void CelestiaCore::setLayoutDirection(celestia::LayoutDirection value)
 {
-    layoutDirection = value;
-    overlay->setTextAlignment(layoutDirection == LayoutDirection::RightToLeft ? TextLayout::HorizontalAlignment::Right : TextLayout::HorizontalAlignment::Left);
-    renderer->setRTL(layoutDirection == LayoutDirection::RightToLeft);
-}
-
-void CelestiaCore::enableMessages()
-{
-    showMessage = true;
-}
-
-void CelestiaCore::disableMessages()
-{
-    showMessage = false;
-}
-
-std::string_view CelestiaCore::getCurrentMessage() const
-{
-    if (currentTime < messageStart + messageDuration && messageTextPosition)
-        return messageText;
-    return {};
-}
-
-void CelestiaCore::enableOverlayImage()
-{
-    showOverlayImage = true;
-}
-
-void CelestiaCore::disableOverlayImage()
-{
-    showOverlayImage = false;
+    metrics.layoutDirection = value;
+    hud->setTextAlignment(metrics.layoutDirection);
+    renderer->setRTL(metrics.layoutDirection == LayoutDirection::RightToLeft);
 }
 
 void CelestiaCore::setLogFile(const fs::path &fn)

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2684,15 +2684,23 @@ bool CelestiaCore::initRenderer([[maybe_unused]] bool useMesaPackInvert)
         setFaintestAutoMag();
     }
 
-    hud->trySetFont(config->fonts.mainFont.empty()
-        ? LoadFontHelper(renderer, "DejaVuSans.ttf,12")
-        : LoadFontHelper(renderer, config->fonts.mainFont));
+    auto mainFont = config->fonts.mainFont.empty()
+                ? LoadFontHelper(renderer, "DejaVuSans.ttf,12")
+                : LoadFontHelper(renderer, config->fonts.mainFont);
+    if (mainFont)
+        hud->font(mainFont);
+    else
+        std::cout << _("Error loading font; text will not be visible.\n");
 
-    if (hud->font() == nullptr)
-        cout << _("Error loading font; text will not be visible.\n");
-
-    if (config->fonts.titleFont.empty() || !hud->trySetTitleFont(LoadFontHelper(renderer, config->fonts.titleFont)))
-        hud->trySetTitleFont(hud->font());
+    if (auto titleFont = config->fonts.titleFont.empty() ? nullptr : LoadFontHelper(renderer, config->fonts.titleFont);
+        titleFont)
+    {
+        hud->titleFont(titleFont);
+    }
+    else
+    {
+        hud->titleFont(mainFont);
+    }
 
     // Set up the overlay
     {
@@ -2897,16 +2905,6 @@ void CelestiaCore::setContextMenuHandler(ContextMenuHandler* handler)
 CelestiaCore::ContextMenuHandler* CelestiaCore::getContextMenuHandler() const
 {
     return contextMenuHandler;
-}
-
-bool CelestiaCore::setFont(const fs::path& fontPath, int collectionIndex, int fontSize)
-{
-    return hud->trySetFont(LoadTextureFont(renderer, fontPath, collectionIndex, fontSize));
-}
-
-bool CelestiaCore::setTitleFont(const fs::path& fontPath, int collectionIndex, int fontSize)
-{
-    return hud->trySetTitleFont(LoadTextureFont(renderer, fontPath, collectionIndex, fontSize));
 }
 
 bool CelestiaCore::setRendererFont(const fs::path& fontPath, int collectionIndex, int fontSize, Renderer::FontStyle fontStyle)

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -362,7 +362,6 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     bool setFont(const fs::path& fontPath, int collectionIndex, int fontSize);
     bool setTitleFont(const fs::path& fontPath, int collectionIndex, int fontSize);
     bool setRendererFont(const fs::path& fontPath, int collectionIndex, int fontSize, Renderer::FontStyle fontStyle);
-    void clearFonts();
 
     void toggleReferenceMark(const std::string& refMark, Selection sel = Selection());
     bool referenceMarkEnabled(const std::string& refMark, Selection sel = Selection()) const;

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -70,7 +70,7 @@ public:
 
 class CelestiaCore // : public Watchable<CelestiaCore>
 {
- public:
+public:
     enum
     {
         LeftButton   = 0x01,
@@ -179,15 +179,6 @@ class CelestiaCore // : public Watchable<CelestiaCore>
         TintSaturationChanged       = 0x0800,
     };
 
-    enum
-    {
-        ShowNoElement = 0x001,
-        ShowTime      = 0x002,
-        ShowVelocity  = 0x004,
-        ShowSelection = 0x008,
-        ShowFrame     = 0x010,
-    };
-
     enum class ScriptSystemAccessPolicy
     {
         Ask         = 0,
@@ -195,7 +186,6 @@ class CelestiaCore // : public Watchable<CelestiaCore>
         Deny        = 2,
     };
 
- public:
     CelestiaCore();
     ~CelestiaCore();
 
@@ -257,7 +247,6 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     FavoritesList* getFavorites();
 
     bool viewUpdateRequired() const;
-    void setViewChanged();
 
     const DestinationList* getDestinations();
 
@@ -265,8 +254,8 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     void setTimeZoneBias(int);
     std::string getTimeZoneName() const;
     void setTimeZoneName(const std::string&);
-    void setTextEnterMode(unsigned int);
-    unsigned int getTextEnterMode() const;
+    void setTextEnterMode(celestia::Hud::TextEnterMode);
+    celestia::Hud::TextEnterMode getTextEnterMode() const;
 
     void initMovieCapture(MovieCapture*);
     void recordBegin();
@@ -280,12 +269,12 @@ class CelestiaCore // : public Watchable<CelestiaCore>
 
     int getHudDetail();
     void setHudDetail(int);
-    Color getTextColor();
-    void setTextColor(Color);
+    const Color& getTextColor() const;
+    void setTextColor(const Color&);
     celestia::astro::Date::Format getDateFormat() const;
     void setDateFormat(celestia::astro::Date::Format format);
-    int getOverlayElements() const;
-    void setOverlayElements(int);
+    celestia::HudElements getOverlayElements() const;
+    void setOverlayElements(celestia::HudElements);
 
     void addWatcher(CelestiaWatcher*);
     void removeWatcher(CelestiaWatcher*);
@@ -296,9 +285,9 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     std::vector<Observer*> getObservers() const;
     celestia::View* getViewByObserver(const Observer*) const;
     void splitView(celestia::View::Type type, celestia::View* av = nullptr, float splitPos = 0.5f);
-    void singleView(celestia::View* av = nullptr);
+    void singleView(const celestia::View* av = nullptr);
     void deleteView(celestia::View* v = nullptr);
-    void setActiveView(celestia::View* v = nullptr);
+    void setActiveView(const celestia::View* v = nullptr);
     bool getFramesVisible() const;
     void setFramesVisible(bool);
     bool getActiveFrameVisible() const;
@@ -409,14 +398,15 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     celestia::LayoutDirection getLayoutDirection() const;
     void setLayoutDirection(celestia::LayoutDirection);
 
- protected:
+private:
+    void charEnteredAutoComplete(const char*);
+    void updateSelectionFromInput();
     bool readStars(const CelestiaConfig&, ProgressNotifier*);
     void renderOverlay();
 #ifdef CELX
     bool initLuaHook(ProgressNotifier*);
 #endif // CELX
 
- private:
     std::unique_ptr<CelestiaConfig> config{ nullptr };
 
     Universe* universe{ nullptr };
@@ -471,8 +461,6 @@ class CelestiaCore // : public Watchable<CelestiaCore>
 
     double sysTime{ 0.0 };
 
-    bool viewChanged{ true };
-
     Eigen::Vector3f joystickRotation{ Eigen::Vector3f::Zero() };
     bool joyButtonsPressed[JoyButtonCount];
     bool keysPressed[KeyCount];
@@ -516,8 +504,8 @@ class CelestiaCore // : public Watchable<CelestiaCore>
     std::vector<celestia::astro::LeapSecondRecord> leapSeconds;
 
 #ifdef CELX
-    friend celestia::View* getViewByObserver(CelestiaCore*, Observer*);
-    friend void getObservers(CelestiaCore*, std::vector<Observer*>&);
+    friend celestia::View* getViewByObserver(const CelestiaCore*, const Observer*);
+    friend void getObservers(const CelestiaCore*, std::vector<Observer*>&);
     friend std::shared_ptr<TextureFont> getFont(CelestiaCore*);
     friend std::shared_ptr<TextureFont> getTitleFont(CelestiaCore*);
 #endif

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -348,8 +348,6 @@ public:
     void setContextMenuHandler(ContextMenuHandler*);
     ContextMenuHandler* getContextMenuHandler() const;
 
-    bool setFont(const fs::path& fontPath, int collectionIndex, int fontSize);
-    bool setTitleFont(const fs::path& fontPath, int collectionIndex, int fontSize);
     bool setRendererFont(const fs::path& fontPath, int collectionIndex, int fontSize, Renderer::FontStyle fontStyle);
 
     void toggleReferenceMark(const std::string& refMark, Selection sel = Selection());

--- a/src/celestia/ffmpegcapture.h
+++ b/src/celestia/ffmpegcapture.h
@@ -34,7 +34,7 @@ public:
     void setEncoderOptions(const std::string&);
 
 protected:
-    void recordingStatusUpdated(bool) override {};
+    void recordingStatusUpdated(bool) override { /* no action necessary */ };
 
 private:
     FFMPEGCapturePrivate *d{ nullptr };

--- a/src/celestia/ffmpegcapture.h
+++ b/src/celestia/ffmpegcapture.h
@@ -13,7 +13,7 @@ class FFMPEGCapturePrivate;
 
 class FFMPEGCapture : public MovieCapture
 {
- public:
+public:
     FFMPEGCapture(const Renderer *r);
     ~FFMPEGCapture() override;
 
@@ -28,12 +28,14 @@ class FFMPEGCapture : public MovieCapture
 
     void setAspectRatio(int, int) override {};
     void setQuality(float) override {};
-    void recordingStatus(bool) override {};
 
     void setVideoCodec(AVCodecID);
     void setBitRate(int64_t);
     void setEncoderOptions(const std::string&);
 
- private:
+protected:
+    void recordingStatusUpdated(bool) override {};
+
+private:
     FFMPEGCapturePrivate *d{ nullptr };
 };

--- a/src/celestia/gtk/actions.cpp
+++ b/src/celestia/gtk/actions.cpp
@@ -349,7 +349,7 @@ void actionCaptureMovie(GtkAction*, AppData* app)
 /* File -> Run Demo... */
 void actionRunDemo(GtkAction*, AppData* app)
 {
-    const auto& demoScriptFile = app->core->getConfig()->paths.demoScriptFile;    
+    const auto& demoScriptFile = app->core->getConfig()->paths.demoScriptFile;
     if (!demoScriptFile.empty())
     {
         app->core->cancelScript();
@@ -656,13 +656,13 @@ void actionMenuBarVisible(GtkToggleAction* action, AppData* app)
 
 void actionMultiSplitH(GtkAction*, AppData* app)
 {
-    app->core->splitView(View::HorizontalSplit);
+    app->core->splitView(celestia::View::HorizontalSplit);
 }
 
 
 void actionMultiSplitV(GtkAction*, AppData* app)
 {
-    app->core->splitView(View::VerticalSplit);
+    app->core->splitView(celestia::View::VerticalSplit);
 }
 
 

--- a/src/celestia/gtk/glwidget.cpp
+++ b/src/celestia/gtk/glwidget.cpp
@@ -237,8 +237,11 @@ static gint glarea_key_press(GtkWidget* widget, GdkEventKey* event, AppData* app
                 if ((event->string != NULL) && (*(event->string)))
                 {
                     /* See if our key accelerators will handle this event. */
-                    if((!app->core->getTextEnterMode()) && gtk_accel_groups_activate (G_OBJECT (app->mainWindow), event->keyval, GDK_SHIFT_MASK))
+                    if (app->core->getTextEnterMode() != celestia::Hud::TextEnterMode::Normal &&
+                        gtk_accel_groups_activate (G_OBJECT (app->mainWindow), event->keyval, GDK_SHIFT_MASK))
+                    {
                         return TRUE;
+                    }
 
                     char* s = event->string;
 

--- a/src/celestia/gtk/main.cpp
+++ b/src/celestia/gtk/main.cpp
@@ -187,7 +187,7 @@ void GtkWatcher::notifyChange(CelestiaCore*, int property)
 
     else if (property == CelestiaCore::TextEnterModeChanged)
     {
-        if (app->core->getTextEnterMode() != 0)
+        if (app->core->getTextEnterMode() != celestia::Hud::TextEnterMode::Normal)
         {
             /* Grey-out the menu */
             gtk_widget_set_sensitive(app->mainMenu, FALSE);

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -1,0 +1,1324 @@
+// hud.cpp
+//
+// Copyright (C) 2023, the Celestia Development Team
+//
+// Split out from celestiacore.h/celestiacore.cpp
+// Copyright (C) 2001-2009, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "hud.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+#include <fmt/format.h>
+
+#include <celcompat/numbers.h>
+#include <celengine/body.h>
+#include <celengine/location.h>
+#include <celengine/observer.h>
+#include <celengine/overlay.h>
+#include <celengine/overlayimage.h>
+#include <celengine/rectangle.h>
+#include <celengine/simulation.h>
+#include <celengine/star.h>
+#include <celengine/textlayout.h>
+#include <celengine/universe.h>
+#include <celmath/geomutil.h>
+#include <celmath/mathlib.h>
+#include <celutil/formatnum.h>
+#include <celutil/gettext.h>
+#include <celutil/utf8.h>
+#include "moviecapture.h"
+#include "textprintposition.h"
+#include "timeinfo.h"
+#include "view.h"
+#include "viewmanager.h"
+
+using namespace celestia::astro::literals;
+
+namespace celestia
+{
+
+namespace
+{
+
+// Ye olde wolde conſtantes for ye olde wolde units
+constexpr double OneMiInKm = 1.609344;
+constexpr double OneFtInKm = 0.0003048;
+constexpr double OneLbInKg = 0.45359237;
+constexpr double OneLbPerFt3InKgPerM3 = OneLbInKg / celmath::cube(OneFtInKm * 1000.0);
+
+constexpr float
+KelvinToCelsius(float kelvin)
+{
+    return kelvin - 273.15f;
+}
+
+constexpr float
+KelvinToFahrenheit(float kelvin)
+{
+    return kelvin * 1.8f - 459.67f;
+}
+
+FormattedNumber
+SigDigitNum(double v, int digits)
+{
+    return FormattedNumber(v, digits,
+                           FormattedNumber::GroupThousands |
+                           FormattedNumber::SignificantDigits);
+}
+
+std::string
+KelvinToStr(float value, int digits, TemperatureScale temperatureScale)
+{
+    const char* unitTemplate = "";
+
+    switch (temperatureScale)
+    {
+        case TemperatureScale::Celsius:
+            value = KelvinToCelsius(value);
+            unitTemplate = "{} °C";
+            break;
+        case TemperatureScale::Fahrenheit:
+            value = KelvinToFahrenheit(value);
+            unitTemplate = "{} °F";
+            break;
+        default: // TemperatureScale::Kelvin
+            unitTemplate = "{} K";
+            break;
+    }
+    return fmt::format(unitTemplate, SigDigitNum(value, digits));
+}
+
+std::string
+DistanceLyToStr(double distance, int digits, MeasurementSystem measurement)
+{
+    const char* units = "";
+
+    if (std::abs(distance) >= astro::parsecsToLightYears(1e+6))
+    {
+        units = _("Mpc");
+        distance = astro::lightYearsToParsecs(distance) / 1e+6;
+    }
+    else if (std::abs(distance) >= 0.5 * astro::parsecsToLightYears(1e+3))
+    {
+        units = _("kpc");
+        distance = astro::lightYearsToParsecs(distance) / 1e+3;
+    }
+    else if (std::abs(distance) >= astro::AUtoLightYears(1000.0f))
+    {
+        units = _("ly");
+    }
+    else if (std::abs(distance) >= astro::kilometersToLightYears(10000000.0))
+    {
+        units = _("au");
+        distance = astro::lightYearsToAU(distance);
+    }
+    else if (measurement == MeasurementSystem::Imperial)
+    {
+        if (abs(distance) > astro::kilometersToLightYears(OneMiInKm))
+        {
+            units = _("mi");
+            distance = astro::lightYearsToKilometers(distance) / OneMiInKm;
+        }
+        else
+        {
+            units = _("ft");
+            distance = astro::lightYearsToKilometers(distance) / OneFtInKm;
+        }
+    }
+    else
+    {
+        if (std::abs(distance) > astro::kilometersToLightYears(1.0f))
+        {
+            units = _("km");
+            distance = astro::lightYearsToKilometers(distance);
+        }
+        else
+        {
+            units = _("m");
+            distance = astro::lightYearsToKilometers(distance) * 1000.0f;
+        }
+    }
+
+    return fmt::format("{} {}", SigDigitNum(distance, digits), units);
+}
+
+std::string
+DistanceKmToStr(double distance, int digits, MeasurementSystem measurement)
+{
+    return DistanceLyToStr(astro::kilometersToLightYears(distance), digits, measurement);
+}
+
+void
+displayRotationPeriod(Overlay& overlay, double days)
+{
+    FormattedNumber n;
+    const char *p;
+
+    if (days > 1.0)
+    {
+        n = FormattedNumber(days, 3, FormattedNumber::GroupThousands);
+        p = _("days");
+    }
+    else if (days > 1.0 / 24.0)
+    {
+        n = FormattedNumber(days * 24.0, 3, FormattedNumber::GroupThousands);
+        p = _("hours");
+    }
+    else if (days > 1.0 / (24.0 * 60.0))
+    {
+        n = FormattedNumber(days * 24.0 * 60.0, 3, FormattedNumber::GroupThousands);
+        p = _("minutes");
+    }
+    else
+    {
+        n = FormattedNumber(days * 24.0 * 60.0 * 60.0, 3, FormattedNumber::GroupThousands);
+        p = _("seconds");
+    }
+
+    overlay.print(_("Rotation period: {} {}\n"), n, p);
+}
+
+void
+displayMass(Overlay& overlay, float mass, MeasurementSystem measurement)
+{
+    if (mass < 0.001f)
+    {
+        if (measurement == MeasurementSystem::Imperial)
+            overlay.printf(_("Mass: %.6g lb\n"), mass * astro::EarthMass / (float) OneLbInKg);
+        else
+            overlay.printf(_("Mass: %.6g kg\n"), mass * astro::EarthMass);
+    }
+    else if (mass > 50)
+        overlay.printf(_("Mass: %.2f Mj\n"), mass * astro::EarthMass / astro::JupiterMass);
+    else
+        overlay.printf(_("Mass: %.2f Me\n"), mass);
+}
+
+void
+displaySpeed(Overlay& overlay, float speed, MeasurementSystem measurement)
+{
+    FormattedNumber n;
+    const char *u;
+
+    if (speed >= (float) 1000.0_au)
+    {
+        n = SigDigitNum(astro::kilometersToLightYears(speed), 3);
+        u = _("ly/s");
+    }
+    else if (speed >= (float) 100.0_c)
+    {
+        n = SigDigitNum(astro::kilometersToAU(speed), 3);
+        u = _("AU/s");
+    }
+    else if (speed >= 10000.0f)
+    {
+        n = SigDigitNum(speed / astro::speedOfLight, 3);
+        u = "c";
+    }
+    else if (measurement == MeasurementSystem::Imperial)
+    {
+        if (speed >= (float) OneMiInKm)
+        {
+            n = SigDigitNum(speed / (float) OneMiInKm, 3);
+            u = _("mi/s");
+        }
+        else
+        {
+            n = SigDigitNum(speed / (float) OneFtInKm, 3);
+            u = _("ft/s");
+        }
+    }
+    else
+    {
+        if (speed >= 1.0f)
+        {
+            n = SigDigitNum(speed, 3);
+            u = _("km/s");
+        }
+        else
+        {
+            n = SigDigitNum(speed * 1000.0f, 3);
+            u = _("m/s");
+        }
+    }
+    overlay.print(_("Speed: {} {}\n"), n, u);
+}
+
+// Display a positive angle as degrees, minutes, and seconds. If the angle is less than one
+// degree, only minutes and seconds are shown; if the angle is less than one minute, only
+// seconds are displayed.
+std::string
+angleToStr(double angle)
+{
+    int degrees, minutes;
+    double seconds;
+    astro::decimalToDegMinSec(angle, degrees, minutes, seconds);
+
+    if (degrees > 0)
+    {
+        return fmt::format("{}" UTF8_DEGREE_SIGN "{:02d}' {:.1f}\"",
+                           degrees, abs(minutes), abs(seconds));
+    }
+
+    if (minutes > 0)
+    {
+        return fmt::format("{:02d}' {:.1f}\"", abs(minutes), abs(seconds));
+    }
+
+    return fmt::format("{:.2f}\"", abs(seconds));
+}
+
+void
+displayApparentDiameter(Overlay& overlay, double radius, double distance)
+{
+    if (distance < radius)
+        return;
+
+    double arcSize = celmath::radToDeg(std::asin(radius / distance) * 2.0);
+
+    // Only display the arc size if it's less than 160 degrees and greater
+    // than one second--otherwise, it's probably not interesting data.
+    if (arcSize < 160.0 && arcSize > 1.0 / 3600.0)
+        overlay.printf(_("Apparent diameter: %s\n"), angleToStr(arcSize));
+}
+
+void
+displayDeclination(Overlay& overlay, double angle)
+{
+    int degrees, minutes;
+    double seconds;
+    astro::decimalToDegMinSec(angle, degrees, minutes, seconds);
+
+    overlay.printf(_("Dec: %+d%s %02d' %.1f\"\n"),
+                   std::abs(degrees), UTF8_DEGREE_SIGN,
+                   std::abs(minutes), std::abs(seconds));
+}
+
+void
+displayRightAscension(Overlay& overlay, double angle)
+{
+    int hours, minutes;
+    double seconds;
+    astro::decimalToHourMinSec(angle, hours, minutes, seconds);
+
+    overlay.printf(_("RA: %dh %02dm %.1fs\n"),
+                          hours, abs(minutes), abs(seconds));
+}
+
+void
+displayApparentMagnitude(Overlay& overlay,
+                         float absMag,
+                         double distance)
+{
+    if (distance > 32.6167)
+    {
+        float appMag = astro::absToAppMag(absMag, (float) distance);
+        overlay.printf(_("Apparent magnitude: %.1f\n"), appMag);
+    }
+    else
+    {
+        overlay.printf(_("Absolute magnitude: %.1f\n"), absMag);
+    }
+}
+
+void
+displayRADec(Overlay& overlay, const Eigen::Vector3d& v)
+{
+    double phi = std::atan2(v.x(), v.z()) - celestia::numbers::pi / 2;
+    if (phi < 0)
+        phi = phi + 2 * celestia::numbers::pi;
+
+    double theta = std::atan2(std::hypot(v.x(), v.z()), v.y());
+    if (theta > 0)
+        theta = celestia::numbers::pi / 2 - theta;
+    else
+        theta = -celestia::numbers::pi / 2 - theta;
+
+
+    displayRightAscension(overlay, celmath::radToDeg(phi));
+    displayDeclination(overlay, celmath::radToDeg(theta));
+}
+
+// Display nicely formatted planetocentric/planetographic coordinates.
+// The latitude and longitude parameters are angles in radians, altitude
+// is in kilometers.
+void
+displayPlanetocentricCoords(Overlay& overlay,
+                            const Body& body,
+                            double longitude,
+                            double latitude,
+                            double altitude,
+                            bool showAltitude,
+                            MeasurementSystem measurement)
+{
+    char ewHemi = ' ';
+    char nsHemi = ' ';
+    double lon = 0.0;
+    double lat = 0.0;
+
+    // Terrible hack for Earth and Moon longitude conventions.  Fix by
+    // adding a field to specify the longitude convention in .ssc files.
+    if (body.getName() == "Earth" || body.getName() == "Moon")
+    {
+        if (latitude < 0.0)
+            nsHemi = 'S';
+        else if (latitude > 0.0)
+            nsHemi = 'N';
+
+        if (longitude < 0.0)
+            ewHemi = 'W';
+        else if (longitude > 0.0f)
+            ewHemi = 'E';
+
+        lon = static_cast<float>(std::abs(celmath::radToDeg(longitude)));
+        lat = static_cast<float>(std::abs(celmath::radToDeg(latitude)));
+    }
+    else
+    {
+        // Swap hemispheres if the object is a retrograde rotator
+        Eigen::Quaterniond q = body.getEclipticToEquatorial(astro::J2000);
+        bool retrograde = (q * Eigen::Vector3d::UnitY()).y() < 0.0;
+
+        if ((latitude < 0.0) ^ retrograde)
+            nsHemi = 'S';
+        else if ((latitude > 0.0) ^ retrograde)
+            nsHemi = 'N';
+
+        if (retrograde)
+            ewHemi = 'E';
+        else
+            ewHemi = 'W';
+
+        lon = -celmath::radToDeg(longitude);
+        if (lon < 0.0)
+            lon += 360.0;
+        lat = std::abs(celmath::radToDeg(latitude));
+    }
+
+    if (showAltitude)
+        overlay.printf("%.6f%c %.6f%c", lat, nsHemi, lon, ewHemi);
+    else
+        overlay.printf(_("%.6f%c %.6f%c %s"), lat, nsHemi, lon, ewHemi, DistanceKmToStr(altitude, 5, measurement));
+}
+
+void
+displayStarInfo(Overlay& overlay,
+                int detail,
+                Star& star,
+                const Universe& universe,
+                double distance,
+                MeasurementSystem measurement,
+                TemperatureScale temperatureScale)
+{
+    overlay.printf(_("Distance: %s\n"), DistanceLyToStr(distance, 5, measurement));
+
+    if (!star.getVisibility())
+    {
+        overlay.print(_("Star system barycenter\n"));
+    }
+    else
+    {
+        overlay.printf(_("Abs (app) mag: %.2f (%.2f)\n"),
+                                star.getAbsoluteMagnitude(),
+                                star.getApparentMagnitude(float(distance)));
+
+        if (star.getLuminosity() > 1.0e-10f)
+            overlay.print(_("Luminosity: {}x Sun\n"), SigDigitNum(star.getLuminosity(), 3));
+
+        const char* star_class;
+        switch (star.getSpectralType()[0])
+        {
+        case 'Q':
+            star_class = _("Neutron star");
+            break;
+        case 'X':
+            star_class = _("Black hole");
+            break;
+        default:
+            star_class = star.getSpectralType();
+        };
+        overlay.printf(_("Class: %s\n"), star_class);
+
+        displayApparentDiameter(overlay, star.getRadius(),
+                                astro::lightYearsToKilometers(distance));
+
+        if (detail > 1)
+        {
+            overlay.printf(_("Surface temp: %s\n"), KelvinToStr(star.getTemperature(), 3, temperatureScale));
+            float solarRadii = star.getRadius() / 6.96e5f;
+
+            if (solarRadii > 0.01f)
+            {
+                overlay.print(_("Radius: {} Rsun  ({})\n"),
+                              SigDigitNum(star.getRadius() / 696000.0f, 2),
+                              DistanceKmToStr(star.getRadius(), 3, measurement));
+            }
+            else
+            {
+                overlay.print(_("Radius: {}\n"),
+                              DistanceKmToStr(star.getRadius(), 3, measurement));
+            }
+
+            if (star.getRotationModel()->isPeriodic())
+            {
+                float period = (float) star.getRotationModel()->getPeriod();
+                displayRotationPeriod(overlay, period);
+            }
+        }
+    }
+
+    if (detail > 1)
+    {
+        SolarSystem* sys = universe.getSolarSystem(&star);
+        if (sys != nullptr && sys->getPlanets()->getSystemSize() != 0)
+            overlay.print(_("Planetary companions present\n"));
+    }
+}
+
+void displayDSOinfo(Overlay& overlay,
+                    const DeepSkyObject& dso,
+                    double distance,
+                    MeasurementSystem measurement)
+{
+    overlay.print(dso.getDescription());
+    overlay.print("\n");
+
+    if (distance >= 0)
+    {
+        overlay.printf(_("Distance: %s\n"),
+                     DistanceLyToStr(distance, 5, measurement));
+    }
+    else
+    {
+        overlay.printf(_("Distance from center: %s\n"),
+                     DistanceLyToStr(distance + dso.getRadius(), 5, measurement));
+     }
+    overlay.printf(_("Radius: %s\n"),
+                 DistanceLyToStr(dso.getRadius(), 5, measurement));
+
+    displayApparentDiameter(overlay, dso.getRadius(), distance);
+    if (dso.getAbsoluteMagnitude() > DSO_DEFAULT_ABS_MAGNITUDE)
+    {
+        displayApparentMagnitude(overlay,
+                                 dso.getAbsoluteMagnitude(),
+                                 distance);
+    }
+}
+
+static void displayPlanetInfo(Overlay& overlay,
+                              int detail,
+                              Body& body,
+                              double t,
+                              double distanceKm,
+                              const Eigen::Vector3d& viewVec,
+                              MeasurementSystem measurement,
+                              TemperatureScale temperatureScale)
+{
+    double distance = distanceKm - body.getRadius();
+    overlay.printf(_("Distance: %s\n"), DistanceKmToStr(distance, 5, measurement));
+
+    if (body.getClassification() == Body::Invisible)
+    {
+        return;
+    }
+
+    overlay.printf(_("Radius: %s\n"), DistanceKmToStr(body.getRadius(), 5, measurement));
+
+    displayApparentDiameter(overlay, body.getRadius(), distanceKm);
+
+    // Display the phase angle
+
+    // Find the parent star of the body. This can be slightly complicated if
+    // the body orbits a barycenter instead of a star.
+    Selection parent = Selection(&body).parent();
+    while (parent.body() != nullptr)
+        parent = parent.parent();
+
+    if (parent.star() != nullptr)
+    {
+        bool showPhaseAngle = false;
+
+        Star* sun = parent.star();
+        if (sun->getVisibility())
+        {
+            showPhaseAngle = true;
+        }
+        else if (const auto* orbitingStars = sun->getOrbitingStars(); orbitingStars != nullptr && orbitingStars->size() == 1)
+        {
+            // The planet's orbit is defined with respect to a barycenter. If there's
+            // a single star orbiting the barycenter, we'll compute the phase angle
+            // for the planet with respect to that star. If there are no stars, the
+            // planet is an orphan, drifting through space with no star. We also skip
+            // displaying the phase angle when there are multiple stars (for now.)
+            sun = orbitingStars->front();
+            showPhaseAngle = sun->getVisibility();
+        }
+
+        if (showPhaseAngle)
+        {
+            Eigen::Vector3d sunVec = Selection(&body).getPosition(t).offsetFromKm(Selection(sun).getPosition(t));
+            sunVec.normalize();
+            double cosPhaseAngle = std::clamp(sunVec.dot(viewVec.normalized()), -1.0, 1.0);
+            double phaseAngle = acos(cosPhaseAngle);
+            overlay.printf(_("Phase angle: %.1f%s\n"), celmath::radToDeg(phaseAngle), UTF8_DEGREE_SIGN);
+        }
+    }
+
+    if (detail > 1)
+    {
+        if (body.getRotationModel(t)->isPeriodic())
+            displayRotationPeriod(overlay, body.getRotationModel(t)->getPeriod());
+
+        if (body.getName() != "Earth" && body.getMass() > 0)
+            displayMass(overlay, body.getMass(), measurement);
+
+        float density = body.getDensity();
+        if (density > 0)
+        {
+            if (measurement == MeasurementSystem::Imperial)
+                overlay.printf(_("Density: %.2f x 1000 lb/ft^3\n"), density / (float) OneLbPerFt3InKgPerM3 / 1000.0f);
+            else
+                overlay.printf(_("Density: %.2f x 1000 kg/m^3\n"), density / 1000.0f);
+        }
+
+        float planetTemp = body.getTemperature(t);
+        if (planetTemp > 0)
+            overlay.printf(_("Temperature: %s\n"), KelvinToStr(planetTemp, 3, temperatureScale));
+    }
+}
+
+void
+displayLocationInfo(Overlay& overlay,
+                    Location& location,
+                    double distanceKm,
+                    MeasurementSystem measurement)
+{
+    overlay.printf(_("Distance: %s\n"), DistanceKmToStr(distanceKm, 5, measurement));
+
+    Body* body = location.getParentBody();
+    if (body == nullptr)
+        return;
+
+    Eigen::Vector3f locPos = location.getPosition();
+    Eigen::Vector3d lonLatAlt = body->cartesianToPlanetocentric(locPos.cast<double>());
+    displayPlanetocentricCoords(overlay, *body,
+                                lonLatAlt.x(), lonLatAlt.y(), lonLatAlt.z(), false, measurement);
+}
+
+std::string
+getSelectionName(const Selection& sel, const Universe& univ)
+{
+    switch (sel.getType())
+    {
+    case SelectionType::Body:
+        return sel.body()->getName(true);
+    case SelectionType::DeepSky:
+        return univ.getDSOCatalog()->getDSOName(sel.deepsky(), true);
+    case SelectionType::Star:
+        return univ.getStarCatalog()->getStarName(*sel.star(), true);
+    case SelectionType::Location:
+        return sel.location()->getName(true);
+    default:
+        return {};
+    }
+}
+
+std::string
+getBodySelectionNames(const Body& body)
+{
+    std::string selectionNames = body.getLocalizedName(); // Primary name, might be localized
+    const std::vector<std::string>& names = body.getNames();
+
+    // Start from the second one because primary name is already in the string
+    auto secondName = names.begin() + 1;
+
+    for (auto iter = secondName; iter != names.end(); ++iter)
+    {
+        selectionNames += " / ";
+
+        // Use localized version of parent name in alternative names.
+        std::string alias = *iter;
+
+        const PlanetarySystem* parentSystem = body.getSystem();
+        if (parentSystem == nullptr)
+        {
+            selectionNames += alias;
+            continue;
+        }
+
+        if (const Body* parentBody = parentSystem->getPrimaryBody(); parentBody != nullptr)
+        {
+            std::string parentName = parentBody->getName();
+            std::string locParentName = parentBody->getName(true);
+            std::string::size_type startPos = alias.find(parentName);
+            if (startPos != std::string::npos)
+                alias.replace(startPos, parentName.length(), locParentName);
+        }
+
+        selectionNames += alias;
+    }
+
+    return selectionNames;
+}
+
+} // end unnamed namespace
+
+Hud::~Hud() = default;
+
+int
+Hud::getDetail() const
+{
+    return hudDetail;
+}
+
+void
+Hud::setDetail(int detail)
+{
+    hudDetail = detail % 3;
+}
+
+astro::Date::Format
+Hud::getDateFormat() const
+{
+    return dateFormat;
+}
+
+void
+Hud::setDateFormat(astro::Date::Format format)
+{
+    dateFormat = format;
+    dateStrWidth = 0;
+}
+
+TextInput&
+Hud::textInput()
+{
+    return m_textInput;
+}
+
+unsigned int
+Hud::getTextEnterMode() const
+{
+    return m_textEnterMode;
+}
+
+void
+Hud::setTextEnterMode(unsigned int value)
+{
+    m_textEnterMode = static_cast<TextEnterMode>(value);
+    if ((value & TextEnterAutoComplete) == 0)
+        m_textInput.reset();
+}
+
+void
+Hud::setOverlay(std::unique_ptr<Overlay>&& _overlay)
+{
+    overlay = std::move(_overlay);
+}
+
+void
+Hud::setWindowSize(int w, int h)
+{
+    if (overlay != nullptr)
+        overlay->setWindowSize(w, h);
+}
+
+void
+Hud::setTextAlignment(LayoutDirection dir)
+{
+    overlay->setTextAlignment(dir == LayoutDirection::RightToLeft
+                                  ? engine::TextLayout::HorizontalAlignment::Right
+                                  : engine::TextLayout::HorizontalAlignment::Left);
+}
+
+int
+Hud::getTextWidth(std::string_view text) const
+{
+    return engine::TextLayout::getTextWidth(text, titleFont.get());
+}
+
+const std::shared_ptr<TextureFont>&
+Hud::getFont() const
+{
+    return font;
+}
+
+const std::shared_ptr<TextureFont>&
+Hud::getTitleFont() const
+{
+    return titleFont;
+}
+
+std::tuple<int, int>
+Hud::getTitleMetrics() const
+{
+    return std::make_tuple(titleEmWidth, titleFontHeight);
+}
+
+void
+Hud::renderOverlay(const WindowMetrics& metrics,
+                   const Simulation* sim,
+                   const ViewManager& views,
+                   const MovieCapture* movieCapture,
+                   const TimeInfo& timeInfo,
+                   bool isScriptRunning,
+                   bool editMode)
+{
+    overlay->setFont(font);
+
+    overlay->begin();
+
+    if (showOverlayImage && isScriptRunning && image != nullptr)
+        image->render(static_cast<float>(timeInfo.currentTime), metrics.width, metrics.height);
+
+    if (views.views().size() > 1)
+        renderViewBorders(metrics, timeInfo.currentTime, views, views.isResizing());
+
+    setlocale(LC_NUMERIC, "");
+
+    if (hudDetail > 0 && (overlayElements & OverlayElements::ShowTime) != 0)
+        renderTimeInfo(metrics, sim, timeInfo);
+
+    if (hudDetail > 0 && (overlayElements & OverlayElements::ShowVelocity) != 0)
+    {
+        // Speed
+        overlay->savePos();
+        overlay->moveBy(metrics.getSafeAreaStart(),
+                        metrics.getSafeAreaBottom(fontHeight * 2 + static_cast<int>(static_cast<float>(metrics.screenDpi) / 25.4f * 1.3f)));
+        overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+
+        overlay->beginText();
+        overlay->print("\n");
+        if (showFPSCounter)
+            overlay->printf(_("FPS: %.1f\n"), timeInfo.fps);
+        else
+            overlay->print("\n");
+
+        displaySpeed(*overlay, sim->getObserver().getVelocity().norm(), measurementSystem);
+
+        overlay->endText();
+        overlay->restorePos();
+    }
+
+    if (hudDetail > 0 && (overlayElements & OverlayElements::ShowFrame) != 0)
+        renderFrameInfo(metrics, sim);
+
+    if (Selection sel = sim->getSelection();
+        !sel.empty() && hudDetail > 0 && (overlayElements & OverlayElements::ShowSelection) != 0)
+    {
+        Eigen::Vector3d v = sel.getPosition(sim->getTime()).offsetFromKm(sim->getObserver().getPosition());
+        renderSelectionInfo(metrics, sim, sel, v);
+    }
+
+    if ((m_textEnterMode & TextEnterAutoComplete) != 0)
+        renderTextInput(metrics);
+
+    if (showMessage)
+        renderTextMessages(metrics, timeInfo.currentTime);
+
+    if (movieCapture != nullptr)
+        renderMovieCapture(metrics, *movieCapture);
+
+    if (editMode)
+    {
+        overlay->savePos();
+        overlay->beginText();
+        int x = (metrics.getSafeAreaWidth() - engine::TextLayout::getTextWidth(_("Edit Mode"), font.get())) / 2;
+        overlay->moveBy(metrics.getSafeAreaStart(x), metrics.getSafeAreaTop(fontHeight));
+        overlay->setColor(1, 0, 1, 1);
+        overlay->print(_("Edit Mode"));
+        overlay->endText();
+        overlay->restorePos();
+    }
+
+    overlay->end();
+    setlocale(LC_NUMERIC, "C");
+}
+
+void
+Hud::renderViewBorders(const WindowMetrics& metrics,
+                       double currentTime,
+                       const ViewManager& views,
+                       bool resizeSplit)
+{
+    // Render a thin border arround all views
+    if (showViewFrames || resizeSplit)
+    {
+        for(const auto v : views.views())
+        {
+            if (v->type == View::ViewWindow)
+                v->drawBorder(metrics.width, metrics.height, frameColor);
+        }
+    }
+
+    // Render a very simple border around the active view
+    const View* av = views.activeView();
+
+    if (showActiveViewFrame)
+    {
+        av->drawBorder(metrics.width, metrics.height, activeFrameColor, 2);
+    }
+
+    if (currentTime < views.flashFrameStart() + 0.5)
+    {
+        float alpha = (float) (1.0 - (currentTime - views.flashFrameStart()) / 0.5);
+        av->drawBorder(metrics.width, metrics.height, {activeFrameColor, alpha}, 8);
+    }
+}
+
+void
+Hud::renderTimeInfo(const WindowMetrics& metrics, const Simulation* sim, const TimeInfo& timeInfo)
+{
+    double lt = 0.0;
+
+    if (sim->getSelection().getType() == SelectionType::Body &&
+        (sim->getTargetSpeed() < 0.99_c))
+    {
+        if (timeInfo.lightTravelFlag)
+        {
+            Eigen::Vector3d v = sim->getSelection().getPosition(sim->getTime()).offsetFromKm(sim->getObserver().getPosition());
+            // light travel time in days
+            lt = v.norm() / (86400.0_c);
+        }
+    }
+
+    double tdb = sim->getTime() + lt;
+    auto dateStr = dateFormatter->formatDate(tdb, timeInfo.timeZoneBias != 0, dateFormat);
+    int dateWidth = (engine::TextLayout::getTextWidth(dateStr, font.get()) / (emWidth * 3) + 2) * emWidth * 3;
+    if (dateWidth > dateStrWidth) dateStrWidth = dateWidth;
+
+    // Time and date
+    overlay->savePos();
+    overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+    overlay->moveBy(metrics.getSafeAreaEnd(dateStrWidth), metrics.getSafeAreaTop(fontHeight));
+    overlay->beginText();
+
+    overlay->print(dateStr);
+
+    if (timeInfo.lightTravelFlag && lt > 0.0)
+    {
+        overlay->setColor(0.42f, 1.0f, 1.0f, 1.0f);
+        overlay->print(_("  LT"));
+        overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+    }
+    overlay->print("\n");
+
+    {
+        if (std::abs(std::abs(sim->getTimeScale()) - 1.0) < 1e-6)
+        {
+            if (celmath::sign(sim->getTimeScale()) == 1)
+                overlay->print(_("Real time"));
+            else
+                overlay->print(_("-Real time"));
+        }
+        else if (std::abs(sim->getTimeScale()) < TimeInfo::MinimumTimeRate)
+        {
+            overlay->print(_("Time stopped"));
+        }
+        else if (std::abs(sim->getTimeScale()) > 1.0)
+        {
+            overlay->printf(_("%.6g x faster"), sim->getTimeScale()); // XXX: %'.12g
+        }
+        else
+        {
+            overlay->printf(_("%.6g x slower"), 1.0 / sim->getTimeScale()); // XXX: %'.12g
+        }
+
+        if (sim->getPauseState() == true)
+        {
+            overlay->setColor(1.0f, 0.0f, 0.0f, 1.0f);
+            overlay->print(_(" (Paused)"));
+        }
+    }
+
+    overlay->endText();
+    overlay->restorePos();
+}
+
+void
+Hud::renderFrameInfo(const WindowMetrics& metrics, const Simulation* sim)
+{
+    // Field of view and camera mode in lower right corner
+    overlay->savePos();
+    overlay->moveBy(metrics.getSafeAreaEnd(emWidth * 15),
+                    metrics.getSafeAreaBottom(fontHeight * 3 + static_cast<int>(static_cast<float>(metrics.screenDpi) / 25.4f * 1.3f)));
+    overlay->beginText();
+    overlay->setColor(0.6f, 0.6f, 1.0f, 1);
+
+    if (sim->getObserverMode() == Observer::Travelling)
+    {
+        double timeLeft = sim->getArrivalTime() - sim->getRealTime();
+        if (timeLeft >= 1)
+            overlay->print(_("Travelling ({})\n"),
+                            FormattedNumber(timeLeft, 0, FormattedNumber::GroupThousands));
+        else
+            overlay->print(_("Travelling\n"));
+    }
+    else
+    {
+        overlay->print("\n");
+    }
+
+    const Universe& u = *sim->getUniverse();
+
+    if (!sim->getTrackedObject().empty())
+        overlay->printf(_("Track %s\n"), CX_("Track", getSelectionName(sim->getTrackedObject(), u)));
+    else
+        overlay->print("\n");
+
+    {
+        Selection refObject = sim->getFrame()->getRefObject();
+        ObserverFrame::CoordinateSystem coordSys = sim->getFrame()->getCoordinateSystem();
+
+        switch (coordSys)
+        {
+        case ObserverFrame::Ecliptical:
+            overlay->printf(_("Follow %s\n"),
+                            CX_("Follow", getSelectionName(refObject, u)));
+            break;
+        case ObserverFrame::BodyFixed:
+            overlay->printf(_("Sync Orbit %s\n"),
+                            CX_("Sync", getSelectionName(refObject, u)));
+            break;
+        case ObserverFrame::PhaseLock:
+            overlay->printf(_("Lock %s -> %s\n"),
+                            CX_("Lock", getSelectionName(refObject, u)),
+                            CX_("LockTo", getSelectionName(sim->getFrame()->getTargetObject(), u)));
+            break;
+
+        case ObserverFrame::Chase:
+            overlay->printf(_("Chase %s\n"),
+                            CX_("Chase", getSelectionName(refObject, u)));
+            break;
+
+        default:
+            overlay->print("\n");
+            break;
+        }
+    }
+
+    overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+
+    // Field of view
+    const Observer* activeObserver = sim->getActiveObserver();
+    float fov = celmath::radToDeg(activeObserver->getFOV());
+    overlay->printf(_("FOV: %s (%.2fx)\n"), angleToStr(fov), activeObserver->getZoom());
+    overlay->endText();
+    overlay->restorePos();
+}
+
+void
+Hud::renderSelectionInfo(const WindowMetrics& metrics,
+                         const Simulation* sim,
+                         Selection sel,
+                         const Eigen::Vector3d& v)
+{
+    overlay->savePos();
+    overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+    overlay->moveBy(metrics.getSafeAreaStart(), metrics.getSafeAreaTop(titleFont->getHeight()));
+
+    overlay->beginText();
+
+    switch (sel.getType())
+    {
+    case SelectionType::Star:
+        {
+            if (sel != lastSelection)
+            {
+                lastSelection = sel;
+                selectionNames = sim->getUniverse()->getStarCatalog()->getStarNameList(*sel.star());
+            }
+
+            overlay->setFont(titleFont);
+            overlay->print(selectionNames);
+            overlay->setFont(font);
+            overlay->print("\n");
+            displayStarInfo(*overlay,
+                            hudDetail,
+                            *(sel.star()),
+                            *(sim->getUniverse()),
+                            astro::kilometersToLightYears(v.norm()),
+                            measurementSystem,
+                            temperatureScale);
+        }
+        break;
+
+    case SelectionType::DeepSky:
+        {
+            if (sel != lastSelection)
+            {
+                lastSelection = sel;
+                selectionNames = sim->getUniverse()->getDSOCatalog()->getDSONameList(sel.deepsky());
+            }
+
+            overlay->setFont(titleFont);
+            overlay->print(selectionNames);
+            overlay->setFont(font);
+            overlay->print("\n");
+            displayDSOinfo(*overlay,
+                            *sel.deepsky(),
+                            astro::kilometersToLightYears(v.norm()) - sel.deepsky()->getRadius(),
+                            measurementSystem);
+        }
+        break;
+
+    case SelectionType::Body:
+        {
+            // Show all names for the body
+            if (sel != lastSelection)
+            {
+                lastSelection = sel;
+                selectionNames = getBodySelectionNames(*sel.body());
+            }
+
+            overlay->setFont(titleFont);
+            overlay->print(selectionNames);
+            overlay->setFont(font);
+            overlay->print("\n");
+            displayPlanetInfo(*overlay,
+                               hudDetail,
+                              *(sel.body()),
+                               sim->getTime(),
+                               v.norm(),
+                               v,
+                               measurementSystem,
+                               temperatureScale);
+        }
+        break;
+
+    case SelectionType::Location:
+        overlay->setFont(titleFont);
+        overlay->print(sel.location()->getName(true).c_str());
+        overlay->setFont(font);
+        overlay->print("\n");
+        displayLocationInfo(*overlay, *(sel.location()), v.norm(), measurementSystem);
+        break;
+
+    default:
+        break;
+    }
+
+    // Display RA/Dec for the selection, but only when the observer is near
+    // the Earth.
+    Selection refObject = sim->getFrame()->getRefObject();
+    if (refObject.body() && refObject.body()->getName() == "Earth")
+    {
+        Body* earth = refObject.body();
+
+        UniversalCoord observerPos = sim->getObserver().getPosition();
+        double distToEarthCenter = observerPos.offsetFromKm(refObject.getPosition(sim->getTime())).norm();
+        double altitude = distToEarthCenter - earth->getRadius();
+        if (altitude < 1000.0)
+        {
+            // Code to show the geocentric RA/Dec
+
+            // Only show the coordinates for stars and deep sky objects, where
+            // the geocentric values will match the apparent values for observers
+            // near the Earth.
+            if (sel.star() != nullptr || sel.deepsky() != nullptr)
+            {
+                Eigen::Vector3d v = sel.getPosition(sim->getTime()).offsetFromKm(Selection(earth).getPosition(sim->getTime()));
+                v = celmath::XRotation(astro::J2000Obliquity) * v;
+                displayRADec(*overlay, v);
+            }
+        }
+    }
+
+    overlay->endText();
+    overlay->restorePos();
+}
+
+void
+Hud::renderTextInput(const WindowMetrics& metrics)
+{
+    overlay->setFont(titleFont);
+    overlay->savePos();
+    int rectHeight = fontHeight * 3.0f + metrics.screenDpi / 25.4f * 9.3f + titleFontHeight;
+    celestia::Rect r(0, 0, metrics.width, metrics.insetBottom + rectHeight);
+    r.setColor(consoleColor);
+    overlay->drawRectangle(r);
+    overlay->moveBy(metrics.getSafeAreaStart(), metrics.getSafeAreaBottom(rectHeight - titleFontHeight));
+    overlay->setColor(0.6f, 0.6f, 1.0f, 1.0f);
+    overlay->beginText();
+    overlay->print(_("Target name: {}"), m_textInput.getTypedText());
+    overlay->endText();
+    overlay->setFont(font);
+    if (auto typedTextCompletion = m_textInput.getCompletion(); !typedTextCompletion.empty())
+    {
+        int nb_cols = 4;
+        int nb_lines = 3;
+        int start = 0;
+        overlay->moveBy(3, -font->getHeight() - 3);
+        auto iter = typedTextCompletion.begin();
+        auto typedTextCompletionIdx = m_textInput.getCompletionIndex();
+        if (typedTextCompletionIdx >= nb_cols * nb_lines)
+        {
+            start = (typedTextCompletionIdx / nb_lines + 1 - nb_cols) * nb_lines;
+            iter += start;
+        }
+        int columnWidth = metrics.getSafeAreaWidth() / nb_cols;
+        for (int i = 0; iter < typedTextCompletion.end() && i < nb_cols; i++)
+        {
+            overlay->savePos();
+            overlay->beginText();
+            for (int j = 0; iter < typedTextCompletion.end() && j < nb_lines; iter++, j++)
+            {
+                if (i * nb_lines + j == typedTextCompletionIdx - start)
+                    overlay->setColor(1.0f, 0.6f, 0.6f, 1);
+                else
+                    overlay->setColor(0.6f, 0.6f, 1.0f, 1);
+                overlay->print(*iter);
+                overlay->print("\n");
+            }
+            overlay->endText();
+            overlay->restorePos();
+            overlay->moveBy(metrics.layoutDirection == LayoutDirection::RightToLeft ? -columnWidth : columnWidth, 0);
+        }
+    }
+
+    overlay->restorePos();
+    overlay->setFont(font);
+}
+
+void
+Hud::renderTextMessages(const WindowMetrics& metrics, double currentTime)
+{
+    std::string_view text = getCurrentMessage(currentTime);
+    if (text.empty())
+        return;
+
+    int x = 0;
+    int y = 0;
+
+    messageTextPosition->resolvePixelPosition(metrics, x, y);
+
+    overlay->setFont(titleFont);
+    overlay->savePos();
+
+    float alpha = 1.0f;
+    if (currentTime > messageStart + messageDuration - 0.5)
+        alpha = static_cast<float>((messageStart + messageDuration - currentTime) / 0.5);
+    overlay->setColor(textColor.red(), textColor.green(), textColor.blue(), alpha);
+    overlay->moveBy(x, y);
+    overlay->beginText();
+    overlay->print(messageText);
+    overlay->endText();
+    overlay->restorePos();
+    overlay->setFont(font);
+}
+
+void
+Hud::renderMovieCapture(const WindowMetrics& metrics, const MovieCapture& movieCapture)
+{
+    int movieWidth = movieCapture.getWidth();
+    int movieHeight = movieCapture.getHeight();
+    overlay->savePos();
+    Color color(1.0f, 0.0f, 0.0f, 1.0f);
+    overlay->setColor(color);
+    celestia::Rect r((metrics.width - movieWidth) / 2 - 1,
+                     (metrics.height - movieHeight) / 2 - 1,
+                     movieWidth + 1,
+                     movieHeight + 1);
+    r.setColor(color);
+    r.setType(celestia::Rect::Type::BorderOnly);
+    overlay->drawRectangle(r);
+    overlay->moveBy((float) ((metrics.width - movieWidth) / 2),
+                    (float) ((metrics.height + movieHeight) / 2 + 2));
+    overlay->beginText();
+    overlay->printf(_("%dx%d at %.2f fps  %s"),
+                    movieWidth, movieHeight,
+                    movieCapture.getFrameRate(),
+                    movieCapture.recordingStatus() ? _("Recording") : _("Paused"));
+
+    overlay->endText();
+    overlay->restorePos();
+
+    overlay->savePos();
+    overlay->moveBy((float) ((metrics.width + movieWidth) / 2 - emWidth * 5),
+                    (float) ((metrics.height + movieHeight) / 2 + 2));
+    float sec = movieCapture.getFrameCount() /
+        movieCapture.getFrameRate();
+    auto min = (int) (sec / 60);
+    sec -= min * 60.0f;
+    overlay->beginText();
+    overlay->print("{:3d}:{:05.2f}", min, sec);
+    overlay->endText();
+    overlay->restorePos();
+
+    overlay->savePos();
+    overlay->moveBy((float) ((metrics.width - movieWidth) / 2),
+                    (float) ((metrics.height - movieHeight) / 2 - fontHeight - 2));
+    overlay->beginText();
+    overlay->print(_("F11 Start/Pause    F12 Stop"));
+    overlay->endText();
+    overlay->restorePos();
+
+    overlay->restorePos();
+}
+
+std::string_view
+Hud::getCurrentMessage(double currentTime) const
+{
+    if (currentTime < messageStart + messageDuration && messageTextPosition)
+        return messageText;
+    return {};
+}
+
+void
+Hud::setImage(std::unique_ptr<OverlayImage>&& _image, double currentTime)
+{
+    image = std::move(_image);
+    image->setStartTime(static_cast<float>(currentTime));
+}
+
+bool
+Hud::setFont(const std::shared_ptr<TextureFont>& f)
+{
+    if (f == nullptr)
+        return false;
+
+    font = f;
+    fontHeight = font->getHeight();
+    emWidth = engine::TextLayout::getTextWidth("M", font.get());
+    assert(emWidth > 0);
+    return true;
+}
+
+bool
+Hud::setTitleFont(const std::shared_ptr<TextureFont>& f)
+{
+    if (f == nullptr)
+        return false;
+
+    titleFont = f;
+    titleFontHeight = titleFont->getHeight();
+    titleEmWidth = engine::TextLayout::getTextWidth("M", titleFont.get());
+    assert(titleEmWidth > 0);
+    return true;
+}
+
+void
+Hud::clearFonts()
+{
+    if (overlay)
+        overlay->setFont(nullptr);
+
+    dateStrWidth = 0;
+    titleFont = nullptr;
+    font = nullptr;
+
+}
+
+} // end namespace celestia

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -189,7 +189,7 @@ displayMass(Overlay& overlay, float mass, MeasurementSystem measurement)
         else
             overlay.printf(_("Mass: %.6g kg\n"), mass * astro::EarthMass);
     }
-    else if (mass > 50)
+    else if (mass > 50.0f)
         overlay.printf(_("Mass: %.2f Mj\n"), mass * astro::EarthMass / astro::JupiterMass);
     else
         overlay.printf(_("Mass: %.2f Me\n"), mass);
@@ -329,14 +329,14 @@ void
 displayRADec(Overlay& overlay, const Eigen::Vector3d& v)
 {
     double phi = std::atan2(v.x(), v.z()) - celestia::numbers::pi / 2;
-    if (phi < 0)
-        phi = phi + 2 * celestia::numbers::pi;
+    if (phi < 0.0)
+        phi = phi + 2.0 * celestia::numbers::pi;
 
     double theta = std::atan2(std::hypot(v.x(), v.z()), v.y());
     if (theta > 0)
-        theta = celestia::numbers::pi / 2 - theta;
+        theta = celestia::numbers::pi * 0.5 - theta;
     else
-        theta = -celestia::numbers::pi / 2 - theta;
+        theta = -celestia::numbers::pi * 0.5 - theta;
 
 
     displayRightAscension(overlay, celmath::radToDeg(phi));
@@ -487,7 +487,7 @@ void displayDSOinfo(Overlay& overlay,
     overlay.print(dso.getDescription());
     overlay.print("\n");
 
-    if (distance >= 0)
+    if (distance >= 0.0)
     {
         overlay.printf(_("Distance: %s\n"),
                      DistanceLyToStr(distance, 5, measurement));
@@ -764,10 +764,22 @@ Hud::font() const
     return m_hudFonts.font();
 }
 
+void
+Hud::font(const std::shared_ptr<TextureFont>& f)
+{
+    m_hudFonts.setFont(f);
+}
+
 const std::shared_ptr<TextureFont>&
 Hud::titleFont() const
 {
     return m_hudFonts.titleFont();
+}
+
+void
+Hud::titleFont(const std::shared_ptr<TextureFont>& f)
+{
+    m_hudFonts.setTitleFont(f);
 }
 
 std::tuple<int, int>
@@ -1201,26 +1213,6 @@ Hud::setImage(std::unique_ptr<OverlayImage>&& _image, double currentTime)
 {
     m_image = std::move(_image);
     m_image->setStartTime(static_cast<float>(currentTime));
-}
-
-bool
-Hud::trySetFont(const std::shared_ptr<TextureFont>& f)
-{
-    if (f == nullptr)
-        return false;
-
-    m_hudFonts.setFont(f);
-    return true;
-}
-
-bool
-Hud::trySetTitleFont(const std::shared_ptr<TextureFont>& f)
-{
-    if (f == nullptr)
-        return false;
-
-    m_hudFonts.setTitleFont(f);
-    return true;
 }
 
 } // end namespace celestia

--- a/src/celestia/hud.h
+++ b/src/celestia/hud.h
@@ -137,9 +137,9 @@ public:
 
     int getTextWidth(std::string_view) const;
     const std::shared_ptr<TextureFont>& font() const;
+    void font(const std::shared_ptr<TextureFont>&);
     const std::shared_ptr<TextureFont>& titleFont() const;
-    bool trySetFont(const std::shared_ptr<TextureFont>&);
-    bool trySetTitleFont(const std::shared_ptr<TextureFont>&);
+    void titleFont(const std::shared_ptr<TextureFont>&);
     std::tuple<int, int> titleMetrics() const;
 
     void renderOverlay(const WindowMetrics&,

--- a/src/celestia/hud.h
+++ b/src/celestia/hud.h
@@ -1,0 +1,181 @@
+// hud.h
+//
+// Copyright (C) 2023, the Celestia Development Team
+//
+// Split out from celestiacore.h/celestiacore.cpp
+// Copyright (C) 2001-2009, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+
+#include <Eigen/Core>
+
+#include <celengine/astro.h>
+#include <celengine/dateformatter.h>
+#include <celengine/selection.h>
+#include <celestia/textinput.h>
+#include <celestia/windowmetrics.h>
+#include <celttf/truetypefont.h>
+#include <celutil/color.h>
+
+class MovieCapture;
+class Overlay;
+class OverlayImage;
+class Simulation;
+
+namespace celestia
+{
+
+class TextPrintPosition;
+class TimeInfo;
+class ViewManager;
+
+namespace engine
+{
+class DateFormatter;
+}
+
+enum class MeasurementSystem
+{
+    Metric      = 0,
+    Imperial    = 1,
+};
+
+enum class TemperatureScale
+{
+    Kelvin      = 0,
+    Celsius     = 1,
+    Fahrenheit  = 2,
+};
+
+class Hud
+{
+public:
+    enum OverlayElements : unsigned int
+    {
+        ShowNoElement  = 0x01,
+        ShowTime       = 0x02,
+        ShowVelocity   = 0x04,
+        ShowSelection  = 0x08,
+        ShowFrame      = 0x10,
+    };
+
+    enum TextEnterMode : unsigned int
+    {
+        TextEnterNormal       = 0x00,
+        TextEnterAutoComplete = 0x01,
+        TextEnterPassToScript = 0x02,
+    };
+
+    Hud() = default;
+    ~Hud();
+
+    int getDetail() const;
+    void setDetail(int);
+    astro::Date::Format getDateFormat() const;
+    void setDateFormat(astro::Date::Format);
+    TextInput& textInput();
+    unsigned int getTextEnterMode() const;
+    void setTextEnterMode(unsigned int mode);
+
+    void setOverlay(std::unique_ptr<Overlay>&&);
+    void setWindowSize(int, int);
+    void setTextAlignment(LayoutDirection);
+
+    int getTextWidth(std::string_view) const;
+    const std::shared_ptr<TextureFont>& getFont() const;
+    const std::shared_ptr<TextureFont>& getTitleFont() const;
+    bool setFont(const std::shared_ptr<TextureFont>&);
+    bool setTitleFont(const std::shared_ptr<TextureFont>&);
+    void clearFonts();
+    std::tuple<int, int> getTitleMetrics() const;
+
+    void renderOverlay(const WindowMetrics&,
+                       const Simulation*,
+                       const ViewManager&,
+                       const MovieCapture*,
+                       const TimeInfo&,
+                       bool isScriptRunning,
+                       bool editMode);
+
+    template<typename T, typename... Args>
+    void showText(std::string_view s, double duration, double currentTime, Args&&... args)
+    {
+        if (!titleFont)
+            return;
+
+        messageText.replace(messageText.begin(), messageText.end(), s);
+        messageTextPosition = std::make_unique<T>(std::forward<Args>(args)...);
+        messageStart = currentTime;
+        messageDuration = duration;
+    }
+
+    void setImage(std::unique_ptr<OverlayImage>&&, double);
+
+    Color textColor{ 1.0f, 1.0f, 1.0f };
+
+    MeasurementSystem measurementSystem{ MeasurementSystem::Metric };
+    TemperatureScale temperatureScale{ TemperatureScale::Kelvin };
+
+    OverlayElements overlayElements{ ShowTime | ShowVelocity | ShowSelection | ShowFrame };
+    bool showViewFrames{ true };
+    bool showActiveViewFrame{ false };
+    bool showFPSCounter{ false };
+    bool showOverlayImage{ true };
+    bool showMessage{ true };
+
+private:
+    void renderViewBorders(const WindowMetrics&, double, const ViewManager&, bool);
+    void renderTimeInfo(const WindowMetrics&, const Simulation*, const TimeInfo&);
+    void renderFrameInfo(const WindowMetrics&, const Simulation*);
+    void renderSelectionInfo(const WindowMetrics&, const Simulation*, Selection, const Eigen::Vector3d&);
+    void renderTextInput(const WindowMetrics&);
+    void renderTextMessages(const WindowMetrics&, double);
+    void renderMovieCapture(const WindowMetrics&, const MovieCapture&);
+
+    std::string_view getCurrentMessage(double) const;
+
+    Color frameColor{ 0.5f, 0.5f, 0.5f, 1.0f };
+    Color activeFrameColor{ 0.5f, 0.5f, 1.0f, 1.0f };
+    Color consoleColor{ 0.7f, 0.7f, 1.0f, 0.2f };
+
+    std::shared_ptr<TextureFont> font;
+    std::shared_ptr<TextureFont> titleFont;
+    int fontHeight{ 0 };
+    int titleFontHeight{ 0 };
+    int emWidth{ 0 };
+    int titleEmWidth{ 0 };
+
+    std::unique_ptr<Overlay> overlay;
+
+    std::unique_ptr<OverlayImage> image;
+
+    std::unique_ptr<celestia::engine::DateFormatter> dateFormatter{ std::make_unique<celestia::engine::DateFormatter>() };
+    celestia::astro::Date::Format dateFormat{ celestia::astro::Date::Locale };
+    int dateStrWidth{ 0 };
+
+    int hudDetail{ 2 };
+
+    TextInput m_textInput;
+    TextEnterMode m_textEnterMode{ TextEnterMode::TextEnterNormal };
+
+    std::string messageText;
+    std::unique_ptr<TextPrintPosition> messageTextPosition;
+    double messageStart{ 0.0 };
+    double messageDuration{ 0.0 };
+
+    Selection lastSelection;
+    std::string selectionNames;
+};
+
+}

--- a/src/celestia/moviecapture.h
+++ b/src/celestia/moviecapture.h
@@ -15,7 +15,7 @@ class Renderer;
 
 class MovieCapture
 {
- public:
+public:
     MovieCapture(const Renderer *r) : renderer(r) {};
     virtual ~MovieCapture() = default;
 
@@ -32,8 +32,18 @@ class MovieCapture
 
     virtual void setAspectRatio(int aspectNumerator, int aspectDenominator) = 0;
     virtual void setQuality(float) = 0;
-    virtual void recordingStatus(bool started) = 0; /* to update UI recording status indicator */
+    bool recordingStatus() const { return m_recordingStatus; }
+    void recordingStatus(bool started)
+    {
+        m_recordingStatus = started;
+        recordingStatusUpdated(started);
+    }
 
- protected:
+protected:
     const Renderer *renderer{ nullptr };
+
+    virtual void recordingStatusUpdated(bool started) = 0;
+
+private:
+    bool m_recordingStatus;
 };

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -1792,7 +1792,7 @@ void
 CelestiaAppWindow::copyText()
 {
     auto typedText = m_appCore->getTypedText();
-    QString text = QString::fromUtf8(typedText.data(), typedText.size());
+    QString text = QString::fromUtf8(typedText.data(), static_cast<int>(typedText.size()));
     if (!text.isEmpty())
         QGuiApplication::clipboard()->setText(text);
 }
@@ -1810,18 +1810,18 @@ CelestiaAppWindow::pasteText()
 void
 CelestiaAppWindow::copyTextOrURL()
 {
-    if (m_appCore->getTextEnterMode()) // True when the search console is opened
-        copyText();
-    else
+    if (m_appCore->getTextEnterMode() == celestia::Hud::TextEnterMode::Normal)
         slotCopyURL();
+    else
+        copyText();
 }
 
 
 void
 CelestiaAppWindow::pasteTextOrURL()
 {
-    if (m_appCore->getTextEnterMode()) // True when the search console is opened
-        pasteText();
-    else
+    if (m_appCore->getTextEnterMode() == celestia::Hud::TextEnterMode::Normal)
         slotPasteURL();
+    else
+        pasteText();
 }

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -1791,7 +1791,8 @@ CelestiaAppWindow::buildScriptsMenu()
 void
 CelestiaAppWindow::copyText()
 {
-    QString text(m_appCore->getTypedText().c_str());
+    auto typedText = m_appCore->getTypedText();
+    QString text = QString::fromUtf8(typedText.data(), typedText.size());
     if (!text.isEmpty())
         QGuiApplication::clipboard()->setText(text);
 }

--- a/src/celestia/qt/qtcelestiaactions.cpp
+++ b/src/celestia/qt/qtcelestiaactions.cpp
@@ -394,7 +394,7 @@ CelestiaActions::slotAdjustLimitingMagnitude()
         // HACK!HACK!HACK!
         // Consider removal relevant entries from menus.
         // If search console is open then pass keys to it.
-        if (appCore->getTextEnterMode() != celestia::Hud::TextEnterNormal)
+        if (appCore->getTextEnterMode() != celestia::Hud::TextEnterMode::Normal)
         {
             appCore->charEntered(act->shortcut().toString().toUtf8().data());
             return;

--- a/src/celestia/qt/qtcelestiaactions.cpp
+++ b/src/celestia/qt/qtcelestiaactions.cpp
@@ -23,6 +23,7 @@
 
 #include <celengine/body.h>
 #include <celengine/simulation.h>
+#include <celestia/hud.h>
 #include <celestia/celestiacore.h>
 #include <celutil/gettext.h>
 
@@ -393,7 +394,7 @@ CelestiaActions::slotAdjustLimitingMagnitude()
         // HACK!HACK!HACK!
         // Consider removal relevant entries from menus.
         // If search console is open then pass keys to it.
-        if (appCore->getTextEnterMode() != CelestiaCore::KbNormal)
+        if (appCore->getTextEnterMode() != celestia::Hud::TextEnterNormal)
         {
             appCore->charEntered(act->shortcut().toString().toUtf8().data());
             return;

--- a/src/celestia/textinput.cpp
+++ b/src/celestia/textinput.cpp
@@ -19,6 +19,7 @@
 #include <celengine/overlay.h>
 #include <celengine/rectangle.h>
 #include <celengine/simulation.h>
+#include <celutil/color.h>
 #include <celutil/gettext.h>
 #include <celutil/utf8.h>
 #include "hud.h"
@@ -26,6 +27,11 @@
 
 namespace celestia
 {
+
+namespace
+{
+constexpr Color consoleColor{ 0.7f, 0.7f, 1.0f, 0.2f };
+}
 
 std::string_view
 TextInput::getTypedText() const
@@ -71,6 +77,8 @@ TextInput::charEntered(const Simulation* sim, std::string_view c_p, bool withLoc
         return CharEnteredResult::Cancelled; // ESC
     case '\177':
         doBackTab();
+        break;
+    default:
         break;
     }
 
@@ -128,8 +136,8 @@ TextInput::doBackTab()
 {
     if (m_completionIdx > 0)
         m_completionIdx--;
-    else if (m_completionIdx == 0 || m_completion.size() > 0)
-        m_completionIdx = m_completion.size() - 1;
+    else if (m_completionIdx == 0 || !m_completion.empty())
+        m_completionIdx = static_cast<int>(m_completion.size() - 1);
 
     if (m_completionIdx >= 0)
     {
@@ -167,13 +175,14 @@ TextInput::reset()
 void
 TextInput::render(Overlay* overlay,
                   const HudFonts& hudFonts,
-                  const WindowMetrics& metrics,
-                  const Color& consoleColor) const
+                  const WindowMetrics& metrics) const
 {
     overlay->setFont(hudFonts.titleFont());
     overlay->savePos();
-    int rectHeight = hudFonts.fontHeight() * 3.0f + metrics.screenDpi / 25.4f * 9.3f + hudFonts.titleFontHeight();
-    celestia::Rect r(0, 0, metrics.width, metrics.insetBottom + rectHeight);
+    auto rectHeight = static_cast<int>(static_cast<float>(hudFonts.fontHeight()) * 3.0f +
+                                       static_cast<float>(metrics.screenDpi) / 25.4f * 9.3f +
+                                       static_cast<float>(hudFonts.titleFontHeight()));
+    celestia::Rect r(0, 0, static_cast<float>(metrics.width), static_cast<float>(metrics.insetBottom + rectHeight));
     r.setColor(consoleColor);
     overlay->drawRectangle(r);
     overlay->moveBy(metrics.getSafeAreaStart(), metrics.getSafeAreaBottom(rectHeight - hudFonts.titleFontHeight()));

--- a/src/celestia/textinput.cpp
+++ b/src/celestia/textinput.cpp
@@ -1,0 +1,145 @@
+// textinput.cpp
+//
+// Copyright (C) 2023, the Celestia Development Team
+//
+// Split out from celestiacore.h/celestiacore.cpp
+// Copyright (C) 2001-2009, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "textinput.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cwctype>
+
+#include <celengine/simulation.h>
+#include <celutil/utf8.h>
+
+namespace celestia
+{
+
+std::string_view
+TextInput::getTypedText() const
+{
+    return m_text;
+}
+
+util::array_view<std::string>
+TextInput::getCompletion() const
+{
+    return m_completion;
+}
+
+int
+TextInput::getCompletionIndex() const
+{
+    return m_completionIdx;
+}
+
+CharEnteredResult
+TextInput::charEntered(const Simulation* sim, std::string_view c_p, bool withLocations)
+{
+    char c = c_p.front();
+    if (std::int32_t uc = 0;
+        UTF8Decode(c_p, uc) && !(uc <= WCHAR_MAX && std::iswcntrl(static_cast<std::wint_t>(uc))))
+    {
+        appendText(sim, c_p, withLocations);
+    }
+    else if (c == '\b')
+    {
+        m_completionIdx = -1;
+        if (!m_text.empty())
+        {
+#ifdef AUTO_COMPLETION
+            do
+            {
+#endif
+                for (;;)
+                {
+                    auto ch = static_cast<std::byte>(m_text.back());
+                    m_text.pop_back();
+                    // If the string is empty, or the removed character was
+                    // not a UTF-8 continuation byte 0b10xx_xxxx then we're
+                    // done.
+                    if (m_text.empty() || (ch & std::byte(0xc0)) != std::byte(0x80))
+                        break;
+                }
+
+                m_completion.clear();
+                if (!m_text.empty())
+                        sim->getObjectCompletion(m_completion, m_text, withLocations);
+#ifdef AUTO_COMPLETION
+            } while (!typedText.empty() && typedTextCompletion.size() == 1);
+#endif
+        }
+    }
+    else if (c == '\011') // TAB
+    {
+        if (m_completionIdx + 1 < (int) m_completion.size())
+            m_completionIdx++;
+        else if ((int) m_completion.size() > 0 && m_completionIdx + 1 == (int) m_completion.size())
+            m_completionIdx = 0;
+
+        if (m_completionIdx >= 0)
+        {
+            auto pos = m_text.rfind('/');
+            m_text.resize(pos == std::string::npos ? 0 : (pos + 1));
+            m_text.append(m_completion[m_completionIdx]);
+        }
+    }
+    else if (c == '\177') // BackTab
+    {
+        if (m_completionIdx > 0)
+            m_completionIdx--;
+        else if (m_completionIdx == 0 || m_completion.size() > 0)
+            m_completionIdx = m_completion.size() - 1;
+
+        if (m_completionIdx >= 0)
+        {
+            auto pos = m_text.rfind('/');
+            m_text.resize(pos == std::string::npos ? 0 : (pos + 1));
+            m_text.append(m_completion[m_completionIdx]);
+        }
+    }
+    else if (c == '\033') // ESC
+    {
+        return CharEnteredResult::Cancelled;
+    }
+    else if (c == '\n' || c == '\r')
+    {
+        return CharEnteredResult::Finished;
+    }
+
+    return CharEnteredResult::Normal;
+}
+
+void
+TextInput::appendText(const Simulation* sim, std::string_view sv, bool withLocations)
+{
+    m_text.append(sv);
+    m_completion.clear();
+    sim->getObjectCompletion(m_completion, m_text, withLocations);
+    m_completionIdx = -1;
+#ifdef AUTO_COMPLETION
+    if (m_completion.size() == 1)
+    {
+        auto pos = m_text.rfind('/');
+        m_text.resize(pos == std::string::npos ? 0 : (pos + 1));
+        m_text.append(m_completion.front());
+    }
+#endif
+}
+
+void
+TextInput::reset()
+{
+    m_text.clear();
+    m_completion.clear();
+    m_completionIdx = -1;
+}
+
+} // end namespace celestia

--- a/src/celestia/textinput.cpp
+++ b/src/celestia/textinput.cpp
@@ -16,8 +16,13 @@
 #include <cstdint>
 #include <cwctype>
 
+#include <celengine/overlay.h>
+#include <celengine/rectangle.h>
 #include <celengine/simulation.h>
+#include <celutil/gettext.h>
 #include <celutil/utf8.h>
+#include "hud.h"
+#include "windowmetrics.h"
 
 namespace celestia
 {
@@ -48,73 +53,90 @@ TextInput::charEntered(const Simulation* sim, std::string_view c_p, bool withLoc
         UTF8Decode(c_p, uc) && !(uc <= WCHAR_MAX && std::iswcntrl(static_cast<std::wint_t>(uc))))
     {
         appendText(sim, c_p, withLocations);
+        return CharEnteredResult::Normal;
     }
-    else if (c == '\b')
-    {
-        m_completionIdx = -1;
-        if (!m_text.empty())
-        {
-#ifdef AUTO_COMPLETION
-            do
-            {
-#endif
-                for (;;)
-                {
-                    auto ch = static_cast<std::byte>(m_text.back());
-                    m_text.pop_back();
-                    // If the string is empty, or the removed character was
-                    // not a UTF-8 continuation byte 0b10xx_xxxx then we're
-                    // done.
-                    if (m_text.empty() || (ch & std::byte(0xc0)) != std::byte(0x80))
-                        break;
-                }
 
-                m_completion.clear();
-                if (!m_text.empty())
-                        sim->getObjectCompletion(m_completion, m_text, withLocations);
-#ifdef AUTO_COMPLETION
-            } while (!typedText.empty() && typedTextCompletion.size() == 1);
-#endif
-        }
-    }
-    else if (c == '\011') // TAB
+    switch (c)
     {
-        if (m_completionIdx + 1 < (int) m_completion.size())
-            m_completionIdx++;
-        else if ((int) m_completion.size() > 0 && m_completionIdx + 1 == (int) m_completion.size())
-            m_completionIdx = 0;
-
-        if (m_completionIdx >= 0)
-        {
-            auto pos = m_text.rfind('/');
-            m_text.resize(pos == std::string::npos ? 0 : (pos + 1));
-            m_text.append(m_completion[m_completionIdx]);
-        }
-    }
-    else if (c == '\177') // BackTab
-    {
-        if (m_completionIdx > 0)
-            m_completionIdx--;
-        else if (m_completionIdx == 0 || m_completion.size() > 0)
-            m_completionIdx = m_completion.size() - 1;
-
-        if (m_completionIdx >= 0)
-        {
-            auto pos = m_text.rfind('/');
-            m_text.resize(pos == std::string::npos ? 0 : (pos + 1));
-            m_text.append(m_completion[m_completionIdx]);
-        }
-    }
-    else if (c == '\033') // ESC
-    {
-        return CharEnteredResult::Cancelled;
-    }
-    else if (c == '\n' || c == '\r')
-    {
+    case '\b':
+        doBackspace(sim, withLocations);
+        break;
+    case '\t':
+        doTab();
+        break;
+    case '\n':
+    case '\r':
         return CharEnteredResult::Finished;
+    case '\033':
+        return CharEnteredResult::Cancelled; // ESC
+    case '\177':
+        doBackTab();
+        break;
     }
 
     return CharEnteredResult::Normal;
+}
+
+void
+TextInput::doBackspace(const Simulation* sim, bool withLocations)
+{
+    m_completionIdx = -1;
+    if (m_text.empty())
+        return;
+
+#ifdef AUTO_COMPLETION
+    do
+    {
+#endif
+        for (;;)
+        {
+            auto ch = static_cast<std::byte>(m_text.back());
+            m_text.pop_back();
+            // If the string is empty, or the removed character was
+            // not a UTF-8 continuation byte 0b10xx_xxxx then we're
+            // done.
+            if (m_text.empty() || (ch & std::byte(0xc0)) != std::byte(0x80))
+                break;
+        }
+
+        m_completion.clear();
+        if (!m_text.empty())
+                sim->getObjectCompletion(m_completion, m_text, withLocations);
+#ifdef AUTO_COMPLETION
+    } while (!typedText.empty() && typedTextCompletion.size() == 1);
+#endif
+}
+
+void
+TextInput::doTab()
+{
+    if (m_completionIdx + 1 < (int) m_completion.size())
+        m_completionIdx++;
+    else if ((int) m_completion.size() > 0 && m_completionIdx + 1 == (int) m_completion.size())
+        m_completionIdx = 0;
+
+    if (m_completionIdx >= 0)
+    {
+        auto pos = m_text.rfind('/');
+        m_text.resize(pos == std::string::npos ? 0 : (pos + 1));
+        m_text.append(m_completion[m_completionIdx]);
+    }
+}
+
+void
+TextInput::doBackTab()
+{
+    if (m_completionIdx > 0)
+        m_completionIdx--;
+    else if (m_completionIdx == 0 || m_completion.size() > 0)
+        m_completionIdx = m_completion.size() - 1;
+
+    if (m_completionIdx >= 0)
+    {
+        auto pos = m_text.rfind('/');
+        m_text.resize(pos == std::string::npos ? 0 : (pos + 1));
+        m_text.append(m_completion[m_completionIdx]);
+    }
 }
 
 void
@@ -140,6 +162,67 @@ TextInput::reset()
     m_text.clear();
     m_completion.clear();
     m_completionIdx = -1;
+}
+
+void
+TextInput::render(Overlay* overlay,
+                  const HudFonts& hudFonts,
+                  const WindowMetrics& metrics,
+                  const Color& consoleColor) const
+{
+    overlay->setFont(hudFonts.titleFont());
+    overlay->savePos();
+    int rectHeight = hudFonts.fontHeight() * 3.0f + metrics.screenDpi / 25.4f * 9.3f + hudFonts.titleFontHeight();
+    celestia::Rect r(0, 0, metrics.width, metrics.insetBottom + rectHeight);
+    r.setColor(consoleColor);
+    overlay->drawRectangle(r);
+    overlay->moveBy(metrics.getSafeAreaStart(), metrics.getSafeAreaBottom(rectHeight - hudFonts.titleFontHeight()));
+    overlay->setColor(0.6f, 0.6f, 1.0f, 1.0f);
+    overlay->beginText();
+    overlay->print(_("Target name: {}"), m_text);
+    overlay->endText();
+    overlay->setFont(hudFonts.font());
+    if (!m_completion.empty())
+        renderCompletion(overlay, metrics, hudFonts.fontHeight());
+
+    overlay->restorePos();
+    overlay->setFont(hudFonts.font());
+}
+
+void
+TextInput::renderCompletion(Overlay* overlay, const WindowMetrics& metrics, int fontHeight) const
+{
+    constexpr int nb_cols = 4;
+    constexpr int nb_lines = 3;
+    constexpr int spacing = 3;
+    int start = 0;
+    overlay->moveBy(spacing, -fontHeight - spacing);
+    auto iter = m_completion.begin();
+    auto typedTextCompletionIdx = m_completionIdx;
+    if (typedTextCompletionIdx >= nb_cols * nb_lines)
+    {
+        start = (typedTextCompletionIdx / nb_lines + 1 - nb_cols) * nb_lines;
+        iter += start;
+    }
+
+    int columnWidth = metrics.getSafeAreaWidth() / nb_cols;
+    for (int i = 0; iter < m_completion.end() && i < nb_cols; i++)
+    {
+        overlay->savePos();
+        overlay->beginText();
+        for (int j = 0; iter < m_completion.end() && j < nb_lines; iter++, j++)
+        {
+            if (i * nb_lines + j == typedTextCompletionIdx - start)
+                overlay->setColor(1.0f, 0.6f, 0.6f, 1);
+            else
+                overlay->setColor(0.6f, 0.6f, 1.0f, 1);
+            overlay->print(*iter);
+            overlay->print("\n");
+        }
+        overlay->endText();
+        overlay->restorePos();
+        overlay->moveBy(metrics.layoutDirection == LayoutDirection::RightToLeft ? -columnWidth : columnWidth, 0);
+    }
 }
 
 } // end namespace celestia

--- a/src/celestia/textinput.h
+++ b/src/celestia/textinput.h
@@ -1,0 +1,50 @@
+// textinput.h
+//
+// Copyright (C) 2023, the Celestia Development Team
+//
+// Split out from celestiacore.h/celestiacore.cpp
+// Copyright (C) 2001-2009, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <celutil/array_view.h>
+
+class Simulation;
+
+namespace celestia
+{
+
+enum class CharEnteredResult
+{
+    Normal,
+    Finished,
+    Cancelled,
+};
+
+class TextInput
+{
+public:
+    std::string_view getTypedText() const;
+    util::array_view<std::string> getCompletion() const;
+    int getCompletionIndex() const;
+
+    CharEnteredResult charEntered(const Simulation*, std::string_view, bool withLocations);
+    void appendText(const Simulation*, std::string_view, bool withLocations);
+    void reset();
+
+private:
+    std::string m_text;
+    std::vector<std::string> m_completion;
+    int m_completionIdx{ -1 };
+};
+
+}

--- a/src/celestia/textinput.h
+++ b/src/celestia/textinput.h
@@ -18,10 +18,15 @@
 
 #include <celutil/array_view.h>
 
+class Color;
+class Overlay;
 class Simulation;
 
 namespace celestia
 {
+
+class HudFonts;
+struct WindowMetrics;
 
 enum class CharEnteredResult
 {
@@ -41,7 +46,15 @@ public:
     void appendText(const Simulation*, std::string_view, bool withLocations);
     void reset();
 
+    void render(Overlay*, const HudFonts&, const WindowMetrics&, const Color&) const;
+
 private:
+    void doBackspace(const Simulation*, bool);
+    void doTab();
+    void doBackTab();
+
+    void renderCompletion(Overlay*, const WindowMetrics&, int) const;
+
     std::string m_text;
     std::vector<std::string> m_completion;
     int m_completionIdx{ -1 };

--- a/src/celestia/textinput.h
+++ b/src/celestia/textinput.h
@@ -46,7 +46,7 @@ public:
     void appendText(const Simulation*, std::string_view, bool withLocations);
     void reset();
 
-    void render(Overlay*, const HudFonts&, const WindowMetrics&, const Color&) const;
+    void render(Overlay*, const HudFonts&, const WindowMetrics&) const;
 
 private:
     void doBackspace(const Simulation*, bool);

--- a/src/celestia/textprintposition.cpp
+++ b/src/celestia/textprintposition.cpp
@@ -1,20 +1,27 @@
 #include "textprintposition.h"
-#include "celestiacore.h"
+
+#include "windowmetrics.h"
 
 namespace celestia
 {
 
-AbsoluteTextPrintPosition::AbsoluteTextPrintPosition(int x, int y) : TextPrintPosition(), x(x), y(y)
+AbsoluteTextPrintPosition::AbsoluteTextPrintPosition(int x, int y) :
+    TextPrintPosition(), x(x), y(y)
 {
 }
 
-void AbsoluteTextPrintPosition::resolvePixelPosition(CelestiaCore*, int& x, int& y)
+
+void
+AbsoluteTextPrintPosition::resolvePixelPosition(const WindowMetrics&, int& x, int& y)
 {
     x = this->x;
     y = this->y;
 }
 
-RelativeTextPrintPosition::RelativeTextPrintPosition(int hOrigin, int vOrigin, int hOffset, int vOffset, int emWidth, int fontHeight) :
+
+RelativeTextPrintPosition::RelativeTextPrintPosition(int hOrigin, int vOrigin,
+                                                     int hOffset, int vOffset,
+                                                     int emWidth, int fontHeight) :
     TextPrintPosition(),
     messageHOrigin(hOrigin),
     messageVOrigin(vOrigin),
@@ -25,7 +32,9 @@ RelativeTextPrintPosition::RelativeTextPrintPosition(int hOrigin, int vOrigin, i
 {
 };
 
-void RelativeTextPrintPosition::resolvePixelPosition(CelestiaCore* appCore, int& x, int& y)
+
+void
+RelativeTextPrintPosition::resolvePixelPosition(const WindowMetrics& metrics, int& x, int& y)
 {
     auto offsetX = messageHOffset * emWidth;
     auto offsetY = messageVOffset * fontHeight;
@@ -33,41 +42,37 @@ void RelativeTextPrintPosition::resolvePixelPosition(CelestiaCore* appCore, int&
     if (messageHOrigin == 0)
     {
         // Align horizontal center with offsetX adjusted to layout direction
-        x += (appCore->getSafeAreaStart() + appCore->getSafeAreaEnd()) / 2;
-        if (appCore->getLayoutDirection() == CelestiaCore::LayoutDirection::RightToLeft)
-        {
+        x += (metrics.getSafeAreaStart() + metrics.getSafeAreaEnd()) / 2;
+        if (metrics.layoutDirection == LayoutDirection::RightToLeft)
             x -= offsetX;
-        }
         else
-        {
             x += offsetX;
-        }
     }
     else if (messageHOrigin > 0)
     {
         // Align horizontal end
-        x = appCore->getSafeAreaEnd(-offsetX);
+        x = metrics.getSafeAreaEnd(-offsetX);
     }
     else
     {
         // Align horizontal start
-        x = appCore->getSafeAreaStart(offsetX);
+        x = metrics.getSafeAreaStart(offsetX);
     }
 
     if (messageVOrigin == 0)
     {
         // Align vertical center
-        y = (appCore->getSafeAreaTop() + appCore->getSafeAreaBottom()) / 2 + offsetY;
+        y = (metrics.getSafeAreaTop() + metrics.getSafeAreaBottom()) / 2 + offsetY;
     }
     else if (messageVOrigin > 0)
     {
         // Align top
-        y = appCore->getSafeAreaTop(-offsetY);
+        y = metrics.getSafeAreaTop(-offsetY);
     }
     else
     {
         // Align bottom
-        y = appCore->getSafeAreaBottom(offsetY - fontHeight);
+        y = metrics.getSafeAreaBottom(offsetY - fontHeight);
     }
 }
 

--- a/src/celestia/textprintposition.cpp
+++ b/src/celestia/textprintposition.cpp
@@ -62,8 +62,8 @@ TextPrintPosition::resolvePixelPosition(const WindowMetrics& metrics, int& x, in
         return;
     }
 
-    auto horizontalOffset = flags & Flags::HorizontalOffset;
-    if (horizontalOffset == Flags::HorizontalMiddle)
+    if (auto horizontalOffset = flags & Flags::HorizontalOffset;
+        horizontalOffset == Flags::HorizontalMiddle)
     {
         // Align horizontal center with offsetX adjusted to layout direction
         x += (metrics.getSafeAreaStart() + metrics.getSafeAreaEnd()) / 2;
@@ -83,8 +83,8 @@ TextPrintPosition::resolvePixelPosition(const WindowMetrics& metrics, int& x, in
         x = metrics.getSafeAreaEnd(-offsetX);
     }
 
-    auto verticalOffset = flags & Flags::VerticalOffset;
-    if (verticalOffset == Flags::VerticalMiddle)
+    if (auto verticalOffset = flags & Flags::VerticalOffset;
+        verticalOffset == Flags::VerticalMiddle)
     {
         // Align vertical center
         y = (metrics.getSafeAreaTop() + metrics.getSafeAreaBottom()) / 2 + offsetY;

--- a/src/celestia/textprintposition.h
+++ b/src/celestia/textprintposition.h
@@ -1,15 +1,18 @@
 #pragma once
 
-class CelestiaCore;
-
 namespace celestia
 {
+
+struct WindowMetrics;
+
+
 class TextPrintPosition
 {
  public:
-    virtual void resolvePixelPosition(CelestiaCore* appCore, int& x, int& y) = 0;
+    virtual void resolvePixelPosition(const WindowMetrics& metrics, int& x, int& y) = 0;
     virtual ~TextPrintPosition() = default;
 };
+
 
 class AbsoluteTextPrintPosition: public TextPrintPosition
 {
@@ -17,11 +20,12 @@ class AbsoluteTextPrintPosition: public TextPrintPosition
     AbsoluteTextPrintPosition(int x, int y);
     ~AbsoluteTextPrintPosition() override = default;
 
-    void resolvePixelPosition(CelestiaCore*, int& x, int& y) override;
+    void resolvePixelPosition(const WindowMetrics& metrics, int& x, int& y) override;
  private:
     int x;
     int y;
 };
+
 
 class RelativeTextPrintPosition: public TextPrintPosition
 {
@@ -29,7 +33,7 @@ class RelativeTextPrintPosition: public TextPrintPosition
     RelativeTextPrintPosition(int hOrigin, int vOrigin, int hOffset, int vOffset, int emWidth, int fontHeight);
 
     ~RelativeTextPrintPosition() override = default;
-    void resolvePixelPosition(CelestiaCore* appCore, int& x, int& y) override;
+    void resolvePixelPosition(const WindowMetrics& metrics, int& x, int& y) override;
 
  private:
     int messageHOrigin;
@@ -39,4 +43,5 @@ class RelativeTextPrintPosition: public TextPrintPosition
     int emWidth;
     int fontHeight;
 };
+
 }

--- a/src/celestia/textprintposition.h
+++ b/src/celestia/textprintposition.h
@@ -5,43 +5,41 @@ namespace celestia
 
 struct WindowMetrics;
 
-
 class TextPrintPosition
 {
- public:
-    virtual void resolvePixelPosition(const WindowMetrics& metrics, int& x, int& y) = 0;
-    virtual ~TextPrintPosition() = default;
-};
+public:
+    TextPrintPosition() = default;
+    static TextPrintPosition absolute(int x, int y);
+    static TextPrintPosition relative(int hOrigin, int vOrigin,
+                                      int hOffset, int vOffset,
+                                      int emWidth, int fontHeight);
 
+    void resolvePixelPosition(const WindowMetrics& metrics, int& x, int& y) const;
 
-class AbsoluteTextPrintPosition: public TextPrintPosition
-{
- public:
-    AbsoluteTextPrintPosition(int x, int y);
-    ~AbsoluteTextPrintPosition() override = default;
+private:
+    enum Flags : unsigned int
+    {
+        Relative           = 0x00,
+        Absolute           = 0x01,
+        PositionType       = 0x01,
+        HorizontalStart    = 0x00,
+        HorizontalMiddle   = 0x02,
+        HorizontalEnd      = 0x04,
+        HorizontalOffset   = 0x06,
+        VerticalBottom     = 0x00,
+        VerticalMiddle     = 0x08,
+        VerticalTop        = 0x0f,
+        VerticalOffset     = 0x18,
+    };
 
-    void resolvePixelPosition(const WindowMetrics& metrics, int& x, int& y) override;
- private:
-    int x;
-    int y;
-};
+    explicit TextPrintPosition(Flags, int, int, int);
 
+    Flags flags{ Flags::Absolute };
+    int offsetX{ 0 };
+    int offsetY{ 0 };
+    int fontHeight{ 0 };
 
-class RelativeTextPrintPosition: public TextPrintPosition
-{
- public:
-    RelativeTextPrintPosition(int hOrigin, int vOrigin, int hOffset, int vOffset, int emWidth, int fontHeight);
-
-    ~RelativeTextPrintPosition() override = default;
-    void resolvePixelPosition(const WindowMetrics& metrics, int& x, int& y) override;
-
- private:
-    int messageHOrigin;
-    int messageVOrigin;
-    int messageHOffset;
-    int messageVOffset;
-    int emWidth;
-    int fontHeight;
+    friend Flags& operator|=(Flags&, Flags);
 };
 
 }

--- a/src/celestia/textprintposition.h
+++ b/src/celestia/textprintposition.h
@@ -19,17 +19,20 @@ public:
 private:
     enum Flags : unsigned int
     {
+        // bit 0: relative/absolute
+        PositionType       = 0x01, // mask
         Relative           = 0x00,
         Absolute           = 0x01,
-        PositionType       = 0x01,
+        // bits 1-2: horizontal offset
+        HorizontalOffset   = 0x06, // mask
         HorizontalStart    = 0x00,
         HorizontalMiddle   = 0x02,
         HorizontalEnd      = 0x04,
-        HorizontalOffset   = 0x06,
+        // bits 3-4: vertical offset
+        VerticalOffset     = 0x18, // mask
         VerticalBottom     = 0x00,
         VerticalMiddle     = 0x08,
-        VerticalTop        = 0x0f,
-        VerticalOffset     = 0x18,
+        VerticalTop        = 0x10,
     };
 
     explicit TextPrintPosition(Flags, int, int, int);

--- a/src/celestia/timeinfo.h
+++ b/src/celestia/timeinfo.h
@@ -1,0 +1,25 @@
+// timeinfo.h
+//
+// Copyright (C) 2023, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+namespace celestia
+{
+
+struct TimeInfo
+{
+    static constexpr double MinimumTimeRate = 1.0e-15;
+
+    double currentTime{ 0.0 };
+    float fps{ 0.0f };
+    int timeZoneBias{ 0 }; // Diff in secs between local time and GMT
+    bool lightTravelFlag{ false };
+};
+
+}

--- a/src/celestia/view.h
+++ b/src/celestia/view.h
@@ -15,8 +15,7 @@
 class Color;
 class FramebufferObject;
 class Observer;
-class Renderer;
-
+class Overlay;
 
 namespace celestia
 {
@@ -31,7 +30,7 @@ public:
         VerticalSplit   = 3
     };
 
-    View(Type, Renderer*, Observer*, float, float, float, float);
+    View(Type, Observer*, float, float, float, float);
     View() = delete;
     ~View();
     View(const View&) = delete;
@@ -45,17 +44,16 @@ public:
 
     Observer* getObserver() const;
     bool isRootView() const;
-    bool isSplittable(Type type) const;
-    void split(Type type, Observer *o, float splitPos, View **split, View **view);
+    bool isSplittable(Type _type) const;
+    void split(Type _type, Observer *o, float splitPos, View **split, View **view);
     void reset();
     static View* remove(View*);
-    void drawBorder(int gWidth, int gHeight, const Color &color, float linewidth = 1.0f) const;
+    void drawBorder(Overlay*, int gWidth, int gHeight, const Color &color, float linewidth = 1.0f) const;
     void updateFBO(int gWidth, int gHeight);
     FramebufferObject *getFBO() const;
 
     Type           type;
 
-    Renderer      *renderer;
     Observer      *observer;
     View          *parent          { nullptr };
     View          *child1          { nullptr };
@@ -64,8 +62,6 @@ public:
     float          y;
     float          width;
     float          height;
-    std::uint64_t  renderFlags     { 0 };
-    int            labelMode       { 0 };
 
 private:
     std::unique_ptr<FramebufferObject> fbo;

--- a/src/celestia/view.h
+++ b/src/celestia/view.h
@@ -9,16 +9,21 @@
 
 #pragma once
 
-class Renderer;
-class Observer;
-class Color;
+#include <cstdint>
+#include <memory>
 
-//namespace celestia
-//{
+class Color;
+class FramebufferObject;
+class Observer;
+class Renderer;
+
+
+namespace celestia
+{
 
 class View
 {
- public:
+public:
     enum Type
     {
         ViewWindow      = 1,
@@ -28,7 +33,7 @@ class View
 
     View(Type, Renderer*, Observer*, float, float, float, float);
     View() = delete;
-    ~View() = default;
+    ~View();
     View(const View&) = delete;
     View(View&&) = delete;
     const View& operator=(const View&) = delete;
@@ -44,27 +49,26 @@ class View
     void split(Type type, Observer *o, float splitPos, View **split, View **view);
     void reset();
     static View* remove(View*);
-    void drawBorder(int gWidth, int gHeight, const Color &color, float linewidth = 1.0f);
+    void drawBorder(int gWidth, int gHeight, const Color &color, float linewidth = 1.0f) const;
     void updateFBO(int gWidth, int gHeight);
     FramebufferObject *getFBO() const;
 
- public:
-    Type      type;
+    Type           type;
 
-    Renderer *renderer;
-    Observer *observer;
-    View     *parent          { nullptr };
-    View     *child1          { nullptr };
-    View     *child2          { nullptr };
-    float     x;
-    float     y;
-    float     width;
-    float     height;
-    uint64_t  renderFlags     { 0 };
-    int       labelMode       { 0 };
+    Renderer      *renderer;
+    Observer      *observer;
+    View          *parent          { nullptr };
+    View          *child1          { nullptr };
+    View          *child2          { nullptr };
+    float          x;
+    float          y;
+    float          width;
+    float          height;
+    std::uint64_t  renderFlags     { 0 };
+    int            labelMode       { 0 };
 
 private:
     std::unique_ptr<FramebufferObject> fbo;
 };
 
-//}
+}

--- a/src/celestia/viewmanager.cpp
+++ b/src/celestia/viewmanager.cpp
@@ -85,12 +85,6 @@ ViewManager::activeView() const
     return *m_activeView;
 }
 
-double
-ViewManager::flashFrameStart() const
-{
-    return m_flashFrameStart;
-}
-
 void
 ViewManager::flashFrameStart(double currentTime)
 {
@@ -331,6 +325,37 @@ ViewManager::deleteView(Simulation* sim, View* v)
     sim->setActiveObserver((*m_activeView)->observer);
 
     return true;
+}
+
+void
+ViewManager::renderBorders(const WindowMetrics& metrics, double currentTime) const
+{
+    if (m_views.size() < 2)
+        return;
+
+    // Render a thin border arround all views
+    if (showViewFrames || m_resizeSplit)
+    {
+        for(const auto v : m_views)
+        {
+            if (v->type == View::ViewWindow)
+                v->drawBorder(metrics.width, metrics.height, frameColor);
+        }
+    }
+
+    // Render a very simple border around the active view
+    const View* av = *m_activeView;
+
+    if (showActiveViewFrame)
+    {
+        av->drawBorder(metrics.width, metrics.height, activeFrameColor, 2);
+    }
+
+    if (currentTime < m_flashFrameStart + 0.5)
+    {
+        float alpha = (float) (1.0 - (currentTime - m_flashFrameStart) / 0.5);
+        av->drawBorder(metrics.width, metrics.height, {activeFrameColor, alpha}, 8);
+    }
 }
 
 } // end namespace celestia

--- a/src/celestia/viewmanager.cpp
+++ b/src/celestia/viewmanager.cpp
@@ -1,0 +1,336 @@
+// viewmanager.cpp
+//
+// Copyright (C) 2023, the Celestia Development Team
+//
+// Split out from celestiacore.h/celestiacore.cpp
+// Copyright (C) 2001-2009, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "viewmanager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <tuple>
+#include <utility>
+
+#include <celengine/observer.h>
+#include <celengine/simulation.h>
+#include "windowmetrics.h"
+
+namespace celestia
+{
+
+namespace
+{
+
+constexpr float borderSize = 2.0f;
+
+inline std::pair<float, float>
+metricsSizeFloat(const WindowMetrics& metrics)
+{
+    return std::make_pair(static_cast<float>(metrics.width), static_cast<float>(metrics.height));
+}
+
+bool
+pointOutsideView(const View& view,
+                 float mwidth, float mheight,
+                 float x, float y)
+{
+    return x + borderSize < view.x * mwidth ||
+        x - borderSize > (view.x + view.width) * mwidth ||
+        (mheight - y) + borderSize < view.y * mheight ||
+        (mheight - y) - borderSize > (view.y + view.height) * mheight;
+}
+
+std::tuple<float, float, float, float>
+viewBoundaryTestValues(const View& view,
+                       float mwidth, float mheight,
+                       float x, float y)
+{
+    float vx = (x / mwidth - view.x) / view.width;
+    float vy = ((1 - y / mheight) - view.y ) / view.height;
+    float vxp = vx * view.width * mwidth;
+    float vyp = vy * view.height * mheight;
+    return std::make_tuple(vx, vy, vxp, vyp);
+}
+
+inline bool
+testEdge(float vpara, float vperpp, float vperpDim, float mperpDim)
+{
+    return vpara >= 0.0f && vpara <= 1.0f &&
+           (std::abs(vperpp) <= borderSize || std::abs(vperpp - vperpDim * mperpDim) <= borderSize);
+}
+
+} // end unnamed namespace
+
+ViewManager::ViewManager(View* view)
+{
+    m_views.push_back(view);
+    m_activeView = m_views.begin();
+}
+
+const std::list<View*>&
+ViewManager::views() const
+{
+    return m_views;
+}
+
+const View*
+ViewManager::activeView() const
+{
+    return *m_activeView;
+}
+
+double
+ViewManager::flashFrameStart() const
+{
+    return m_flashFrameStart;
+}
+
+void
+ViewManager::flashFrameStart(double currentTime)
+{
+    m_flashFrameStart = currentTime;
+}
+
+bool
+ViewManager::isResizing() const
+{
+    return m_resizeSplit != nullptr;
+}
+
+ViewBorderType
+ViewManager::checkViewBorder(const WindowMetrics& metrics, float x, float y) const
+{
+    auto [mwidth, mheight] = metricsSizeFloat(metrics);
+    for (const auto v : m_views)
+    {
+        if (v->type != View::ViewWindow)
+            continue;
+
+        auto [vx, vy, vxp, vyp] = viewBoundaryTestValues(*v, mwidth, mheight, x, y);
+        if (testEdge(vx, vyp, v->height, mheight))
+            return ViewBorderType::SizeVertical;
+
+        if (testEdge(vy, vxp, v->width, mwidth))
+            return ViewBorderType::SizeHorizontal;
+    }
+
+    return ViewBorderType::None;
+}
+
+/// Makes the view under x, y the active view.
+bool
+ViewManager::pickView(Simulation* sim, const WindowMetrics& metrics, float x, float y)
+{
+    // Clang does not support capturing structured bindings, so work with the pair here
+    auto msize = metricsSizeFloat(metrics);
+    if (!pointOutsideView(**m_activeView, msize.first, msize.second, x, y))
+        return false;
+
+    m_activeView = std::find_if(m_views.begin(), m_views.end(),
+                                [&msize, x, y](const View* view) {
+                                    return view->type == View::ViewWindow &&
+                                           !pointOutsideView(*view, msize.first, msize.second, x, y);
+                                });
+
+    // Make sure that we're left with a valid view
+    if (m_activeView == m_views.end())
+        m_activeView = m_views.begin();
+
+    sim->setActiveObserver((*m_activeView)->observer);
+    return true;
+}
+
+void
+ViewManager::nextView(Simulation* sim)
+{
+    do
+    {
+        ++m_activeView;
+        if (m_activeView == m_views.end())
+            m_activeView = m_views.begin();
+    } while ((*m_activeView)->type != View::ViewWindow);
+    sim->setActiveObserver((*m_activeView)->observer);
+}
+
+void
+ViewManager::tryStartResizing(const WindowMetrics& metrics, float x, float y)
+{
+    View* v1 = nullptr;
+    View* v2 = nullptr;
+    auto [mwidth, mheight] = metricsSizeFloat(metrics);
+    for (View* v : m_views)
+    {
+        if (v->type != View::ViewWindow)
+            continue;
+
+        auto [vx, vy, vxp, vyp] = viewBoundaryTestValues(*v, mwidth, mheight, x, y);
+        if (testEdge(vx, vyp, v->height, mheight) || testEdge(vy, vxp, v->width, mwidth))
+        {
+            if (v1 == nullptr)
+            {
+                v1 = v;
+            }
+            else
+            {
+                v2 = v;
+                break;
+            }
+        }
+    }
+
+    if (v2 == nullptr)
+        return;
+
+    // Look for common ancestor to v1 & v2 = split being dragged.
+    View *p1 = v1;
+    View *p2 = v2;
+    while ((p1 = p1->parent) != nullptr )
+    {
+        p2 = v2;
+        while (((p2 = p2->parent) != nullptr) && p1 != p2) ;
+        if (p2 != nullptr)
+            break;
+    }
+
+    if (p2 != nullptr)
+        m_resizeSplit = p1;
+}
+
+bool
+ViewManager::resizeViews(const WindowMetrics& metrics, float dx, float dy)
+{
+    if (!isResizing())
+        return false;
+
+    switch(m_resizeSplit->type)
+    {
+    case View::HorizontalSplit:
+        if (m_resizeSplit->walkTreeResizeDelta(m_resizeSplit->child1, dy / metrics.height, true) &&
+            m_resizeSplit->walkTreeResizeDelta(m_resizeSplit->child2, dy / metrics.height, true))
+        {
+            m_resizeSplit->walkTreeResizeDelta(m_resizeSplit->child1, dy / metrics.height, false);
+            m_resizeSplit->walkTreeResizeDelta(m_resizeSplit->child2, dy / metrics.height, false);
+        }
+        break;
+    case View::VerticalSplit:
+        if (m_resizeSplit->walkTreeResizeDelta(m_resizeSplit->child1, dx / metrics.width, true) &&
+            m_resizeSplit->walkTreeResizeDelta(m_resizeSplit->child2, dx / metrics.width, true))
+        {
+            m_resizeSplit->walkTreeResizeDelta(m_resizeSplit->child1, dx / metrics.width, false);
+            m_resizeSplit->walkTreeResizeDelta(m_resizeSplit->child2, dx / metrics.width, false);
+        }
+        break;
+    case View::ViewWindow:
+        break;
+    }
+
+    return true;
+}
+
+bool
+ViewManager::stopResizing()
+{
+    if (m_resizeSplit == nullptr)
+        return false;
+
+    m_resizeSplit = nullptr;
+    return true;
+}
+
+ViewSplitResult
+ViewManager::splitView(Simulation* sim, View::Type type, View* av, float splitPos)
+{
+    if (type == View::ViewWindow)
+        return ViewSplitResult::Ignored;
+
+    if (av == nullptr)
+        av = *m_activeView;
+
+    if (!av->isSplittable(type))
+        return ViewSplitResult::NotSplittable;
+
+    Observer* o = sim->duplicateActiveObserver();
+
+    View* split;
+    View* view;
+    av->split(type, o, splitPos, &split, &view);
+    m_views.push_back(split);
+    m_views.push_back(view);
+
+    return ViewSplitResult::Ok;
+}
+
+void
+ViewManager::singleView(Simulation* sim, const View* av)
+{
+    if (av == nullptr)
+        av = *m_activeView;
+
+    auto start = m_views.begin();
+    auto it = std::find(start, m_views.end(), av);
+    if (it == m_views.end())
+        return;
+
+    if (it != start)
+        std::iter_swap(start, it);
+
+    ++start;
+    for (auto delIter = start; delIter != m_views.end(); ++delIter)
+    {
+        sim->removeObserver((*delIter)->getObserver());
+        delete (*delIter)->getObserver();
+        delete (*delIter);
+    }
+
+    m_views.resize(1);
+
+    m_activeView = m_views.begin();
+    (*m_activeView)->reset();
+    sim->setActiveObserver((*m_activeView)->observer);
+}
+
+void
+ViewManager::setActiveView(Simulation* sim, const View* view)
+{
+    auto it = std::find(m_views.begin(), m_views.end(), view);
+    if (it == m_views.end())
+        return;
+
+    m_activeView = it;
+    sim->setActiveObserver((*m_activeView)->observer);
+}
+
+bool
+ViewManager::deleteView(Simulation* sim, View* v)
+{
+    if (v == nullptr)
+        v = *m_activeView;
+
+    if (v->isRootView())
+        return false;
+
+    //Erase view and parent view from views
+    m_views.erase(std::remove_if(m_views.begin(), m_views.end(),
+                                 [v](const auto mv) { return mv == v || mv == v->parent; }),
+                  m_views.end());
+
+    sim->removeObserver(v->getObserver());
+    delete(v->getObserver());
+    auto sibling = View::remove(v);
+
+    View* nextActiveView = sibling;
+    while (nextActiveView->type != View::ViewWindow)
+        nextActiveView = nextActiveView->child1;
+    m_activeView = std::find(m_views.begin(), m_views.end(), nextActiveView);
+    sim->setActiveObserver((*m_activeView)->observer);
+
+    return true;
+}
+
+} // end namespace celestia

--- a/src/celestia/viewmanager.h
+++ b/src/celestia/viewmanager.h
@@ -14,6 +14,7 @@
 
 #include <list>
 
+#include <celutil/color.h>
 #include "view.h"
 
 class Simulation;
@@ -44,7 +45,6 @@ public:
 
     const std::list<View*>& views() const;
     const View* activeView() const;
-    double flashFrameStart() const;
     void flashFrameStart(double);
     bool isResizing() const;
 
@@ -62,11 +62,19 @@ public:
     void setActiveView(Simulation*, const View*);
     bool deleteView(Simulation*, View*);
 
+    void renderBorders(const WindowMetrics&, double) const;
+
+    bool showViewFrames{ true };
+    bool showActiveViewFrame{ false };
+
 private:
     std::list<View*> m_views;
     std::list<View*>::iterator m_activeView;
     View* m_resizeSplit{ nullptr };
     double m_flashFrameStart{ 0.0 };
+
+    Color frameColor{ 0.5f, 0.5f, 0.5f, 1.0f };
+    Color activeFrameColor{ 0.5f, 0.5f, 1.0f, 1.0f };
 };
 
 }

--- a/src/celestia/viewmanager.h
+++ b/src/celestia/viewmanager.h
@@ -1,0 +1,72 @@
+// viewmanager.h
+//
+// Copyright (C) 2023, the Celestia Development Team
+//
+// Split out from celestiacore.h/celestiacore.cpp
+// Copyright (C) 2001-2009, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <list>
+
+#include "view.h"
+
+class Simulation;
+
+namespace celestia
+{
+
+struct WindowMetrics;
+
+enum class ViewBorderType
+{
+    None,
+    SizeHorizontal,
+    SizeVertical,
+};
+
+enum class ViewSplitResult
+{
+    Ignored,
+    NotSplittable,
+    Ok,
+};
+
+class ViewManager
+{
+public:
+    explicit ViewManager(View*);
+
+    const std::list<View*>& views() const;
+    const View* activeView() const;
+    double flashFrameStart() const;
+    void flashFrameStart(double);
+    bool isResizing() const;
+
+    ViewBorderType checkViewBorder(const WindowMetrics&, float x, float y) const;
+
+    bool pickView(Simulation*, const WindowMetrics&, float x, float y);
+    void nextView(Simulation*);
+
+    void tryStartResizing(const WindowMetrics&, float x, float y);
+    bool resizeViews(const WindowMetrics&, float dx, float dy);
+    bool stopResizing();
+
+    ViewSplitResult splitView(Simulation*, View::Type, View*, float);
+    void singleView(Simulation*, const View*);
+    void setActiveView(Simulation*, const View*);
+    bool deleteView(Simulation*, View*);
+
+private:
+    std::list<View*> m_views;
+    std::list<View*>::iterator m_activeView;
+    View* m_resizeSplit{ nullptr };
+    double m_flashFrameStart{ 0.0 };
+};
+
+}

--- a/src/celestia/viewmanager.h
+++ b/src/celestia/viewmanager.h
@@ -12,11 +12,12 @@
 
 #pragma once
 
+#include <limits>
 #include <list>
 
-#include <celutil/color.h>
 #include "view.h"
 
+class Overlay;
 class Simulation;
 
 namespace celestia
@@ -45,12 +46,10 @@ public:
 
     const std::list<View*>& views() const;
     const View* activeView() const;
-    void flashFrameStart(double);
-    bool isResizing() const;
 
     ViewBorderType checkViewBorder(const WindowMetrics&, float x, float y) const;
 
-    bool pickView(Simulation*, const WindowMetrics&, float x, float y);
+    void pickView(Simulation*, const WindowMetrics&, float x, float y);
     void nextView(Simulation*);
 
     void tryStartResizing(const WindowMetrics&, float x, float y);
@@ -62,19 +61,23 @@ public:
     void setActiveView(Simulation*, const View*);
     bool deleteView(Simulation*, View*);
 
-    void renderBorders(const WindowMetrics&, double) const;
+    void renderBorders(Overlay*, const WindowMetrics&, double) const;
 
-    bool showViewFrames{ true };
-    bool showActiveViewFrame{ false };
+    bool showViewFrames() const noexcept { return m_showViewFrames; }
+    void showViewFrames(bool value) noexcept { m_showViewFrames = value; }
+    bool showActiveViewFrame() const noexcept { return m_showActiveViewFrame; }
+    void showActiveViewFrame(bool value) noexcept { m_showActiveViewFrame = value; }
 
 private:
     std::list<View*> m_views;
     std::list<View*>::iterator m_activeView;
     View* m_resizeSplit{ nullptr };
-    double m_flashFrameStart{ 0.0 };
 
-    Color frameColor{ 0.5f, 0.5f, 0.5f, 1.0f };
-    Color activeFrameColor{ 0.5f, 0.5f, 1.0f, 1.0f };
+    mutable double m_flashFrameStart{ -std::numeric_limits<double>::infinity() };
+    mutable bool m_startFlash{ false };
+
+    bool m_showViewFrames{ true };
+    bool m_showActiveViewFrame{ false };
 };
 
 }

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -4287,11 +4287,11 @@ LRESULT CALLBACK MainWindowProc(HWND hWnd,
             break;
 
         case ID_VIEW_HSPLIT:
-            appCore->splitView(View::HorizontalSplit);
+            appCore->splitView(celestia::View::HorizontalSplit);
             break;
 
         case ID_VIEW_VSPLIT:
-            appCore->splitView(View::VerticalSplit);
+            appCore->splitView(celestia::View::VerticalSplit);
             break;
 
         case ID_VIEW_SINGLE:

--- a/src/celestia/windowmetrics.cpp
+++ b/src/celestia/windowmetrics.cpp
@@ -1,0 +1,58 @@
+// windowmetrics.cpp
+//
+// Copyright (C) 2023, the Celestia Development Team
+//
+// Split out from celestiacore.h/celestiacore.cpp
+// Copyright (C) 2001-2009, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "windowmetrics.h"
+
+namespace celestia
+{
+
+int
+WindowMetrics::getSafeAreaWidth() const
+{
+    return width - insetLeft - insetRight;
+}
+
+int
+WindowMetrics::getSafeAreaHeight() const
+{
+    return height - insetTop - insetBottom;
+}
+
+int
+WindowMetrics::getSafeAreaStart(int offset) const
+{
+    return layoutDirection == LayoutDirection::LeftToRight
+        ? insetLeft + offset
+        : width - insetRight - offset;
+}
+
+int
+WindowMetrics::getSafeAreaEnd(int offset) const
+{
+    return layoutDirection == LayoutDirection::LeftToRight
+        ? width - insetRight - offset
+        : insetLeft + offset;
+}
+
+int
+WindowMetrics::getSafeAreaTop(int offset) const
+{
+    return height - insetTop - offset;
+}
+
+int
+WindowMetrics::getSafeAreaBottom(int offset) const
+{
+    return insetBottom + offset;
+}
+
+} // end namespace celestia

--- a/src/celestia/windowmetrics.h
+++ b/src/celestia/windowmetrics.h
@@ -1,0 +1,44 @@
+// windowmetrics.h
+//
+// Copyright (C) 2023, the Celestia Development Team
+//
+// Split out from celestiacore.h/celestiacore.cpp
+// Copyright (C) 2001-2009, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+namespace celestia
+{
+
+enum class LayoutDirection
+{
+    LeftToRight   = 0,
+    RightToLeft   = 1,
+};
+
+struct WindowMetrics
+{
+    int getSafeAreaWidth() const;
+    int getSafeAreaHeight() const;
+    // Offset is applied towards the safearea
+    int getSafeAreaStart(int offset = 0) const;
+    int getSafeAreaEnd(int offset = 0) const;
+    int getSafeAreaTop(int offset = 0) const;
+    int getSafeAreaBottom(int offset = 0) const;
+
+    int width{ 1 };
+    int height{ 1 };
+    int insetLeft{ 0 };
+    int insetRight{ 0 };
+    int insetTop{ 0 };
+    int insetBottom{ 0 };
+    int screenDpi{ 96 };
+    LayoutDirection layoutDirection { LayoutDirection::LeftToRight };
+};
+
+}

--- a/src/celscript/common/scriptmaps.cpp
+++ b/src/celscript/common/scriptmaps.cpp
@@ -4,6 +4,7 @@
 #include <celengine/location.h>
 #include <celengine/render.h>
 #include <celestia/celestiacore.h>
+#include <celestia/hud.h>
 
 using namespace std::string_view_literals;
 
@@ -151,10 +152,10 @@ void initLocationFlagMap(FlagMap64 &LocationFlagMap)
 
 void initOverlayElementMap(FlagMap &OverlayElementMap)
 {
-    OverlayElementMap["Time"sv]            = CelestiaCore::ShowTime;
-    OverlayElementMap["Velocity"sv]        = CelestiaCore::ShowVelocity;
-    OverlayElementMap["Selection"sv]       = CelestiaCore::ShowSelection;
-    OverlayElementMap["Frame"sv]           = CelestiaCore::ShowFrame;
+    OverlayElementMap["Time"sv]            = static_cast<std::uint32_t>(HudElements::ShowTime);
+    OverlayElementMap["Velocity"sv]        = static_cast<std::uint32_t>(HudElements::ShowVelocity);
+    OverlayElementMap["Selection"sv]       = static_cast<std::uint32_t>(HudElements::ShowSelection);
+    OverlayElementMap["Frame"sv]           = static_cast<std::uint32_t>(HudElements::ShowFrame);
 }
 
 void initOrbitVisibilityMap(FlagMap &OrbitVisibilityMap)

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -726,7 +726,7 @@ void CommandSplitView::processInstantaneous(ExecutionEnvironment& env)
     std::vector<Observer*> observer_list = env.getCelestiaCore()->getObservers();
     if (view >= 1 && view <= observer_list.size())
     {
-        Observer* obs = observer_list[view - 1];
+        const Observer* obs = observer_list[view - 1];
         View* view = env.getCelestiaCore()->getViewByObserver(obs);
         View::Type type = (compareIgnoringCase(splitType, "h") == 0) ? View::HorizontalSplit : View::VerticalSplit;
         env.getCelestiaCore()->splitView(type, view, static_cast<float>(splitPos));
@@ -748,7 +748,7 @@ void CommandDeleteView::processInstantaneous(ExecutionEnvironment& env)
 
     if (view >= 1 && view <= observer_list.size())
     {
-        Observer* obs = observer_list[view - 1];
+        const Observer* obs = observer_list[view - 1];
         View* view = env.getCelestiaCore()->getViewByObserver(obs);
         env.getCelestiaCore()->deleteView(view);
     }
@@ -760,7 +760,7 @@ void CommandDeleteView::processInstantaneous(ExecutionEnvironment& env)
 
 void CommandSingleView::processInstantaneous(ExecutionEnvironment& env)
 {
-    View* view = env.getCelestiaCore()->getViewByObserver(env.getSimulation()->getActiveObserver());
+    const View* view = env.getCelestiaCore()->getViewByObserver(env.getSimulation()->getActiveObserver());
     env.getCelestiaCore()->singleView(view);
 }
 
@@ -779,8 +779,8 @@ void CommandSetActiveView::processInstantaneous(ExecutionEnvironment& env)
 
     if (view >= 1 && view <= observer_list.size())
     {
-        Observer* obs = observer_list[view - 1];
-        View* view = env.getCelestiaCore()->getViewByObserver(obs);
+        const Observer* obs = observer_list[view - 1];
+        const View* view = env.getCelestiaCore()->getViewByObserver(obs);
         env.getCelestiaCore()->setActiveView(view);
     }
 }

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -448,7 +448,7 @@ bool LuaState::charEntered(const char* c_p)
             GetLogger()->error("ERROR: appCore not found\n");
             return true;
         }
-        appCore->setTextEnterMode(appCore->getTextEnterMode() & ~celestia::Hud::TextEnterPassToScript);
+        appCore->setTextEnterMode(appCore->getTextEnterMode() & ~celestia::Hud::TextEnterMode::PassToScript);
         appCore->showText("", 0, 0, 0, 0);
         // Restore renderflags:
         lua_pushstring(costate, "celestia-savedrenderflags");
@@ -784,7 +784,7 @@ bool LuaState::tick(double dt)
                               "y = yes, ESC = cancel script, any other key = no"),
                               0, 0,
                               -15, 5, 5);
-            appCore->setTextEnterMode(appCore->getTextEnterMode() | celestia::Hud::TextEnterPassToScript);
+            appCore->setTextEnterMode(appCore->getTextEnterMode() | celestia::Hud::TextEnterMode::PassToScript);
         }
         else
         {
@@ -794,7 +794,7 @@ bool LuaState::tick(double dt)
                               "Do you trust the script and want to allow this?"),
                               0, 0,
                               -15, 5, 5);
-            appCore->setTextEnterMode(appCore->getTextEnterMode() & ~celestia::Hud::TextEnterPassToScript);
+            appCore->setTextEnterMode(appCore->getTextEnterMode() & ~celestia::Hud::TextEnterMode::PassToScript);
         }
 
         return false;
@@ -922,7 +922,7 @@ LuaState* getLuaStateObject(lua_State* l)
 
 // Map the observer to its View. Return nullptr if no view exists
 // for this observer (anymore).
-celestia::View* getViewByObserver(CelestiaCore* appCore, Observer* obs)
+celestia::View* getViewByObserver(const CelestiaCore* appCore, const Observer* obs)
 {
     for (const auto view : appCore->viewManager->views())
         if (view->observer == obs)
@@ -931,7 +931,7 @@ celestia::View* getViewByObserver(CelestiaCore* appCore, Observer* obs)
 }
 
 // Fill list with all Observers
-void getObservers(CelestiaCore* appCore, vector<Observer*>& observerList)
+void getObservers(const CelestiaCore* appCore, vector<Observer*>& observerList)
 {
     for (const auto view : appCore->viewManager->views())
         if (view->type == celestia::View::ViewWindow)

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -30,7 +30,9 @@
 #include <celutil/logger.h>
 #include <celutil/stringutils.h>
 #include <celestia/celestiacore.h>
+#include <celestia/hud.h>
 #include <celestia/url.h>
+#include <celestia/viewmanager.h>
 
 #include "celx_internal.h"
 #include "celx_misc.h"
@@ -446,7 +448,7 @@ bool LuaState::charEntered(const char* c_p)
             GetLogger()->error("ERROR: appCore not found\n");
             return true;
         }
-        appCore->setTextEnterMode(appCore->getTextEnterMode() & ~CelestiaCore::KbPassToScript);
+        appCore->setTextEnterMode(appCore->getTextEnterMode() & ~celestia::Hud::TextEnterPassToScript);
         appCore->showText("", 0, 0, 0, 0);
         // Restore renderflags:
         lua_pushstring(costate, "celestia-savedrenderflags");
@@ -782,7 +784,7 @@ bool LuaState::tick(double dt)
                               "y = yes, ESC = cancel script, any other key = no"),
                               0, 0,
                               -15, 5, 5);
-            appCore->setTextEnterMode(appCore->getTextEnterMode() | CelestiaCore::KbPassToScript);
+            appCore->setTextEnterMode(appCore->getTextEnterMode() | celestia::Hud::TextEnterPassToScript);
         }
         else
         {
@@ -792,7 +794,7 @@ bool LuaState::tick(double dt)
                               "Do you trust the script and want to allow this?"),
                               0, 0,
                               -15, 5, 5);
-            appCore->setTextEnterMode(appCore->getTextEnterMode() & ~CelestiaCore::KbPassToScript);
+            appCore->setTextEnterMode(appCore->getTextEnterMode() & ~celestia::Hud::TextEnterPassToScript);
         }
 
         return false;
@@ -920,9 +922,9 @@ LuaState* getLuaStateObject(lua_State* l)
 
 // Map the observer to its View. Return nullptr if no view exists
 // for this observer (anymore).
-View* getViewByObserver(CelestiaCore* appCore, Observer* obs)
+celestia::View* getViewByObserver(CelestiaCore* appCore, Observer* obs)
 {
-    for (const auto view : appCore->views)
+    for (const auto view : appCore->viewManager->views())
         if (view->observer == obs)
             return view;
     return nullptr;
@@ -931,8 +933,8 @@ View* getViewByObserver(CelestiaCore* appCore, Observer* obs)
 // Fill list with all Observers
 void getObservers(CelestiaCore* appCore, vector<Observer*>& observerList)
 {
-    for (const auto view : appCore->views)
-        if (view->type == View::ViewWindow)
+    for (const auto view : appCore->viewManager->views())
+        if (view->type == celestia::View::ViewWindow)
             observerList.push_back(view->observer);
 }
 

--- a/src/celscript/lua/celx.h
+++ b/src/celscript/lua/celx.h
@@ -30,7 +30,11 @@ int lua_isinteger(lua_State *L, int index);
 #endif
 
 class CelestiaCore;
+
+namespace celestia
+{
 class View;
+}
 
 class LuaState
 {
@@ -93,5 +97,5 @@ private:
     bool eventHandlerEnabled{ false };
 };
 
-View* getViewByObserver(CelestiaCore*, Observer*);
+celestia::View* getViewByObserver(CelestiaCore*, Observer*);
 void getObservers(CelestiaCore*, std::vector<Observer*>&);

--- a/src/celscript/lua/celx.h
+++ b/src/celscript/lua/celx.h
@@ -97,5 +97,5 @@ private:
     bool eventHandlerEnabled{ false };
 };
 
-celestia::View* getViewByObserver(CelestiaCore*, Observer*);
-void getObservers(CelestiaCore*, std::vector<Observer*>&);
+celestia::View* getViewByObserver(const CelestiaCore*, const Observer*);
+void getObservers(const CelestiaCore*, std::vector<Observer*>&);

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -18,6 +18,7 @@
 #include <celengine/category.h>
 #include <celengine/texture.h>
 #include <celestia/audiosession.h>
+#include <celestia/hud.h>
 #include <celestia/url.h>
 #include <celestia/celestiacore.h>
 #include <celestia/view.h>
@@ -404,10 +405,10 @@ static int celestia_getlayoutdirection(lua_State* l)
     Celx_CheckArgs(l, 1, 1, "No argument expected in celestia:getlayoutdirection");
     switch (this_celestia(l)->getLayoutDirection())
     {
-    case CelestiaCore::LayoutDirection::LeftToRight:
+    case celestia::LayoutDirection::LeftToRight:
         lua_pushstring(l, "ltr");
         break;
-    case CelestiaCore::LayoutDirection::RightToLeft:
+    case celestia::LayoutDirection::RightToLeft:
         lua_pushstring(l, "rtl");
         break;
     default:
@@ -424,9 +425,9 @@ static int celestia_setlayoutdirection(lua_State* l)
 
     string layoutDirection = Celx_SafeGetString(l, 2, AllErrors, "Argument to celestia:setlayoutdirection must be a string");
     if (layoutDirection == "ltr") // NOSONAR
-        appCore->setLayoutDirection(CelestiaCore::LayoutDirection::LeftToRight);
+        appCore->setLayoutDirection(LayoutDirection::LeftToRight);
     else if (layoutDirection == "rtl")
-        appCore->setLayoutDirection(CelestiaCore::LayoutDirection::RightToLeft);
+        appCore->setLayoutDirection(LayoutDirection::RightToLeft);
     else
        Celx_DoError(l, "Invalid layoutDirection");
     return 0;
@@ -1984,7 +1985,7 @@ static int celestia_requestkeyboard(lua_State* l)
         return 0;
     }
 
-    int mode = appCore->getTextEnterMode();
+    unsigned int mode = appCore->getTextEnterMode();
 
     if (lua_toboolean(l, 2))
     {
@@ -1996,11 +1997,11 @@ static int celestia_requestkeyboard(lua_State* l)
         }
         lua_remove(l, -1);
 
-        mode = mode | CelestiaCore::KbPassToScript;
+        mode = mode | Hud::TextEnterPassToScript;
     }
     else
     {
-        mode = mode & ~CelestiaCore::KbPassToScript;
+        mode = mode & ~Hud::TextEnterPassToScript;
     }
     appCore->setTextEnterMode(mode);
 
@@ -2192,7 +2193,7 @@ static int celestia_seturl(lua_State* l)
     Observer* obs = to_observer(l, 3);
     if (obs == nullptr)
         obs = appCore->getSimulation()->getActiveObserver();
-    View* view = getViewByObserver(appCore, obs);
+    celestia::View* view = getViewByObserver(appCore, obs);
     appCore->setActiveView(view);
 
     appCore->goToUrl(url);
@@ -2208,7 +2209,7 @@ static int celestia_geturl(lua_State* l)
     Observer* obs = to_observer(l, 2);
     if (obs == nullptr)
         obs = appCore->getSimulation()->getActiveObserver();
-    View* view = getViewByObserver(appCore, obs);
+    celestia::View* view = getViewByObserver(appCore, obs);
     appCore->setActiveView(view);
 
     CelestiaState appState(appCore);
@@ -2765,7 +2766,7 @@ static int celestia_loadfont(lua_State* l)
 
 std::shared_ptr<TextureFont> getFont(CelestiaCore* appCore)
 {
-    return appCore->font;
+    return appCore->hud->getFont();
 }
 
 static int celestia_getfont(lua_State* l)
@@ -2783,7 +2784,7 @@ static int celestia_getfont(lua_State* l)
 
 std::shared_ptr<TextureFont> getTitleFont(CelestiaCore* appCore)
 {
-    return appCore->titleFont;
+    return appCore->hud->getTitleFont();
 }
 
 static int celestia_gettitlefont(lua_State* l)

--- a/src/celscript/lua/celx_observer.cpp
+++ b/src/celscript/lua/celx_observer.cpp
@@ -804,13 +804,15 @@ static int observer_splitview(lua_State* l)
     Observer* obs = this_observer(l);
     CelestiaCore* appCore = celx.appCore(AllErrors);
     const char* splitType = celx.safeGetString(2, AllErrors, "First argument to observer:splitview() must be a string");
-    View::Type type = (compareIgnoringCase(splitType, "h") == 0) ? View::HorizontalSplit : View::VerticalSplit;
+    celestia::View::Type type = (compareIgnoringCase(splitType, "h") == 0)
+        ? celestia::View::HorizontalSplit
+        : celestia::View::VerticalSplit;
     double splitPos = celx.safeGetNumber(3, WrongType, "Number expected as argument to observer:splitview()", 0.5);
     if (splitPos < 0.1)
         splitPos = 0.1;
     if (splitPos > 0.9)
         splitPos = 0.9;
-    View* view = getViewByObserver(appCore, obs);
+    celestia::View* view = getViewByObserver(appCore, obs);
     appCore->splitView(type, view, (float)splitPos);
     return 0;
 }
@@ -822,7 +824,7 @@ static int observer_deleteview(lua_State* l)
 
     Observer* obs = this_observer(l);
     CelestiaCore* appCore = celx.appCore(AllErrors);
-    View* view = getViewByObserver(appCore, obs);
+    celestia::View* view = getViewByObserver(appCore, obs);
     appCore->deleteView(view);
     return 0;
 }
@@ -834,7 +836,7 @@ static int observer_singleview(lua_State* l)
 
     Observer* obs = this_observer(l);
     CelestiaCore* appCore = celx.appCore(AllErrors);
-    View* view = getViewByObserver(appCore, obs);
+    celestia::View* view = getViewByObserver(appCore, obs);
     appCore->singleView(view);
     return 0;
 }
@@ -846,7 +848,7 @@ static int observer_makeactiveview(lua_State* l)
 
     Observer* obs = this_observer(l);
     CelestiaCore* appCore = celx.appCore(AllErrors);
-    View* view = getViewByObserver(appCore, obs);
+    celestia::View* view = getViewByObserver(appCore, obs);
     appCore->setActiveView(view);
     return 0;
 }

--- a/src/celscript/lua/celx_observer.cpp
+++ b/src/celscript/lua/celx_observer.cpp
@@ -46,8 +46,8 @@ Observer* to_observer(lua_State* l, int index)
 {
     CelxLua celx(l);
 
-    Observer** o = static_cast<Observer**>(lua_touserdata(l, index));
-    CelestiaCore* appCore = celx.appCore(AllErrors);
+    auto o = static_cast<Observer* const*>(lua_touserdata(l, index));
+    const CelestiaCore* appCore = celx.appCore(AllErrors);
 
     // Check if pointer is still valid, i.e. is used by a view:
     if (o != nullptr && getViewByObserver(appCore, *o) != nullptr)
@@ -764,7 +764,7 @@ static int observer_getspeed(lua_State* l)
     CelxLua celx(l);
     celx.checkArgs(1, 1, "No argument expected for observer:getspeed()");
 
-    Observer* obs = this_observer(l);
+    const Observer* obs = this_observer(l);
 
     lua_pushnumber(l, (lua_Number) astro::kilometersToMicroLightYears(obs->getTargetSpeed()));
 
@@ -801,7 +801,7 @@ static int observer_splitview(lua_State* l)
     CelxLua celx(l);
     celx.checkArgs(2, 3, "One or two arguments expected for observer:splitview()");
 
-    Observer* obs = this_observer(l);
+    const Observer* obs = this_observer(l);
     CelestiaCore* appCore = celx.appCore(AllErrors);
     const char* splitType = celx.safeGetString(2, AllErrors, "First argument to observer:splitview() must be a string");
     celestia::View::Type type = (compareIgnoringCase(splitType, "h") == 0)
@@ -822,7 +822,7 @@ static int observer_deleteview(lua_State* l)
     CelxLua celx(l);
     celx.checkArgs(1, 1, "No argument expected for observer:deleteview()");
 
-    Observer* obs = this_observer(l);
+    const Observer* obs = this_observer(l);
     CelestiaCore* appCore = celx.appCore(AllErrors);
     celestia::View* view = getViewByObserver(appCore, obs);
     appCore->deleteView(view);
@@ -834,9 +834,9 @@ static int observer_singleview(lua_State* l)
     CelxLua celx(l);
     celx.checkArgs(1, 1, "No argument expected for observer:singleview()");
 
-    Observer* obs = this_observer(l);
+    const Observer* obs = this_observer(l);
     CelestiaCore* appCore = celx.appCore(AllErrors);
-    celestia::View* view = getViewByObserver(appCore, obs);
+    const celestia::View* view = getViewByObserver(appCore, obs);
     appCore->singleView(view);
     return 0;
 }
@@ -846,9 +846,9 @@ static int observer_makeactiveview(lua_State* l)
     CelxLua celx(l);
     celx.checkArgs(1, 1, "No argument expected for observer:makeactiveview()");
 
-    Observer* obs = this_observer(l);
+    const Observer* obs = this_observer(l);
     CelestiaCore* appCore = celx.appCore(AllErrors);
-    celestia::View* view = getViewByObserver(appCore, obs);
+    const celestia::View* view = getViewByObserver(appCore, obs);
     appCore->setActiveView(view);
     return 0;
 }

--- a/src/celutil/flag.h
+++ b/src/celutil/flag.h
@@ -11,23 +11,52 @@
 
 #include <type_traits>
 
-template<typename flag, typename = typename std::enable_if_t<std::is_enum_v<flag>>>
-constexpr inline flag operator|(flag f1, flag f2)
-{
-    using type = std::underlying_type_t<flag>;
-    return flag(type(f1) | type(f2));
+#define ENUM_CLASS_BITWISE_OPS(E)                                       \
+constexpr E& operator|=(E& f1, E f2)                                    \
+{                                                                       \
+    using type = std::underlying_type_t<E>;                             \
+    f1 = static_cast<E>(static_cast<type>(f1) | static_cast<type>(f2)); \
+    return f1;                                                          \
+}                                                                       \
+constexpr E& operator&=(E& f1, E f2)                                    \
+{                                                                       \
+    using type = std::underlying_type_t<E>;                             \
+    f1 = static_cast<E>(static_cast<type>(f1) & static_cast<type>(f2)); \
+    return f1;                                                          \
+}                                                                       \
+constexpr E& operator^=(E& f1, E f2)                                    \
+{                                                                       \
+    using type = std::underlying_type_t<E>;                             \
+    f1 = static_cast<E>(static_cast<type>(f1) ^ static_cast<type>(f2)); \
+    return f1;                                                          \
+}                                                                       \
+constexpr E operator|(E f1, E f2)                                       \
+{                                                                       \
+    f1 |= f2;                                                           \
+    return f1;                                                          \
+}                                                                       \
+constexpr E operator&(E f1, E f2)                                       \
+{                                                                       \
+    f1 &= f2;                                                           \
+    return f1;                                                          \
+}                                                                       \
+constexpr E operator^(E f1, E f2)                                       \
+{                                                                       \
+    f1 ^= f2;                                                           \
+    return f1;                                                          \
+}                                                                       \
+constexpr E operator~(E f)                                              \
+{                                                                       \
+    return static_cast<E>(~static_cast<std::underlying_type_t<E>>(f));  \
 }
 
-template<typename flag, typename = typename std::enable_if_t<std::is_enum_v<flag>>>
-constexpr inline flag operator&(flag f1, flag f2)
+namespace celestia::util
 {
-    using type = std::underlying_type_t<flag>;
-    return flag(type(f1) & type(f2));
+
+template<typename E, std::enable_if_t<std::is_enum_v<E>, int> = 0>
+constexpr bool is_set(E f, E t)
+{
+    return (f & t) != static_cast<E>(0);
 }
 
-template<typename flag, typename = typename std::enable_if_t<std::is_enum_v<flag>>>
-constexpr inline bool is_set(flag f, flag t)
-{
-    using type = std::underlying_type_t<flag>;
-    return ((type(f) & type(t)) != 0);
 }

--- a/src/celutil/unicode.cpp
+++ b/src/celutil/unicode.cpp
@@ -26,8 +26,9 @@
 #include <unicode/ustring.h>
 #endif
 
-#include "flag.h"
+#include <celutil/flag.h>
 
+using celestia::util::is_set;
 
 static_assert(std::is_same_v<UChar, char16_t>);
 

--- a/src/celutil/unicode.h
+++ b/src/celutil/unicode.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <string_view>
 
+#include <celutil/flag.h>
+
 namespace celestia::util
 {
 
@@ -21,6 +23,8 @@ enum class ConversionOption : unsigned int
     ArabicShaping   = 0x01,
     BidiReordering  = 0x02,
 };
+
+ENUM_CLASS_BITWISE_OPS(ConversionOption);
 
 bool UTF8StringToUnicodeString(std::string_view input, std::u16string &output);
 bool ApplyBidiAndShaping(std::u16string_view input,

--- a/test/unit/unicode_test.cpp
+++ b/test/unit/unicode_test.cpp
@@ -1,4 +1,3 @@
-#include <celutil/flag.h>
 #include <celutil/unicode.h>
 
 #if !defined(HAVE_WIN_ICU_COMBINED_HEADER) && !defined(HAVE_WIN_ICU_SEPARATE_HEADERS)


### PR DESCRIPTION
The original idea I had here was to update formatnum.cpp to use ICU. However this would involve storing ICU format objects somewhere and I didn't want to add yet more stuff to the mess that is celestiacore.cpp.

So here goes with moving some of the stuff in celestiacore.cpp out into their own classes: here I focus on the overlay, which also pulls with it the text input and the handling of views.

This is a first step towards reducing the amount of stuff in celestiacore, in the future it should be possible to remove some of the proxy methods and just expose the various component classes directly.

Regarding the Sonar complaints, this is already large enough without trying to fix all the old code that's accumulated here.

Quick tests of Qt5 and Windows front-ends indicates that this seems to work.

Will squash the commits before merging but for now leaving as-is in case of the need to debug.