### PR TITLE
Add rings radius to renderable body radius

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -3245,6 +3245,8 @@ void Renderer::addRenderListEntries(RenderListEntry& rle,
             rle.isOpaque = true;
         }
         rle.radius = body.getRadius();
+        if (body.getRings() != nullptr)
+            rle.radius += body.getRings()->outerRadius;
         renderList.push_back(rle);
     }
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -5276,8 +5276,6 @@ Renderer::renderSolarSystemObjects(const Observer &observer,
 
         setCurrentProjectionMatrix(proj);
 
-        auto intervalFrustum = projectionMode->getFrustum(nearPlaneDistance, farPlaneDistance, observer.getZoom());
-
         int firstInInterval = i;
 
         // Render just the opaque objects in the first pass
@@ -5298,6 +5296,8 @@ Renderer::renderSolarSystemObjects(const Observer &observer,
         // Render orbit paths
         if (!orbitPathList.empty())
         {
+            celmath::Frustum intervalFrustum = projectionMode->getFrustum(nearPlaneDistance, farPlaneDistance, observer.getZoom());
+
             // Scan through the list of orbits and render any that overlap this interval
             for (const auto& orbit : orbitPathList)
             {


### PR DESCRIPTION
When we have a satellite close to the planet then its rings and the planet
itself is not visible (it has centerZ > 0) but the rings are visible
Celestia incorrectly sorts render list for solar system object because
it uses objects' farZ which is computed as centerZ - radius. So when
the satellite is too close and the planet is "behind" such computation
gives a result that the satellite is further then the planet (centerZ for
the satellite < 0, but for the planet > 0) As a result depth partitions
are incorrectly computed and we have a close object (the satellite) and
a distant object (the planet) in the same depth partition. And this
partition has huge farZ/nearZ (> 1e6). Such huge difference between
the near and the far plans gives rendering artifacts.

To fix this we should take into account rings radius when calculating
render item radius.