### PR TITLE
Simplify winutil.h API

### DIFF
--- a/src/celastro/date.cpp
+++ b/src/celastro/date.cpp
@@ -102,7 +102,7 @@ MonthAbbreviations::MonthAbbreviations()
         std::wostringstream stream;
         stream.imbue(loc);
         stream << std::put_time(&tm, L"%b");
-        abbreviations[i] = WideToUTF8(stream.str());
+        abbreviations[i] = util::WideToUTF8(stream.str());
     }
 }
 

--- a/src/celestia/win32/winbookmarks.h
+++ b/src/celestia/win32/winbookmarks.h
@@ -16,7 +16,7 @@
 #include "celestia/celestiacore.h"
 #include "odmenu.h"
 
-#include <Windows.h>
+#include <windows.h>
 #include <commctrl.h>
 
 

--- a/src/celestia/win32/windatepicker.cpp
+++ b/src/celestia/win32/windatepicker.cpp
@@ -18,6 +18,7 @@
 using namespace std;
 
 namespace astro = celestia::astro;
+namespace util = celestia::util;
 
 // DatePicker is a Win32 control for setting the date. It replaces the
 // date picker from commctl, adding a number of features appropriate
@@ -159,7 +160,7 @@ DatePicker::redraw(HDC hdc)
     char dayBuf[32];
     char yearBuf[32];
 
-    string monthStr = UTF8ToCurrentCP(_(Months[date.month - 1]));
+    string monthStr = util::UTF8ToCurrentCP(_(Months[date.month - 1]));
     sprintf(dayBuf, "%02d", date.day);
     sprintf(yearBuf, "%5d", date.year);
 

--- a/src/celestia/win32/wineclipses.cpp
+++ b/src/celestia/win32/wineclipses.cpp
@@ -37,6 +37,7 @@ using namespace celestia::win32;
 
 namespace astro = celestia::astro;
 namespace math = celestia::math;
+namespace util = celestia::util;
 
 static vector<Eclipse> eclipseList;
 
@@ -62,11 +63,11 @@ bool InitEclipseFinderColumns(HWND listView)
     for (i = 0; i < nColumns; i++)
         columns[i] = lvc;
 
-    string header0 = UTF8ToCurrentCP(_("Planet"));
-    string header1 = UTF8ToCurrentCP(_("Satellite"));
-    string header2 = UTF8ToCurrentCP(_("Date"));
-    string header3 = UTF8ToCurrentCP(_("Start"));
-    string header4 = UTF8ToCurrentCP(_("Duration"));
+    string header0 = util::UTF8ToCurrentCP(_("Planet"));
+    string header1 = util::UTF8ToCurrentCP(_("Satellite"));
+    string header2 = util::UTF8ToCurrentCP(_("Date"));
+    string header3 = util::UTF8ToCurrentCP(_("Start"));
+    string header4 = util::UTF8ToCurrentCP(_("Duration"));
 
     columns[0].pszText = const_cast<char*>(header0.c_str());
     columns[0].cx = DpToPixels(65, listView);
