### PR TITLE
Move astro.h/astro.cpp to new celastro directory, split functionality

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 20:42+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -19,80 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-#, fuzzy
-msgid "Jan"
-msgstr "جينوس"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-#, fuzzy
-msgid "Mar"
-msgstr "المريخ"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-#, fuzzy
-msgid "May"
-msgstr ""
-"يوجد خطأ في تحميلك لبرنامج Celestia . دليلشاشة التناثر غير موجودة. \n"
-"البدء سوف يكمل, لكن البرنامج سوف يفقد بعض البياناتوبعض الملفات لن تقوم "
-"بالعمل بالشكل المطلوب, تأكد من التحميل"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-#, fuzzy
-msgid "Sep"
-msgstr "ضبط"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-#, fuzzy
-msgid "Oct"
-msgstr "عنصر"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-#, fuzzy
-msgid "Nov"
-msgstr "الآن"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr ""
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr ""
 
@@ -148,12 +79,12 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 #, fuzzy
 msgid "Nebula"
 msgstr "إظهار لوحات اسماء السديم"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 #, fuzzy
 msgid "Open cluster"
 msgstr "إظهار أسماء المجموعات المفتوحة"
@@ -287,11 +218,11 @@ msgstr "نجمة غير صحيحة : نوع الطيف مفقود.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " غير موجود.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr ""
 
@@ -629,26 +560,26 @@ msgstr "خطأ في قراءة ملف التركيبة"
 msgid "Initialization of SPICE library failed."
 msgstr "خطأ في انشاء مستند برنامج جزئي"
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "لا يمكن قراءة قاعدة بيانات النجمة"
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "خطأ في تحميل دليل النظام الشمسي.\n"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "لا يمكن قراءة قاعدة بيانات النجمة"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "خطأ في تحميل دليل النظام الشمسي.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "خطأ في فتح ملف حدود الابراج."
@@ -702,7 +633,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "اصدار سيء للفهرس المتقاطع\n"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "خطأ في فتح ملف الشكل النجمي."
@@ -823,26 +754,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "كيلومتر"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr "كيلومتر"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " الأيام"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " الساعات"
@@ -1184,17 +1115,17 @@ msgstr "العناصر المعلّمة"
 msgid "Event Finder"
 msgstr "كاشف الكسوف أو الخسوف"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "وقت"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1821,13 +1752,13 @@ msgstr "موافق"
 msgid "Orbits"
 msgstr "المسارات"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1902,7 +1833,6 @@ msgstr "الكويكبات"
 msgid "Comets"
 msgstr "المذنبات"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1912,6 +1842,7 @@ msgstr "المذنبات"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1941,11 +1872,11 @@ msgstr "&أسرع بـ 10 أضعاف\tL"
 msgid "Labels"
 msgstr "أسماء"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2518,170 +2449,170 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&معلومات"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&معلومات"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 غير ممتد</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "نص المعلومات"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "وحدة قياس فضائية"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "الحجم:"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "الحجم:"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "الحجم:"
@@ -4243,6 +4174,63 @@ msgstr "مضجر"
 msgid "WinLangID"
 msgstr "401"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+#, fuzzy
+msgid "Jan"
+msgstr "جينوس"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+#, fuzzy
+msgid "Mar"
+msgstr "المريخ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+#, fuzzy
+msgid "May"
+msgstr ""
+"يوجد خطأ في تحميلك لبرنامج Celestia . دليلشاشة التناثر غير موجودة. \n"
+"البدء سوف يكمل, لكن البرنامج سوف يفقد بعض البياناتوبعض الملفات لن تقوم "
+"بالعمل بالشكل المطلوب, تأكد من التحميل"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+#, fuzzy
+msgid "Nov"
+msgstr "الآن"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+#, fuzzy
+msgid "Oct"
+msgstr "عنصر"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+#, fuzzy
+msgid "Sep"
+msgstr "ضبط"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr ""
@@ -4459,7 +4447,7 @@ msgstr "إذهب إلى &موقع..."
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 #, fuzzy
 msgid "Version: "
 msgstr "اصدار سيء للفهرس المتقاطع\n"
@@ -4474,33 +4462,43 @@ msgstr "منطقة الوقت"
 msgid "UTC Offset"
 msgstr "UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "تحميل صورة من ملف "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr "نوع الصورة غير مدعوم أو غير معروف.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "خطأ في قراءة ملف من نوع PNG"
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "خطأ في قراءة ملف من نوع PNG"
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "خطأ في فتح الصورة "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr "ليس ملف من نوع PNG.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "خطأ في قراءة ملف من نوع PNG"
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "خطأ في قراءة ملف من نوع PNG"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6139,10 +6137,6 @@ msgstr "اصدار سيء للفهرس المتقاطع\n"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "تشغيل جزئية برنامج ARB . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr "نوع الصورة غير مدعوم أو غير معروف.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "تشغيل برنامج القمة NV: "

--- a/po/be.po
+++ b/po/be.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>, 2023\n"
 "Language-Team: Belarusian (https://app.transifex.com/celestia/teams/93131/"
@@ -24,71 +24,11 @@ msgstr ""
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
 "(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Сту"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Лют"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Сак"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Кра"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Тра"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Чэр"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Ліп"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Жні"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Вер"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Кас"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Ліс"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Сьн"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -143,11 +83,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr "Індэкс мэша {} большы за колькасьць VBO {}!"
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Туманнасьць"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Адкрытае скопішча"
 
@@ -275,11 +215,11 @@ msgstr "Недапушчальная зорка: спэктральны тып �
 msgid "Barycenter {} does not exist.\n"
 msgstr "Барыцэнтар {} не існуе.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Стварэньне мазаічнай тэкстуры. Шырыня={}, макс={}\n"
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Стварэньне звычайнае тэкстуры: {}×{}\n"
 
@@ -598,23 +538,23 @@ msgstr "Памылка падчас чытаньня файла настаўле
 msgid "Initialization of SPICE library failed."
 msgstr "Не ўдалося ініцыялізаваць бібліятэку SPICE."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Немагчыма прачытаць базу зорак."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Памылка адкрыцьця файла каталёґу глыбокага космасу {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Немагчыма прачытаць базу аб'ектаў глыбокага космасу {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Памылка падчас адкрыцьця каталёґу сонечнай сыстэмы {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Памылка падчас адкрыцьця файлаў зь межамі сузор'яў {}.\n"
 
@@ -662,7 +602,7 @@ msgstr "Не атрымалася захапіць кадр!\n"
 msgid "Unsupported image type: {}!\n"
 msgstr "Тып відарыса не падтрымліваецца: {}!\n"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 msgid "Error opening asterisms file {}.\n"
 msgstr "Памылка падчас адкрыцьця файла астэрызму {}.\n"
 
@@ -781,24 +721,24 @@ msgstr "футаў"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr "дзён"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "гадзін"
 
@@ -1123,17 +1063,17 @@ msgstr "Аб'екты глыбокага космасу"
 msgid "Event Finder"
 msgstr "Пошук падзей"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Час"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Накіроўныя"
@@ -1697,13 +1637,13 @@ msgstr "Арб"
 msgid "Orbits"
 msgstr "Арбіты"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1776,7 +1716,6 @@ msgstr "Астэроіды"
 msgid "Comets"
 msgstr "Камэты"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1786,6 +1725,7 @@ msgstr "Камэты"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1813,11 +1753,11 @@ msgstr "Наз"
 msgid "Labels"
 msgstr "Назвы"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2347,167 +2287,167 @@ msgstr "Celestia ня здолела ініцыялізаваць OpenGLGLES 2.0
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia ня здолела ініцыялізаваць OpenGL 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr "Памылка: ніякі аб'ект ня вылучаны!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Зьвесткі"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr "Сеціўныя зьвесткі: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Экватарыяльны радыюс:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Памер:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr "<b>Сплюшчанасьць: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Сыдэрычны пэрыяд авароту:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr "Праґрадны"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr "Рэтраґрадны"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Напрамак аварачэньня:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Даўжыня дня:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Мае кольцы</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Мае атмасфэру</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Пачатак:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Канец:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Зьвесткі пра арбіту"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Аскуляваныя элемэнты для %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "гады"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Пэрыяд:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "АА"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Дадатковыя восі:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Эксцэнтрысытэт:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>Схіленьне:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Адлегласьць да пэрыцэнтру:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Адлегласьць да апацэнтру:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>Узыходны вузел:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>Парамэтар пэрыяпсыды:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>Сярэдняя анамалія:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Пэрыяд (разьлічаны):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "<b>Пэрыяд (разьлічаны):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>ПУ:</b> %L1г %L2м %L3с"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Сх:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Д:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Ш:</b> %L1%2 %L3' %L4\""
@@ -3952,6 +3892,54 @@ msgstr "Падрабязна"
 msgid "WinLangID"
 msgstr "423"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Кра"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Лют"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Сту"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Чэр"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Сак"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Тра"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Жні"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Сьн"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Ліп"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Ліс"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Кас"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Вер"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Спадарожнік"
@@ -4156,7 +4144,7 @@ msgstr "Загрузка URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Вэрсія: "
 
@@ -4168,29 +4156,38 @@ msgstr "Нозва часавага поясу"
 msgid "UTC Offset"
 msgstr "Зрух ад UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 msgid "Loading image from file {}\n"
 msgstr "Загрузка відарыса з файла {}\n"
 
-#: ../src/celimage/png.cpp:53
-msgid "Error opening image file {}.\n"
-msgstr "Памылка адкрыцьця файла відарыса {}.\n"
+#: ../src/celimage/image.cpp:409
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
 
-#: ../src/celimage/png.cpp:61
-msgid "Error: {} is not a PNG file.\n"
-msgstr "Памылка: {} не зьяўляецца файлам PNG.\n"
-
-#: ../src/celimage/png.cpp:87
-msgid "Error reading PNG image file {}\n"
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
 msgstr "Памылка чытаньня файла відарыса PNG {}\n"
 
-#: ../src/celimage/png.cpp:177
+#: ../src/celimage/png.cpp:49
 msgid "Can't open screen capture file '{}'\n"
 msgstr "Не атрымалася адкрыць файл для захопу відэа '{}'\n"
 
-#: ../src/celimage/png.cpp:226
+#: ../src/celimage/png.cpp:105
 msgid "Error writing PNG file '{}'\n"
 msgstr "Памылка запісу файла PNG {}\n"
+
+#: ../src/celimage/png.cpp:153
+msgid "Error opening image file {}.\n"
+msgstr "Памылка адкрыцьця файла відарыса {}.\n"
+
+#: ../src/celimage/png.cpp:161
+msgid "Error: {} is not a PNG file.\n"
+msgstr "Памылка: {} не зьяўляецца файлам PNG.\n"
+
+#: ../src/celimage/png.cpp:187
+msgid "Error reading PNG image file {}\n"
+msgstr "Памылка чытаньня файла відарыса PNG {}\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."

--- a/po/bg.po
+++ b/po/bg.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Georgi Georgiev (Жоро) <g.georgiev.shumen@gmail.com>, 2023\n"
 "Language-Team: Bulgarian (https://app.transifex.com/celestia/teams/93131/"
@@ -23,71 +23,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Яну"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Феб"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Мар"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Апр"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Май"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Юни"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Юли"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Авг"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Сеп"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Окт"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Ное"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Дек"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "ЛЧВ"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "СЧВ"
 
@@ -141,11 +81,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Мъглявина"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Разсеян куп"
 
@@ -273,11 +213,11 @@ msgstr "Невалидна звезда: липсва спектралния к�
 msgid "Barycenter {} does not exist.\n"
 msgstr "Центърът на масата {} не съществува.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Създаване на плочкова текстура. Ширина={}, макс.={}\n"
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Създаване на обикновена текстура: {}х{}\n"
 
@@ -599,23 +539,23 @@ msgstr "Грешка при четене на конфигурационния �
 msgid "Initialization of SPICE library failed."
 msgstr "Създаването на библиотеката „SPICE“ се провали."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Звездната база данни не може да бъде прочетена."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Грешка при отваряне на каталога за ОДН {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Базата от данни с ОДН не може да бъде прочетена {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Грешка при отваряне на системния каталог {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Грешка при отваряне на очертанията на съзвездията {}.\n"
 
@@ -663,7 +603,7 @@ msgstr "Неуспешно прихващане на кадъра!\n"
 msgid "Unsupported image type: {}!\n"
 msgstr "Неподдържан формат на изображението: {}!\n"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 msgid "Error opening asterisms file {}.\n"
 msgstr "Грешка при отваряне на астеризмите {}.\n"
 
@@ -781,24 +721,24 @@ msgstr "фт"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr "дни"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "часа"
 
@@ -1123,17 +1063,17 @@ msgstr "Обекти от дълбокото небе"
 msgid "Event Finder"
 msgstr "Търсач на събития"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Време"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Водачи"
@@ -1700,13 +1640,13 @@ msgstr "ОРБ"
 msgid "Orbits"
 msgstr "Орбити"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1779,7 +1719,6 @@ msgstr "Астероиди"
 msgid "Comets"
 msgstr "Комети"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1789,6 +1728,7 @@ msgstr "Комети"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1816,11 +1756,11 @@ msgstr "НДП"
 msgid "Labels"
 msgstr "Надписи"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2353,167 +2293,167 @@ msgstr "„Celestia“ не успя да стартира „OpenGL“ 2.1."
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "„Celestia“ не успя да стартира „OpenGL“ 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr "Грешка: не е избран обект!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Информация"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr "Интернет информация: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Екваториален радиус</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Размер:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr "<b>Сплеснатост: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Звезден ден:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr "Проградна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr "Ретроградна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Посока на въртене:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Продължителност на деня:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Има пръстени</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Има атмосфера</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Начало:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Край:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Орбитална информация"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Оскулационни елементи за %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "години"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Период:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "АЕ"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Полуголяма ос:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Ексцентрицитет:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>Наклон:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Разстояние до перицентъра:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Разстояние до апоцентъра:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>Възходящ възел:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>Параметър на перихелия:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>Средна аномалия:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Период (изчислен):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "<b>Период (изчислен):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>α:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>δ:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
@@ -3956,6 +3896,54 @@ msgstr "Подробна"
 msgid "WinLangID"
 msgstr "0402"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Апр"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Феб"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Яну"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Юни"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Мар"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Май"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Авг"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Дек"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Юли"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Ное"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Окт"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Сеп"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Сателит"
@@ -4162,7 +4150,7 @@ msgstr "Зареждане на връзка"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Версия: "
 
@@ -4174,29 +4162,38 @@ msgstr "Име на часовата зона"
 msgid "UTC Offset"
 msgstr "Отклонение по „UTC“"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 msgid "Loading image from file {}\n"
 msgstr "Зареждане на изображение от файл {}\n"
 
-#: ../src/celimage/png.cpp:53
-msgid "Error opening image file {}.\n"
-msgstr "Грешка при отваряне на изображение {}.\n"
+#: ../src/celimage/image.cpp:409
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
 
-#: ../src/celimage/png.cpp:61
-msgid "Error: {} is not a PNG file.\n"
-msgstr "Грешка: {} не е „PNG“ файл.\n"
-
-#: ../src/celimage/png.cpp:87
-msgid "Error reading PNG image file {}\n"
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
 msgstr "Грешка при четене на „PNG“ изображението {}\n"
 
-#: ../src/celimage/png.cpp:177
+#: ../src/celimage/png.cpp:49
 msgid "Can't open screen capture file '{}'\n"
 msgstr "Прихванатото изображение „{}“ не може да бъде отворено\n"
 
-#: ../src/celimage/png.cpp:226
+#: ../src/celimage/png.cpp:105
 msgid "Error writing PNG file '{}'\n"
 msgstr "Грешка при записване на „PNG“ изображението „{}“\n"
+
+#: ../src/celimage/png.cpp:153
+msgid "Error opening image file {}.\n"
+msgstr "Грешка при отваряне на изображение {}.\n"
+
+#: ../src/celimage/png.cpp:161
+msgid "Error: {} is not a PNG file.\n"
+msgstr "Грешка: {} не е „PNG“ файл.\n"
+
+#: ../src/celimage/png.cpp:187
+msgid "Error reading PNG image file {}\n"
+msgstr "Грешка при четене на „PNG“ изображението {}\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."

--- a/po/celestia.pot
+++ b/po/celestia.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,71 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr ""
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr ""
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr ""
 
@@ -134,11 +74,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr ""
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr ""
 
@@ -263,11 +203,11 @@ msgstr ""
 msgid "Barycenter {} does not exist.\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr ""
 
@@ -578,23 +518,23 @@ msgstr ""
 msgid "Initialization of SPICE library failed."
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 msgid "Error opening solar system catalog {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr ""
 
@@ -642,7 +582,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 msgid "Error opening asterisms file {}.\n"
 msgstr ""
 
@@ -760,24 +700,24 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr ""
 
@@ -1098,17 +1038,17 @@ msgstr ""
 msgid "Event Finder"
 msgstr ""
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr ""
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr ""
@@ -1670,13 +1610,13 @@ msgstr ""
 msgid "Orbits"
 msgstr ""
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1749,7 +1689,6 @@ msgstr ""
 msgid "Comets"
 msgstr ""
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1759,6 +1698,7 @@ msgstr ""
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1786,11 +1726,11 @@ msgstr ""
 msgid "Labels"
 msgstr ""
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2320,167 +2260,167 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:317
-#, qt-format
-msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
-msgid "<b>Eccentricity:</b> %L1"
+msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
+msgid "<b>Eccentricity:</b> %L1"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
@@ -3919,6 +3859,54 @@ msgstr ""
 msgid "WinLangID"
 msgstr ""
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr ""
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr ""
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr ""
@@ -4119,7 +4107,7 @@ msgstr ""
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr ""
 
@@ -4131,28 +4119,36 @@ msgstr ""
 msgid "UTC Offset"
 msgstr ""
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 msgid "Loading image from file {}\n"
 msgstr ""
 
-#: ../src/celimage/png.cpp:53
-msgid "Error opening image file {}.\n"
+#: ../src/celimage/image.cpp:409
+msgid "{}: unrecognized or unsupported image file type.\n"
 msgstr ""
 
-#: ../src/celimage/png.cpp:61
-msgid "Error: {} is not a PNG file.\n"
+#: ../src/celimage/png.cpp:27
+msgid "Error reading PNG data"
 msgstr ""
 
-#: ../src/celimage/png.cpp:87
-msgid "Error reading PNG image file {}\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:177
+#: ../src/celimage/png.cpp:49
 msgid "Can't open screen capture file '{}'\n"
 msgstr ""
 
-#: ../src/celimage/png.cpp:226
+#: ../src/celimage/png.cpp:105
 msgid "Error writing PNG file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:153
+msgid "Error opening image file {}.\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:161
+msgid "Error: {} is not a PNG file.\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:187
+msgid "Error reading PNG image file {}\n"
 msgstr ""
 
 #: ../src/celscript/legacy/legacyscript.cpp:101

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-08-10 19:42+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Feb"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mär"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Apr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mai"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jun"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Jul"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Aug"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Sep"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Okt"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dez"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -138,11 +78,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nebel"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Offene Sternhaufen"
 
@@ -277,12 +217,12 @@ msgstr "Ungültiger Eintrag: Spektraltyp fehlt.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " existiert nicht.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Erzeuge gekachelte Textur. Breite="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Erzeuge einfache Textur: "
@@ -617,26 +557,26 @@ msgstr "Fehler beim Einlesen der Konfigurationsdatei."
 msgid "Initialization of SPICE library failed."
 msgstr "Initialisierung der SPICE-Bibliothek ist fehlgeschlagen."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Konnte Stern-Datenbank nicht einlesen."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Fehler beim Öffnen des DSO-Katalogs."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Konnte Stern-Datenbank nicht einlesen."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Fehler beim Öffnen des Sonnensystem-Katalogs.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Fehler beim Öffnen der Sternbildgrenzen-Dateien."
@@ -690,7 +630,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Unterstützte Erweiterungen:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Fehler beim Öffnen der Asterismen-Datei."
@@ -810,26 +750,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " Tage"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " Stunden"
@@ -1170,17 +1110,17 @@ msgstr "Deep-Space-Objekte"
 msgid "Event Finder"
 msgstr "Finsternis-Suche"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Zeit"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1798,13 +1738,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Orbit-Linien"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1877,7 +1817,6 @@ msgstr "Asteroiden"
 msgid "Comets"
 msgstr "Kometen"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1887,6 +1826,7 @@ msgstr "Kometen"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1916,11 +1856,11 @@ msgstr "10x Schne&ller\tL"
 msgid "Labels"
 msgstr "Bezeichnungen"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2485,172 +2425,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL-Informationen"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Infotext"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "AE"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Größe: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Größe: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Größe: %1 MB"
@@ -4156,6 +4096,54 @@ msgstr "Ausführlich"
 msgid "WinLangID"
 msgstr "407"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Apr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Feb"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jun"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mär"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mai"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Aug"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dez"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Jul"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Okt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Sep"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satellit"
@@ -4362,7 +4350,7 @@ msgstr "Lade URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Version: "
 
