### PR TITLE
[win] Do not process ka.po for Windows front-end

### DIFF
--- a/src/celestia/win32/res/CMakeLists.txt
+++ b/src/celestia/win32/res/CMakeLists.txt
@@ -8,6 +8,9 @@ if(PERL_FOUND)
   include(windres)
 
   file(GLOB PO_FILES2 "${CMAKE_SOURCE_DIR}/po/*.po")
+  # Georgian does not have an associated 8-bit codepage
+  # If the Windows frontend is rewritten to use wchar APIs this can be re-enabled
+  list(REMOVE_ITEM PO_FILES2 "${CMAKE_SOURCE_DIR}/po/ka.po")
   WINDRES_CREATE_TRANSLATIONS(celestia.rc ALL ${PO_FILES2})
 else()
   message("Perl not found, skipping generation of translations")


### PR DESCRIPTION
Currently we can't support Georgian in the Windows front-end since there is no 8-bit code page to support it. Maybe if we change the Windows front-end to use the Unicode wide character APIs instead we can re-enable this.

Qt should still work here.

For now this should unbreak the build, created issue #1966 for the Windows front-end rewrite.