@@ -125,19 +126,19 @@ void EclipseFinderDisplayItem(LPNMLVDISPINFOA nm)
     switch (nm->item.iSubItem)
     {
     case 0:
-        strncpy(callbackScratch, UTF8ToCurrentCP(eclipse->receiver->getName(true)).c_str(), sizeof(callbackScratch) - 1);
+        strncpy(callbackScratch, util::UTF8ToCurrentCP(eclipse->receiver->getName(true)).c_str(), sizeof(callbackScratch) - 1);
         nm->item.pszText = callbackScratch;
         break;
 
     case 1:
-        strncpy(callbackScratch, UTF8ToCurrentCP(eclipse->occulter->getName(true)).c_str(), sizeof(callbackScratch) - 1);
+        strncpy(callbackScratch, util::UTF8ToCurrentCP(eclipse->occulter->getName(true)).c_str(), sizeof(callbackScratch) - 1);
         nm->item.pszText = callbackScratch;
         break;
 
     case 2:
         {
             astro::Date startDate(eclipse->startTime);
-            string monthStr = UTF8ToCurrentCP(_(MonthNames[startDate.month - 1]));
+            string monthStr = util::UTF8ToCurrentCP(_(MonthNames[startDate.month - 1]));
             sprintf(callbackScratch, "%2d %s %4d",
                     startDate.day,
                     monthStr.c_str(),
@@ -294,12 +295,12 @@ BOOL APIENTRY EclipseFinderProc(HWND hDlg,
             CheckRadioButton(hDlg, IDC_SOLARECLIPSE, IDC_LUNARECLIPSE, IDC_SOLARECLIPSE);
             efd->type = Eclipse::Solar;
 
-            string item0 = UTF8ToCurrentCP(_("Earth"));
-            string item1 = UTF8ToCurrentCP(_("Jupiter"));
-            string item2 = UTF8ToCurrentCP(_("Saturn"));
-            string item3 = UTF8ToCurrentCP(_("Uranus"));
-            string item4 = UTF8ToCurrentCP(_("Neptune"));
-            string item5 = UTF8ToCurrentCP(_("Pluto"));
+            string item0 = util::UTF8ToCurrentCP(_("Earth"));
+            string item1 = util::UTF8ToCurrentCP(_("Jupiter"));
+            string item2 = util::UTF8ToCurrentCP(_("Saturn"));
+            string item3 = util::UTF8ToCurrentCP(_("Uranus"));
+            string item4 = util::UTF8ToCurrentCP(_("Neptune"));
+            string item5 = util::UTF8ToCurrentCP(_("Pluto"));
 
             SendDlgItemMessage(hDlg, IDC_ECLIPSETARGET, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(item0.c_str()));
             SendDlgItemMessage(hDlg, IDC_ECLIPSETARGET, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(item1.c_str()));

--- a/src/celestia/win32/wineclipses.h
+++ b/src/celestia/win32/wineclipses.h
@@ -15,7 +15,7 @@
 
 #include "celestia/celestiacore.h"
 
-#include <Windows.h>
+#include <windows.h>
 
 
 class EclipseFinderDialog

--- a/src/celestia/win32/wingotodlg.cpp
+++ b/src/celestia/win32/wingotodlg.cpp
@@ -20,6 +20,7 @@ using namespace std;
 
 namespace astro = celestia::astro;
 namespace math = celestia::math;
+namespace util = celestia::util;
 
 static bool GetDialogFloat(HWND hDlg, int id, float& f)
 {
@@ -74,7 +75,7 @@ static BOOL APIENTRY GotoObjectProc(HWND hDlg,
                 SetDialogFloat(hDlg, IDC_EDIT_LONGITUDE, "%.5f", (float)longitude);
                 SetDialogFloat(hDlg, IDC_EDIT_LATITUDE, "%.5f", (float)latitude);
                 SetDlgItemText(hDlg, IDC_EDIT_OBJECTNAME,
-                 const_cast<char*>(UTF8ToCurrentCP(sim->getSelection().body()->getName(true)).c_str()));
+                 const_cast<char*>(util::UTF8ToCurrentCP(sim->getSelection().body()->getName(true)).c_str()));
             }
 //            else if (sim->getSelection().star != NULL)
 //            {

--- a/src/celestia/win32/wingotodlg.h
+++ b/src/celestia/win32/wingotodlg.h
@@ -13,7 +13,7 @@
 
 #include "celestia/celestiacore.h"
 
-#include <Windows.h>
+#include <windows.h>
 
 
 class GotoObjectDialog

--- a/src/celestia/win32/winlocations.h
+++ b/src/celestia/win32/winlocations.h
@@ -13,7 +13,7 @@
 
 #include "celestia/celestiacore.h"
 
-#include <Windows.h>
+#include <windows.h>
 #include <commctrl.h>
 
 class LocationsDialog : public CelestiaWatcher

--- a/src/celestia/win32/winsplash.cpp
+++ b/src/celestia/win32/winsplash.cpp
@@ -23,6 +23,8 @@ using namespace std;
 using namespace celestia::win32;
 using namespace celestia::engine;
 
+namespace util = celestia::util;
+
 
 // Required for transparent Windows, but not present in VC6 headers. Only present
 // on Win2k or later.
@@ -137,9 +139,7 @@ SplashWindow::paint(HDC hDC)
 
     HFONT hFont = reinterpret_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
     SelectObject(hDC, hFont);
- //   string s;
- //   s += UTF8ToCurrentCP(_("Version: "));
-    string text = UTF8ToCurrentCP(_("Version: ")) + string(VERSION_STRING "\n") + message;
+    string text = util::UTF8ToCurrentCP(_("Version: ")) + string(VERSION_STRING "\n") + message;
     DrawText(hDC, text.c_str(), text.length(), &r, DT_LEFT | DT_VCENTER);
 }
 

--- a/src/celestia/win32/winssbrowser.cpp
+++ b/src/celestia/win32/winssbrowser.cpp
@@ -25,6 +25,8 @@
 
 using namespace std;
 
+namespace util = celestia::util;
+
 
 HTREEITEM AddItemToTree(HWND hwndTV, LPSTR lpszItem, int nLevel, void* data,
                         HTREEITEM parent)
@@ -81,7 +83,7 @@ void AddPlanetarySystemToTree(const PlanetarySystem* sys, HWND treeView, int lev
         {
             HTREEITEM item;
             item = AddItemToTree(treeView,
-                                 const_cast<char*>(UTF8ToCurrentCP(world->getName(true)).c_str()),
+                                 const_cast<char*>(util::UTF8ToCurrentCP(world->getName(true)).c_str()),
                                  level,
                                  static_cast<void*>(world),
                                  parent);
@@ -115,7 +117,7 @@ BOOL APIENTRY SolarSystemBrowserProc(HWND hDlg,
             if (solarSys != NULL)
             {
                 Universe* u = browser->appCore->getSimulation()->getUniverse();
-                string starNameString = UTF8ToCurrentCP(u->getStarCatalog()->getStarName(*(solarSys->getStar())));
+                string starNameString = util::UTF8ToCurrentCP(u->getStarCatalog()->getStarName(*(solarSys->getStar())));
                 HTREEITEM rootItem = AddItemToTree(hwnd, const_cast<char*>(starNameString.c_str()), 1, NULL,
                                                    (HTREEITEM) TVI_ROOT);
                 const PlanetarySystem* planets = solarSys->getPlanets();

--- a/src/celestia/win32/winssbrowser.h
+++ b/src/celestia/win32/winssbrowser.h
@@ -13,7 +13,7 @@
 
 #include "celestia/celestiacore.h"
 
-#include <Windows.h>
+#include <windows.h>
 
 
 class SolarSystemBrowser

--- a/src/celestia/win32/winstarbrowser.cpp
+++ b/src/celestia/win32/winstarbrowser.cpp
@@ -30,6 +30,7 @@ using namespace celestia::win32;
 
 namespace astro = celestia::astro;
 namespace math = celestia::math;
+namespace util = celestia::util;
 
 static const int MinListStars = 10;
 static const int MaxListStars = 500;
@@ -61,11 +62,11 @@ bool InitStarBrowserColumns(HWND listView)
     for (i = 0; i < nColumns; i++)
         columns[i] = lvc;
 
-    string header0 = UTF8ToCurrentCP(_("Name"));
-    string header1 = UTF8ToCurrentCP(_("Distance (ly)"));
-    string header2 = UTF8ToCurrentCP(_("App. mag"));
-    string header3 = UTF8ToCurrentCP(_("Abs. mag"));
-    string header4 = UTF8ToCurrentCP(_("Type"));
+    string header0 = util::UTF8ToCurrentCP(_("Name"));
+    string header1 = util::UTF8ToCurrentCP(_("Distance (ly)"));
+    string header2 = util::UTF8ToCurrentCP(_("App. mag"));
+    string header3 = util::UTF8ToCurrentCP(_("Abs. mag"));
+    string header4 = util::UTF8ToCurrentCP(_("Type"));
 
     columns[0].pszText = const_cast<char*>(header0.c_str());
     columns[0].cx = DpToPixels(100, listView);
@@ -341,7 +342,7 @@ void StarBrowserDisplayItem(LPNMLVDISPINFOA nm, StarBrowser* browser)
     case 0:
         {
             Universe* u = browser->appCore->getSimulation()->getUniverse();
-            starNameString = UTF8ToCurrentCP(u->getStarCatalog()->getStarName(*star));
+            starNameString = util::UTF8ToCurrentCP(u->getStarCatalog()->getStarName(*star));
             nm->item.pszText = const_cast<char*>(starNameString.c_str());
         }
         break;

--- a/src/celestia/win32/winstarbrowser.h
+++ b/src/celestia/win32/winstarbrowser.h
@@ -13,7 +13,7 @@
 
 #include "celestia/celestiacore.h"
 
-#include <Windows.h>
+#include <windows.h>
 
 
 class StarBrowser

--- a/src/celestia/win32/wintime.cpp
+++ b/src/celestia/win32/wintime.cpp
@@ -22,6 +22,7 @@
 using namespace std;
 
 namespace astro = celestia::astro;
+namespace util = celestia::util;
 
 class SetTimeDialog
 {
@@ -93,10 +94,10 @@ SetTimeDialog::init(HWND _hDlg)
     useLocalTime = appCore->getTimeZoneBias() != 0;
     useUTCOffset = appCore->getDateFormat() == 2;
 
-    string item0 = UTF8ToCurrentCP(_("Universal Time"));
-    string item1 = UTF8ToCurrentCP(_("Local Time"));
-    string item2 = UTF8ToCurrentCP(_("Time Zone Name"));
-    string item3 = UTF8ToCurrentCP(_("UTC Offset"));
+    string item0 = util::UTF8ToCurrentCP(_("Universal Time"));
+    string item1 = util::UTF8ToCurrentCP(_("Local Time"));
+    string item2 = util::UTF8ToCurrentCP(_("Time Zone Name"));
+    string item3 = util::UTF8ToCurrentCP(_("UTC Offset"));
 
     SendDlgItemMessage(hDlg, IDC_COMBOBOX_TIMEZONE, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(item0.c_str()));
     SendDlgItemMessage(hDlg, IDC_COMBOBOX_TIMEZONE, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(item1.c_str()));

--- a/src/celestia/win32/wintourguide.cpp
+++ b/src/celestia/win32/wintourguide.cpp
@@ -26,6 +26,8 @@
 using namespace Eigen;
 using namespace std;
 
+namespace util = celestia::util;
+
 
 BOOL APIENTRY TourGuideProc(HWND hDlg,
                             UINT message,
@@ -58,7 +60,7 @@ BOOL APIENTRY TourGuideProc(HWND hDlg,
                     if (dest != NULL)
                     {
                         SendMessage(hwnd, CB_INSERTSTRING, -1,
-                                    reinterpret_cast<LPARAM>(UTF8ToCurrentCP(dest->name).c_str()));
+                                    reinterpret_cast<LPARAM>(util::UTF8ToCurrentCP(dest->name).c_str()));
                     }
                 }
 
@@ -67,7 +69,7 @@ BOOL APIENTRY TourGuideProc(HWND hDlg,
                     SendMessage(hwnd, CB_SETCURSEL, 0, 0);
                     SetDlgItemText(hDlg,
                                    IDC_TEXT_DESCRIPTION,
-                                   UTF8ToCurrentCP((*destinations)[0]->description).c_str());
+                                   util::UTF8ToCurrentCP((*destinations)[0]->description).c_str());
                 }
             }
         }
@@ -131,7 +133,7 @@ BOOL APIENTRY TourGuideProc(HWND hDlg,
                     Destination* dest = (*destinations)[item];
                     SetDlgItemText(hDlg,
                                    IDC_TEXT_DESCRIPTION,
-                                   UTF8ToCurrentCP(dest->description).c_str());
+                                   util::UTF8ToCurrentCP(dest->description).c_str());
                     tourGuide->selectedDest = dest;
                 }
             }

--- a/src/celestia/win32/wintourguide.h
+++ b/src/celestia/win32/wintourguide.h
@@ -13,7 +13,7 @@
 
 #include "celestia/celestiacore.h"
 
-#include <Windows.h>
+#include <windows.h>
 
 
 class TourGuide

--- a/src/celestia/win32/winviewoptsdlg.h
+++ b/src/celestia/win32/winviewoptsdlg.h
@@ -13,7 +13,7 @@
 
 #include "celestia/celestiacore.h"
 
-#include <Windows.h>
+#include <windows.h>
 
 class ViewOptionsDialog : public CelestiaWatcher
 {

--- a/src/celutil/tzutil.cpp
+++ b/src/celutil/tzutil.cpp
@@ -14,6 +14,9 @@
 #include "winutil.h"
 #include "gettext.h"
 #include "logger.h"
+
+namespace util = celestia::util;
+
 #else
 // we need the C version of this header to get the POSIX function localtime_r
 #include <time.h>
@@ -49,7 +52,7 @@ bool GetTZInfo(std::string& tzName, int& dstBias)
         return false;
     }
 
-    tzName = name == nullptr ? "   " : WideToUTF8(name);
+    tzName = name == nullptr ? "   " : util::WideToUTF8(name);
     dstBias = (tzi.Bias + bias) * -60;
     return true;
 #else

--- a/src/celutil/winutil.cpp
+++ b/src/celutil/winutil.cpp
@@ -10,71 +10,74 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <windows.h>
 #include "winutil.h"
 
-using namespace std;
+#include <Windows.h>
 
-const char* CurrentCP()
+namespace celestia::util
 {
-    static bool set = false;
-    static char cp[20] = "CP";
-    if (!set)
-    {
-        GetLocaleInfoA(GetThreadLocale(), LOCALE_IDEFAULTANSICODEPAGE, cp+2, 18);
-        set = true;
-    }
-    return cp;
-}
 
-string UTF8ToCurrentCP(const string& str)
+namespace
 {
-    return WideToCurrentCP(UTF8ToWide(str));
-}
 
-string CurrentCPToUTF8(const string& str)
-{
-    return WideToUTF8(CurrentCPToWide(str));
-}
-
-string WStringToString(UINT codePage, const wstring& ws)
+std::string
+WStringToString(UINT codePage, std::wstring_view ws)
 {
     if (ws.empty())
         return {};
+
     // get a converted string length
-    auto len = WideCharToMultiByte(codePage, 0, ws.c_str(), ws.length(), NULL, 0, nullptr, nullptr);
-    string out(len, 0);
-    WideCharToMultiByte(codePage, 0, ws.c_str(), ws.length(), &out[0], len, nullptr, nullptr);
+    const auto srcLen = static_cast<int>(ws.size());
+    const auto len = WideCharToMultiByte(codePage, 0, ws.data(), srcLen, nullptr, 0, nullptr, nullptr);
+    if (len <= 0)
+        return {};
+
+    std::string out(static_cast<std::string::size_type>(len), '\0');
+    WideCharToMultiByte(codePage, 0, ws.data(), srcLen, out.data(), len, nullptr, nullptr);
     return out;
 }
 
-wstring StringToWString(UINT codePage, const string& s)
+std::wstring
+StringToWString(UINT codePage, std::string_view s)
 {
     if (s.empty())
         return {};
+
     // get a converted string length
-    auto len = MultiByteToWideChar(codePage, 0, s.c_str(), s.length(), nullptr, 0);
-    wstring out(len, 0);
-    MultiByteToWideChar(codePage, 0, s.c_str(), s.length(), &out[0], len);
+    const auto srcLen = static_cast<int>(s.size());
+    const auto len = MultiByteToWideChar(codePage, 0, s.data(), srcLen, nullptr, 0);
+    if (len <= 0)
+        return {};
+
+    std::wstring out(static_cast<std::wstring::size_type>(len), L'\0');
+    MultiByteToWideChar(codePage, 0, s.data(), srcLen, out.data(), len);
     return out;
 }
 
-string WideToCurrentCP(const wstring& ws)
+inline std::wstring
+UTF8ToWide(std::string_view s)
+{
+    return StringToWString(CP_UTF8, s);
+}
+
+inline std::string
+WideToCurrentCP(std::wstring_view ws)
 {
     return WStringToString(CP_ACP, ws);
 }
 
-wstring CurrentCPToWide(const string& s)
+} // end unnamed namespace
+
+std::string
+UTF8ToCurrentCP(std::string_view str)
 {
-    return StringToWString(CP_ACP, s);
+    return WideToCurrentCP(UTF8ToWide(str));
 }
 
-string WideToUTF8(const wstring& ws)
+std::string
+WideToUTF8(std::wstring_view ws)
 {
     return WStringToString(CP_UTF8, ws);
 }
 
-wstring UTF8ToWide(const string& s)
-{
-    return StringToWString(CP_UTF8, s);
-}
+} // end namespace celestia::util

--- a/src/celutil/winutil.cpp
+++ b/src/celutil/winutil.cpp
@@ -12,7 +12,7 @@
 
 #include "winutil.h"
 
-#include <Windows.h>
+#include <windows.h>
 
 namespace celestia::util
 {

--- a/src/celutil/winutil.h
+++ b/src/celutil/winutil.h
@@ -13,11 +13,12 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
-const char* CurrentCP();
-std::string UTF8ToCurrentCP(const std::string& str);
-std::string CurrentCPToUTF8(const std::string& str);
-std::string WideToCurrentCP(const std::wstring& ws);
-std::wstring CurrentCPToWide(const std::string& str);
-std::string WideToUTF8(const std::wstring& ws);
-std::wstring UTF8ToWide(const std::string& str);
+namespace celestia::util
+{
+
+std::string UTF8ToCurrentCP(std::string_view str);
+std::string WideToUTF8(std::wstring_view ws);
+
+}

--- a/test/unit/winutil_test.cpp
+++ b/test/unit/winutil_test.cpp
@@ -4,24 +4,10 @@
 
 TEST_SUITE_BEGIN("WinUtil");
 
-TEST_CASE("CurrentCPToWide")
-{
-    REQUIRE(CurrentCPToWide("").empty() == true);
-    REQUIRE(CurrentCPToWide("").length() == 0);
-    REQUIRE(CurrentCPToWide("foo") == L"foo");
-    REQUIRE(CurrentCPToWide("foo").length() == 3);
-}
-
-TEST_CASE("WideToCurrentCP")
-{
-    REQUIRE(WideToCurrentCP(L"").empty() == true);
-    REQUIRE(WideToCurrentCP(L"").length() == 0);
-    REQUIRE(WideToCurrentCP(L"foo") == "foo");
-    REQUIRE(WideToCurrentCP(L"foo").length() == 3);
-}
-
 TEST_CASE("WideToUTF8")
 {
+    using celestia::util::WideToUTF8;
+
     REQUIRE(WideToUTF8(L"").empty() == true);
     REQUIRE(WideToUTF8(L"").length() == 0);
     REQUIRE(WideToUTF8(L"foo") == "foo");
@@ -30,18 +16,6 @@ TEST_CASE("WideToUTF8")
     REQUIRE(WideToUTF8(L"\u0422\u044d\u0441\u0442").length() == 8);
     REQUIRE(WideToUTF8(L"\u2079") == "\342\201\271"); // superscript 9
     REQUIRE(WideToUTF8(L"\u2079").length() == 3);
-}
-
-TEST_CASE("UTF8ToWide")
-{
-    REQUIRE(UTF8ToWide("").empty() == true);
-    REQUIRE(UTF8ToWide("").length() == 0);
-    REQUIRE(UTF8ToWide("foo") == L"foo");
-    REQUIRE(UTF8ToWide("foo").length() == 3);
-    REQUIRE(UTF8ToWide("\321\202\321\215\321\201\321\202") == L"\u0442\u044d\u0441\u0442");
-    REQUIRE(UTF8ToWide("\321\202\321\215\321\201\321\202").length() == 4);
-    REQUIRE(UTF8ToWide("\342\201\271") == L"\u2079");
-    REQUIRE(UTF8ToWide("\342\201\271").length() == 1);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Remove some unused methods, and move the remaining ones to the celestia::util namespace.