@@ -4374,33 +4362,43 @@ msgstr "Zeitzone"
 msgid "UTC Offset"
 msgstr "UTC-Versatz"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Lade Bild aus Datei "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": unbekanntes oder nicht unterstütztes Bild-Dateiformat.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Fehler beim Lesen der PNG-Bilddatei "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Fehler beim Lesen der PNG-Bilddatei "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Fehler beim Öffnen der Bilddatei "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " ist keine PNG-Datei.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Fehler beim Lesen der PNG-Bilddatei "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Fehler beim Lesen der PNG-Bilddatei "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6818,10 +6816,6 @@ msgstr "Unterstützte Erweiterungen:"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Initialisiere ARB fragment programs . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": unbekanntes oder nicht unterstütztes Bild-Dateiformat.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Lade NV vertex program: "

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 20:45+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Ιαν"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Φεβ"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Μαρ"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Απρ"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Μάι"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Ιούν"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Ιούλ"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Αύγ"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Σεπ"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Οκτ "
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Νοέ"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Δεκ"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -138,11 +78,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Νεφέλωμα"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Ανοιχτό σμήνος "
 
@@ -277,12 +217,12 @@ msgstr "Άκυρο αστέρι: λείπει φασματικός τύπος.\n
 msgid "Barycenter {} does not exist.\n"
 msgstr " δεν υπάρχει.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Δημιουργία υφής σε παράθεση. Πλάτος="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Δημιουργία συνηθισμένης υφής:"
@@ -617,26 +557,26 @@ msgstr "Σφάλμα κατά την ανάγνωση του αρχείου ρυ
 msgid "Initialization of SPICE library failed."
 msgstr "Η αρχικοποίηση της βιβλιοθήκης SPICE απέτυχε."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Δεν ήταν δυνατή η ανάγνωση της βάσης δεδομένων των αστέρων."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του καταλόγου deepsky"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Δεν ήταν δυνατή η ανάγνωση της βάσης δεδομένων των αστέρων."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του καταλόγου του πλανητικού συστήματος .\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Σφάλμα κατά το άνοιγμα των αρχείων των συνόρων των αστερισμών."
@@ -691,7 +631,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Υποστηριζόμενες Επεκτάσεις:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του αρχείου αστερισμών."
@@ -811,26 +751,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "χμ"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " μ/δ"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " μέρες"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " ώρες"
@@ -1172,17 +1112,17 @@ msgstr " αντικείμενα βαθέως ουρανού"
 msgid "Event Finder"
 msgstr "Εύρεση Έκλειψης "
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Χρόνος "
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1814,13 +1754,13 @@ msgstr "Εντάξει"
 msgid "Orbits"
 msgstr "Τροχιές"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1893,7 +1833,6 @@ msgstr "Αστεροειδείς"
 msgid "Comets"
 msgstr "Κομήτες"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1903,6 +1842,7 @@ msgstr "Κομήτες"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1932,11 +1872,11 @@ msgstr "10x Πιο &Γρήγορα\tL"
 msgid "Labels"
 msgstr "Ετικέτες"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2502,172 +2442,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Πληροφορίες"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Πληροφορίες OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Βελιγράδι"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Βελιγράδι"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Πληροφοριακό Κείμενο"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "αμ"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Μέγεθος: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Μέγεθος: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Μέγεθος: %1 MB"
@@ -4216,6 +4156,54 @@ msgstr "Διεξοδικός"
 msgid "WinLangID"
 msgstr "408"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Απρ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Φεβ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Ιαν"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Ιούν"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Μαρ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Μάι"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Αύγ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Δεκ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Ιούλ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Νοέ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Οκτ "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Σεπ"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Δορυφόρος"
@@ -4423,7 +4411,7 @@ msgstr "Φόρτωση URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Έκδοση:"
 
@@ -4435,33 +4423,43 @@ msgstr "Όνομα Ζώνης Ώρας "
 msgid "UTC Offset"
 msgstr "Αντιστάθμιση UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Φόρτωση εικόνας από αρχείο"
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": μη αναγνωρίσιμο ή μη υποστηριζόμενο αρχείο εικόνας.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Σφάλμα κατά την ανάγνωση του αρχείου εικόνας PNG "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Σφάλμα κατά την ανάγνωση του αρχείου εικόνας PNG "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Σφάλμα κατά το άνοιγμα του αρχείου εικόνας "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " δεν είναι αρχείο PNG.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Σφάλμα κατά την ανάγνωση του αρχείου εικόνας PNG "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Σφάλμα κατά την ανάγνωση του αρχείου εικόνας PNG "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6518,10 +6516,6 @@ msgstr "Υποστηριζόμενες Επεκτάσεις:"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Αρχικοποιήση ARB fragment προγραμμάτων . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": μη αναγνωρίσιμο ή μη υποστηριζόμενο αρχείο εικόνας.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Φόρτωση του  NV vertex προγράμματος: "

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 20:45+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Ene"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Feb"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Abr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "May"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jun"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Jul"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Ago"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Sep"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Oct"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dic"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Hora de verano"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -139,11 +79,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nebulosa"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Cúmulo abierto"
 
@@ -278,12 +218,12 @@ msgstr "Estrella inválida: tipo espectral no disponible.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " no existe.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Creando textura en baldosas. Ancho="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Creando textura ordinaria: "
@@ -618,26 +558,26 @@ msgstr "Error al leer el archivo de configuración"
 msgid "Initialization of SPICE library failed."
 msgstr "Falla en la inicialización de la biblioteca SPICE."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Imposible leer la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Error al abrir catálogo estelar "
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Imposible leer la base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Error al abrir el catálogo del sistema solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Error abriendo el archivo de límites de las constelaciones."
@@ -691,7 +631,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensiones aceptadas: "
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Error abriendo archivo de asterismos."
@@ -812,26 +752,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " días"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " horas"
@@ -1173,17 +1113,17 @@ msgstr " objetos de espacio profundo"
 msgid "Event Finder"
 msgstr "Buscador de eclipses"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Tiempo"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1816,13 +1756,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Órbitas"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1895,7 +1835,6 @@ msgstr "Asteroides"
 msgid "Comets"
 msgstr "Cometas"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1905,6 +1844,7 @@ msgstr "Cometas"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1934,11 +1874,11 @@ msgstr "10x más rápido\tL"
 msgid "Labels"
 msgstr "Etiquetas"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2504,172 +2444,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Información"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Información OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 sin extensiones</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Información"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "UA"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamaño: %1 MB"
@@ -4224,6 +4164,54 @@ msgstr "Completa"
 msgid "WinLangID"
 msgstr "40a"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Abr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Feb"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Ene"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jun"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "May"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Ago"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dic"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Jul"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Oct"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Sep"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satélite"
@@ -4430,7 +4418,7 @@ msgstr "Cargando URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versión: "
 
