### PR TITLE
[win32] Replace GetWindowLong/SetWindowLong to support 64-bit platforms

### DIFF
--- a/src/celestia/win32/windatepicker.cpp
+++ b/src/celestia/win32/windatepicker.cpp
@@ -610,10 +610,10 @@ DatePicker::getSystemTime(SYSTEMTIME* sysTime)
 static LRESULT
 DatePickerNCCreate(HWND hwnd, CREATESTRUCT& cs)
 {
-    DWORD exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
+    LONG_PTR exStyle = GetWindowLongPtr(hwnd, GWL_EXSTYLE);
 
     exStyle |= WS_EX_CLIENTEDGE;
-    SetWindowLong(hwnd, GWL_EXSTYLE, exStyle);
+    SetWindowLongPtr(hwnd, GWL_EXSTYLE, exStyle);
 
     return DefWindowProc(hwnd, WM_NCCREATE, 0, reinterpret_cast<LPARAM>(&cs));
 }

--- a/src/celestia/win32/wineclipses.cpp
+++ b/src/celestia/win32/wineclipses.cpp
@@ -276,7 +276,6 @@ BOOL APIENTRY EclipseFinderProc(HWND hDlg,
                                 WPARAM wParam,
                                 LPARAM lParam)
 {
-    //EclipseFinderDialog* eclipseFinderDlg = reinterpret_cast<EclipseFinderDialog*>(GetWindowLong(hDlg, DWL_USER));
     EclipseFinderDialog* eclipseFinderDlg = reinterpret_cast<EclipseFinderDialog*>(GetWindowLongPtr(hDlg, DWLP_USER));
 
     switch (message)
@@ -286,7 +285,6 @@ BOOL APIENTRY EclipseFinderProc(HWND hDlg,
             EclipseFinderDialog* efd = reinterpret_cast<EclipseFinderDialog*>(lParam);
             if (efd == NULL)
                 return EndDialog(hDlg, 0);
-            //SetWindowLong(hDlg, DWL_USER, lParam);
             SetWindowLongPtr(hDlg, DWLP_USER, lParam);
             HWND hwnd = GetDlgItem(hDlg, IDC_ECLIPSES_LIST);
             InitEclipseFinderColumns(hwnd);

--- a/src/celestia/win32/winhyperlinks.cpp
+++ b/src/celestia/win32/winhyperlinks.cpp
@@ -166,18 +166,18 @@ BOOL MakeHyperlinkFromStaticCtrl(HWND hDlg, UINT ctrlID)
             if (origProc != _HyperlinkParentProc)
             {
                 SetProp(hParent, hyperLinkOriginalProc, (HANDLE)origProc);
-                SetWindowLong(hParent, GWLP_WNDPROC, (LONG_PTR)(WNDPROC)_HyperlinkParentProc);
+                SetWindowLongPtr(hParent, GWLP_WNDPROC, (LONG_PTR)(WNDPROC)_HyperlinkParentProc);
             }
         }
 
         // Make sure the control will send notifications.
-        DWORD dwStyle = GetWindowLong(hCtrl, GWL_STYLE);
-        SetWindowLong(hCtrl, GWL_STYLE, dwStyle | SS_NOTIFY);
+        LONG_PTR dwStyle = GetWindowLongPtr(hCtrl, GWL_STYLE);
+        SetWindowLongPtr(hCtrl, GWL_STYLE, dwStyle | SS_NOTIFY);
 
         // Subclass the existing control.
         WNDPROC origProc = (WNDPROC)GetWindowLongPtr(hCtrl, GWLP_WNDPROC);
         SetProp(hCtrl, hyperLinkOriginalProc, (HANDLE)origProc);
-        SetWindowLong(hCtrl, GWLP_WNDPROC, (LONG_PTR)(WNDPROC)_HyperlinkProc);
+        SetWindowLongPtr(hCtrl, GWLP_WNDPROC, (LONG_PTR)(WNDPROC)_HyperlinkProc);
 
         // Create an updated font by adding an underline.
         HFONT hOrigFont = (HFONT) SendMessage(hCtrl, WM_GETFONT, 0, 0);

--- a/src/celestia/win32/winsplash.cpp
+++ b/src/celestia/win32/winsplash.cpp
@@ -243,7 +243,7 @@ SplashWindow::createWindow()
         // style to layered.
         if (useLayeredWindow)
         {
-            SetWindowLong(hwnd, GWL_EXSTYLE, GetWindowLong(hwnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+            SetWindowLongPtr(hwnd, GWL_EXSTYLE, GetWindowLongPtr(hwnd, GWL_EXSTYLE) | WS_EX_LAYERED);
         }
 
         ShowWindow(hwnd, SW_SHOW);

--- a/src/celestia/win32/winuiutils.cpp
+++ b/src/celestia/win32/winuiutils.cpp
@@ -70,15 +70,15 @@ void CenterWindow(HWND hParent, HWND hWnd)
 
 void RemoveButtonDefaultStyle(HWND hWnd)
 {
-    SetWindowLong(hWnd, GWL_STYLE,
-        ::GetWindowLong(hWnd, GWL_STYLE) & ~BS_DEFPUSHBUTTON);
+    SetWindowLongPtr(hWnd, GWL_STYLE,
+                     ::GetWindowLongPtr(hWnd, GWL_STYLE) & ~BS_DEFPUSHBUTTON);
     InvalidateRect(hWnd, nullptr, TRUE);
 }
 
 void AddButtonDefaultStyle(HWND hWnd)
 {
-    SetWindowLong(hWnd, GWL_STYLE,
-        ::GetWindowLong(hWnd, GWL_STYLE) | BS_DEFPUSHBUTTON);
+    SetWindowLongPtr(hWnd, GWL_STYLE,
+                     ::GetWindowLongPtr(hWnd, GWL_STYLE) | BS_DEFPUSHBUTTON);
     InvalidateRect(hWnd, nullptr, TRUE);
 }
 


### PR DESCRIPTION
- Per Microsoft documentation, should use GetWindowLongPtr/SetWindowLongPtr instead
- Fixes formatting/cursor of the hyperlink in the about box