### PR TITLE
Disable geometry shaders on Navi with radeonsi Mesa driver

### DIFF
--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -1,5 +1,6 @@
 #include "glsupport.h"
 #include <algorithm>
+#include <cstring>
 
 namespace celestia::gl
 {
@@ -24,6 +25,8 @@ CELAPI GLint maxTextureAnisotropy          = 0;
 namespace
 {
 
+bool EnableGeomShaders = true;
+
 inline bool has_extension(const char *name) noexcept
 {
     return epoxy_has_gl_extension(name);
@@ -35,7 +38,38 @@ bool check_extension(util::array_view<std::string> list, const char *name) noexc
            && has_extension(name);
 }
 
-bool EnableGeomShaders = true;
+void enable_workarouds()
+{
+    bool isMesa = false;
+    bool isAMD = false;
+    bool isNavi = false;
+
+    const char* s;
+    s = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+    // "4.6 (Compatibility Profile) Mesa 22.3.6"
+    // "OpenGL ES 3.2 Mesa 22.3.6"
+    if (s != nullptr)
+        isMesa = std::strstr(s, "Mesa") != nullptr;
+
+    s = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+    // "AMD" for radeonsi
+    // "Mesa/X.org" for llvmpipe
+    // "Collabora Ltd" for zink
+    if (s != nullptr)
+        isAMD = std::strcmp(s, "AMD") == 0;
+
+    s = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+    // "AMD Radeon RX 6600 (navi23, LLVM 15.0.6, DRM 3.52, 6.4.0-0.deb12.2-amd64)"" for radeonsi
+    // "llvmpipe (LLVM 15.0.6, 256 bits)""
+    // "zink (llvmpipe (LLVM 15.0.6, 256 bits))""
+    // "zink (AMD Radeon RX 6600 (RADV NAVI23))""
+    if (s != nullptr)
+        isNavi = std::strstr(s, "navi") != nullptr;
+
+    // https://gitlab.freedesktop.org/mesa/mesa/-/issues/9971
+    if (isMesa && isAMD && isNavi)
+        EnableGeomShaders = false;
+}
 
 } // namespace
 
@@ -70,6 +104,8 @@ bool init(util::array_view<std::string> ignore) noexcept
 
     if (gl::EXT_texture_filter_anisotropic)
         glGetIntegerv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxTextureAnisotropy);
+
+    enable_workarouds();
 
     return true;
 }

--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -38,7 +38,7 @@ bool check_extension(util::array_view<std::string> list, const char *name) noexc
            && has_extension(name);
 }
 
-void enable_workarouds()
+void enable_workarounds()
 {
     bool isMesa = false;
     bool isAMD = false;
@@ -105,7 +105,7 @@ bool init(util::array_view<std::string> ignore) noexcept
     if (gl::EXT_texture_filter_anisotropic)
         glGetIntegerv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxTextureAnisotropy);
 
-    enable_workarouds();
+    enable_workarounds();
 
     return true;
 }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -237,7 +237,7 @@ Renderer::Renderer() :
 #ifndef GL_ES
     renderMode(GL_FILL),
 #endif
-    labelMode(LocationLabels), //def. NoLabels
+    labelMode(NoLabels),
     renderFlags(DefaultRenderFlags),
     orbitMask(Body::Planet | Body::Moon | Body::Stellar),
     brightnessBias(0.0f),


### PR DESCRIPTION
There is a bug in the driver, so only top-left triangle is rendered.

Also disable location labels shown by default cause it's annoying (restore 1.6 behavior).