@@ -4442,33 +4430,43 @@ msgstr "Zona horaria"
 msgid "UTC Offset"
 msgstr "Corrimiento UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Cargando imagen del archivo "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": formato de imagen no reconocido o no soportado.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Error al leer un archivo PNG "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Error al leer un archivo PNG "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Error abriendo archivo de imagen "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " no es un archivo PNG.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Error al leer un archivo PNG "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Error al leer un archivo PNG "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6887,10 +6885,6 @@ msgstr "Extensiones aceptadas: "
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Inicialización de los programas de fragmentos ARB . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": formato de imagen no reconocido o no soportado.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Cargando programa de vértices NV : "

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2019-02-14 21:33+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: French (https://www.transifex.com/celestia/teams/93131/fr/)\n"
@@ -21,71 +21,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Fév"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Avr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mai"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Juin"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Juil"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Août"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Sep"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Oct"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Déc"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "heure d’été"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "heure d’hiver"
 
@@ -141,11 +81,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nébuleuse"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Amas ouvert"
 
@@ -275,11 +215,11 @@ msgstr "Étoile invalide : type spectral manquant.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr "Le répertoire \"extras\" %1 n’existe pas"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr ""
 
@@ -604,26 +544,26 @@ msgstr "Erreur lors de la lecture du fichier de configuration."
 msgid "Initialization of SPICE library failed."
 msgstr "L’initialisation de la bibliothèque SPICE a échoué."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Impossible de lire la base de données des étoiles."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Erreur lors de l’ouverture du fichier de script."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Impossible de lire la base de données des étoiles."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Erreur lors de la lecture du catalogue du Système solaire.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Erreur lors de l’ouverture du fichier des limites des constellations."
@@ -679,7 +619,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensions supportées : "
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Erreur lors de l’ouverture du fichier d’astérismes."
@@ -798,24 +738,24 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr ""
 
@@ -1137,17 +1077,17 @@ msgstr ""
 msgid "Event Finder"
 msgstr ""
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Temps"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr ""
@@ -1713,13 +1653,13 @@ msgstr ""
 msgid "Orbits"
 msgstr "Orbites"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1792,7 +1732,6 @@ msgstr "Astéroïdes"
 msgid "Comets"
 msgstr "Comètes"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1802,6 +1741,7 @@ msgstr "Comètes"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1830,11 +1770,11 @@ msgstr ""
 msgid "Labels"
 msgstr "Noms"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2367,169 +2307,169 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrade"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrade"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "Moteur de rendu : "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:317
-#, qt-format
-msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
-msgid "<b>Eccentricity:</b> %L1"
+msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
+msgid "<b>Eccentricity:</b> %L1"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
@@ -3981,6 +3921,54 @@ msgstr "Complet"
 msgid "WinLangID"
 msgstr "40c"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Avr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Fév"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Juin"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mai"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Août"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Déc"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Juil"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Oct"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Sep"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satellite"
@@ -4184,7 +4172,7 @@ msgstr "Chargement de l’URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Version : "
 
@@ -4196,32 +4184,41 @@ msgstr "Nom du fuseau horaire"
 msgid "UTC Offset"
 msgstr "Décalage UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Erreur lors de la lecture du fichier de favoris."
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Erreur lors de la lecture du fichier de favoris."
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Erreur lors de la lecture du fichier de favoris."
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Erreur lors de l’ouverture du fichier d’astérismes."
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 msgid "Error: {} is not a PNG file.\n"
 msgstr ""
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Erreur lors de la lecture du fichier de favoris."
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Erreur lors de la lecture du fichier de favoris."
 
 #: ../src/celscript/legacy/legacyscript.cpp:101

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2022-08-06 14:24+0200\n"
 "Last-Translator: Parodper <parodper@gmail.com>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Xan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Feb"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Abr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mai"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Xuñ"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Xul"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Ago"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Set"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Out"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dec"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -141,11 +81,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nebulosa"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Cúmulo aberto"
 
@@ -273,11 +213,11 @@ msgstr "Estrela non válida: falta o tipo espectral.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr "Non existe o baricentro {}.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Creando textura tipo mosaico. Ancho={}, máx={}\n"
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Creando textura típica: {}x{}\n"
 
@@ -601,24 +541,24 @@ msgstr "Erro lendo o arquivo de configuración."
 msgid "Initialization of SPICE library failed."
 msgstr "A inicialización da librerí­a SPICE fallou."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Non se puido ler a base de datos estelar."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr ""
 "Erro ao abrir o ficheiro {} co catálogo de obxectos do espazo profundo.\n"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Non se puido ler a base de datos de obxectos do espazo profundo {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Non se puido abrir o ficheiro do catálogo do Sistema Solar {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Non se puido abrir o ficheiro {} cos bordes das constelacións.\n"
 
@@ -666,7 +606,7 @@ msgstr "Non se puido capturar un fotograma!\n"
 msgid "Unsupported image type: {}!\n"
 msgstr "Tipo de imaxe non admitido: {}!\n"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 msgid "Error opening asterisms file {}.\n"
 msgstr "Non se puido abrir o ficheiro de asterismos {}.\n"
 
@@ -784,24 +724,24 @@ msgstr "pés"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr "días"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "horas"
 
@@ -1132,17 +1072,17 @@ msgstr "Obxectos do Espazo Profundo"
 msgid "Event Finder"
 msgstr "Buscador de Eventos"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Hora"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Guías"
@@ -1712,13 +1652,13 @@ msgstr "O"
 msgid "Orbits"
 msgstr "Órbitas"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1791,7 +1731,6 @@ msgstr "Asteroides"
 msgid "Comets"
 msgstr "Cometas"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1801,6 +1740,7 @@ msgstr "Cometas"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1828,11 +1768,11 @@ msgstr "L"
 msgid "Labels"
 msgstr "Nomes"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2367,167 +2307,167 @@ msgstr "Celestia non puido inicializar OpenGL 2.1."
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia non puido inicializar OpenGL 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr "Error: non hai obxectos seleccionados!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Información"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr "Información Web: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Radio ecuatorial:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Tamaño:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr "<b>Oblatidade: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Período de rotación sideral:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr "Progrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr "Retrógrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Dirección da rotación:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Duración do día:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Ten aneis</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Ten atmosfera</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Inicio:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Fin:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Información orbital"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Elementos oscilantes de %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "anos"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Período:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "UA"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Semieixe maior:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Excentricidade:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>Inclinación:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Distancia do pericentro:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Distancia do apocentro:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>Nodo ascendente:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>Argumento da periapse:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>Anomalía media:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Período (calculado):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "<b>Período (calculado):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>Asc. recta:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Dec:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
@@ -3970,6 +3910,54 @@ msgstr "Completa"
 msgid "WinLangID"
 msgstr "0456"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Abr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Feb"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Xan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Xuñ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mai"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Ago"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dec"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Xul"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Out"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Set"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satélite"
@@ -4177,7 +4165,7 @@ msgstr "Cargando URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versión: "
 
@@ -4189,29 +4177,39 @@ msgstr "Zona Horaria"
 msgid "UTC Offset"
 msgstr "Diferenza co UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 msgid "Loading image from file {}\n"
 msgstr "Cargando imaxe dende o ficheiro {}\n"
 
-#: ../src/celimage/png.cpp:53
-msgid "Error opening image file {}.\n"
-msgstr "Erro abrindo o ficheiro da imaxe {}.\n"
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": tipo do arquivo de imaxe non recoñecido ou non soportado.\n"
 
-#: ../src/celimage/png.cpp:61
-msgid "Error: {} is not a PNG file.\n"
-msgstr "Erro: {} non é un ficheiro PNG.\n"
-
-#: ../src/celimage/png.cpp:87
-msgid "Error reading PNG image file {}\n"
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
 msgstr "Non se puido ler o ficheiro {} coa imaxe PNG\n"
 
-#: ../src/celimage/png.cpp:177
+#: ../src/celimage/png.cpp:49
 msgid "Can't open screen capture file '{}'\n"
 msgstr "Non se puido abrir o ficheiro coa captura de pantalla «{}»\n"
 
-#: ../src/celimage/png.cpp:226
+#: ../src/celimage/png.cpp:105
 msgid "Error writing PNG file '{}'\n"
 msgstr "Non se puido escribir ao ficheiro PNG «{}»\n"
+
+#: ../src/celimage/png.cpp:153
+msgid "Error opening image file {}.\n"
+msgstr "Erro abrindo o ficheiro da imaxe {}.\n"
+
+#: ../src/celimage/png.cpp:161
+msgid "Error: {} is not a PNG file.\n"
+msgstr "Erro: {} non é un ficheiro PNG.\n"
+
+#: ../src/celimage/png.cpp:187
+msgid "Error reading PNG image file {}\n"
+msgstr "Non se puido ler o ficheiro {} coa imaxe PNG\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."
@@ -6686,10 +6684,6 @@ msgstr "Número de díxitos {} incompatibles, esperábanse {}.\n"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Inicializando os programas de fragmentos ARB . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": tipo do arquivo de imaxe non recoñecido ou non soportado.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Cargando programa de vértices NV:"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 20:47+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Febr"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Márc"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Ápr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Máj"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jún"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Júl"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Aug"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Szept"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Okt"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dec"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Nyári idő"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "Téli idő"
 
@@ -138,11 +78,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nebula"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Nyílt galaxishalmazok"
 
@@ -277,12 +217,12 @@ msgstr "Érvénytelen csillag: hibás spektrális típus.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr "nem létező.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Darabolt textúra készítése. Szélesség="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Textúra készítése:"
@@ -617,26 +557,26 @@ msgstr "Hiba a konfigurációs fájl olvasásakor."
 msgid "Initialization of SPICE library failed."
 msgstr "Hiba a SPICE könyvtár inicializálásakor."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Csillag adatbázis nem olvasható."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Hiba a mélyég katalógus megnyitásakor"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Csillag adatbázis nem olvasható."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Hiba a naprendszer katalógus megnyitásakor.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Hiba a constellation boundaries fájl megnyitásakor."
@@ -690,7 +630,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Supported Extensions:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Hiba az asterisms fájl megnyitásakor."
@@ -810,26 +750,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr "nap"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr "óra"
@@ -1171,17 +1111,17 @@ msgstr "Mélyég objektumok"
 msgid "Event Finder"
 msgstr "Fogyatkozás-kereső"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Idő"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1814,13 +1754,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Pályák"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1893,7 +1833,6 @@ msgstr "Kisbolygók"
 msgid "Comets"
 msgstr "Üstökösök"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1903,6 +1842,7 @@ msgstr "Üstökösök"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1932,11 +1872,11 @@ msgstr "10x Gyorsabb\tL"
 msgid "Labels"
 msgstr "Címkék"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2502,172 +2442,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Adatok"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Adatok"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrád"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrád"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Kiterjesztések nélküli OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Adatok"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "CSE"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Méret: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Méret: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Méret: %1 MB"
@@ -4219,6 +4159,54 @@ msgstr "Bőséges"
 msgid "WinLangID"
 msgstr "40e"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Ápr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Febr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jún"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Márc"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Máj"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Aug"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dec"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Júl"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Okt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Szept"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Égitest"
@@ -4425,7 +4413,7 @@ msgstr "URL betöltése:"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Verzió:"
 
@@ -4437,33 +4425,43 @@ msgstr "Időzóna neve: "
 msgid "UTC Offset"
 msgstr "UTC eltérés"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Kép betöltése fájlból"
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": ismeretlen, vagy nem támogatott képfájl típus.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Hiba a PNG képfájlban"
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Hiba a PNG képfájlban"
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Hiba a képfájl megnyitásakor"
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr "nem PNG fájl.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Hiba a PNG képfájlban"
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Hiba a PNG képfájlban"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6882,10 +6880,6 @@ msgstr "Supported Extensions:"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "ARB fragment programok inicializálása . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": ismeretlen, vagy nem támogatott képfájl típus.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "NV vertex program betöltése:"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2023-08-06 17:40+0200\n"
 "Last-Translator: Mattia Verga <mattia.verga@tiscali.it>\n"
 "Language-Team: \n"
@@ -19,71 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.3.2\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Gen"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Feb"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Apr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mag"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Giu"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Lug"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Ago"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Set"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Ott"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dic"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Ora legale"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "Ora solare"
 
@@ -140,11 +80,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nebulosa"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Ammasso aperto"
 
@@ -274,11 +214,11 @@ msgstr "Stella non valida: manca il tipo spettrale.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr "Baricentro {} non esistente.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Creazione di trama a mosaico. Larghezza={}, max={}\n"
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Creazione di trama ordinaria: {}x{}\n"
 
@@ -602,23 +542,23 @@ msgstr "Errore di lettura del file di configurazione."
 msgid "Initialization of SPICE library failed."
 msgstr "Inizializzazione della libreria SPICE fallita."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Impossibile leggere il database delle stelle."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Errore di apertura del catalogo oggetti di profondo cielo {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Impossibile leggere il database degli oggetti di profondo cielo {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Errore di apertura del catalogo del sistema solare {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Errore di apertura del file dei confini delle costellazioni {}.\n"
 
@@ -666,7 +606,7 @@ msgstr "Impossibile registrare un fotogramma!\n"
 msgid "Unsupported image type: {}!\n"
 msgstr "Tipo di immagine non supportata: {}!\n"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 msgid "Error opening asterisms file {}.\n"
 msgstr "Errore di apertura del file degli asterismi {}.\n"
 
@@ -784,24 +724,24 @@ msgstr "ft"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr "giorni"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "ore"
 
@@ -1132,17 +1072,17 @@ msgstr "Oggetti di profondo cielo"
 msgid "Event Finder"
 msgstr "Cercatore di Eventi"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Tempo"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Guide"
@@ -1712,13 +1652,13 @@ msgstr "O"
 msgid "Orbits"
 msgstr "Orbite"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1791,7 +1731,6 @@ msgstr "Asteroidi"
 msgid "Comets"
 msgstr "Comete"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1801,6 +1740,7 @@ msgstr "Comete"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1828,11 +1768,11 @@ msgstr "L"
 msgid "Labels"
 msgstr "Etichette"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2369,167 +2309,167 @@ msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 "Celestia non è stato in grado di inizializzare le estensioni OpenGL 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr "Errore: nessun oggetto selezionato!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Informazioni"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr "Informazioni web: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Raggio equatoriale:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Dimensione:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr "<b>Schiacciamento: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Periodo di rotazione siderale:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr "Progrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr "Retrogrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Direzione di rotazione:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Durata del giorno:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Ha anelli</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Ha un'atmosfera</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Inizio:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Fine:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Informazioni sull'orbita"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Elementi osculanti per %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "anni"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Periodo:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "UA"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Semiasse maggiore:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Eccentricità:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>Inclinazione:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Distanza pericentro:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Distanza apocentro:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>Nodo ascendente:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>Argomento del pericentro:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>Anomalia media:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Periodo (calcolato):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "<b>Periodo (calcolato):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>AR:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Dec:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
@@ -3974,6 +3914,54 @@ msgstr "Dettagliato"
 msgid "WinLangID"
 msgstr "WinLangID"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Apr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Feb"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Gen"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Giu"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mag"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Ago"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dic"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Lug"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Ott"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Set"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satellite"
@@ -4179,7 +4167,7 @@ msgstr "Caricamento dell'URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versione: "
 
@@ -4191,29 +4179,39 @@ msgstr "Nome fuso orario"
 msgid "UTC Offset"
 msgstr "Differenza tempo universale"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 msgid "Loading image from file {}\n"
 msgstr "Caricamento immagine dal file {}\n"
 
-#: ../src/celimage/png.cpp:53
-msgid "Error opening image file {}.\n"
-msgstr "Errore nell'apertura del file di immagine {}.\n"
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": tipo di file di immagine non riconosciuto o non supportato.\n"
 
-#: ../src/celimage/png.cpp:61
-msgid "Error: {} is not a PNG file.\n"
-msgstr "Errore: {} non è un file PNG.\n"
-
-#: ../src/celimage/png.cpp:87
-msgid "Error reading PNG image file {}\n"
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
 msgstr "Errore di lettura del file di immagine PNG {}\n"
 
-#: ../src/celimage/png.cpp:177
+#: ../src/celimage/png.cpp:49
 msgid "Can't open screen capture file '{}'\n"
 msgstr "Impossibile aprire il file della schermata acquisita '{}'\n"
 
-#: ../src/celimage/png.cpp:226
+#: ../src/celimage/png.cpp:105
 msgid "Error writing PNG file '{}'\n"
 msgstr "Errore di scrittura del file di immagine PNG '{}'\n"
+
+#: ../src/celimage/png.cpp:153
+msgid "Error opening image file {}.\n"
+msgstr "Errore nell'apertura del file di immagine {}.\n"
+
+#: ../src/celimage/png.cpp:161
+msgid "Error: {} is not a PNG file.\n"
+msgstr "Errore: {} non è un file PNG.\n"
+
+#: ../src/celimage/png.cpp:187
+msgid "Error reading PNG image file {}\n"
+msgstr "Errore di lettura del file di immagine PNG {}\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."
@@ -6695,10 +6693,6 @@ msgstr "Numero di cifre {} non supportato, previsto {}.\n"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Inizializzazione dei frammenti di programma ARB . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": tipo di file di immagine non riconosciuto o non supportato.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Caricamento del programma vertici NV: "

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2020-07-05 21:01+0900\n"
 "Last-Translator: Sui Ota <aqua@aqsp.net>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.3.1\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "1"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "2"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "3"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "4"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "5"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "6"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "7"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "8"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "9"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "10"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "11"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "12"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "夏時間"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "標準時"
 
@@ -139,11 +79,11 @@ msgstr "   モデル統計: %u vertices, %u primitives, %u materials (%u unique)
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "星雲"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "散開星団"
 
@@ -278,12 +218,12 @@ msgstr "無効な恒星です: スペクトル型がありません。\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr "重心 %sは存在しません。\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "タイルテクスチャを生成中。幅: %i, 最大: %i\n"
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "通常テクスチャを生成中: %i×%i\n"
@@ -614,26 +554,26 @@ msgstr "設定ファイルの読み込みでエラーが発生しました。"
 msgid "Initialization of SPICE library failed."
 msgstr "SPICEライブラリの初期化に失敗しました。"
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "恒星データベースを読み込めません。"
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "遠距離天体カタログ %sのオープンでエラーが発生しました。\n"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "遠距離天体データベース %sを読み込めません。 \n"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "恒星系カタログ %sのオープンでエラーが発生しました。\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "星座境界線ファイル %sのオープンでエラーが発生しました。\n"
@@ -687,7 +627,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "サポートされた拡張:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "星座線ファイル %sのオープンでエラーが発生しました。\n"
@@ -807,24 +747,24 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr "日"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "時間"
 
@@ -1156,17 +1096,17 @@ msgstr "遠距離天体"
 msgid "Event Finder"
 msgstr "天体現象を検索"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "時間"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "ガイド"
@@ -1742,13 +1682,13 @@ msgstr "O"
 msgid "Orbits"
 msgstr "軌道"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1821,7 +1761,6 @@ msgstr "小惑星"
 msgid "Comets"
 msgstr "彗星"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1831,6 +1770,7 @@ msgstr "彗星"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1859,11 +1799,11 @@ msgstr "L"
 msgid "Labels"
 msgstr "名称"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2401,169 +2341,169 @@ msgstr ""
 "CelestiaはOpenGL拡張の初期化に失敗しました(エラー %i)。グラフィック品質が低下"
 "します。"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr "エラー: 天体が選択されていません。\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "情報"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr "Web情報: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>赤道半径:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>大きさ:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr "<b>偏平率: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>自転周期(恒星時):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "ベオグラード"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "ベオグラード"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>レンダラー: </b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>1日の長さ:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>軌道長半径:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>周期:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "軌道情報"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "%1 の接触要素"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "年"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>周期:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "天文単位"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>軌道長半径:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>軌道長半径:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>軌道傾斜角:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>近点距離:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>遠点距離:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>昇交点:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>近点引数:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>平均近点角:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>自転周期 (計算):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "<b>自転周期 (計算):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>赤経:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>赤緯:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
@@ -4013,6 +3953,54 @@ msgstr "多い"
 msgid "WinLangID"
 msgstr "411"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "4"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "2"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "1"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "6"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "3"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "5"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "8"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "12"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "7"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "11"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "10"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "9"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "衛星"
@@ -4223,7 +4211,7 @@ msgstr "URLを読み込んでいます..."
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "バージョン: "
 
@@ -4235,33 +4223,43 @@ msgstr "タイムゾーン名"
 msgid "UTC Offset"
 msgstr "協定世界時との差"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "画像ファイル %sを読み込んでいます\n"
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr "%s: 認識できないか，サポートされていない画像ファイルです。\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "PNG画像ファイル %sの読み込みでエラーが発生しました\n"
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "PNG画像ファイル %sの読み込みでエラーが発生しました\n"
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "画像ファイル %sの読み込みでエラーが発生しました\n"
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr "エラー: %sはPNGファイルではありません。\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "PNG画像ファイル %sの読み込みでエラーが発生しました\n"
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "PNG画像ファイル %sの読み込みでエラーが発生しました\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6853,9 +6851,6 @@ msgstr "サポートされていない桁数 %iです。%iが必要です。\n"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "ARBフラグメントプログラムを初期化しています...\n"
-
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr "%s: 認識できないか，サポートされていない画像ファイルです。\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "次のNVバーテックスプログラムを読み込んでいます: "

--- a/po/ka.po
+++ b/po/ka.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2023-11-03 13:48+0200\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023\n"
 "Language-Team: Georgian (https://app.transifex.com/celestia/teams/93131/"
@@ -22,71 +22,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "იან"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "თებ"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "მარ"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "აპრ"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "მაისი"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "ივნ"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "ივლ"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "აგვ"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "სექ"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "ოქტ"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "ნოემ"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "დეკ"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -139,11 +79,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "ნისლეული"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "კლასტერის გახსნა"
 
@@ -268,11 +208,11 @@ msgstr "არასწორი ვარსკვლავი: სპექტ
 msgid "Barycenter {} does not exist.\n"
 msgstr "ბარიცენტრი {} არ არსებობს.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "ჩვეულებრივი ტექსტურის შექმნა:{}x{}\n"
 
@@ -591,23 +531,23 @@ msgstr "შეცდომა კონფიგურაციის ფაი�
 msgid "Initialization of SPICE library failed."
 msgstr "SPICE ბიბლიოთეკის ინიციალიზაცია ჩავარდა."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "ვარსკვლავების ბაზის წაკითხვა შეუძლებელია."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 msgid "Error opening solar system catalog {}.\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr ""
 
@@ -655,7 +595,7 @@ msgstr "კადრის გადაღება შეუძლებელ�
 msgid "Unsupported image type: {}!\n"
 msgstr "გამოსახულების ფალის მხარდაუჭერელი ტიპი: {}!\n"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 msgid "Error opening asterisms file {}.\n"
 msgstr ""
 
@@ -773,24 +713,24 @@ msgstr "ფტ"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "კმ"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr "წთ"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr "დღე"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "საათი"
 
@@ -1113,17 +1053,17 @@ msgstr "ღრმა კოსმოსის ობიექტები"
 msgid "Event Finder"
 msgstr "მოვლენის მომძებნი"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "დრო"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "გიდები"
@@ -1687,13 +1627,13 @@ msgstr "O"
 msgid "Orbits"
 msgstr "ორბიტები"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1766,7 +1706,6 @@ msgstr "ასტეროიდები"
 msgid "Comets"
 msgstr "კომეტები"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1776,6 +1715,7 @@ msgstr "კომეტები"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1803,11 +1743,11 @@ msgstr "L"
 msgid "Labels"
 msgstr "ჭდეები"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2337,167 +2277,167 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "ინფორმაცია"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>ეკვატორული რადიუსი:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>ზომა:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>ბრუნვის მიმართულება:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>დღის სიგრძე:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>აქვს რგოლები</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>აქვს ატმოსფერო</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>დასაწყისი:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>დასასრული:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "ორბიტის ინფორმაცია"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "წელი"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>პერიოდი:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "აე"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>ნახევრად-მნიშვნელოვანი ღერძი:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>ექსცენტრულობა:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>დახრა:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>პერიცენტრს დაშორება:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>აპოცენტრის დაშორება:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
@@ -3939,6 +3879,54 @@ msgstr "დამატებითი შეტყობინებები"
 msgid "WinLangID"
 msgstr ""
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "აპრ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "თებ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "იან"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "ივნ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "მარ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "მაისი"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "აგვ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "დეკ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "ივლ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "ნოემ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "ოქტ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "სექ"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "თანამგზავრი"
@@ -4139,7 +4127,7 @@ msgstr "ბმულის ჩატვირთვა"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "ვერსია: "
 
@@ -4151,29 +4139,38 @@ msgstr "დროის სარტყლის სახელი"
 msgid "UTC Offset"
 msgstr "UTC დროიდან წანაცვლება"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 msgid "Loading image from file {}\n"
 msgstr "გამოსახულების ჩატვირთვა ფაილიდან {}\n"
 
-#: ../src/celimage/png.cpp:53
-msgid "Error opening image file {}.\n"
-msgstr "გამოსახულების ფაილის გახსნის შეცდომა {}.\n"
+#: ../src/celimage/image.cpp:409
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
 
-#: ../src/celimage/png.cpp:61
-msgid "Error: {} is not a PNG file.\n"
-msgstr "შეცდომა: {} PNG ფაილი არაა.\n"
-
-#: ../src/celimage/png.cpp:87
-msgid "Error reading PNG image file {}\n"
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
 msgstr "შეცდომა PNG ფაილის წაკითხვისას: {}\n"
 
-#: ../src/celimage/png.cpp:177
+#: ../src/celimage/png.cpp:49
 msgid "Can't open screen capture file '{}'\n"
 msgstr "ეკრანის ანაბეჭდის ფაილის '{}' გახსნა შეუძლებელია\n"
 
-#: ../src/celimage/png.cpp:226
+#: ../src/celimage/png.cpp:105
 msgid "Error writing PNG file '{}'\n"
 msgstr "PNG ფაილის '{}' ჩაწერის შეცდომა\n"
+
+#: ../src/celimage/png.cpp:153
+msgid "Error opening image file {}.\n"
+msgstr "გამოსახულების ფაილის გახსნის შეცდომა {}.\n"
+
+#: ../src/celimage/png.cpp:161
+msgid "Error: {} is not a PNG file.\n"
+msgstr "შეცდომა: {} PNG ფაილი არაა.\n"
+
+#: ../src/celimage/png.cpp:187
+msgid "Error reading PNG image file {}\n"
+msgstr "შეცდომა PNG ფაილის წაკითხვისას: {}\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 20:48+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "1"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "2"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "3"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "4"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "5"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "6"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "7"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "8"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "9"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "10"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "11"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "12"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "일광절약시간"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "표준시간"
 
@@ -138,11 +78,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "성운"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "산개성단"
 
@@ -277,12 +217,12 @@ msgstr "잘못된 항성: 분광형이 없습니다.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " 파일을 찾을 수 없습니다.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "타일 텍스처 생성중. 폭="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "일반 텍스처 생성중: "
@@ -617,26 +557,26 @@ msgstr "설정 파일 읽는 중 오류가 발생했습니다."
 msgid "Initialization of SPICE library failed."
 msgstr "SPICE 라이브러리 초기화에 실패했습니다."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "항성 데이타베이스를 읽을 수 없습니다."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "항성 카탈로그 파일 읽는 중 에러: "
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "항성 데이타베이스를 읽을 수 없습니다."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "항성계 카탈로그의 여는 중 오류 발생.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "별자리 경계선 파일을 여는 중 오류가 발생"
@@ -690,7 +630,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "지원되는 확장"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "별자리 파일 여는 중 오류가 발생했습니다."
@@ -810,26 +750,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " 일"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " 시간"
@@ -1171,17 +1111,17 @@ msgstr " 먼 우주 천체(DSO)"
 msgid "Event Finder"
 msgstr "식 찾기"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "현재 시각"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1814,13 +1754,13 @@ msgstr "확인"
 msgid "Orbits"
 msgstr "궤도"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1893,7 +1833,6 @@ msgstr "소행성"
 msgid "Comets"
 msgstr "혜성"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1903,6 +1842,7 @@ msgstr "혜성"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1932,11 +1872,11 @@ msgstr "10x 빠르게(&F)\tL"
 msgid "Labels"
 msgstr "이름"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2502,172 +2442,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "천체정보(&I)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL정보"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "자전주기: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "베오그라드"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "베오그라드"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>미확장 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "천체 정보 표시"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "AU"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "자전주기: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "자전주기: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "크기: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "크기: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "크기: %1 MB"
@@ -4216,6 +4156,54 @@ msgstr "많이"
 msgid "WinLangID"
 msgstr "412"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "4"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "2"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "1"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "6"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "3"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "5"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "8"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "12"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "7"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "11"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "10"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "9"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "위성"
@@ -4423,7 +4411,7 @@ msgstr "URL 로딩중"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "버전: "
 
@@ -4435,33 +4423,43 @@ msgstr "표준시간대"
 msgid "UTC Offset"
 msgstr "UTC 오프셋"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "이미지 파일 읽는 중: "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": 지원하지 않거나 알수없는 파일입니다.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "PNG파일 읽기 오류: "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "PNG파일 읽기 오류: "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "이미지 파일 에러: "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " 는 PNG파일이 아닙니다.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "PNG파일 읽기 오류: "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "PNG파일 읽기 오류: "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6877,10 +6875,6 @@ msgstr "지원되는 확장"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "ARB 프레그먼트 프로그램을 초기화 합니다\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": 지원하지 않거나 알수없는 파일입니다.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "NV 버텍스 프로그램 읽는 중: "

--- a/po/lt.po
+++ b/po/lt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia lt\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2020-07-14 06:47+0300\n"
 "Last-Translator: Mantas Kriaučiūnas <baltix@gmail.com>\n"
 "Language-Team: \n"
@@ -12,71 +12,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Saus"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Vas"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Kov"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Bal"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Gegužė"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Bir"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Lie"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Rugp"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Rugs"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Spa"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Lap"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Gru"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -133,11 +73,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Ūkas"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Padrikasis spiečius"
 
@@ -272,12 +212,12 @@ msgstr "Negaliojanti žvaigždė: prarastas spektrinis tipas.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " neegzistuoja.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Sukuriama skaidyta tekstūra. Plotis="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Kuriama paprastoji tekstūra:"
@@ -606,26 +546,26 @@ msgstr "Klaida nuskaitant konfigūracijos failą."
 msgid "Initialization of SPICE library failed."
 msgstr "Nesėkmingas SPICE bibliotekos inicijavimas."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Neįmanoma nuskaityti žvaigždžių duomenų bazės."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Klaida atveriant gilaus dangaus katalogo failą."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Neįmanoma nuskaityti žvaigždžių duomenų bazės."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Klaida atveriant saulės sistemos katalogą.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Klaida atveriant žvaigždynų failą."
@@ -678,7 +618,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Klaida atveriant asterisms failą."
@@ -797,25 +737,25 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr "dienos"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr "valandos"
@@ -1157,17 +1097,17 @@ msgstr "Rodyti objektus"
 msgid "Event Finder"
 msgstr "Užtemimų paiška"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Laikas"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1778,13 +1718,13 @@ msgstr "Gerai"
 msgid "Orbits"
 msgstr "Orbitos"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1857,7 +1797,6 @@ msgstr "Asteroidai"
 msgid "Comets"
 msgstr "Kometos"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1867,6 +1806,7 @@ msgstr "Kometos"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1895,11 +1835,11 @@ msgstr ""
 msgid "Labels"
 msgstr "Pavadinimai"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2456,171 +2396,171 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Didis:  %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgradas"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgradas"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "Plokštė:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informacinis tekstas"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:317
-#, qt-format
-msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
-msgid "<b>Eccentricity:</b> %L1"
+msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
+msgid "<b>Eccentricity:</b> %L1"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
@@ -4160,6 +4100,54 @@ msgstr "Pilnas"
 msgid "WinLangID"
 msgstr "WinKalbID"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Bal"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Vas"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Saus"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Bir"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Kov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Gegužė"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Rugp"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Gru"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Lie"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Lap"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Spa"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Rugs"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Palydovas"
@@ -4366,7 +4354,7 @@ msgstr "Įkeliamas URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versija: "
 
@@ -4378,34 +4366,44 @@ msgstr "Laiko juostos pavadinimas"
 msgid "UTC Offset"
 msgstr "UTC kompensacija"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Įkeliamas paveikslas iš failo "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": nežinomas arba nepalaikomas atvaizdo failo tipas.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Klaida skaitant PNG atvaizdo failą "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Klaida įrašant '%s'.\n"
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Klaida įkeliant atvaizdo failą "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " tai ne PNG failas.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
 msgstr "Klaida skaitant PNG atvaizdo failą "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
-msgstr "Klaida įrašant '%s'.\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."
@@ -6858,9 +6856,6 @@ msgstr ""
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "ARB fragmento programų inicijavimas . . .\n"
-
-#~ msgid ": unrecognized or unsupported image file type.\n"
-#~ msgstr ": nežinomas arba nepalaikomas atvaizdo failo tipas.\n"
 
 #~ msgid "   Model statistics: "
 #~ msgstr "  Modelio statistika: "

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 20:49+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -19,71 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
 "2);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Feb"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Apr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mai"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jūn"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Jūl"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Aug"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Sep"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Okt"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dec"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -139,11 +79,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Miglājus"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Vaļējās kopas"
 
@@ -278,12 +218,12 @@ msgstr "Kļūdaina zvaigzne: nav norādīta spektra klase.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " neeksistē.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Tiek veidota sadalīta tekstūra. Platums="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Tiek veidota parasta tekstūra: "
@@ -618,26 +558,26 @@ msgstr "Kļūda nolasot konfigurācijas failu."
 msgid "Initialization of SPICE library failed."
 msgstr "SPICE bibliotēkas inicializācija neizdevās."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Nevar ielasīt zvaigžņu datubāzi."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Kļūda atverot deespky kataloga failu."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Nevar ielasīt zvaigžņu datubāzi."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Kļūda atverot zvaigžņu sistēmas katalogu.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Kļūda atverot zvaigznāju robežu failus."
@@ -691,7 +631,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Atbalstītie paplašinājumi:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Kļūda atverot asterismu failu."
@@ -811,26 +751,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " dienas"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " stundas"
@@ -1172,17 +1112,17 @@ msgstr " dziļā kosmosa objekti"
 msgid "Event Finder"
 msgstr "Aptumsumu meklētājs"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Laiks"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1815,13 +1755,13 @@ msgstr "Labi"
 msgid "Orbits"
 msgstr "Orbītas"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1894,7 +1834,6 @@ msgstr "Asteroīdiem"
 msgid "Comets"
 msgstr "Komētām"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1904,6 +1843,7 @@ msgstr "Komētām"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1933,11 +1873,11 @@ msgstr "10x Ā&trāk\tL"
 msgid "Labels"
 msgstr "Nosaukumus"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2503,172 +2443,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Informācija"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL informācija"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrada"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrada"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Nepaplašināts OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informatīvais teksts"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Izmērs: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Izmērs: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Izmērs: %1 MB"
@@ -4215,6 +4155,54 @@ msgstr "pilnīgs"
 msgid "WinLangID"
 msgstr "0426"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Apr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Feb"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jūn"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mai"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Aug"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dec"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Jūl"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Okt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Sep"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Pavadonis"
@@ -4421,7 +4409,7 @@ msgstr "Ielādē URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versija: "
 
@@ -4433,33 +4421,43 @@ msgstr "Laika zona"
 msgid "UTC Offset"
 msgstr "UTC nobīde"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Ielādē attēlu no faila"
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": neatpazīts vai neatbalstīts attēla faila tips.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Kļūda ielādējot PNG attēla failu"
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Kļūda ielādējot PNG attēla failu"
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Kļūda atverot attēla failu"
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " nav PNG fails. \n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Kļūda ielādējot PNG attēla failu"
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Kļūda ielādējot PNG attēla failu"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6772,10 +6770,6 @@ msgstr "Atbalstītie paplašinājumi:"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Inicializē ARB fragmentprogrammas . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": neatpazīts vai neatbalstīts attēla faila tips.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Ielādē NV verteksu programmu: "

--- a/po/nb.po
+++ b/po/nb.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2010-02-25 17:50+0100\n"
 "Last-Translator: Bjørn Steensrud <bjornst@skogkatt.homelinux.org>\n"
 "Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
@@ -19,71 +19,11 @@ msgstr ""
 "X-Generator: Lokalize 1.0\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "feb."
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Apr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mai"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jun"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Jul"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Aug"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Sep"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Okt"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Des"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Sommertid"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "Standardtid"
 
@@ -139,12 +79,12 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 #, fuzzy
 msgid "Nebula"
 msgstr "Tåker"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 #, fuzzy
 msgid "Open cluster"
 msgstr "Åpne stjernehoper"
@@ -280,12 +220,12 @@ msgstr "Ugyldig stjerne: spektraltype mangler.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " finnes ikke.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Oppretter flislagt tekstur. Bredde="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Oppretter vanlig tekstur: "
@@ -614,26 +554,26 @@ msgstr "Feil ved lesing av oppsettsfil."
 msgid "Initialization of SPICE library failed."
 msgstr "Klarte kke klargjøre SPICE-biblioteket."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Kan ikke lese stjernedatabase."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Feil ved åpning av katalogfil med fjerne objekter."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Kan ikke lese stjernedatabase."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Feil ved åpning av solsystemkatalogen.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Feil ved åpning av fil med stjernebildelinjer."
@@ -686,7 +626,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr ""
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Feil ved åpning av fil med asterismer."
@@ -806,26 +746,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " dager"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " timer"
@@ -1166,17 +1106,17 @@ msgstr "Vis baner"
 msgid "Event Finder"
 msgstr "Formørkelsesfinner"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Tid"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1787,13 +1727,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Baner"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1866,7 +1806,6 @@ msgstr "Asteroider"
 msgid "Comets"
 msgstr "Kometer"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1876,6 +1815,7 @@ msgstr "Kometer"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1904,11 +1844,11 @@ msgstr ""
 msgid "Labels"
 msgstr "Etiketter"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2466,169 +2406,169 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "Omløpstid: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informasjonstekst"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:317
-#, qt-format
-msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
-msgid "<b>Eccentricity:</b> %L1"
+msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
+msgid "<b>Eccentricity:</b> %L1"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
@@ -4164,6 +4104,54 @@ msgstr "Pratsomt"
 msgid "WinLangID"
 msgstr "WinLangID"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Apr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "feb."
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jun"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mai"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Aug"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Des"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Jul"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Okt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Sep"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satellitt"
@@ -4370,7 +4358,7 @@ msgstr "Laster URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versjon: "
 
@@ -4382,34 +4370,44 @@ msgstr "Navn på tidssone "
 msgid "UTC Offset"
 msgstr "UTC-avstand"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Laster inn bilde fra fil "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": bildefiltypen er ukjent eller ikke støttet.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Feil ved lesing av PNG-bildefil "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Feil ved åpning av skript «%s»"
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Feil ved åpning av bildefil "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " er ikke en PNG-fil.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
 msgstr "Feil ved lesing av PNG-bildefil "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
-msgstr "Feil ved åpning av skript «%s»"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."
@@ -4539,9 +4537,6 @@ msgstr ""
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Klargjør ARB fragmentprogrammer . . .\n"
-
-#~ msgid ": unrecognized or unsupported image file type.\n"
-#~ msgstr ": bildefiltypen er ukjent eller ikke støttet.\n"
 
 #~ msgid "Error: "
 #~ msgstr "Feil: "

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 20:50+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Feb"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mrt"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Apr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mei"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jun"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Jul"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Aug"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Sep"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Oct"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dec"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Zomertijd"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -138,11 +78,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nevels"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Open sterrenhoop"
 
@@ -277,12 +217,12 @@ msgstr "Ongeldige ster: spectraal type niet aanwezig.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr "bestaat niet.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Aanmaken getegelde textuur. Breedte="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Aanmaken normale textuur: "
@@ -617,26 +557,26 @@ msgstr "Fout tijdens het lezen van het configuratiebestand."
 msgid "Initialization of SPICE library failed."
 msgstr "Initializatie van SPICE bibliotheek faalde."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Kan sterrendatabase niet lezen."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Fout bij openen deepsky catalogusbestand."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Kan sterrendatabase niet lezen."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Fout tijdens openen van zonnestelselcatalogus.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Fout tijdens openen van bestanden met sterrenbeeldgrenzingen."
@@ -690,7 +630,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Ondersteunde extensies:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Fout tijdens openen van niet-officiële sterrenbeelden bestand."
@@ -810,26 +750,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr "dagen"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr "uren"
@@ -1171,17 +1111,17 @@ msgstr "diep ruimte objecten"
 msgid "Event Finder"
 msgstr "Eclips Vinder"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Tijd"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1813,13 +1753,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Omloopbanen"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1892,7 +1832,6 @@ msgstr "Planetoiden"
 msgid "Comets"
 msgstr "Kometen"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1902,6 +1841,7 @@ msgstr "Kometen"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1931,11 +1871,11 @@ msgstr "10x &Sneller\tL"
 msgid "Labels"
 msgstr "Labels"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2501,172 +2441,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informatietekst"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Grootte: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Grootte: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Grootte: %1 MB"
@@ -4211,6 +4151,54 @@ msgstr "Volledig"
 msgid "WinLangID"
 msgstr "413"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Apr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Feb"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jun"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mrt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mei"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Aug"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dec"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Jul"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Oct"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Sep"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satelliet"
@@ -4417,7 +4405,7 @@ msgstr "Laden van URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versie: "
 
@@ -4429,33 +4417,43 @@ msgstr "Tijdzonenaam"
 msgid "UTC Offset"
 msgstr "UTC Offset"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Bezig met laden van afbeelding uit bestand"
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": onbekend of niet ondersteund type voor afbeeldingsbestand.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Fout bij lezen van PNG afbeeldingsbestand"
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Fout bij lezen van PNG afbeeldingsbestand"
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Fout tijdens openen van afbeeldingsbestand"
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr "is geen PNG bestand.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Fout bij lezen van PNG afbeeldingsbestand"
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Fout bij lezen van PNG afbeeldingsbestand"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6874,10 +6872,6 @@ msgstr "Ondersteunde extensies:"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Initialiseren van ARB fragment programma's\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": onbekend of niet ondersteund type voor afbeeldingsbestand.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Bezig met laden van NV vertex programma: "

--- a/po/pl.po
+++ b/po/pl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2019-02-14 21:31+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: Polish (https://www.transifex.com/celestia/teams/93131/pl/)\n"
@@ -24,71 +24,11 @@ msgstr ""
 "n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Sty"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Lut"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Kwi"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Maj"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Cze"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Lip"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Sie"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Wrz"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Paź"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Lis"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Gru"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -143,11 +83,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Mgławica"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Gromada otwarta "
 
@@ -277,11 +217,11 @@ msgstr "Nieprawidłowa gwiazda: brak typu spektralnego.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr "Katalog z dodatkami %1 nie istnieje"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr ""
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr ""
 
@@ -609,26 +549,26 @@ msgstr "Błąd odczytu pliku konfiguracyjnego."
 msgid "Initialization of SPICE library failed."
 msgstr "Nie udało się wczytać biblioteki SPICE."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Nie można odczytać bazy danych gwiazd."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Błąd otwierania pliku skryptu."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Nie można odczytać bazy danych gwiazd."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Błąd otwierania katalogu układu słonecznego.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Błąd otwierania plików granic gwiazdozbiorów."
@@ -682,7 +622,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Obsługiwane rozszerzenia:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Błąd podczas otwierania pliku astronomów."
@@ -801,24 +741,24 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr ""
 
@@ -1143,17 +1083,17 @@ msgstr "Obiekty głębokiego nieba"
 msgid "Event Finder"
 msgstr "Wyszukiwarka wydarzeń"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Czas"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Przewodniki"
@@ -1721,13 +1661,13 @@ msgstr ""
 msgid "Orbits"
 msgstr "Orbity"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1800,7 +1740,6 @@ msgstr "Asteroidy"
 msgid "Comets"
 msgstr "Komety"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1810,6 +1749,7 @@ msgstr "Komety"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1838,11 +1778,11 @@ msgstr ""
 msgid "Labels"
 msgstr "Nazwy"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2381,169 +2321,169 @@ msgstr ""
 "Celestia nie mogła zainicjować rozszerzeń OpenGL (błąd %1). Jakość grafiki "
 "będzie zmniejszona."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "Renderer: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:317
-#, qt-format
-msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
-msgid "<b>Eccentricity:</b> %L1"
+msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
+msgid "<b>Eccentricity:</b> %L1"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr ""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr ""
@@ -3997,6 +3937,54 @@ msgstr "Szczegółowe"
 msgid "WinLangID"
 msgstr "415"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Kwi"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Lut"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Sty"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Cze"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Maj"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Sie"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Gru"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Lip"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Lis"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Paź"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Wrz"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satelita"
@@ -4200,7 +4188,7 @@ msgstr "Ładowanie URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Wersja:"
 
@@ -4212,32 +4200,41 @@ msgstr "Nazwa strefy czasowej"
 msgid "UTC Offset"
 msgstr "Przesunięcie do UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Błąd odczytu pliku ulubionych."
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Błąd odczytu pliku ulubionych."
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Błąd odczytu pliku ulubionych."
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Błąd podczas otwierania pliku astronomów."
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 msgid "Error: {} is not a PNG file.\n"
 msgstr ""
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Błąd odczytu pliku ulubionych."
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Błąd odczytu pliku ulubionych."
 
 #: ../src/celscript/legacy/legacyscript.cpp:101

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 20:52+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Fev"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Abr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mai"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jun"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Jul"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Ago"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Set"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Out"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dez"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Hora de Verão"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -138,11 +78,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nebulosa"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Aglomerados Abertos"
 
@@ -277,12 +217,12 @@ msgstr "Estrela inválida: classe espectral ausente.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " não existe.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Criando uma textura em mosaico. Largura="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Criando textura normal: "
@@ -617,26 +557,26 @@ msgstr "Erro ao ler o ficheiro de configuração."
 msgid "Initialization of SPICE library failed."
 msgstr "Inicialização da livraria SPICE falhou."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Erro ao abrir o catálogo de céu profundo. "
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Erro ao abrir o catálogo do Sistema Solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Erro ao abrir o ficheiro das fronteiras das constelações."
@@ -690,7 +630,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Erro ao abrir o ficheiro dos asterismos."
@@ -810,26 +750,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " dias"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " horas"
@@ -1171,17 +1111,17 @@ msgstr " objectos de céu profundo"
 msgid "Event Finder"
 msgstr "Buscador de eclipses"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Hora"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1813,13 +1753,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Órbitas"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1892,7 +1832,6 @@ msgstr "Asteróides"
 msgid "Comets"
 msgstr "Cometas"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1902,6 +1841,7 @@ msgstr "Cometas"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1931,11 +1871,11 @@ msgstr "10x Mais &Rápido\tL"
 msgid "Labels"
 msgstr "Legendas"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2501,172 +2441,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Informação"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Informação"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
@@ -4212,6 +4152,54 @@ msgstr "Completo"
 msgid "WinLangID"
 msgstr "0816"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Abr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Fev"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jun"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mai"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Ago"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dez"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Jul"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Out"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Set"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satélite"
@@ -4418,7 +4406,7 @@ msgstr "A carregar o URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versão: "
 
@@ -4430,33 +4418,43 @@ msgstr "Fuso Horário"
 msgid "UTC Offset"
 msgstr "Desvio em relação ao GMT"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "A carregar imagem do ficheiro "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": tipo de ficheiro de imagem irreconhecível ou não suportado.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Erro ao ler o ficheiro de imagem PNG "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Erro ao ler o ficheiro de imagem PNG "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Erro ao abrir o ficheiro de imagem "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " não é um ficheiro PNG.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Erro ao ler o ficheiro de imagem PNG "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Erro ao ler o ficheiro de imagem PNG "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6875,10 +6873,6 @@ msgstr "Extensões suportadas: "
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "A inicialzar os programas de fragmentos ARB . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": tipo de ficheiro de imagem irreconhecível ou não suportado.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "A carregar o programa de vértices NV: "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 20:52+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Fev"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Abr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mai"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jun"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Jul"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Ago"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Set"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Out"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dez"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Hora de Verão"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -138,11 +78,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nebulosa"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Aglomerados Abertos"
 
@@ -277,12 +217,12 @@ msgstr "Estrela inválida: classe espectral ausente.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " não existe.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Criando uma textura em mosaico. Largura="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Criando textura normal: "
@@ -617,26 +557,26 @@ msgstr "Erro ao ler o ficheiro de configuração."
 msgid "Initialization of SPICE library failed."
 msgstr "Inicialização da livraria SPICE falhou."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Erro ao abrir o catálogo de céu profundo. "
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Não é possível ler a base de dados de estrelas."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Erro ao abrir o catálogo do Sistema Solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Erro ao abrir o ficheiro das fronteiras das constelações."
@@ -690,7 +630,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensões suportadas: "
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Erro ao abrir o ficheiro dos asterismos."
@@ -810,26 +750,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " dias"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " horas"
@@ -1171,17 +1111,17 @@ msgstr " objectos de céu profundo"
 msgid "Event Finder"
 msgstr "Buscador de eclipses"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Hora"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1813,13 +1753,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Órbitas"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1892,7 +1832,6 @@ msgstr "Asteróides"
 msgid "Comets"
 msgstr "Cometas"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1902,6 +1841,7 @@ msgstr "Cometas"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1931,11 +1871,11 @@ msgstr "10x Mais &Rápido\tL"
 msgid "Labels"
 msgstr "Legendas"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2501,172 +2441,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Informação"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Informação do OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Tamanho: %1 MB"
@@ -4211,6 +4151,54 @@ msgstr "Completo"
 msgid "WinLangID"
 msgstr "0816"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Abr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Fev"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jun"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mai"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Ago"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dez"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Jul"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Out"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Set"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satélite"
@@ -4417,7 +4405,7 @@ msgstr "A carregar o URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versão: "
 
@@ -4429,33 +4417,43 @@ msgstr "Fuso Horário"
 msgid "UTC Offset"
 msgstr "Desvio em relação ao GMT"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "A carregar imagem do ficheiro "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": tipo de ficheiro de imagem irreconhecível ou não suportado.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Erro ao ler o ficheiro de imagem PNG "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Erro ao ler o ficheiro de imagem PNG "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Erro ao abrir o ficheiro de imagem "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " não é um ficheiro PNG.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Erro ao ler o ficheiro de imagem PNG "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Erro ao ler o ficheiro de imagem PNG "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6874,10 +6872,6 @@ msgstr "Extensões suportadas: "
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "A inicialzar os programas de fragmentos ARB . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": tipo de ficheiro de imagem irreconhecível ou não suportado.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "A carregar o programa de vértices NV: "

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 21:00+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -19,71 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
 "2:1));\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Ian"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Feb"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Apr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mai"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Iun"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Iul"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Aug"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Sep"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Oct"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Noi"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dec"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "ora de vară"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "ora de iarnă"
 
@@ -139,12 +79,12 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 #, fuzzy
 msgid "Nebula"
 msgstr "Randarizează numele nebuloaselor"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 #, fuzzy
 msgid "Open cluster"
 msgstr "Randarizează numele roiurilor deschise"
@@ -280,12 +220,12 @@ msgstr "Stea invalidă: tipul spectral lipseste.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " nu există.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Crearea texturii de pavaj. Laţime="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Crearea texturii: "
@@ -620,26 +560,26 @@ msgstr "Eroare la citirea fişierului de configurare."
 msgid "Initialization of SPICE library failed."
 msgstr "Iniţializarea librăriei SPICE a eşuat."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Baza de date stelara nu poate fi citită."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Eroare la deschiderea catalogului cu obiecte cerestre îndepărtate."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Baza de date stelara nu poate fi citită."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Eroare la deschiderea catalogului sistemului solar.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Eroare la deschiderea fişierelor cu limitele constelaţiilor."
@@ -693,7 +633,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Extensii suportate: "
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Eroare la deschiderea fişierului asterisms."
@@ -813,26 +753,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " zile"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " ore"
@@ -1174,17 +1114,17 @@ msgstr " obiect cerestru îndepărtat"
 msgid "Event Finder"
 msgstr "Caută eclipse"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Timp"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1816,13 +1756,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Orbite"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1895,7 +1835,6 @@ msgstr "Asteroizi"
 msgid "Comets"
 msgstr "Comete"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1905,6 +1844,7 @@ msgstr "Comete"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1934,11 +1874,11 @@ msgstr "10x Mai &repede\tL"
 msgid "Labels"
 msgstr "Etichete"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2504,170 +2444,170 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Informaţii OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 neextins</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Text informativ"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensiune: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensiune: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Dimensiune: %1 MB"
@@ -4215,6 +4155,54 @@ msgstr "Complet"
 msgid "WinLangID"
 msgstr "418"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Apr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Feb"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Ian"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Iun"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mai"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Aug"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dec"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Iul"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Noi"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Oct"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Sep"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satelit"
@@ -4421,7 +4409,7 @@ msgstr "Încarcare URL-ul"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Versiune: "
 
@@ -4433,33 +4421,44 @@ msgstr "Numele fusului orar"
 msgid "UTC Offset"
 msgstr "Decalaj GMT"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Încărcarea imaginei din fişier "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
+": formatul fişierului imagine este necunoscut sau nu este implementat.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Eroare la citirea fişierului cu imagine PNG "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Eroare la citirea fişierului cu imagine PNG "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Eroare la deschiderea fişierului imagine "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr "nu este un fişier PNG.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Eroare la citirea fişierului cu imagine PNG "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Eroare la citirea fişierului cu imagine PNG "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6140,11 +6139,6 @@ msgstr "Extensii suportate: "
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Iniţializarea programelor de fragmentare ARB...\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ""
-#~ ": formatul fişierului imagine este necunoscut sau nu este implementat.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Încărcarea programului NV vertex: "

--- a/po/ru.po
+++ b/po/ru.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Askaniy Anpilogov, 2023\n"
 "Language-Team: Russian (https://app.transifex.com/celestia/teams/93131/ru/)\n"
@@ -25,71 +25,11 @@ msgstr ""
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
 "(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "янв"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "фев"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "мар"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "апр"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "мая"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "июн"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "июл"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "авг"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "сен"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "окт"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "ноя"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "дек"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "STD"
 
@@ -144,11 +84,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr "Индекс сетки {} превышает счётчик VBO {}!"
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Туманность"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Рассеянное скопление"
 
@@ -275,11 +215,11 @@ msgstr "Ошибка у звезды: отсутствие спектральн�
 msgid "Barycenter {} does not exist.\n"
 msgstr "Барицентр {} не существует.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Создание мозаичной текстуры. Ширина={}, макс.={}\n"
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Создание обычной текстуры: {}x{}\n"
 
@@ -600,23 +540,23 @@ msgstr "Ошибка чтения файла конфигурации."
 msgid "Initialization of SPICE library failed."
 msgstr "Ошибка инициализации SPICE библиотеки."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Ошибка чтения базы данных звёзд."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Ошибка открытия файла каталога объектов глубокого космоса {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Ошибка чтения базы данных объектов глубокого космоса {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Ошибка открытия каталога системы {}.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Ошибка открытия файла границ созвездий {}.\n"
 
@@ -664,7 +604,7 @@ msgstr "Не удалось сделать снимок экрана!\n"
 msgid "Unsupported image type: {}!\n"
 msgstr "Неподдерживаемый формат изображения: {}!\n"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 msgid "Error opening asterisms file {}.\n"
 msgstr "Ошибка открытия файла астеризмов {}.\n"
 
@@ -782,24 +722,24 @@ msgstr "фут(ов)"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr "дн."
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "ч."
 
@@ -1124,17 +1064,17 @@ msgstr "Объекты глубокого космоса"
 msgid "Event Finder"
 msgstr "Поиск затмений"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Время"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Вспомогательные элементы"
@@ -1698,13 +1638,13 @@ msgstr "О"
 msgid "Orbits"
 msgstr "Орбиты"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1777,7 +1717,6 @@ msgstr "Астероиды"
 msgid "Comets"
 msgstr "Кометы"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1787,6 +1726,7 @@ msgstr "Кометы"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1814,11 +1754,11 @@ msgstr "Н"
 msgid "Labels"
 msgstr "Названия"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2349,167 +2289,167 @@ msgstr "Celestia не удалось инициализировать OpenGLES 2
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia не удалось инициализировать OpenGL 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr "Ошибка: нет выделенного!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Информация"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr "В интернете: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Экв. радиус:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Размер:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr "<b>Полярное сжатие: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Звёздные сутки:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr "Прямое"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr "Ретроградное"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Направление вращения:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Солнечные сутки:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Есть кольца</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Есть атмосфера</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>От:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>До:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Параметры орбиты"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Оскулирующие элементы на %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "л."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Период обращения:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "а.е."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Большая полуось:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Эксцентриситет:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>Наклонение:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Перицентрическое расстояние:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Апоцентрическое расстояние:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>Долгота восходящего узла:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>Аргумент перицентра:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>Средняя аномалия:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Период обращения (вычисленный):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "<b>Период обращения (вычисленный):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>Прямое восх.:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Склонение:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
@@ -3953,6 +3893,54 @@ msgstr "Подробно"
 msgid "WinLangID"
 msgstr "419"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "апр"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "фев"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "янв"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "июн"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "мар"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "мая"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "авг"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "дек"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "июл"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "ноя"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "окт"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "сен"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Спутник"
@@ -4158,7 +4146,7 @@ msgstr "Загрузка URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Версия: "
 
@@ -4170,29 +4158,38 @@ msgstr "Часовой пояс"
 msgid "UTC Offset"
 msgstr "Смещение по UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 msgid "Loading image from file {}\n"
 msgstr "Загрузка изображения из файла {}\n"
 
-#: ../src/celimage/png.cpp:53
-msgid "Error opening image file {}.\n"
-msgstr "Ошибка при открытии файла изображения {}.\n"
+#: ../src/celimage/image.cpp:409
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
 
-#: ../src/celimage/png.cpp:61
-msgid "Error: {} is not a PNG file.\n"
-msgstr "Ошибка: {} не PNG файл.\n"
-
-#: ../src/celimage/png.cpp:87
-msgid "Error reading PNG image file {}\n"
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
 msgstr "Ошибка чтения файла PNG {}\n"
 
-#: ../src/celimage/png.cpp:177
+#: ../src/celimage/png.cpp:49
 msgid "Can't open screen capture file '{}'\n"
 msgstr "Не удаётся открыть файл снимка экрана «{}»\n"
 
-#: ../src/celimage/png.cpp:226
+#: ../src/celimage/png.cpp:105
 msgid "Error writing PNG file '{}'\n"
 msgstr "Ошибка записи файла PNG «{}»\n"
+
+#: ../src/celimage/png.cpp:153
+msgid "Error opening image file {}.\n"
+msgstr "Ошибка при открытии файла изображения {}.\n"
+
+#: ../src/celimage/png.cpp:161
+msgid "Error: {} is not a PNG file.\n"
+msgstr "Ошибка: {} не PNG файл.\n"
+
+#: ../src/celimage/png.cpp:187
+msgid "Error reading PNG image file {}\n"
+msgstr "Ошибка чтения файла PNG {}\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 21:00+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Feb"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Apr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Máj"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jún"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Júl"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Aug"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Sep"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Okt"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dec"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Letný čas"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "Štandardný čas"
 
@@ -139,11 +79,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Hmlovina"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Otvorená hviezdokopa"
 
@@ -278,12 +218,12 @@ msgstr "Neplatná hviezda: chýba spektrálny typ.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " neexistuje.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Vytvára sa dlaždicová textúra. Šírka="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Vytvára sa jednoduchá textúra: "
@@ -618,26 +558,26 @@ msgstr "Chyba pri čítaní konfiguračného súboru."
 msgid "Initialization of SPICE library failed."
 msgstr "Inicializácia knižnice SPICE sa nepodarila."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Nedá sa čítať databáza hviezd."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Chyba pri otváraní katalógu deepsky objektov."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Nedá sa čítať databáza hviezd."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Chyba pri otváraní katalógu Slnečnej sústavy.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Chyba pri otváraní súboru hraníc súhvezdí."
@@ -691,7 +631,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Podporované rozšírenia:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Chyba pri otváraní súboru asterizmov."
@@ -811,26 +751,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " dní"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " hodín"
@@ -1172,17 +1112,17 @@ msgstr " telesá hlbokého vesmíru"
 msgid "Event Finder"
 msgstr "Vyhľadávač zatmení..."
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Čas"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1817,13 +1757,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Obežné dráhy"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1896,7 +1836,6 @@ msgstr "Asteroidy"
 msgid "Comets"
 msgstr "Kométy"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1906,6 +1845,7 @@ msgstr "Kométy"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1935,11 +1875,11 @@ msgstr "10x Rýchlejšie\tL"
 msgid "Labels"
 msgstr "Názvy"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2505,172 +2445,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Informácie"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Informácie"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belehrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belehrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 bez rozšírení</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informačný text"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "AU"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Veľkosť: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Veľkosť: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Veľkosť: %1 MB"
@@ -4218,6 +4158,54 @@ msgstr "Podrobný"
 msgid "WinLangID"
 msgstr "41b"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Apr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Feb"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jún"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Máj"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Aug"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dec"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Júl"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Okt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Sep"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satelit"
@@ -4424,7 +4412,7 @@ msgstr "Načítava sa URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Verzia: "
 
@@ -4436,33 +4424,43 @@ msgstr "Názov časového pásma"
 msgid "UTC Offset"
 msgstr "Posun voči svetovému času"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Načítava sa obrázok zo súboru "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": neznámy alebo nepodporovaný formát obrázku.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Chyba pri čítaní súboru typu PNG "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Chyba pri čítaní súboru typu PNG "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Chyba pri otváraní obrázku "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " nie je súbor typu PNG.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Chyba pri čítaní súboru typu PNG "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Chyba pri čítaní súboru typu PNG "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6881,10 +6879,6 @@ msgstr "Podporované rozšírenia:"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Inicializujú sa ARB fragment programy . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": neznámy alebo nepodporovaný formát obrázku.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Načítava sa NV vertex program: "

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 21:01+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Jan"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Feb"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mar"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Apr"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Maj"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Jun"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Jul"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Aug"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Sep"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Okt"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Nov"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Dec"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Sommartid"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "Standardtid"
 
@@ -138,11 +78,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nebulosa"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Öppen stjärnhop"
 
@@ -277,12 +217,12 @@ msgstr "Ogiltig stjärna: saknar spektraltyp.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " finns ej.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Skapar rutad textur. Bredd="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Skapar vanlig textur: "
@@ -617,26 +557,26 @@ msgstr "Fel vid läsning av konfigurationsfil."
 msgid "Initialization of SPICE library failed."
 msgstr "Initiering av SPICE-biblioteket misslyckades."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Kan inte läsa stjärndatabas."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Fel vid öppning av deep-sky-katalog "
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Kan inte läsa stjärndatabas."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Fel vid öppning av solsystemskatalog.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Fel vid öppning av filer för begränsning av stjärnbilder."
@@ -690,7 +630,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Utökningar som stöds:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Fel vid öppning av asterismfil."
@@ -810,26 +750,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " dagar"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " timmar"
@@ -1171,17 +1111,17 @@ msgstr " rymdobjekt"
 msgid "Event Finder"
 msgstr "Förmörkelsefinnare"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Tid"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1813,13 +1753,13 @@ msgstr "OK"
 msgid "Orbits"
 msgstr "Omloppsbanor"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1892,7 +1832,6 @@ msgstr "Asteroider"
 msgid "Comets"
 msgstr "Kometer"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1902,6 +1841,7 @@ msgstr "Kometer"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1931,11 +1871,11 @@ msgstr "10x &snabbare\tL"
 msgid "Labels"
 msgstr "Etiketter"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2501,172 +2441,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL-info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Ej utökad OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informationstext"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Storlek: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Storlek: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Storlek: %1 MB"
@@ -4212,6 +4152,54 @@ msgstr "Informativ"
 msgid "WinLangID"
 msgstr "41d"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Apr"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Feb"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Jan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Jun"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mar"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Maj"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Aug"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Dec"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Jul"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Nov"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Okt"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Sep"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Satellit"
@@ -4418,7 +4406,7 @@ msgstr "Läser url"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Version: "
 
@@ -4430,33 +4418,43 @@ msgstr "Namn på tidszon"
 msgid "UTC Offset"
 msgstr "Avvikelse från UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Läser bild från fil "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ": okänd eller ej stödd bildfilstyp.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Fel vid läsning av PNG-bildfil "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Fel vid läsning av PNG-bildfil "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Fel vid öppning av bildfil "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " är inte en PNG-fil.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Fel vid läsning av PNG-bildfil "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Fel vid läsning av PNG-bildfil "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6875,10 +6873,6 @@ msgstr "Utökningar som stöds:"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Initierar ARB-fragmentprogram . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ": okänd eller ej stödd bildfilstyp.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Läser NV-vertexprogram: "

--- a/po/tr.po
+++ b/po/tr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2021-12-20 00:20+0200\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: Turkish (https://www.transifex.com/celestia/teams/93131/tr/)\n"
@@ -21,71 +21,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Ocak"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Şubat"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Mart"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Nisan"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Mayıs"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Haziran"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Temmuz"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Ağustos"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Eylül"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Ekim "
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Kasım"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Aralık"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "DST (Yaz saati uy.)"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "Yaz saati"
 
@@ -141,11 +81,11 @@ msgstr "Model istatistikleri: %u köşe, %u ilkel, %u materyal (%u özgün)\n"
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Nebula"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Açık küme"
 
@@ -274,11 +214,11 @@ msgstr "Geçersiz yıldız: tayf türü yok.\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr "Kütle merkezi {} mevcut değil.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Karolu doku oluşturuluyor. Genişlik={}, maks={}\n"
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Sıradan doku oluşturuluyor: {}x{}\n"
 
@@ -602,23 +542,23 @@ msgstr "Yapılandırma dosyası okunurken hata oluştu."
 msgid "Initialization of SPICE library failed."
 msgstr "SPICE kütüphanesinin başlatılması başarısız oldu."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Yıldız veritabanı okunamıyor"
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "{} derin uzay katalog dosyası açılırken hata.\n"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "{} Derin Uzay Cisimleri veritabanı okunamıyor.\n"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 msgid "Error opening solar system catalog {}.\n"
 msgstr "{} güneş sistemi katalogu açılırken hata.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "{} takımyıldız sınırları dosyası açılırken hata.\n"
 
@@ -667,7 +607,7 @@ msgstr "Bir kare yakalanamadı!\n"
 msgid "Unsupported image type: {}!\n"
 msgstr "Desteklenmeyen URL modu \"%s\"!\n"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 msgid "Error opening asterisms file {}.\n"
 msgstr "{} yıldız kümeleri dosyası açılırken hata.\n"
 
@@ -786,24 +726,24 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr "gün"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "saat"
 
@@ -1134,17 +1074,17 @@ msgstr "Derin Uzay Cisimleri"
 msgid "Event Finder"
 msgstr "Olay Bulucu"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Zaman"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "Rehberler"
@@ -1712,13 +1652,13 @@ msgstr "O"
 msgid "Orbits"
 msgstr "Yörüngeler"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1791,7 +1731,6 @@ msgstr "Asteroitler"
 msgid "Comets"
 msgstr "Kuyruklu yıldızlar"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1801,6 +1740,7 @@ msgstr "Kuyruklu yıldızlar"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1828,11 +1768,11 @@ msgstr "L"
 msgid "Labels"
 msgstr "Etiketler"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2366,169 +2306,169 @@ msgstr "Celestia, OpenGL 2.1'i başlatamadı."
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia, OpenGL 2.1'i başlatamadı."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr "Hata: hiçbir cisim seçilmedi!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Bilgi"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr "Web bilgisi: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Ekvatoral yarıçap:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Boyut:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr "<b>Yassılık:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Yıldızsal dönüş periyodu:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Renderer:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Gün uzunluğu:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Halkalı</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Atmosfere sahip</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Başlangıç:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Bitiş:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Yörünge bilgisi"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "%1 için elemanlar teğet"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "yıl"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Periyot:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "AB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Yarı-büyük eksen:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Dış merkezlilik:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>Eğiklik:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Enberi uzaklığı:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Enöte uzaklığı:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>Yükselen düğüm:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>Periapsis argümanı:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>Ortalama anomali:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Periyot (hesaplanan):</b>  %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "<b>Periyot (hesaplanan):</b>  %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>SY:</b> %L1sa %L2d %L3sn"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>Sap:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
@@ -3973,6 +3913,54 @@ msgstr "Ayrıntılı"
 msgid "WinLangID"
 msgstr "WinLangID"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Nisan"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Şubat"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Ocak"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Haziran"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Mart"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Mayıs"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Ağustos"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Aralık"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Temmuz"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Kasım"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Ekim "
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Eylül"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Uydu"
@@ -4178,7 +4166,7 @@ msgstr "URL yükleniyor"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Sürüm:"
 
@@ -4190,30 +4178,39 @@ msgstr "Saat Dilimi Adı"
 msgid "UTC Offset"
 msgstr "UTC kayması"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 msgid "Loading image from file {}\n"
 msgstr "Dosyadan resim yükleniyor {}\n"
 
-#: ../src/celimage/png.cpp:53
-msgid "Error opening image file {}.\n"
-msgstr "Resim dosyasını açarken hata {}\n"
+#: ../src/celimage/image.cpp:409
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
 
-#: ../src/celimage/png.cpp:61
-msgid "Error: {} is not a PNG file.\n"
-msgstr "Hata: {} bir PNG dosyası değil.\n"
-
-#: ../src/celimage/png.cpp:87
-msgid "Error reading PNG image file {}\n"
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
 msgstr "PNG dosyasını okurken hata {}\n"
 
-#: ../src/celimage/png.cpp:177
+#: ../src/celimage/png.cpp:49
 msgid "Can't open screen capture file '{}'\n"
 msgstr ""
 
-#: ../src/celimage/png.cpp:226
+#: ../src/celimage/png.cpp:105
 #, fuzzy
 msgid "Error writing PNG file '{}'\n"
 msgstr "PNG dosyasını okurken hata %s\n"
+
+#: ../src/celimage/png.cpp:153
+msgid "Error opening image file {}.\n"
+msgstr "Resim dosyasını açarken hata {}\n"
+
+#: ../src/celimage/png.cpp:161
+msgid "Error: {} is not a PNG file.\n"
+msgstr "Hata: {} bir PNG dosyası değil.\n"
+
+#: ../src/celimage/png.cpp:187
+msgid "Error reading PNG image file {}\n"
+msgstr "PNG dosyasını okurken hata {}\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 21:02+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -19,71 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "Січ"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "Лют"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "Бер"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "Кві"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "Тра"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "Чер"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "Лип"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "Сер"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "Вер"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "Жов"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "Лис"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "Гру"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "Лтн"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "Стд"
 
@@ -139,11 +79,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "Туманність"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "Розсіяне скупчення"
 
@@ -278,12 +218,12 @@ msgstr "Некоректний запис: не вказано спектрал�
 msgid "Barycenter {} does not exist.\n"
 msgstr " не існує.\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "Створення плиткових текстур. Ширина="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "Створення звичайної текстури: "
@@ -618,26 +558,26 @@ msgstr "Помилка під час читання файла налаштув�
 msgid "Initialization of SPICE library failed."
 msgstr "Помилка під час ініціалізації бібліотеки SPICE."
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "Не вдалося прочитати базу даних зірок."
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "Помилка під час відкриття каталогу віддалених об’єктів."
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "Не вдалося прочитати базу даних зірок."
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "Помилка під час відкриття каталогу сонячної системи.\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "Помилка під час відкриття файла меж сузір’їв."
@@ -691,7 +631,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "Підтримувані додатки:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "Помилка під час відкриття файла астероїдів."
@@ -811,26 +751,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr " м/с"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " днів"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " годин"
@@ -1172,17 +1112,17 @@ msgstr " віддалені об’єкти"
 msgid "Event Finder"
 msgstr "Пошук затемнень"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "Час"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1815,13 +1755,13 @@ msgstr "Гаразд"
 msgid "Orbits"
 msgstr "Орбіти"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1894,7 +1834,6 @@ msgstr "Астероїди"
 msgid "Comets"
 msgstr "Комети"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1904,6 +1843,7 @@ msgstr "Комети"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1933,11 +1873,11 @@ msgstr "При&скорення у 10 разів\tL"
 msgid "Labels"
 msgstr "Мітки"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2503,172 +2443,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Інформація"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Інформація"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Період обертання: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "Белград"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "Белград"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 без додатків</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Інформаційний текст"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "а. о."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Період обертання: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "Період обертання: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "Розмір: %1 Мб"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "Розмір: %1 Мб"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "Розмір: %1 Мб"
@@ -4214,6 +4154,54 @@ msgstr "Докладно"
 msgid "WinLangID"
 msgstr "422"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "Кві"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "Лют"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "Січ"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "Чер"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "Бер"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "Тра"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "Сер"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "Гру"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "Лип"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "Лис"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "Жов"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "Вер"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "Супутник"
@@ -4420,7 +4408,7 @@ msgstr "Завантаження адреси"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "Версія: "
 
@@ -4432,33 +4420,45 @@ msgstr "Часовий пояс"
 msgid "UTC Offset"
 msgstr "Відступ від UTC"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "Завантаження зображення з файла "
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
+": не вдалося встановити тип зображення або зображення належить до типу, який "
+"не підтримується.\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "Помилка під час читання файла зображення PNG "
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "Помилка під час читання файла зображення PNG "
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "Помилка під час відкриття файла зображення "
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " не є файлом PNG.\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "Помилка під час читання файла зображення PNG "
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "Помилка під час читання файла зображення PNG "
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6879,12 +6879,6 @@ msgstr "Підтримувані додатки:"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "Ініціалізація програм фрагментів ABR . . .\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ""
-#~ ": не вдалося встановити тип зображення або зображення належить до типу, "
-#~ "який не підтримується.\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "Завантаження вершинної програми NV: "

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: LBV 2012-26 <lbv2012-26@outlook.com>, 2023\n"
 "Language-Team: Chinese (China) (https://app.transifex.com/celestia/"
@@ -24,71 +24,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "1"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "2"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "3"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "4"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "5"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "6"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "7"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "8"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "9"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "10"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "11"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "12"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "夏令时"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "标准时间"
 
@@ -141,11 +81,11 @@ msgstr "模型统计数据：{} 顶点，{} 原语，{} 材质（{} 专有）\n"
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr "网格索引 {} 高于 VBO 数量 {}"
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "星云"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "疏散星团"
 
@@ -270,11 +210,11 @@ msgstr "无效恒星数据：缺少恒星光谱类型。\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr "质心 {} 不存在。\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "正在创建块贴图。Width={}，max={}\n"
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "正在创建一般纹理：{}×{}\n"
 
@@ -585,23 +525,23 @@ msgstr "读取配置文件时出错。"
 msgid "Initialization of SPICE library failed."
 msgstr "Spice 库初始化失败。"
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "无法读取星体数据库。"
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "读取深空天体目录文件 {} 时出错。\n"
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "深空天体数据库 {} 无法读取。\n"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 msgid "Error opening solar system catalog {}.\n"
 msgstr "打开太阳系目录文件 {} 时出错。\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "打开星座边界文件 {} 时出错。\n"
 
@@ -649,7 +589,7 @@ msgstr "无法捕获当前帧\n"
 msgid "Unsupported image type: {}!\n"
 msgstr "不支持的图像格式：{}\n"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 msgid "Error opening asterisms file {}.\n"
 msgstr "打开星群文件 {} 时出错。\n"
 
@@ -767,24 +707,24 @@ msgstr "ft"
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 msgid "days"
 msgstr "天"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "小时"
 
@@ -1105,17 +1045,17 @@ msgstr "深空天体"
 msgid "Event Finder"
 msgstr "事件查找器"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "时间"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 msgid "Guides"
 msgstr "向导"
@@ -1679,13 +1619,13 @@ msgstr "O"
 msgid "Orbits"
 msgstr "轨道"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1758,7 +1698,6 @@ msgstr "小行星"
 msgid "Comets"
 msgstr "彗星"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1768,6 +1707,7 @@ msgstr "彗星"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1795,11 +1735,11 @@ msgstr "L"
 msgid "Labels"
 msgstr "标签"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2329,167 +2269,167 @@ msgstr "Celesita 无法初始化 OpenGL ES 2.0。"
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia 无法初始化 OpenGL 2.1。"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr "错误：未选择天体\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "信息"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, qt-format
 msgid "Web info: %1"
 msgstr "Web 信息：%1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>赤道半径：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>大小：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr "<b>扁率："
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>自转周期：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Prograde"
 msgstr "Prograde"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 msgid "Retrograde"
 msgstr "Retrograde"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>旋转方向：</b>%1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>太阳日：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>拥有光环</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>拥有大气层</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>开始：</b>%1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>结束：</b>%1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "轨道信息"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "密切元素 %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "yr"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>周期：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "AU"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>半长轴：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>离心率：</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "<b>倾角：</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>近心点距离：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>远心点距离：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "<b>升交点经度：</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "<b>近心点幅角：</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "<b>平近点角：</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>周期（计算结果）：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "<b>网格动作（已计算）：</b>%L1%2/天"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>赤经：</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "<b>赤纬：</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "<b>L：</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "<b>B：</b> %L1%2 %L3' %L4\""
@@ -3928,6 +3868,54 @@ msgstr "详细"
 msgid "WinLangID"
 msgstr "804"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "4"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "2"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "1"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "6"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "3"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "5"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "8"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "12"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "7"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "11"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "10"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "9"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "卫星"
@@ -4132,7 +4120,7 @@ msgstr "加载 URL"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "版本："
 
@@ -4144,29 +4132,38 @@ msgstr "时区名称"
 msgid "UTC Offset"
 msgstr "与 UTC 的差异"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 msgid "Loading image from file {}\n"
 msgstr "正在从 {} 中加载图片\n"
 
-#: ../src/celimage/png.cpp:53
-msgid "Error opening image file {}.\n"
-msgstr "打开图像文件 {} 时出错。\n"
+#: ../src/celimage/image.cpp:409
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ""
 
-#: ../src/celimage/png.cpp:61
-msgid "Error: {} is not a PNG file.\n"
-msgstr "错误：{} 不是一个 PNG 文件。\n"
-
-#: ../src/celimage/png.cpp:87
-msgid "Error reading PNG image file {}\n"
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
 msgstr "读取 PNG 图像文件 {} 时出错\n"
 
-#: ../src/celimage/png.cpp:177
+#: ../src/celimage/png.cpp:49
 msgid "Can't open screen capture file '{}'\n"
 msgstr "无法打开录屏文件“{}”\n"
 
-#: ../src/celimage/png.cpp:226
+#: ../src/celimage/png.cpp:105
 msgid "Error writing PNG file '{}'\n"
 msgstr "写入 PNG 文件“{}”时出错\n"
+
+#: ../src/celimage/png.cpp:153
+msgid "Error opening image file {}.\n"
+msgstr "打开图像文件 {} 时出错。\n"
+
+#: ../src/celimage/png.cpp:161
+msgid "Error: {} is not a PNG file.\n"
+msgstr "错误：{} 不是一个 PNG 文件。\n"
+
+#: ../src/celimage/png.cpp:187
+msgid "Error reading PNG image file {}\n"
+msgstr "读取 PNG 图像文件 {} 时出错\n"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
 msgid "Error opening script file."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-11-18 13:30+0200\n"
+"POT-Creation-Date: 2023-11-19 18:43+0100\n"
 "PO-Revision-Date: 2018-05-28 21:03+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -18,71 +18,11 @@ msgstr ""
 "X-Generator: Poedit 2.0.7\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../src/celengine/astro.cpp:118
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jan"
-msgstr "1"
-
-#: ../src/celengine/astro.cpp:119
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Feb"
-msgstr "2"
-
-#: ../src/celengine/astro.cpp:120
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Mar"
-msgstr "3"
-
-#: ../src/celengine/astro.cpp:121
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Apr"
-msgstr "4"
-
-#: ../src/celengine/astro.cpp:122
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "May"
-msgstr "5"
-
-#: ../src/celengine/astro.cpp:123
-#: ../src/celestia/win32/res/resource_strings.cpp:241
-msgid "Jun"
-msgstr "6"
-
-#: ../src/celengine/astro.cpp:124
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Jul"
-msgstr "7"
-
-#: ../src/celengine/astro.cpp:125
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Aug"
-msgstr "8"
-
-#: ../src/celengine/astro.cpp:126
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Sep"
-msgstr "9"
-
-#: ../src/celengine/astro.cpp:127
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Oct"
-msgstr "10"
-
-#: ../src/celengine/astro.cpp:128
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Nov"
-msgstr "11"
-
-#: ../src/celengine/astro.cpp:129
-#: ../src/celestia/win32/res/resource_strings.cpp:242
-msgid "Dec"
-msgstr "12"
-
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "DST"
 msgstr "日光節約時間"
 
-#: ../src/celengine/astro.cpp:715
+#: ../src/celastro/date.cpp:496
 msgid "STD"
 msgstr "標準時間"
 
@@ -138,11 +78,11 @@ msgstr ""
 msgid "Mesh index {} is higher than VBO count {}!"
 msgstr ""
 
-#: ../src/celengine/nebula.cpp:34
+#: ../src/celengine/nebula.cpp:33
 msgid "Nebula"
 msgstr "星雲"
 
-#: ../src/celengine/opencluster.cpp:36
+#: ../src/celengine/opencluster.cpp:35
 msgid "Open cluster"
 msgstr "疏散星團"
 
@@ -275,12 +215,12 @@ msgstr "無效的恆星內容:遺漏光譜型。\n"
 msgid "Barycenter {} does not exist.\n"
 msgstr " 不存在。\n"
 
-#: ../src/celengine/texture.cpp:361
+#: ../src/celengine/texture.cpp:365
 #, fuzzy
 msgid "Creating tiled texture. Width={}, max={}\n"
 msgstr "產生平舖紋理。寬度="
 
-#: ../src/celengine/texture.cpp:367
+#: ../src/celengine/texture.cpp:371
 #, fuzzy
 msgid "Creating ordinary texture: {}x{}\n"
 msgstr "產生一般紋理:"
@@ -615,26 +555,26 @@ msgstr "讀取設定檔時發生錯誤。"
 msgid "Initialization of SPICE library failed."
 msgstr "初始化 SPICE 函式庫時失敗。"
 
-#: ../src/celestia/celestiacore.cpp:2391
+#: ../src/celestia/celestiacore.cpp:2393
 msgid "Cannot read star database."
 msgstr "無法讀取星體資料庫。"
 
-#: ../src/celestia/celestiacore.cpp:2411
+#: ../src/celestia/celestiacore.cpp:2413
 #, fuzzy
 msgid "Error opening deepsky catalog file {}.\n"
 msgstr "開啟深空目錄時發生錯誤 "
 
-#: ../src/celestia/celestiacore.cpp:2415
+#: ../src/celestia/celestiacore.cpp:2417
 #, fuzzy
 msgid "Cannot read Deep Sky Objects database {}.\n"
 msgstr "無法讀取星體資料庫。"
 
-#: ../src/celestia/celestiacore.cpp:2462
+#: ../src/celestia/celestiacore.cpp:2464
 #, fuzzy
 msgid "Error opening solar system catalog {}.\n"
 msgstr "開啟太陽系目錄時發生錯誤。\n"
 
-#: ../src/celestia/celestiacore.cpp:2504
+#: ../src/celestia/celestiacore.cpp:2506
 #, fuzzy
 msgid "Error opening constellation boundaries file {}.\n"
 msgstr "開啟星座邊界檔時發生錯誤。"
@@ -688,7 +628,7 @@ msgstr ""
 msgid "Unsupported image type: {}!\n"
 msgstr "支援的延伸功能:"
 
-#: ../src/celestia/celestiacore.cpp:3535
+#: ../src/celestia/celestiacore.cpp:3526
 #, fuzzy
 msgid "Error opening asterisms file {}.\n"
 msgstr "開啟星群檔時發生錯誤。"
@@ -808,26 +748,26 @@ msgstr ""
 
 #. i18n: file: ../src/celestia/qt/gotoobjectdialog.ui:180
 #. i18n: ectx: property (text), widget (QRadioButton, kmButton)
-#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:193
-#: ../src/celestia/qt/qtinfopanel.cpp:314 ../src/celestia/qt/rc.cpp:30
+#: ../src/celestia/hud.cpp:134 ../src/celestia/qt/qtinfopanel.cpp:194
+#: ../src/celestia/qt/qtinfopanel.cpp:315 ../src/celestia/qt/rc.cpp:30
 #: ../src/celestia/win32/res/resource_strings.cpp:125
 msgid "km"
 msgstr "公里"
 
-#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:197
+#: ../src/celestia/hud.cpp:139 ../src/celestia/qt/qtinfopanel.cpp:198
 #, fuzzy
 msgid "m"
 msgstr "m/s"
 
-#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:249
-#: ../src/celestia/qt/qtinfopanel.cpp:295
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/hud.cpp:161 ../src/celestia/qt/qtinfopanel.cpp:250
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy
 msgid "days"
 msgstr " 日"
 
-#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:245
-#: ../src/celestia/qt/qtinfopanel.cpp:291
+#: ../src/celestia/hud.cpp:166 ../src/celestia/qt/qtinfopanel.cpp:246
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " 時"
@@ -1169,17 +1109,17 @@ msgstr "深太空天體"
 msgid "Event Finder"
 msgstr "食相尋找器"
 
-#. addDockWidget(Qt::DockWidgetArea, eventFinder);
-#. Create the time toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:1138
 #. i18n: ectx: attribute (title), widget (QWidget, timeTab)
+#. addDockWidget(Qt::DockWidgetArea, eventFinder);
+#. Create the time toolbar
 #: ../src/celestia/qt/qtappwin.cpp:400 ../src/celestia/qt/rc.cpp:351
 msgid "Time"
 msgstr "時間"
 
-#. Create the guides toolbar
 #. i18n: file: ../src/celestia/qt/preferences.ui:228
 #. i18n: ectx: attribute (title), widget (QWidget, guidesTab)
+#. Create the guides toolbar
 #: ../src/celestia/qt/qtappwin.cpp:407 ../src/celestia/qt/rc.cpp:139
 #, fuzzy
 msgid "Guides"
@@ -1811,13 +1751,13 @@ msgstr "確定"
 msgid "Orbits"
 msgstr "軌道"
 
-#. Skip sorting if we are dealing with the planets in our own Solar System.
 #. i18n: file: ../src/celestia/qt/preferences.ui:49
 #. i18n: ectx: property (text), widget (QCheckBox, planetsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:286
 #. i18n: ectx: property (text), widget (QCheckBox, planetOrbitsCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:506
 #. i18n: ectx: property (text), widget (QCheckBox, planetLabelsCheck)
+#. Skip sorting if we are dealing with the planets in our own Solar System.
 #: ../src/celestia/qt/qtcelestiaactions.cpp:95
 #: ../src/celestia/qt/qtcelestiaactions.cpp:122
 #: ../src/celestia/qt/qtselectionpopup.cpp:402
@@ -1890,7 +1830,6 @@ msgstr "小行星"
 msgid "Comets"
 msgstr "彗星"
 
-#. TRANSLATORS: translate this as plural
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:91
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftsCheck)
@@ -1900,6 +1839,7 @@ msgstr "彗星"
 #. i18n: TRANSLATORS: translate this as plural
 #. i18n: file: ../src/celestia/qt/preferences.ui:548
 #. i18n: ectx: property (text), widget (QCheckBox, spacecraftLabelsCheck)
+#. TRANSLATORS: translate this as plural
 #: ../src/celestia/qt/qtcelestiaactions.cpp:101
 #: ../src/celestia/qt/qtcelestiaactions.cpp:128
 #: ../src/celestia/qt/qtselectionpopup.cpp:420
@@ -1929,11 +1869,11 @@ msgstr "10x 快轉(&F)\tL"
 msgid "Labels"
 msgstr "標籤"
 
+#. Buttons to select filtering criterion for dsos
 #. i18n: file: ../src/celestia/qt/preferences.ui:98
 #. i18n: ectx: property (text), widget (QCheckBox, galaxiesCheck)
 #. i18n: file: ../src/celestia/qt/preferences.ui:555
 #. i18n: ectx: property (text), widget (QCheckBox, galaxyLabelsCheck)
-#. Buttons to select filtering criterion for dsos
 #: ../src/celestia/qt/qtcelestiaactions.cpp:129
 #: ../src/celestia/qt/qtcelestiaactions.cpp:153
 #: ../src/celestia/qt/qtdeepskybrowser.cpp:480 ../src/celestia/qt/rc.cpp:97
@@ -2499,172 +2439,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:154
+#: ../src/celestia/qt/qtinfopanel.cpp:155
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:166
+#: ../src/celestia/qt/qtinfopanel.cpp:167
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "資訊(&I)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:186
+#: ../src/celestia/qt/qtinfopanel.cpp:187
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL 資訊"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:202
+#: ../src/celestia/qt/qtinfopanel.cpp:203
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:205
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:209
+#: ../src/celestia/qt/qtinfopanel.cpp:210
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:252
+#: ../src/celestia/qt/qtinfopanel.cpp:253
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "自轉週期:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Prograde"
 msgstr "貝爾格萊德"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:255
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy
 msgid "Retrograde"
 msgstr "貝爾格萊德"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:256
+#: ../src/celestia/qt/qtinfopanel.cpp:257
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>未延伸 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:260
+#: ../src/celestia/qt/qtinfopanel.cpp:261
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:267
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:269
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:277
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:282
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "資訊文字"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:299
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:303
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:309
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "天文單位"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:318
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:319
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
 msgid "<b>Inclination:</b> %L1%2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:322
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:323
+#: ../src/celestia/qt/qtinfopanel.cpp:324
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:325
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
 msgid "<b>Ascending node:</b> %L1%2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:327
+#: ../src/celestia/qt/qtinfopanel.cpp:328
 #, fuzzy, qt-format
 msgid "<b>Argument of periapsis:</b> %L1%2"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:329
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Mean anomaly:</b> %L1%2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:333
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "自轉週期:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:337
+#: ../src/celestia/qt/qtinfopanel.cpp:338
 #, fuzzy, qt-format
 msgid "<b>Mean motion (calculated):</b> %L1%2/day"
 msgstr "自轉週期:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:361
-#: ../src/celestia/qt/qtinfopanel.cpp:384
+#: ../src/celestia/qt/qtinfopanel.cpp:362
+#: ../src/celestia/qt/qtinfopanel.cpp:385
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:365
-#: ../src/celestia/qt/qtinfopanel.cpp:388
+#: ../src/celestia/qt/qtinfopanel.cpp:366
+#: ../src/celestia/qt/qtinfopanel.cpp:389
 #, fuzzy, qt-format
 msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
 msgstr "大小:%1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:396
+#: ../src/celestia/qt/qtinfopanel.cpp:397
 #, fuzzy, qt-format
 msgid "<b>L:</b> %L1%2 %L3' %L4\""
 msgstr "大小:%1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:400
+#: ../src/celestia/qt/qtinfopanel.cpp:401
 #, fuzzy, qt-format
 msgid "<b>B:</b> %L1%2 %L3' %L4\""
 msgstr "大小:%1 MB"
@@ -4211,6 +4151,54 @@ msgstr "詳細"
 msgid "WinLangID"
 msgstr "WinLangID"
 
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Apr"
+msgstr "4"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Feb"
+msgstr "2"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jan"
+msgstr "1"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Jun"
+msgstr "6"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "Mar"
+msgstr "3"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:241
+msgid "May"
+msgstr "5"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Aug"
+msgstr "8"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Dec"
+msgstr "12"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Jul"
+msgstr "7"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Nov"
+msgstr "11"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Oct"
+msgstr "10"
+
+#: ../src/celestia/win32/res/resource_strings.cpp:242
+msgid "Sep"
+msgstr "9"
+
 #: ../src/celestia/win32/wineclipses.cpp:66
 msgid "Satellite"
 msgstr "衛星"
@@ -4417,7 +4405,7 @@ msgstr "載入網址中"
 
 #. string s;
 #. s += UTF8ToCurrentCP(_("Version: "));
-#: ../src/celestia/win32/winsplash.cpp:141
+#: ../src/celestia/win32/winsplash.cpp:142
 msgid "Version: "
 msgstr "版本:"
 
@@ -4429,33 +4417,43 @@ msgstr "時區名稱"
 msgid "UTC Offset"
 msgstr "與世界協調時間的差異"
 
-#: ../src/celimage/image.cpp:363
+#: ../src/celimage/image.cpp:385
 #, fuzzy
 msgid "Loading image from file {}\n"
 msgstr "從檔案讀取影像"
 
-#: ../src/celimage/png.cpp:53
+#: ../src/celimage/image.cpp:409
+#, fuzzy
+msgid "{}: unrecognized or unsupported image file type.\n"
+msgstr ":無法辨識或未支援的影像格式。\n"
+
+#: ../src/celimage/png.cpp:27
+#, fuzzy
+msgid "Error reading PNG data"
+msgstr "讀取PNG影像檔發生錯誤"
+
+#: ../src/celimage/png.cpp:49
+msgid "Can't open screen capture file '{}'\n"
+msgstr ""
+
+#: ../src/celimage/png.cpp:105
+#, fuzzy
+msgid "Error writing PNG file '{}'\n"
+msgstr "讀取PNG影像檔發生錯誤"
+
+#: ../src/celimage/png.cpp:153
 #, fuzzy
 msgid "Error opening image file {}.\n"
 msgstr "影像檔案開啟失敗"
 
-#: ../src/celimage/png.cpp:61
+#: ../src/celimage/png.cpp:161
 #, fuzzy
 msgid "Error: {} is not a PNG file.\n"
 msgstr " 並不是一個PNG檔案。\n"
 
-#: ../src/celimage/png.cpp:87
+#: ../src/celimage/png.cpp:187
 #, fuzzy
 msgid "Error reading PNG image file {}\n"
-msgstr "讀取PNG影像檔發生錯誤"
-
-#: ../src/celimage/png.cpp:177
-msgid "Can't open screen capture file '{}'\n"
-msgstr ""
-
-#: ../src/celimage/png.cpp:226
-#, fuzzy
-msgid "Error writing PNG file '{}'\n"
 msgstr "讀取PNG影像檔發生錯誤"
 
 #: ../src/celscript/legacy/legacyscript.cpp:101
@@ -6874,10 +6872,6 @@ msgstr "支援的延伸功能:"
 
 #~ msgid "Initializing ARB fragment programs . . .\n"
 #~ msgstr "初始化 ARB 片段程式中...\n"
-
-#, fuzzy
-#~ msgid "%s: unrecognized or unsupported image file type.\n"
-#~ msgstr ":無法辨識或未支援的影像格式。\n"
 
 #~ msgid "Loading NV vertex program: "
 #~ msgstr "載入 NV 頂點程式:"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(CELESTIA_LIBS
   cel3ds
+  celastro
   celcompat
   celengine
   celephem

--- a/src/celastro/CMakeLists.txt
+++ b/src/celastro/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(CELASTRO_SOURCES
+  astro.cpp
+  astro.h
+  date.cpp
+  date.h
+  units.cpp
+  units.h)
+
+add_library(celastro OBJECT ${CELASTRO_SOURCES})

--- a/src/celastro/astro.cpp
+++ b/src/celastro/astro.cpp
@@ -1,0 +1,317 @@
+// astro.cpp
+//
+// Copyright (C) 2001-2009, the Celestia Development Team
+// Original version by Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "astro.h"
+
+#include <celcompat/numbers.h>
+#include <celmath/geomutil.h>
+
+using namespace std::string_view_literals;
+
+namespace celestia::astro
+{
+
+namespace
+{
+
+const Eigen::Quaterniond ECLIPTIC_TO_EQUATORIAL_ROTATION = math::XRotation(-J2000Obliquity);
+const Eigen::Matrix3d ECLIPTIC_TO_EQUATORIAL_MATRIX = ECLIPTIC_TO_EQUATORIAL_ROTATION.toRotationMatrix();
+
+const Eigen::Quaterniond EQUATORIAL_TO_ECLIPTIC_ROTATION =
+    Eigen::Quaterniond(Eigen::AngleAxis<double>(-J2000Obliquity, Eigen::Vector3d::UnitX()));
+const Eigen::Matrix3d EQUATORIAL_TO_ECLIPTIC_MATRIX = EQUATORIAL_TO_ECLIPTIC_ROTATION.toRotationMatrix();
+const Eigen::Matrix3f EQUATORIAL_TO_ECLIPTIC_MATRIX_F = EQUATORIAL_TO_ECLIPTIC_MATRIX.cast<float>();
+
+// Equatorial to galactic coordinate transformation
+// North galactic pole at:
+// RA 12h 51m 26.282s (192.85958 deg)
+// Dec 27 d 07' 42.01" (27.1283361 deg)
+// Zero longitude at position angle 122.932
+// (J2000 coordinates)
+constexpr double GALACTIC_NODE = 282.85958;
+constexpr double GALACTIC_INCLINATION = 90.0 - 27.1283361;
+constexpr double GALACTIC_LONGITUDE_AT_NODE = 32.932;
+
+const Eigen::Quaterniond EQUATORIAL_TO_GALACTIC_ROTATION =
+    math::ZRotation(math::degToRad(GALACTIC_NODE)) *
+    math::XRotation(math::degToRad(GALACTIC_INCLINATION)) *
+    math::ZRotation(math::degToRad(-GALACTIC_LONGITUDE_AT_NODE));
+const Eigen::Matrix3d EQUATORIAL_TO_GALACTIC_MATRIX = EQUATORIAL_TO_GALACTIC_ROTATION.toRotationMatrix();
+
+inline void
+negateIf(double& d, bool condition)
+{
+    if (condition)
+        d = -d;
+}
+
+} // end unnamed namespace
+
+float
+lumToAbsMag(float lum)
+{
+    return SOLAR_ABSMAG - std::log(lum) * LN_MAG;
+}
+
+// Return the apparent magnitude of a star with lum times solar
+// luminosity viewed at lyrs light years
+float
+lumToAppMag(float lum, float lyrs)
+{
+    return absToAppMag(lumToAbsMag(lum), lyrs);
+}
+
+float
+absMagToLum(float mag)
+{
+    return std::exp((SOLAR_ABSMAG - mag) / LN_MAG);
+}
+
+float
+appMagToLum(float mag, float lyrs)
+{
+    return absMagToLum(appToAbsMag(mag, lyrs));
+}
+
+void
+decimalToDegMinSec(double angle, int& degrees, int& minutes, double& seconds)
+{
+    degrees = static_cast<int>(angle);
+
+    double A = angle - static_cast<double>(degrees);
+    double B = A * 60.0;
+    minutes = static_cast<int>(B);
+    double C = B - static_cast<double>(minutes);
+    seconds = C * 60.0;
+}
+
+double
+degMinSecToDecimal(int degrees, int minutes, double seconds)
+{
+    return static_cast<double>(degrees) + (seconds / 60.0 + static_cast<double>(minutes)) / 60.0;
+}
+
+void
+decimalToHourMinSec(double angle, int& hours, int& minutes, double& seconds)
+{
+    double A = angle / 15.0;
+    hours = static_cast<int>(A);
+    double B = (A - static_cast<double>(hours)) * 60.0;
+    minutes = static_cast<int>(B);
+    seconds = (B - (double) minutes) * 60.0;
+}
+
+// Convert equatorial coordinates to Cartesian celestial (or ecliptical)
+// coordinates.
+Eigen::Vector3f
+equatorialToCelestialCart(float ra, float dec, float distance)
+{
+    using celestia::numbers::pi;
+    double theta = ra / 24.0 * pi * 2 + pi;
+    double phi = (dec / 90.0 - 1.0) * pi / 2;
+    double stheta;
+    double ctheta;
+    math::sincos(theta, stheta, ctheta);
+    double sphi;
+    double cphi;
+    math::sincos(phi, sphi, cphi);
+    auto x = static_cast<float>(ctheta * sphi * distance);
+    auto y = static_cast<float>(cphi * distance);
+    auto z = static_cast<float>(-stheta * sphi * distance);
+
+    return EQUATORIAL_TO_ECLIPTIC_MATRIX_F * Eigen::Vector3f(x, y, z);
+}
+
+// Convert equatorial coordinates to Cartesian celestial (or ecliptical)
+// coordinates.
+Eigen::Vector3d
+equatorialToCelestialCart(double ra, double dec, double distance)
+{
+    using celestia::numbers::pi;
+    double theta = ra / 24.0 * pi * 2 + pi;
+    double phi = (dec / 90.0 - 1.0) * pi / 2;
+    double stheta;
+    double ctheta;
+    math::sincos(theta, stheta, ctheta);
+    double sphi;
+    double cphi;
+    math::sincos(phi, sphi, cphi);
+    double x = ctheta * sphi * distance;
+    double y = cphi * distance;
+    double z = -stheta * sphi * distance;
+
+    return EQUATORIAL_TO_ECLIPTIC_MATRIX * Eigen::Vector3d(x, y, z);
+}
+
+void
+anomaly(double meanAnomaly, double eccentricity,
+        double& trueAnomaly, double& eccentricAnomaly)
+{
+    using celestia::numbers::pi;
+    constexpr double tol = 1.745e-8;
+    int iterations = 20;    // limit while() to maximum of 20 iterations.
+
+    double e = meanAnomaly - 2.0 * pi * static_cast<int>(meanAnomaly / (2.0 * pi));
+    double err = 1.0;
+    while(std::abs(err) > tol && iterations > 0)
+    {
+        err = e - eccentricity * std::sin(e) - meanAnomaly;
+        double delta = err / (1.0 - eccentricity * std::cos(e));
+        e -= delta;
+        iterations--;
+    }
+
+    trueAnomaly = 2.0 * std::atan(std::sqrt((1.0 + eccentricity) / (1.0 - eccentricity)) * std::tan(0.5 * e));
+    eccentricAnomaly = e;
+}
+
+/*! Return the angle between the mean ecliptic plane and mean equator at
+ *  the specified Julian date.
+ */
+// TODO: replace this with a better precession model
+double
+meanEclipticObliquity(double jd)
+{
+    jd -= 2451545.0;
+    double t = jd / 36525;
+    double de = (46.815 * t + 0.0006 * t * t - 0.00181 * t * t * t) / 3600;
+
+    return J2000Obliquity - de;
+}
+
+/*! Return a quaternion giving the transformation from the J2000 ecliptic
+ *  coordinate system to the J2000 Earth equatorial coordinate system.
+ */
+Eigen::Quaterniond
+eclipticToEquatorial()
+{
+    return ECLIPTIC_TO_EQUATORIAL_ROTATION;
+}
+
+/*! Rotate a vector in the J2000 ecliptic coordinate system to
+ *  the J2000 Earth equatorial coordinate system.
+ */
+Eigen::Vector3d
+eclipticToEquatorial(const Eigen::Vector3d& v)
+{
+    return ECLIPTIC_TO_EQUATORIAL_MATRIX.transpose() * v;
+}
+
+/*! Return a quaternion giving the transformation from the J2000 Earth
+ *  equatorial coordinate system to the galactic coordinate system.
+ */
+Eigen::Quaterniond
+equatorialToGalactic()
+{
+    return EQUATORIAL_TO_GALACTIC_ROTATION;
+}
+
+/*! Rotate a vector int the J2000 Earth equatorial coordinate system to
+ *  the galactic coordinate system.
+ */
+Eigen::Vector3d
+equatorialToGalactic(const Eigen::Vector3d& v)
+{
+    return EQUATORIAL_TO_GALACTIC_MATRIX.transpose() * v;
+}
+
+KeplerElements
+StateVectorToElements(const Eigen::Vector3d& r,
+                      const Eigen::Vector3d& v,
+                      double mu)
+{
+    constexpr double tolerance = 1e-9;
+
+    Eigen::Vector3d h = r.cross(v);
+    double rNorm = r.norm();
+
+    KeplerElements result;
+
+    // Compute eccentricity
+    Eigen::Vector3d evec = v.cross(h) / mu - r / rNorm;
+    result.eccentricity = evec.norm();
+
+    // Compute inclination
+    result.inclination = std::acos(std::clamp(h.y() / h.norm(), -1.0, 1.0));
+
+    // Normal vector (UnitY x h)
+    Eigen::Vector3d nvec(h[2], 0, -h[0]);
+    double nNorm = nvec.norm();
+
+    // compute longAscendingNode and argPericenter
+    if (result.inclination < tolerance)
+    {
+        // handle face-on orbit: by convention Omega = 0.0
+        if (result.eccentricity >= tolerance)
+        {
+            result.argPericenter = std::acos(evec.x() / result.eccentricity);
+            negateIf(result.argPericenter, evec.z() >= 0.0);
+        }
+    }
+    else
+    {
+        result.longAscendingNode = std::acos(nvec.x() / nNorm);
+        negateIf(result.longAscendingNode, nvec.z() >= 0.0);
+        if (result.eccentricity >= tolerance)
+        {
+            result.argPericenter = std::acos(std::clamp(nvec.dot(evec) / (nNorm * result.eccentricity), -1.0, 1.0));
+            negateIf(result.argPericenter, evec.y() < 0.0);
+        }
+    }
+
+    // compute true anomaly
+    double nu;
+    if (result.eccentricity >= tolerance)
+    {
+        nu = std::acos(std::clamp(evec.dot(r) / (result.eccentricity * rNorm), -1.0, 1.0));
+        negateIf(nu, r.dot(v) < 0.0);
+    }
+    else
+    {
+        if (result.inclination < tolerance)
+        {
+            // circular face-on orbit
+            nu = std::acos(r.x() / rNorm);
+            negateIf(nu, v.x() > 0.0);
+        }
+        else
+        {
+            nu = std::acos(std::clamp(nvec.dot(r) / (nNorm * rNorm), -1.0, 1.0));
+            negateIf(nu, nvec.dot(v) > 0.0);
+        }
+    }
+
+    double s_nu;
+    double c_nu;
+    math::sincos(nu, s_nu, c_nu);
+
+    // compute mean anomaly
+    double e2 = math::square(result.eccentricity);
+    if (result.eccentricity < 1.0)
+    {
+        double E = std::atan2(std::sqrt(1.0 - e2) * s_nu,
+                              result.eccentricity + c_nu);
+        result.meanAnomaly = E - result.eccentricity * std::sin(E);
+    }
+    else
+    {
+        double sinhE = std::sqrt(e2 - 1.0) * s_nu / (1.0 + result.eccentricity * c_nu);
+        double E = std::asinh(sinhE);
+        result.meanAnomaly = result.eccentricity * sinhE - E;
+    }
+
+    // compute semimajor axis
+    result.semimajorAxis = 1.0 / (2.0 / rNorm - v.squaredNorm() / mu);
+    result.period = 2.0 * celestia::numbers::pi * std::sqrt(math::cube(std::abs(result.semimajorAxis)) / mu);
+
+    return result;
+}
+
+} // end namespace celestia::astro

--- a/src/celastro/astro.h
+++ b/src/celastro/astro.h
@@ -13,14 +13,11 @@
 #include <cmath>
 #include <cstdint>
 #include <optional>
-#include <string>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
 #include <celmath/mathlib.h>
-#include <celutil/array_view.h>
-
 
 namespace celestia::astro
 {
@@ -29,13 +26,13 @@ constexpr inline float SOLAR_ABSMAG = 4.83f;
 constexpr inline float LN_MAG = 1.085736f;
 
 template<typename T>
-constexpr inline T LY_PER_PARSEC = static_cast<T>(3.26167);
+constexpr inline T LY_PER_PARSEC = T(3.26167);
 
 template<typename T>
-constexpr inline T KM_PER_LY = static_cast<T>(9460730472580.8);
+constexpr inline T KM_PER_LY = T(9460730472580.8);
 
 template<typename T>
-constexpr inline T KM_PER_AU = static_cast<T>(149597870.7);
+constexpr inline T KM_PER_AU = T(149597870.7);
 
 template<typename T>
 constexpr inline T AU_PER_LY = KM_PER_LY<T> / KM_PER_AU<T>;
@@ -43,96 +40,18 @@ constexpr inline T AU_PER_LY = KM_PER_LY<T> / KM_PER_AU<T>;
 template<typename T>
 constexpr inline T KM_PER_PARSEC = KM_PER_LY<T> * LY_PER_PARSEC<T>;
 
-// Julian year
-constexpr inline double DAYS_PER_YEAR = 365.25;
-
-constexpr inline double SECONDS_PER_DAY = 86400.0;
-constexpr inline double MINUTES_PER_DAY = 1440.0;
-constexpr inline double HOURS_PER_DAY   = 24.0;
-
 constexpr inline double MINUTES_PER_DEG = 60.0;
 constexpr inline double SECONDS_PER_DEG = 3600.0;
 constexpr inline double DEG_PER_HRA     = 15.0;
 
 template<typename T>
-constexpr inline T EARTH_RADIUS = static_cast<T>(6378.14);
+constexpr inline T EARTH_RADIUS = T(6378.14);
 
 template<typename T>
-constexpr inline T JUPITER_RADIUS = static_cast<T>(71492.0);
+constexpr inline T JUPITER_RADIUS = T(71492.0);
 
 template<typename T>
-constexpr inline T SOLAR_RADIUS = static_cast<T>(696000.0);
-
-class Date
-{
-public:
-    Date();
-    Date(int Y, int M, int D);
-    Date(double);
-
-    enum Format
-    {
-        Locale          = 0,
-        TZName          = 1,
-        UTCOffset       = 2,
-        ISO8601         = 3,
-        FormatCount     = 4,
-    };
-
-    std::string toString(Format format = Locale) const;
-
-    operator double() const;
-
-    static Date systemDate();
-
-    int year;
-    int month;
-    int day;
-    int hour;
-    int minute;
-    int wday;           // week day, 0 Sunday to 6 Saturday
-    int utc_offset;     // offset from utc in seconds
-    std::string tzname; // timezone name
-    double seconds;
-};
-
-bool parseDate(const std::string&, Date&);
-
-// Time scale conversions
-// UTC - Coordinated Universal Time
-// TAI - International Atomic Time
-// TT  - Terrestrial Time
-// TCB - Barycentric Coordinate Time
-// TDB - Barycentric Dynamical Time
-
-constexpr double secsToDays(double s)
-{
-    return s * (1.0 / SECONDS_PER_DAY);
-}
-
-constexpr double daysToSecs(double d)
-{
-    return d * SECONDS_PER_DAY;
-}
-
-// Convert to and from UTC dates
-double UTCtoTAI(const Date& utc);
-Date TAItoUTC(double tai);
-double UTCtoTDB(const Date& utc);
-Date TDBtoUTC(double tdb);
-Date TDBtoLocal(double tdb);
-
-// Convert among uniform time scales
-double TTtoTAI(double tt);
-double TAItoTT(double tai);
-double TTtoTDB(double tt);
-double TDBtoTT(double tdb);
-
-// Conversions to and from Julian Date UTC--other time systems
-// should be preferred, since UTC Julian Dates aren't defined
-// during leapseconds.
-double JDUTCtoTAI(double utc);
-double TAItoJDUTC(double tai);
+constexpr inline T SOLAR_RADIUS = T(696000.0);
 
 // Magnitude conversions
 float lumToAbsMag(float lum);
@@ -143,13 +62,13 @@ float appMagToLum(float mag, float lyrs);
 template<class T> constexpr T absToAppMag(T absMag, T lyrs)
 {
     using std::log10;
-    return (T) (absMag - 5 + 5 * log10(lyrs / LY_PER_PARSEC<T>));
+    return absMag - T(5) + T(5) * log10(lyrs / LY_PER_PARSEC<T>);
 }
 
 template<class T> constexpr T appToAbsMag(T appMag, T lyrs)
 {
     using std::log10;
-    return (T) (appMag + 5 - 5 * log10(lyrs / LY_PER_PARSEC<T>));
+    return appMag + T(5) - T(5) * log10(lyrs / LY_PER_PARSEC<T>);
 }
 
 // Distance conversions
@@ -195,86 +114,23 @@ template<class T> constexpr T kilometersToAU(T km)
 
 template<class T> constexpr T microLightYearsToKilometers(T ly)
 {
-    return ly * (KM_PER_LY<T> * 1e-6);
+    return ly * (KM_PER_LY<T> * T(1e-6));
 }
 
 template<class T> constexpr T kilometersToMicroLightYears(T km)
 {
-    return km / (KM_PER_LY<T> * 1e-6);
+    return km / (KM_PER_LY<T> * T(1e-6));
 }
 
 template<class T> constexpr T microLightYearsToAU(T ly)
 {
-    return ly * (AU_PER_LY<T> * 1e-6);
+    return ly * (AU_PER_LY<T> * T(1e-6));
 }
 
 template<class T> constexpr T AUtoMicroLightYears(T au)
 {
-    return au / (AU_PER_LY<T> * 1e-6);
+    return au / (AU_PER_LY<T> * T(1e-6));
 }
-
-constexpr double secondsToJulianDate(double sec)
-{
-    return sec / SECONDS_PER_DAY;
-}
-constexpr double julianDateToSeconds(double jd)
-{
-    return jd * SECONDS_PER_DAY;
-}
-
-
-enum class LengthUnit : std::uint8_t
-{
-    Default = 0,
-    Kilometer,
-    Meter,
-    EarthRadius,
-    JupiterRadius,
-    SolarRadius,
-    AstronomicalUnit,
-    LightYear,
-    Parsec,
-    Kiloparsec,
-    Megaparsec,
-};
-
-
-enum class TimeUnit : std::uint8_t
-{
-    Default = 0,
-    Second,
-    Minute,
-    Hour,
-    Day,
-    JulianYear,
-};
-
-
-enum class AngleUnit : std::uint8_t
-{
-    Default = 0,
-    Milliarcsecond,
-    Arcsecond,
-    Arcminute,
-    Degree,
-    Hour,
-    Radian,
-};
-
-
-enum class MassUnit : std::uint8_t
-{
-    Default = 0,
-    Kilogram,
-    EarthMass,
-    JupiterMass,
-};
-
-
-std::optional<double> getLengthScale(LengthUnit unit);
-std::optional<double> getTimeScale(TimeUnit unit);
-std::optional<double> getAngleScale(AngleUnit unit);
-std::optional<double> getMassScale(MassUnit unit);
 
 void decimalToDegMinSec(double angle, int& degrees, int& minutes, double& seconds);
 double degMinSecToDecimal(int degrees, int minutes, double seconds);
@@ -292,8 +148,6 @@ void anomaly(double meanAnomaly, double eccentricity,
              double& trueAnomaly, double& eccentricAnomaly);
 double meanEclipticObliquity(double jd);
 
-// epoch J2000: 12 UT on 1 Jan 2000
-constexpr inline double J2000            = 2451545.0;
 constexpr inline double speedOfLight     = 299792.458; // km/s
 constexpr inline double G                = 6.672e-11; // N m^2 / kg^2; gravitational constant
 constexpr inline double SolarMass        = 1.989e30;
@@ -308,18 +162,6 @@ constexpr inline double J2000Obliquity   = 23.4392911_deg;
 
 constexpr inline double SOLAR_IRRADIANCE = 1367.6; // Watts / m^2
 constexpr inline double SOLAR_POWER      = 3.8462e26;  // in Watts
-
-
-struct LeapSecondRecord
-{
-    int seconds;
-    double t;
-};
-
-
-// Provide leap seconds data loaded from an external source
-void setLeapSeconds(celestia::util::array_view<LeapSecondRecord>);
-
 
 namespace literals
 {

--- a/src/celastro/date.h
+++ b/src/celastro/date.h
@@ -1,0 +1,119 @@
+// date.h
+//
+// Copyright (C) 2001-2023, the Celestia Development Team
+// Original version by Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <string>
+
+#include <celutil/array_view.h>
+
+namespace celestia::astro
+{
+
+// epoch J2000: 12 UT on 1 Jan 2000
+constexpr inline double J2000            = 2451545.0;
+
+// Julian year
+constexpr inline double DAYS_PER_YEAR = 365.25;
+
+constexpr inline double SECONDS_PER_DAY = 86400.0;
+constexpr inline double MINUTES_PER_DAY = 1440.0;
+constexpr inline double HOURS_PER_DAY   = 24.0;
+
+constexpr double secsToDays(double s)
+{
+    return s * (1.0 / SECONDS_PER_DAY);
+}
+
+constexpr double daysToSecs(double d)
+{
+    return d * SECONDS_PER_DAY;
+}
+
+struct LeapSecondRecord
+{
+    int seconds;
+    double t;
+};
+
+// Provide leap seconds data loaded from an external source
+void setLeapSeconds(celestia::util::array_view<LeapSecondRecord>);
+
+constexpr double secondsToJulianDate(double sec)
+{
+    return sec / SECONDS_PER_DAY;
+}
+constexpr double julianDateToSeconds(double jd)
+{
+    return jd * SECONDS_PER_DAY;
+}
+
+class Date
+{
+public:
+    Date() = default;
+    Date(int Y, int M, int D);
+    Date(double);
+
+    enum Format
+    {
+        Locale          = 0,
+        TZName          = 1,
+        UTCOffset       = 2,
+        ISO8601         = 3,
+        FormatCount     = 4,
+    };
+
+    std::string toString(Format format = Locale) const;
+
+    operator double() const;
+
+    static Date systemDate();
+
+    int year{ 0 };
+    int month{ 0 };
+    int day{ 0 };
+    int hour{ 0 };
+    int minute{ 0 };
+    int wday{ 0 };               // week day, 0 Sunday to 6 Saturday
+    int utc_offset{ 0 };         // offset from utc in seconds
+    std::string tzname{ "UTC" }; // timezone name
+    double seconds{ 0.0 };
+};
+
+bool parseDate(const std::string&, Date&);
+
+// Time scale conversions
+// UTC - Coordinated Universal Time
+// TAI - International Atomic Time
+// TT  - Terrestrial Time
+// TCB - Barycentric Coordinate Time
+// TDB - Barycentric Dynamical Time
+
+// Convert among uniform time scales
+double TTtoTAI(double tt);
+double TAItoTT(double tai);
+double TTtoTDB(double tt);
+double TDBtoTT(double tdb);
+
+// Conversions to and from Julian Date UTC--other time systems
+// should be preferred, since UTC Julian Dates aren't defined
+// during leapseconds.
+double JDUTCtoTAI(double utc);
+double TAItoJDUTC(double tai);
+
+// Convert to and from UTC dates
+double UTCtoTAI(const Date& utc);
+Date TAItoUTC(double tai);
+double UTCtoTDB(const Date& utc);
+Date TDBtoUTC(double tdb);
+Date TDBtoLocal(double tdb);
+
+} // end namespace celestia::astro

--- a/src/celastro/units.cpp
+++ b/src/celastro/units.cpp
@@ -1,0 +1,84 @@
+// units.cpp
+//
+// Copyright (C) 2001-2023, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "units.h"
+
+#include <celcompat/numbers.h>
+#include "astro.h"
+#include "date.h"
+
+namespace celestia::astro
+{
+
+// Get scale of given length unit in kilometers
+std::optional<double>
+getLengthScale(LengthUnit unit)
+{
+    switch (unit)
+    {
+    case LengthUnit::Kilometer: return 1.0;
+    case LengthUnit::Meter: return 1e-3;
+    case LengthUnit::EarthRadius: return EARTH_RADIUS<double>;
+    case LengthUnit::JupiterRadius: return JUPITER_RADIUS<double>;
+    case LengthUnit::SolarRadius: return SOLAR_RADIUS<double>;
+    case LengthUnit::AstronomicalUnit: return KM_PER_AU<double>;
+    case LengthUnit::LightYear: return KM_PER_LY<double>;
+    case LengthUnit::Parsec: return KM_PER_PARSEC<double>;
+    case LengthUnit::Kiloparsec: return 1e3 * KM_PER_PARSEC<double>;
+    case LengthUnit::Megaparsec: return 1e6 * KM_PER_PARSEC<double>;
+    default: return std::nullopt;
+    }
+}
+
+
+// Get scale of given time unit in days
+std::optional<double>
+getTimeScale(TimeUnit unit)
+{
+    switch (unit)
+    {
+    case TimeUnit::Second: return 1.0 / SECONDS_PER_DAY;
+    case TimeUnit::Minute: return 1.0 / MINUTES_PER_DAY;
+    case TimeUnit::Hour: return 1.0 / HOURS_PER_DAY;
+    case TimeUnit::Day: return 1.0;
+    case TimeUnit::JulianYear: return DAYS_PER_YEAR;
+    default: return std::nullopt;
+    }
+}
+
+
+// Get scale of given angle unit in degrees
+std::optional<double>
+getAngleScale(AngleUnit unit)
+{
+    switch (unit)
+    {
+    case AngleUnit::Milliarcsecond: return 1e-3 / SECONDS_PER_DEG;
+    case AngleUnit::Arcsecond: return 1.0 / SECONDS_PER_DEG;
+    case AngleUnit::Arcminute: return 1.0 / MINUTES_PER_DEG;
+    case AngleUnit::Degree: return 1.0;
+    case AngleUnit::Hour: return DEG_PER_HRA;
+    case AngleUnit::Radian: return 180.0 / celestia::numbers::pi;
+    default: return std::nullopt;
+    }
+}
+
+std::optional<double>
+getMassScale(MassUnit unit)
+{
+    switch (unit)
+    {
+    case MassUnit::Kilogram: return 1.0 / EarthMass;
+    case MassUnit::EarthMass: return 1.0;
+    case MassUnit::JupiterMass: return JupiterMass / EarthMass;
+    default: return std::nullopt;
+    }
+}
+
+} // end namespace celestia::astro

--- a/src/celastro/units.h
+++ b/src/celastro/units.h
@@ -1,0 +1,67 @@
+// units.h
+//
+// Copyright (C) 2001-2023, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace celestia::astro
+{
+
+enum class LengthUnit : std::uint8_t
+{
+    Default = 0,
+    Kilometer,
+    Meter,
+    EarthRadius,
+    JupiterRadius,
+    SolarRadius,
+    AstronomicalUnit,
+    LightYear,
+    Parsec,
+    Kiloparsec,
+    Megaparsec,
+};
+
+enum class TimeUnit : std::uint8_t
+{
+    Default = 0,
+    Second,
+    Minute,
+    Hour,
+    Day,
+    JulianYear,
+};
+
+enum class AngleUnit : std::uint8_t
+{
+    Default = 0,
+    Milliarcsecond,
+    Arcsecond,
+    Arcminute,
+    Degree,
+    Hour,
+    Radian,
+};
+
+enum class MassUnit : std::uint8_t
+{
+    Default = 0,
+    Kilogram,
+    EarthMass,
+    JupiterMass,
+};
+
+std::optional<double> getLengthScale(LengthUnit unit);
+std::optional<double> getTimeScale(TimeUnit unit);
+std::optional<double> getAngleScale(AngleUnit unit);
+std::optional<double> getMassScale(MassUnit unit);
+
+} // end namespace celestia::astro

--- a/src/celengine/CMakeLists.txt
+++ b/src/celengine/CMakeLists.txt
@@ -1,8 +1,6 @@
 set(CELENGINE_SOURCES
   asterism.cpp
   asterism.h
-  astro.cpp
-  astro.h
   astroobj.h
   atmosphere.h
   axisarrow.cpp

--- a/src/celengine/boundaries.cpp
+++ b/src/celengine/boundaries.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <utility>
 
-#include "astro.h"
+#include <celastro/astro.h>
 
 namespace astro = celestia::astro;
 

--- a/src/celengine/dateformatter.h
+++ b/src/celengine/dateformatter.h
@@ -24,7 +24,7 @@
 #include <array>
 #endif
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 
 namespace celestia::engine
 {

--- a/src/celengine/deepskyobj.cpp
+++ b/src/celengine/deepskyobj.cpp
@@ -12,9 +12,9 @@
 
 #include <cmath>
 
+#include <celastro/astro.h>
 #include <celmath/intersect.h>
 #include <celmath/sphere.h>
-#include "astro.h"
 #include "hash.h"
 
 namespace astro = celestia::astro;

--- a/src/celengine/frame.cpp
+++ b/src/celengine/frame.cpp
@@ -11,6 +11,8 @@
 // of the License, or (at your option) any later version.
 
 #include <cassert>
+#include <celastro/astro.h>
+#include <celastro/date.h>
 #include <celengine/star.h>
 #include <celengine/body.h>
 #include <celengine/deepskyobj.h>

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <celengine/astro.h>
 #include <celengine/selection.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/src/celengine/hash.cpp
+++ b/src/celengine/hash.cpp
@@ -8,10 +8,10 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <celastro/units.h>
 #include <celmath/mathlib.h>
 #include <celutil/color.h>
 #include <celutil/fsutils.h>
-#include "astro.h"
 #include "hash.h"
 #include "value.h"
 

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -11,7 +11,6 @@
 #include <celmath/mathlib.h>
 #include <celmath/vecgl.h>
 #include <celutil/gettext.h>
-#include "astro.h"
 #include "meshmanager.h"
 #include "nebula.h"
 #include "rendcontext.h"

--- a/src/celengine/opencluster.cpp
+++ b/src/celengine/opencluster.cpp
@@ -9,7 +9,6 @@
 
 #include <config.h>
 #include "render.h"
-#include "astro.h"
 #include "opencluster.h"
 #include "meshmanager.h"
 #include <celmath/mathlib.h>

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -18,6 +18,8 @@
 #include "trajmanager.h"
 #include "rotationmanager.h"
 #include "universe.h"
+#include <celastro/astro.h>
+#include <celastro/date.h>
 #include <celcompat/numbers.h>
 #include <celephem/customorbit.h>
 #include <celephem/customrotation.h>

--- a/src/celengine/parser.cpp
+++ b/src/celengine/parser.cpp
@@ -12,8 +12,8 @@
 #include <utility>
 #include <variant>
 
+#include <celastro/units.h>
 #include <celutil/tokenizer.h>
-#include "astro.h"
 #include "parser.h"
 
 using namespace std::string_view_literals;

--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <Eigen/Geometry>
 #include <fmt/format.h>
+#include <celastro/date.h>
 #include <celcompat/numbers.h>
 #include <celmath/geomutil.h>
 #include <celmath/intersect.h>

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -23,7 +23,6 @@
 #include "boundaries.h"
 #include "dsorenderer.h"
 #include "asterism.h"
-#include "astro.h"
 #include "glshader.h"
 #include "shadermanager.h"
 #include "spheremesh.h"
@@ -48,6 +47,8 @@
 #include "orbitsampler.h"
 #include "rendcontext.h"
 #include "textlayout.h"
+#include <celastro/astro.h>
+#include <celastro/date.h>
 #include <celcompat/numbers.h>
 #include <celengine/observer.h>
 #include <celmath/frustum.h>

--- a/src/celengine/simulation.h
+++ b/src/celengine/simulation.h
@@ -21,7 +21,6 @@
 
 #include <celengine/texture.h>
 #include <celengine/universe.h>
-#include <celengine/astro.h>
 #include <celengine/galaxy.h>
 #include <celengine/globular.h>
 #include <celengine/texmanager.h>

--- a/src/celengine/star.cpp
+++ b/src/celengine/star.cpp
@@ -18,6 +18,8 @@
 
 #include <fmt/format.h>
 
+#include <celastro/astro.h>
+#include <celastro/date.h>
 #include <celephem/orbit.h>
 #include <celephem/rotation.h>
 #include "univcoord.h"

--- a/src/celengine/univcoord.h
+++ b/src/celengine/univcoord.h
@@ -16,10 +16,9 @@
 
 #include <Eigen/Core>
 
+#include <celastro/astro.h>
 #include <celutil/r128.h>
 #include <celutil/r128util.h>
-
-#include "astro.h"
 
 
 class UniversalCoord

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -24,7 +24,6 @@
 #include <celutil/greek.h>
 #include <celutil/utf8.h>
 #include "asterism.h"
-#include "astro.h"
 #include "body.h"
 #include "boundaries.h"
 #include "frametree.h"

--- a/src/celengine/value.h
+++ b/src/celengine/value.h
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include "astro.h"
+#include <celastro/units.h>
 #include "hash.h"
 
 

--- a/src/celephem/customorbit.cpp
+++ b/src/celephem/customorbit.cpp
@@ -19,8 +19,9 @@
 #include <memory>
 #include <utility>
 
+#include <celastro/astro.h>
+#include <celastro/date.h>
 #include <celcompat/numbers.h>
-#include <celengine/astro.h>
 #include <celmath/mathlib.h>
 #include <celmath/geomutil.h>
 #include <celutil/logger.h>

--- a/src/celephem/customrotation.cpp
+++ b/src/celephem/customrotation.cpp
@@ -21,7 +21,7 @@
 
 #include <Eigen/Geometry>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celmath/geomutil.h>
 #include <celmath/mathlib.h>
 #include "precession.h"

--- a/src/celephem/orbit.h
+++ b/src/celephem/orbit.h
@@ -13,7 +13,7 @@
 
 #include <Eigen/Core>
 
-#include <celengine/astro.h>
+#include <celastro/astro.h>
 
 class Body;
 

--- a/src/celephem/samporbit.cpp
+++ b/src/celephem/samporbit.cpp
@@ -26,8 +26,8 @@
 
 #include <Eigen/Core>
 
+#include <celastro/date.h>
 #include <celcompat/bit.h>
-#include <celengine/astro.h>
 #include <celmath/mathlib.h>
 #include <celutil/gettext.h>
 #include <celutil/logger.h>

--- a/src/celephem/spiceorbit.cpp
+++ b/src/celephem/spiceorbit.cpp
@@ -13,7 +13,7 @@
 
 #include <SpiceUsr.h>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celutil/logger.h>
 #include "spiceinterface.h"
 #include "spiceorbit.h"

--- a/src/celephem/spicerotation.cpp
+++ b/src/celephem/spicerotation.cpp
@@ -16,8 +16,8 @@
 
 #include <SpiceUsr.h>
 
+#include <celastro/date.h>
 #include <celcompat/numbers.h>
-#include <celengine/astro.h>
 #include <celmath/geomutil.h>
 #include <celutil/logger.h>
 #include "spiceinterface.h"

--- a/src/celephem/vsop87.cpp
+++ b/src/celephem/vsop87.cpp
@@ -22,9 +22,10 @@
 
 #include <config.h>
 
+#include <celastro/astro.h>
+#include <celastro/date.h>
 #include <celcompat/numbers.h>
 #include <celmath/mathlib.h>
-#include <celengine/astro.h>
 #include "orbit.h"
 
 namespace celestia::ephem

--- a/src/celestia/CMakeLists.txt
+++ b/src/celestia/CMakeLists.txt
@@ -64,6 +64,7 @@ if(ENABLE_MINIAUDIO)
 endif()
 
 set(CELESTIA_CORE_LIBS $<TARGET_OBJECTS:cel3ds>
+                       $<TARGET_OBJECTS:celastro>
                        $<TARGET_OBJECTS:celengine>
                        $<TARGET_OBJECTS:celephem>
                        $<TARGET_OBJECTS:celimage>

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -18,8 +18,9 @@
 #include "textprintposition.h"
 #include "url.h"
 #include "viewmanager.h"
+#include <celastro/astro.h>
+#include <celastro/date.h>
 #include <celcompat/numbers.h>
-#include <celengine/astro.h>
 #include <celengine/asterism.h>
 #include <celengine/body.h>
 #include <celengine/boundaries.h>

--- a/src/celestia/destination.cpp
+++ b/src/celestia/destination.cpp
@@ -9,7 +9,7 @@
 
 #include <algorithm>
 
-#include <celengine/astro.h>
+#include <celastro/astro.h>
 #include <celengine/hash.h>
 #include <celengine/parser.h>
 #include <celengine/value.h>

--- a/src/celestia/gtk/common.cpp
+++ b/src/celestia/gtk/common.cpp
@@ -14,7 +14,7 @@
 #include <gtk/gtk.h>
 #include <time.h>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celengine/galaxy.h>
 #include <celengine/render.h>
 #include <celestia/celestiacore.h>

--- a/src/celestia/gtk/dialog-eclipse.cpp
+++ b/src/celestia/gtk/dialog-eclipse.cpp
@@ -12,8 +12,8 @@
 
 #include <gtk/gtk.h>
 
+#include <celastro/date.h>
 #include <celcompat/numbers.h>
-#include <celengine/astro.h>
 #include <celengine/body.h>
 #include <celengine/simulation.h>
 #include <celestia/eclipsefinder.h>

--- a/src/celestia/gtk/dialog-time.cpp
+++ b/src/celestia/gtk/dialog-time.cpp
@@ -13,7 +13,7 @@
 #include <gtk/gtk.h>
 #include <time.h>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celengine/simulation.h>
 
 #include "dialog-time.h"

--- a/src/celestia/gtk/main.cpp
+++ b/src/celestia/gtk/main.cpp
@@ -31,7 +31,6 @@
 #include "gtkegl.h"
 #endif
 
-#include <celengine/astro.h>
 #include <celengine/galaxy.h>
 #include <celengine/glsupport.h>
 #include <celengine/simulation.h>

--- a/src/celestia/hud.h
+++ b/src/celestia/hud.h
@@ -21,7 +21,7 @@
 
 #include <Eigen/Core>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celengine/dateformatter.h>
 #include <celengine/selection.h>
 #include <celestia/textinput.h>

--- a/src/celestia/qt/qtcelestialbrowser.cpp
+++ b/src/celestia/qt/qtcelestialbrowser.cpp
@@ -41,7 +41,7 @@
 #include <QVariant>
 #include <QVBoxLayout>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celengine/astroobj.h>
 #include <celengine/marker.h>
 #include <celengine/selection.h>

--- a/src/celestia/qt/qtdeepskybrowser.cpp
+++ b/src/celestia/qt/qtdeepskybrowser.cpp
@@ -43,7 +43,7 @@
 #include <QVariant>
 #include <QVBoxLayout>
 
-#include <celengine/astro.h>
+#include <celastro/astro.h>
 #include <celengine/deepskyobj.h>
 #include <celengine/dsodb.h>
 #include <celengine/marker.h>

--- a/src/celestia/qt/qteventfinder.cpp
+++ b/src/celestia/qt/qteventfinder.cpp
@@ -46,7 +46,7 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celengine/body.h>
 #include <celengine/observer.h>
 #include <celengine/selection.h>

--- a/src/celestia/qt/qtgotoobjectdialog.cpp
+++ b/src/celestia/qt/qtgotoobjectdialog.cpp
@@ -9,7 +9,7 @@
 #include <QPushButton>
 #include <QString>
 
-#include <celengine/astro.h>
+#include <celastro/astro.h>
 #include <celengine/body.h>
 #include <celengine/observer.h>
 #include <celengine/selection.h>

--- a/src/celestia/qt/qtinfopanel.cpp
+++ b/src/celestia/qt/qtinfopanel.cpp
@@ -24,8 +24,9 @@
 #include <QTextBrowser>
 #include <QTextStream>
 
+#include <celastro/astro.h>
+#include <celastro/date.h>
 #include <celcompat/numbers.h>
-#include <celengine/astro.h>
 #include <celengine/body.h>
 #include <celengine/selection.h>
 #include <celengine/universe.h>

--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -23,7 +23,7 @@
 #include <QSpinBox>
 #include <QVariant>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celengine/body.h>
 #include <celengine/location.h>
 #include <celengine/observer.h>

--- a/src/celestia/qt/qtsettimedialog.cpp
+++ b/src/celestia/qt/qtsettimedialog.cpp
@@ -20,7 +20,7 @@
 #include <QSpinBox>
 #include <QVBoxLayout>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celestia/celestiacore.h>
 #include <celutil/gettext.h>
 

--- a/src/celestia/qt/qttimetoolbar.cpp
+++ b/src/celestia/qt/qttimetoolbar.cpp
@@ -19,7 +19,7 @@
 #include <QString>
 #include <QTime>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celestia/celestiacore.h>
 #include <celutil/gettext.h>
 

--- a/src/celestia/url.h
+++ b/src/celestia/url.h
@@ -16,7 +16,7 @@
 
 #include <Eigen/Geometry>
 
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celengine/observer.h>
 #include <celengine/selection.h>
 

--- a/src/celestia/win32/windatepicker.cpp
+++ b/src/celestia/win32/windatepicker.cpp
@@ -11,7 +11,7 @@
 
 #include <windows.h>
 #include <commctrl.h>
-#include "celengine/astro.h"
+#include "celastro/date.h"
 #include "celutil/gettext.h"
 #include "celutil/winutil.h"
 

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -28,6 +28,7 @@
 #include <celengine/body.h>
 #include <celengine/glsupport.h>
 
+#include <celastro/date.h>
 #include <celcompat/charconv.h>
 #include <celcompat/filesystem.h>
 #include <celmath/mathlib.h>
@@ -39,7 +40,6 @@
 #include <celutil/filetype.h>
 #include <celutil/logger.h>
 #include <celutil/stringutils.h>
-#include <celengine/astro.h>
 #include <celscript/legacy/cmdparser.h>
 
 #include "celestia/celestiacore.h"

--- a/src/celestia/win32/wintime.cpp
+++ b/src/celestia/win32/wintime.cpp
@@ -15,7 +15,7 @@
 #include <commctrl.h>
 #include <time.h>
 #include "res/resource.h"
-#include <celengine/astro.h>
+#include <celastro/date.h>
 #include <celutil/gettext.h>
 #include <celutil/winutil.h>
 

--- a/src/celrender/cometrenderer.cpp
+++ b/src/celrender/cometrenderer.cpp
@@ -15,8 +15,8 @@
 
 #include <Eigen/Geometry>
 
+#include <celastro/astro.h>
 #include <celcompat/numbers.h>
-#include <celengine/astro.h>
 #include <celengine/body.h>
 #include <celengine/glsupport.h>
 #include <celengine/observer.h>

--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -29,6 +29,8 @@
 #include <Eigen/Core>
 #include <fmt/format.h>
 
+#include <celastro/astro.h>
+#include <celastro/date.h>
 #include <celengine/hash.h>
 #include <celengine/parser.h>
 #include <celengine/render.h>

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <string_view>
 #include <utility>
-#include <celengine/astro.h>
+#include <celastro/astro.h>
 #include <celengine/asterism.h>
 #include <celscript/legacy/cmdparser.h>
 #include <celscript/legacy/execution.h>

--- a/src/tools/stardb/makestardb.cpp
+++ b/src/tools/stardb/makestardb.cpp
@@ -14,8 +14,8 @@
 #include <iomanip>
 #include <cctype>
 #include <cassert>
+#include <celastro/astro.h>
 #include <celutil/bytes.h>
-#include <celengine/astro.h>
 #include <celengine/star.h>
 
 using namespace std;

--- a/src/tools/stardb/startextdump.cpp
+++ b/src/tools/stardb/startextdump.cpp
@@ -13,9 +13,9 @@
 #include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <celastro/astro.h>
 #include <celcompat/numbers.h>
 #include <celutil/bytes.h>
-#include <celengine/astro.h>
 #include <celengine/stellarclass.h>
 
 using namespace std;

--- a/test/unit/kepler_test.cpp
+++ b/test/unit/kepler_test.cpp
@@ -1,8 +1,8 @@
 #include <array>
 #include <cmath>
 
+#include <celastro/astro.h>
 #include <celcompat/numbers.h>
-#include <celengine/astro.h>
 #include <celephem/orbit.h>
 #include <celmath/mathlib.h>
 #include <celutil/array_view.h>


### PR DESCRIPTION
Additional change: on Windows, get month abbreviations from the locale rather than the translation files.