### PR TITLE
Hide symbols in executable files, we need them in shared libraries only

### DIFF
--- a/src/celestia/gtk/CMakeLists.txt
+++ b/src/celestia/gtk/CMakeLists.txt
@@ -97,6 +97,8 @@ if (ENABLE_GLES)
   target_link_libraries(celestia-gtk celestia ${GLESv2_LIBRARIES})
 endif()
 
+set_target_properties(celestia-gtk PROPERTIES CXX_VISIBILITY_PRESET hidden)
+
 install(
   TARGETS celestia-gtk
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/celestia/qt5/CMakeLists.txt
+++ b/src/celestia/qt5/CMakeLists.txt
@@ -36,6 +36,8 @@ if(USE_WAYLAND)
   target_include_directories(celestia-qt5 PRIVATE ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 
+set_target_properties(celestia-qt5 PROPERTIES CXX_VISIBILITY_PRESET hidden)
+
 if(APPLE)
   # Qt5 and Qt6 installed via homebrew conflict, so re-add the core include directories
   target_include_directories(celestia-qt5 PRIVATE ${Qt5Core_INCLUDE_DIRS})

--- a/src/celestia/qt6/CMakeLists.txt
+++ b/src/celestia/qt6/CMakeLists.txt
@@ -34,6 +34,8 @@ if(USE_WAYLAND)
   target_include_directories(celestia-qt6 PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 
+set_target_properties(celestia-qt6 PROPERTIES CXX_VISIBILITY_PRESET hidden)
+
 if(APPLE)
   set_property(TARGET celestia-qt6 APPEND_STRING PROPERTY LINK_FLAGS " -framework CoreFoundation")
   set_property(TARGET celestia-qt6 APPEND_STRING PROPERTY LINK_FLAGS " -framework CoreServices")

--- a/src/celestia/sdl/CMakeLists.txt
+++ b/src/celestia/sdl/CMakeLists.txt
@@ -4,10 +4,15 @@ if(NOT ENABLE_SDL)
 endif()
 
 find_package(SDL2 CONFIG REQUIRED)
+
 set(SDL_SOURCES sdlmain.cpp)
+
 add_executable(celestia-sdl ${SDL_SOURCES})
 add_dependencies(celestia-sdl celestia)
 target_link_libraries(celestia-sdl PRIVATE celestia)
+
+set_target_properties(celestia-sdl PROPERTIES CXX_VISIBILITY_PRESET hidden)
+
 if(TARGET SDL2::SDL2main AND TARGET SDL2::SDL2)
   if(MINGW)
     target_compile_definitions(celestia-sdl PRIVATE SDL_MAIN_HANDLED)
@@ -17,6 +22,7 @@ else()
   target_include_directories(celestia-sdl PRIVATE ${SDL2_INCLUDE_DIRS})
   target_link_libraries(celestia-sdl PRIVATE ${SDL2_LIBRARIES})
 endif()
+
 install(
   TARGETS celestia-sdl
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/celestia/win32/CMakeLists.txt
+++ b/src/celestia/win32/CMakeLists.txt
@@ -47,6 +47,9 @@ add_executable(celestia-win WIN32 ${WIN32_SOURCES} ${RESOURCES})
 add_dependencies(celestia-win celestia)
 target_link_libraries(celestia-win celestia ${OPENGL_LIBRARIES})
 target_include_directories(celestia-win PRIVATE ${OPENGL_INCLUDE_DIRS})
+
+set_target_properties(celestia-win PROPERTIES CXX_VISIBILITY_PRESET hidden)
+
 install(
   TARGETS celestia-win
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
before:
```console
-rwxrwxr-x 1 redacted redacted  656136 ліс  3 16:14 build/src/celestia/gtk/celestia-gtk
-rwxrwxr-x 1 redacted redacted 1207152 ліс  3 16:14 build/src/celestia/qt5/celestia-qt5
-rwxrwxr-x 1 redacted redacted  439704 ліс  3 16:14 build/src/celestia/sdl/celestia-sdl
```
after:
```console
-rwxrwxr-x 1 redacted redacted  635656 ліс  3 16:22 build/src/celestia/gtk/celestia-gtk
-rwxrwxr-x 1 redacted redacted 1194480 ліс  3 16:23 build/src/celestia/qt5/celestia-qt5
-rwxrwxr-x 1 redacted redacted  419224 ліс  3 16:20 build/src/celestia/sdl/celestia-sdl
```
12-20 kB saved