### PR TITLE
Consolidate star browser implementations across the front-ends

### DIFF
--- a/src/celengine/starbrowser.h
+++ b/src/celengine/starbrowser.h
@@ -1,6 +1,11 @@
 // starbrowser.h
 //
+// Copyright (C) 2023, The Celestia Development Team
+//
+// Original version:
 // Copyright (C) 2001, Chris Laurel <claurel@shatters.net>
+// Incorporates elements from qtcelestialbrowser.cpp
+// Copyright (C) 2007-2008, Celestia Development Team
 //
 // Star browser tool for celestia.
 //
@@ -11,37 +16,107 @@
 
 #pragma once
 
-#include "star.h"
-#include "stardb.h"
-#include "simulation.h"
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <utility>
+#include <vector>
 
+#include <Eigen/Core>
+
+#include <celastro/date.h>
+#include <celutil/array_view.h>
+#include <celutil/flag.h>
+#include "solarsys.h"
+#include "univcoord.h"
+
+class Star;
+class Universe;
+
+namespace celestia::engine
+{
+
+struct StarBrowserRecord
+{
+    explicit StarBrowserRecord(const Star* _star) : star(_star) {}
+    const Star* star;
+    float distance{ std::numeric_limits<float>::max() };
+    float appMag{ std::numeric_limits<float>::max() };
+};
 
 class StarBrowser
 {
- public:
-    enum {
-        NearestStars = 0,
-        BrighterStars = 1,
-        BrightestStars = 2,
-        StarsWithPlanets = 3,
+public:
+    static constexpr std::uint32_t MinListStars = 10;
+    static constexpr std::uint32_t DefaultListStars = 100;
+    static constexpr std::uint32_t MaxListStars = 1000;
+
+    static_assert(MinListStars <= DefaultListStars);
+    static_assert(DefaultListStars <= MaxListStars);
+
+    enum class Comparison : int
+    {
+        Nearest,
+        ApparentMagnitude,
+        AbsoluteMagnitude,
     };
 
-    StarBrowser();
-    StarBrowser(Simulation *_appSim, int pred = NearestStars);
-    std::vector<const Star*>* listStars(unsigned int);
-    void setSimulation(Simulation *_appSim);
-    const Star *nearestStar(void);
-    bool setPredicate(int pred);
-    void refresh();
+    enum class Filter : unsigned int
+    {
+        All = 0,
+        Visible = 1,
+        Multiple = 2,
+        WithPlanets = 4,
+        SpectralType = 8,
+    };
 
- public:
+    StarBrowser(const Universe*,
+                std::uint32_t = DefaultListStars,
+                Comparison = Comparison::Nearest,
+                Filter = Filter::Visible);
+
+    inline const Universe* universe() const { return m_universe; }
+
+    inline Comparison comparison() const { return m_comparison; }
+    inline void setComparison(Comparison newComparison) { m_comparison = newComparison; }
+
+    inline Filter filter() const { return m_filter; }
+    inline void setFilter(Filter newFilter) { m_filter = newFilter; }
+
+    inline std::uint32_t size() const { return m_size; }
+    bool setSize(std::uint32_t newSize);
+
+    // Currently this is only used by the Qt front-end, whose implementation
+    // relies on Qt's regular expression classes. For now, we allow this to be
+    // supplied as a function, in future we may want to implement a more
+    // specialized version to enable queries like "B5-F5"
+    void setSpectralTypeFilter(const std::function<bool(const char*)>& filter) { m_spectralTypeFilter = filter; }
+
+    const UniversalCoord& position() const { return m_ucPos; }
+    void setPosition(const UniversalCoord&);
+    double time() const { return m_jd; }
+    inline void setTime(double jd) { m_jd = jd; }
+
+    void populate(std::vector<StarBrowserRecord>&) const;
+
+private:
+    const Universe* m_universe;
+
     // The star browser data is valid for a particular point
-    // in space, and for performance issues is not continuously
+    // in space/time, and for performance issues is not continuously
     // updated.
-    Eigen::Vector3f pos;
-    UniversalCoord ucPos;
+    Eigen::Vector3f m_pos;
+    UniversalCoord m_ucPos;
+    double m_jd{ celestia::astro::J2000 };
 
- private:
-    Simulation *appSim;
-    int predicate;
+    std::uint32_t m_size;
+
+    Comparison m_comparison;
+    Filter m_filter;
+
+    std::function<bool(const char*)> m_spectralTypeFilter;
 };
+
+ENUM_CLASS_BITWISE_OPS(StarBrowser::Filter);
+
+} // end namespace celestia::engine

--- a/src/celengine/univcoord.h
+++ b/src/celengine/univcoord.h
@@ -114,12 +114,12 @@ class UniversalCoord
                                static_cast<double>(z)) * 1.0e-6;
     }
 
-    double distanceFromKm(const UniversalCoord& uc)
+    double distanceFromKm(const UniversalCoord& uc) const
     {
         return offsetFromKm(uc).norm();
     }
 
-    double distanceFromLy(const UniversalCoord& uc)
+    double distanceFromLy(const UniversalCoord& uc) const
     {
         return celestia::astro::kilometersToLightYears(offsetFromKm(uc).norm());
     }

--- a/src/celestia/gtk/dialog-star.cpp
+++ b/src/celestia/gtk/dialog-star.cpp
@@ -12,6 +12,13 @@
 
 #include <gtk/gtk.h>
 
+#include <cinttypes>
+#include <cstdint>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include <celcompat/charconv.h>
 #include <celengine/body.h>
 #include <celengine/selection.h>
 #include <celengine/simulation.h>
@@ -26,32 +33,226 @@
 #include "common.h"
 
 using namespace std;
+namespace engine = celestia::engine;
 
-/* Declarations: Callbacks */
-static void listStarSelect(GtkTreeSelection* sel, AppData* app);
-static void radioClicked(GtkButton*, gpointer choice);
-static void refreshBrowser(GtkWidget*, sbData* sb);
-static void listStarEntryChange(GtkEntry *entry, GdkEventFocus *event, sbData* sb);
-static void listStarSliderChange(GtkRange *range, sbData* sb);
-static void starDestroy(GtkWidget* w, gint, sbData* sb);
+namespace
+{
 
-/* Declarations: Helpers */
-static void addStars(sbData* sb);
+constexpr std::array<const char*, 5> sbTitles
+{
+    "Name",
+    "Distance(LY)",
+    "App. Mag",
+    "Abs. Mag",
+    "Type",
+};
+
+constexpr std::array<const char*, 5> sbRadioLabels
+{
+    "Nearest",
+    "Brightest (App.)",
+    "Brightest (Abs.)",
+    "With Planets",
+    nullptr,
+};
+
+/* Local Data Structures */
+struct sbData {
+    explicit sbData(AppData*);
+
+    AppData* app;
+
+    engine::StarBrowser browser;
+    std::vector<engine::StarBrowserRecord> records;
+    GtkListStore* starListStore{ nullptr };
+    GtkWidget* entry{ nullptr };
+    GtkWidget* scale{ nullptr };
+};
+
+sbData::sbData(AppData* appData) :
+    app(appData),
+    browser(appData->simulation->getUniverse())
+{
+}
+
+
+/* HELPER: Clear and Add stars to the starListStore */
+static void addStars(sbData* sb)
+{
+    const char *values[5];
+    GtkTreeIter iter;
+
+    std::uint32_t currentLength;
+    UniversalCoord ucPos;
+
+    /* Load the catalogs and set data */
+    const StarDatabase* stardb = sb->app->simulation->getUniverse()->getStarCatalog();
+    sb->browser.setPosition(sb->app->simulation->getObserver().getPosition());
+    sb->browser.populate(sb->records);
+    currentLength = sb->records.size();
+    if (!sb->records.empty())
+        sb->app->simulation->setSelection(Selection(const_cast<Star*>(sb->records.front().star)));
+    ucPos = sb->app->simulation->getObserver().getPosition();
+
+    gtk_list_store_clear(sb->starListStore);
+
+    for (std::uint32_t i = 0; i < currentLength; i++)
+    {
+        char buf[20];
+        const engine::StarBrowserRecord& record = sb->records[i];
+        values[0] = g_strdup(ReplaceGreekLetterAbbr((stardb->getStarName(*record.star, true))).c_str());
+
+        /* Calculate distance to star */
+        sprintf(buf, " %.3f ", record.distance);
+        values[1] = g_strdup(buf);
+
+        sprintf(buf, " %.2f ", record.appMag);
+        values[2] = g_strdup(buf);
+
+        sprintf(buf, " %.2f ", record.star->getAbsoluteMagnitude());
+        values[3] = g_strdup(buf);
+
+        gtk_list_store_append(sb->starListStore, &iter);
+        gtk_list_store_set(sb->starListStore, &iter,
+                           0, values[0],
+                           1, values[1],
+                           2, values[2],
+                           3, values[3],
+                           4, record.star->getSpectralType(),
+                           5, (gpointer)&record, -1);
+    }
+}
+
+
+/* CALLBACK: When Star is selected in Star Browser */
+static void listStarSelect(GtkTreeSelection* sel, AppData* app)
+{
+    GValue value = { 0, {{0}} }; /* Initialize GValue to 0 */
+    GtkTreeIter iter;
+    GtkTreeModel* model;
+
+    /* IF prevents selection while list is being updated */
+    if (!gtk_tree_selection_get_selected(sel, &model, &iter))
+        return;
+
+    gtk_tree_model_get_value(model, &iter, 5, &value);
+    auto record = (const engine::StarBrowserRecord*)g_value_get_pointer(&value);
+    g_value_unset(&value);
+
+    if (record)
+        app->simulation->setSelection(Selection(const_cast<Star*>(record->star)));
+}
+
+
+/* CALLBACK: Refresh button is pressed. */
+static void refreshBrowser(GtkWidget*, sbData* sb)
+{
+    addStars(sb);
+}
+
+
+/* CALLBACK: One of the RadioButtons is pressed */
+static void radioClicked(GtkButton* r, gpointer choice)
+{
+    sbData* sb = (sbData*)g_object_get_data(G_OBJECT(r), "data");
+    gint selection = GPOINTER_TO_INT(choice);
+
+    switch (selection)
+    {
+        case 0:
+            sb->browser.setComparison(engine::StarBrowser::Comparison::Nearest);
+            sb->browser.setFilter(engine::StarBrowser::Filter::Visible);
+            break;
+        case 1:
+            sb->browser.setComparison(engine::StarBrowser::Comparison::ApparentMagnitude);
+            sb->browser.setFilter(engine::StarBrowser::Filter::Visible);
+            break;
+        case 2:
+            sb->browser.setComparison(engine::StarBrowser::Comparison::AbsoluteMagnitude);
+            sb->browser.setFilter(engine::StarBrowser::Filter::Visible);
+            break;
+        case 3:
+            sb->browser.setComparison(engine::StarBrowser::Comparison::Nearest);
+            sb->browser.setFilter(engine::StarBrowser::Filter::WithPlanets);
+            break;
+        default:
+            return;
+    }
+
+    refreshBrowser(NULL, sb);
+}
+
+
+/* CALLBACK: Maximum stars EntryBox changed. */
+static void listStarEntryChange(GtkEntry *entry, GdkEventFocus *event, sbData* sb)
+{
+    /* If not called by the slider, but rather by user.
+       Prevents infinite recursion. */
+    if (event != NULL)
+    {
+        std::string_view entryText = gtk_entry_get_text(entry);
+        std::uint32_t numListStars;
+        if (auto ec = celestia::compat::from_chars(entryText.data(), entryText.data() + entryText.size(), numListStars).ec;
+            ec == std::errc{})
+        {
+            if (!sb->browser.setSize(numListStars))
+            {
+                /* Call self to set text (NULL event = no recursion) */
+                listStarEntryChange(entry, NULL, sb);
+            }
+
+            gtk_range_set_value(GTK_RANGE(sb->scale), static_cast<gdouble>(numListStars));
+        }
+        else
+        {
+            /* Call self to set text (NULL event = no recursion) */
+            listStarEntryChange(entry, NULL, sb);
+        }
+    }
+
+    /* Update value of this box */
+    char stars[4];
+    sprintf(stars, "%" PRIu32, sb->browser.size());
+    gtk_entry_set_text(entry, stars);
+}
+
+
+/* CALLBACK: Maximum stars RangeSlider changed. */
+static void listStarSliderChange(GtkRange *range, sbData* sb)
+{
+    /* Update the value of the text entry box */
+    sb->browser.setSize(static_cast<std::uint32_t>(gtk_range_get_value(GTK_RANGE(range))));
+    listStarEntryChange(GTK_ENTRY(sb->entry), NULL, sb);
+
+    /* Refresh the browser listbox */
+    refreshBrowser(NULL, sb);
+}
+
+
+/* CALLBACK: Destroy Window */
+static void starDestroy(GtkWidget* w, gint responseId, sbData* sb)
+{
+    gtk_widget_destroy(GTK_WIDGET(w));
+
+    if (responseId = GTK_RESPONSE_DELETE_EVENT)
+        delete sb;
+}
+
+
+} // end unnamed namespace
 
 
 /* ENTRY: Navigation -> Star Browser... */
 void dialogStarBrowser(AppData* app)
 {
-    sbData* sb = g_new0(sbData, 1);
-    sb->app = app;
-    sb->numListStars = 100;
+    auto sb = new sbData(app);
 
     GtkWidget *browser = gtk_dialog_new_with_buttons("Star System Browser",
                                                      GTK_WINDOW(app->mainWindow),
                                                      GTK_DIALOG_DESTROY_WITH_PARENT,
                                                      GTK_STOCK_OK, GTK_RESPONSE_OK,
                                                      NULL);
-    app->simulation->setSelection(Selection((Star *) NULL));
+    app->simulation->setSelection(Selection());
 
     /* Star System Browser */
     GtkWidget *mainbox = gtk_dialog_get_content_area(GTK_DIALOG(browser));
@@ -92,9 +293,6 @@ void dialogStarBrowser(AppData* app)
         gtk_tree_view_append_column(GTK_TREE_VIEW(starList), column);
     }
 
-    /* Initialize the star browser */
-    sb->browser.setSimulation(sb->app->simulation);
-
     /* Set up callback for when a star is selected */
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(starList));
     g_signal_connect(selection, "changed", G_CALLBACK(listStarSelect), app);
@@ -117,7 +315,7 @@ void dialogStarBrowser(AppData* app)
     gtk_entry_set_width_chars(GTK_ENTRY(sb->entry), 5);
     gtk_box_pack_start(GTK_BOX(hbox2), sb->entry, TRUE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(vbox), hbox2, TRUE, FALSE, 0);
-    sb->scale = gtk_hscale_new_with_range(MINLISTSTARS, MAXLISTSTARS, 1);
+    sb->scale = gtk_hscale_new_with_range(engine::StarBrowser::MinListStars, engine::StarBrowser::MaxListStars, 1);
     gtk_scale_set_draw_value(GTK_SCALE(sb->scale), FALSE);
     g_signal_connect(sb->scale, "value-changed", G_CALLBACK(listStarSliderChange), sb);
     g_signal_connect(sb->entry, "focus-out-event", G_CALLBACK(listStarEntryChange), sb);
@@ -125,8 +323,8 @@ void dialogStarBrowser(AppData* app)
     gtk_box_pack_start(GTK_BOX(hbox), vbox, TRUE, FALSE, 0);
 
     /* Set initial Star Value */
-    gtk_range_set_value(GTK_RANGE(sb->scale), sb->numListStars);
-    if (sb->numListStars == MINLISTSTARS)
+    gtk_range_set_value(GTK_RANGE(sb->scale), sb->browser.size());
+    if (sb->browser.size() == engine::StarBrowser::MinListStars)
     {
         /* Force update manually (scale won't trigger event) */
         listStarEntryChange(GTK_ENTRY(sb->entry), NULL, sb);
@@ -135,7 +333,7 @@ void dialogStarBrowser(AppData* app)
 
     /* Radio Buttons */
     vbox = gtk_vbox_new(TRUE, 0);
-    makeRadioItems(sbRadioLabels, vbox, G_CALLBACK(radioClicked), NULL, sb);
+    makeRadioItems(sbRadioLabels.data(), vbox, G_CALLBACK(radioClicked), NULL, sb);
     gtk_box_pack_start(GTK_BOX(hbox), vbox, TRUE, TRUE, 0);
 
     /* Common Buttons */
@@ -148,154 +346,8 @@ void dialogStarBrowser(AppData* app)
         return;
     gtk_box_pack_start(GTK_BOX(mainbox), hbox, FALSE, FALSE, 0);
 
-    g_signal_connect(browser, "response", G_CALLBACK(starDestroy), browser);
+    g_signal_connect(browser, "response", G_CALLBACK(starDestroy), sb);
 
     gtk_widget_set_size_request(browser, -1, 400); /* Absolute Size, urghhh */
     gtk_widget_show_all(browser);
-}
-
-
-/* CALLBACK: When Star is selected in Star Browser */
-static void listStarSelect(GtkTreeSelection* sel, AppData* app)
-{
-    GValue value = { 0, {{0}} }; /* Initialize GValue to 0 */
-    GtkTreeIter iter;
-    GtkTreeModel* model;
-
-    /* IF prevents selection while list is being updated */
-    if (!gtk_tree_selection_get_selected(sel, &model, &iter))
-        return;
-
-    gtk_tree_model_get_value(model, &iter, 5, &value);
-    Star *selStar = (Star *)g_value_get_pointer(&value);
-    g_value_unset(&value);
-
-    if (selStar)
-        app->simulation->setSelection(Selection(selStar));
-}
-
-
-/* CALLBACK: Refresh button is pressed. */
-static void refreshBrowser(GtkWidget*, sbData* sb)
-{
-    addStars(sb);
-}
-
-
-/* CALLBACK: One of the RadioButtons is pressed */
-static void radioClicked(GtkButton* r, gpointer choice)
-{
-    sbData* sb = (sbData*)g_object_get_data(G_OBJECT(r), "data");
-    gint selection = GPOINTER_TO_INT(choice);
-
-    sb->browser.setPredicate(selection);
-    refreshBrowser(NULL, sb);
-}
-
-
-/* CALLBACK: Maximum stars EntryBox changed. */
-static void listStarEntryChange(GtkEntry *entry, GdkEventFocus *event, sbData* sb)
-{
-    /* If not called by the slider, but rather by user.
-       Prevents infinite recursion. */
-    if (event != NULL)
-    {
-        sb->numListStars = atoi(gtk_entry_get_text(entry));
-
-        /* Sanity Check */
-        if (sb->numListStars < MINLISTSTARS)
-        {
-            sb->numListStars = MINLISTSTARS;
-            /* Call self to set text (NULL event = no recursion) */
-            listStarEntryChange(entry, NULL, sb);
-        }
-        if (sb->numListStars > MAXLISTSTARS)
-        {
-            sb->numListStars = MAXLISTSTARS;
-            /* Call self to set text */
-            listStarEntryChange(entry, NULL, sb);
-        }
-
-        gtk_range_set_value(GTK_RANGE(sb->scale), (gdouble)sb->numListStars);
-    }
-
-    /* Update value of this box */
-    char stars[4];
-    sprintf(stars, "%d", sb->numListStars);
-    gtk_entry_set_text(entry, stars);
-}
-
-
-/* CALLBACK: Maximum stars RangeSlider changed. */
-static void listStarSliderChange(GtkRange *range, sbData* sb)
-{
-    /* Update the value of the text entry box */
-    sb->numListStars = (int)gtk_range_get_value(GTK_RANGE(range));
-    listStarEntryChange(GTK_ENTRY(sb->entry), NULL, sb);
-
-    /* Refresh the browser listbox */
-    refreshBrowser(NULL, sb);
-}
-
-
-/* CALLBACK: Destroy Window */
-static void starDestroy(GtkWidget* w, gint, sbData*)
-{
-    gtk_widget_destroy(GTK_WIDGET(w));
-
-    /* Cannot do this, as the program crashes because of the StarBrowser:
-     * g_free(sb); */
-}
-
-
-/* HELPER: Clear and Add stars to the starListStore */
-static void addStars(sbData* sb)
-{
-    const char *values[5];
-    GtkTreeIter iter;
-
-    StarDatabase* stardb;
-    vector<const Star*> *stars;
-    unsigned int currentLength;
-    UniversalCoord ucPos;
-
-    /* Load the catalogs and set data */
-    stardb = sb->app->simulation->getUniverse()->getStarCatalog();
-    sb->browser.refresh();
-    stars = sb->browser.listStars(sb->numListStars);
-    currentLength = (*stars).size();
-    sb->app->simulation->setSelection(Selection((Star *)(*stars)[0]));
-    ucPos = sb->app->simulation->getObserver().getPosition();
-
-    gtk_list_store_clear(sb->starListStore);
-
-    for (unsigned int i = 0; i < currentLength; i++)
-    {
-        char buf[20];
-        const Star *star=(*stars)[i];
-        values[0] = g_strdup(ReplaceGreekLetterAbbr((stardb->getStarName(*star))).c_str());
-
-        /* Calculate distance to star */
-        float d = ucPos.offsetFromLy(star->getPosition()).norm();
-
-        sprintf(buf, " %.3f ", d);
-        values[1] = g_strdup(buf);
-
-        sprintf(buf, " %.2f ", star->getApparentMagnitude(d));
-        values[2] = g_strdup(buf);
-
-        sprintf(buf, " %.2f ", star->getAbsoluteMagnitude());
-        values[3] = g_strdup(buf);
-
-        gtk_list_store_append(sb->starListStore, &iter);
-        gtk_list_store_set(sb->starListStore, &iter,
-                           0, values[0],
-                           1, values[1],
-                           2, values[2],
-                           3, values[3],
-                           4, star->getSpectralType(),
-                           5, (gpointer)star, -1);
-    }
-
-    delete stars;
 }

--- a/src/celestia/gtk/dialog-star.h
+++ b/src/celestia/gtk/dialog-star.h
@@ -14,44 +14,7 @@
 
 #include <gtk/gtk.h>
 
-#include <celengine/starbrowser.h>
-
 #include "common.h"
-
-#define MINLISTSTARS 10
-#define MAXLISTSTARS 500
-
 
 /* Entry Function */
 void dialogStarBrowser(AppData* app);
-
-
-/* Local Data Structures */
-typedef struct _sbData sbData;
-struct _sbData {
-    AppData* app;
-
-    StarBrowser browser;
-    GtkListStore* starListStore;
-    int numListStars;
-    GtkWidget* entry;
-    GtkWidget* scale;
-};
-
-static const char * const sbTitles[] =
-{
-    "Name",
-    "Distance(LY)",
-    "App. Mag",
-    "Abs. Mag",
-    "Type"
-};
-
-static const char * const sbRadioLabels[] =
-{
-    "Nearest",
-    "Brightest (App.)",
-    "Brightest (Abs.)",
-    "With Planets",
-    NULL
-};

--- a/src/celestia/win32/winstarbrowser.cpp
+++ b/src/celestia/win32/winstarbrowser.cpp
@@ -17,6 +17,7 @@
 #include <windows.h>
 #include <commctrl.h>
 #include <cstring>
+#include <celestia/celestiacore.h>
 #include <celutil/gettext.h>
 #include <celutil/winutil.h>
 #include "winuiutils.h"
@@ -24,27 +25,16 @@
 #include "res/resource.h"
 #include "winuiutils.h"
 
+#include <fmt/format.h>
+
 using namespace Eigen;
 using namespace std;
 using namespace celestia::win32;
 
 namespace astro = celestia::astro;
+namespace engine = celestia::engine;
 namespace math = celestia::math;
 namespace util = celestia::util;
-
-static const int MinListStars = 10;
-static const int MaxListStars = 500;
-static const int DefaultListStars = 100;
-
-// TODO: More of the functions in this module should be converted to
-// methods of the StarBrowser class.
-
-enum {
-    BrightestStars = 0,
-    NearestStars = 1,
-    StarsWithPlanets = 2,
-};
-
 
 bool InitStarBrowserColumns(HWND listView)
 {
@@ -91,118 +81,7 @@ bool InitStarBrowserColumns(HWND listView)
     return true;
 }
 
-
-struct CloserStarPredicate
-{
-    Vector3f pos;
-    bool operator()(const Star* star0, const Star* star1) const
-    {
-        return ((pos - star0->getPosition()).squaredNorm() <
-                (pos - star1->getPosition()).squaredNorm());
-
-    }
-};
-
-struct BrighterStarPredicate
-{
-    Vector3f pos;
-    UniversalCoord ucPos;
-    bool operator()(const Star* star0, const Star* star1) const
-    {
-        float d0 = (pos - star0->getPosition()).norm();
-        float d1 = (pos - star1->getPosition()).norm();
-
-        // If the stars are closer than one light year, use
-        // a more precise distance estimate.
-        if (d0 < 1.0f)
-            d0 = ucPos.offsetFromLy(star0->getPosition()).norm();
-        if (d1 < 1.0f)
-            d1 = ucPos.offsetFromLy(star1->getPosition()).norm();
-
-        return (star0->getApparentMagnitude(d0) <
-                star1->getApparentMagnitude(d1));
-    }
-};
-
-struct SolarSystemPredicate
-{
-    Vector3f pos;
-    SolarSystemCatalog* solarSystems;
-
-    bool operator()(const Star* star0, const Star* star1) const
-    {
-        SolarSystemCatalog::iterator iter;
-
-        iter = solarSystems->find(star0->getIndex());
-        bool hasPlanets0 = (iter != solarSystems->end());
-        iter = solarSystems->find(star1->getIndex());
-        bool hasPlanets1 = (iter != solarSystems->end());
-        if (hasPlanets1 == hasPlanets0)
-        {
-            return ((pos - star0->getPosition()).squaredNorm() <
-                    (pos - star1->getPosition()).squaredNorm());
-        }
-        else
-        {
-            return hasPlanets0;
-        }
-    }
-};
-
-
-// Find the nearest/brightest/X-est N stars in a database.  The
-// supplied predicate determines which of two stars is a better match.
-template<class Pred> vector<const Star*>*
-FindStars(const StarDatabase& stardb, Pred pred, int nStars)
-{
-    vector<const Star*>* finalStars = new vector<const Star*>();
-    if (nStars == 0)
-        return finalStars;
-
-    typedef multiset<const Star*, Pred> StarSet;
-    StarSet firstStars(pred);
-
-    int totalStars = stardb.size();
-    if (totalStars < nStars)
-        nStars = totalStars;
-
-    // We'll need at least nStars in the set, so first fill
-    // up the list indiscriminately.
-    int i = 0;
-    for (i = 0; i < nStars; i++)
-    {
-        Star* star = stardb.getStar(i);
-        if (star->getVisibility())
-            firstStars.insert(star);
-    }
-
-    // From here on, only add a star to the set if it's
-    // a better match than the worst matching star already
-    // in the set.
-    const Star* lastStar = *--firstStars.end();
-    for (; i < totalStars; i++)
-    {
-        Star* star = stardb.getStar(i);
-        if (star->getVisibility() && pred(star, lastStar))
-        {
-            firstStars.insert(star);
-            firstStars.erase(--firstStars.end());
-            lastStar = *--firstStars.end();
-        }
-    }
-
-    // Move the best matching stars into the vector
-    finalStars->reserve(nStars);
-    for (const auto& star : firstStars)
-    {
-        finalStars->insert(finalStars->end(), star);
-    }
-
-    return finalStars;
-}
-
-
-bool InitStarBrowserLVItems(HWND listView, vector<const Star*>& stars)
+bool InitStarBrowserLVItems(HWND listView, std::vector<engine::StarBrowserRecord>& records)
 {
     LVITEM lvi;
 
@@ -211,127 +90,133 @@ bool InitStarBrowserLVItems(HWND listView, vector<const Star*>& stars)
     lvi.stateMask = 0;
     lvi.pszText = LPSTR_TEXTCALLBACK;
 
-    for (unsigned int i = 0; i < stars.size(); i++)
+    int index = 0;
+    for (const auto& record : records)
     {
-        lvi.iItem = i;
+        lvi.iItem = index;
         lvi.iSubItem = 0;
-        lvi.lParam = (LPARAM) stars[i];
+        lvi.lParam = (LPARAM) &record;
         ListView_InsertItem(listView, &lvi);
+        ++index;
     }
 
     return true;
 }
 
-
 bool InitStarBrowserItems(HWND listView, StarBrowser* browser)
 {
-    Universe* univ = browser->appCore->getSimulation()->getUniverse();
-    StarDatabase* stardb = univ->getStarCatalog();
-    SolarSystemCatalog* solarSystems = univ->getSolarSystemCatalog();
-
-    vector<const Star*>* stars = NULL;
-    switch (browser->predicate)
-    {
-    case BrightestStars:
-        {
-            BrighterStarPredicate brighterPred;
-            brighterPred.pos = browser->pos;
-            brighterPred.ucPos = browser->ucPos;
-            stars = FindStars(*stardb, brighterPred, browser->nStars);
-        }
-        break;
-
-    case NearestStars:
-        {
-            CloserStarPredicate closerPred;
-            closerPred.pos = browser->pos;
-            stars = FindStars(*stardb, closerPred, browser->nStars);
-        }
-        break;
-
-    case StarsWithPlanets:
-        {
-            if (solarSystems == NULL)
-                return false;
-            SolarSystemPredicate solarSysPred;
-            solarSysPred.pos = browser->pos;
-            solarSysPred.solarSystems = solarSystems;
-            stars = FindStars(*stardb, solarSysPred,
-                              min((unsigned int) browser->nStars, (unsigned int) solarSystems->size()));
-        }
-        break;
-
-    default:
-        return false;
-    }
-
-    bool succeeded = InitStarBrowserLVItems(listView, *stars);
-    delete stars;
-
+    const Observer& obs = browser->appCore->getSimulation()->getObserver();
+    browser->starBrowser.setPosition(obs.getPosition());
+    browser->starBrowser.setTime(obs.getTime());
+    browser->starBrowser.populate(browser->stars);
+    bool succeeded = InitStarBrowserLVItems(listView, browser->stars);
+    browser->sortColumn = -1;
+    browser->sortColumnReverse = false;
     return succeeded;
 }
 
-
 // Crud used for the list item display callbacks
-static string starNameString("");
+static string starNameString;
+static string starNameString2;
 static char callbackScratch[256];
 
 struct StarBrowserSortInfo
 {
-    int subItem;
-    Vector3f pos;
-    UniversalCoord ucPos;
+    const StarDatabase* stardb;
+    bool reverse;
 };
 
-int CALLBACK StarBrowserCompareFunc(LPARAM lParam0, LPARAM lParam1,
-                                    LPARAM lParamSort)
+template<std::size_t SIZE, typename Allocator>
+static void
+nameToWide(std::string_view name, fmt::basic_memory_buffer<wchar_t, SIZE, Allocator>& buffer)
 {
-    StarBrowserSortInfo* sortInfo = reinterpret_cast<StarBrowserSortInfo*>(lParamSort);
-    Star* star0 = reinterpret_cast<Star*>(lParam0);
-    Star* star1 = reinterpret_cast<Star*>(lParam1);
+    auto nameLength = static_cast<int>(name.size());
+    int length = MultiByteToWideChar(CP_UTF8, 0, name.data(), nameLength, nullptr, 0);
+    if (length <= 0)
+        return;
 
-    switch (sortInfo->subItem)
-    {
-    case 0:
-        return 0;
-
-    case 1:
-        {
-            float d0 = (sortInfo->pos - star0->getPosition()).norm();
-            float d1 = (sortInfo->pos - star1->getPosition()).norm();
-            return (int) math::sign(d0 - d1);
-        }
-
-    case 2:
-        {
-            float d0 = (sortInfo->pos - star0->getPosition()).norm();
-            float d1 = (sortInfo->pos - star1->getPosition()).norm();
-            if (d0 < 1.0f)
-                d0 = sortInfo->ucPos.offsetFromLy(star0->getPosition()).norm();
-            if (d1 < 1.0f)
-                d1 = sortInfo->ucPos.offsetFromLy(star1->getPosition()).norm();
-            return (int) math::sign(star0->getApparentMagnitude(d0) -
-                                    star1->getApparentMagnitude(d1));
-        }
-
-    case 3:
-        return (int) math::sign(star0->getAbsoluteMagnitude() - star1->getAbsoluteMagnitude());
-
-    case 4:
-        return strcmp(star0->getSpectralType(), star1->getSpectralType());
-
-    default:
-        return 0;
-    }
+    buffer.resize(static_cast<std::size_t>(length));
+    MultiByteToWideChar(CP_UTF8, 0, name.data(), nameLength, buffer.data(), buffer.size());
 }
 
+static int CALLBACK StarBrowserCompareName(LPARAM lParam0, LPARAM lParam1, LPARAM lParamInfo)
+{
+    auto record0 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam0);
+    auto record1 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam1);
+    auto info = reinterpret_cast<const StarBrowserSortInfo*>(lParamInfo);
+
+    fmt::basic_memory_buffer<wchar_t, 260> wname0;
+    nameToWide(info->stardb->getStarName(*record0->star, true), wname0);
+    fmt::basic_memory_buffer<wchar_t, 260> wname1;
+    nameToWide(info->stardb->getStarName(*record1->star, true), wname1);
+
+    auto result = CompareStringEx(LOCALE_NAME_USER_DEFAULT, NORM_LINGUISTIC_CASING,
+                                  wname0.data(), static_cast<int>(wname0.size()),
+                                  wname1.data(), static_cast<int>(wname1.size()),
+                                  nullptr, nullptr, 0);
+    // MS: To maintain the C runtime convention of comparing strings, the
+    // value 2 can be subtracted from a nonzero return value
+    if (result != 0)
+        result -= 2;
+
+    return info->reverse ? -result : result;
+}
+
+static int CALLBACK StarBrowserCompareDistance(LPARAM lParam0, LPARAM lParam1, LPARAM lParamInfo)
+{
+    auto record0 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam0);
+    auto record1 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam1);
+    auto info = reinterpret_cast<const StarBrowserSortInfo*>(lParamInfo);
+
+    auto result = static_cast<int>(math::sign(record0->distance - record1->distance));
+    return info->reverse ? -result : result;
+}
+
+static int CALLBACK StarBrowserCompareAppMag(LPARAM lParam0, LPARAM lParam1, LPARAM lParamInfo)
+{
+    auto record0 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam0);
+    auto record1 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam1);
+    auto info = reinterpret_cast<const StarBrowserSortInfo*>(lParamInfo);
+
+    auto result = static_cast<int>(math::sign(record0->appMag - record1->appMag));
+    return info->reverse ? -result : result;
+}
+
+static int CALLBACK StarBrowserCompareAbsMag(LPARAM lParam0, LPARAM lParam1, LPARAM lParamInfo)
+{
+    auto record0 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam0);
+    auto record1 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam1);
+    auto info = reinterpret_cast<const StarBrowserSortInfo*>(lParamInfo);
+
+    auto result = static_cast<int>(math::sign(record0->star->getAbsoluteMagnitude() - record1->star->getAbsoluteMagnitude()));
+    return info->reverse ? -result : result;
+}
+
+static int CALLBACK StarBrowserCompareSpectralType(LPARAM lParam0, LPARAM lParam1, LPARAM lParamInfo)
+{
+    auto record0 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam0);
+    auto record1 = reinterpret_cast<const engine::StarBrowserRecord*>(lParam1);
+    auto info = reinterpret_cast<const StarBrowserSortInfo*>(lParamInfo);
+
+    auto result = std::strcmp(record0->star->getSpectralType(), record1->star->getSpectralType());
+    return info->reverse ? -result : result;
+}
+
+static constexpr std::array<PFNLVCOMPARE, 5> compareFuncs
+{
+    &StarBrowserCompareName,
+    &StarBrowserCompareDistance,
+    &StarBrowserCompareAppMag,
+    &StarBrowserCompareAbsMag,
+    &StarBrowserCompareSpectralType,
+};
 
 void StarBrowserDisplayItem(LPNMLVDISPINFOA nm, StarBrowser* browser)
 {
     double tdb = browser->appCore->getSimulation()->getTime();
 
-    Star* star = reinterpret_cast<Star*>(nm->item.lParam);
-    if (star == NULL)
+    auto record = reinterpret_cast<const engine::StarBrowserRecord*>(nm->item.lParam);
+    if (record == nullptr)
     {
         nm->item.pszText = const_cast<char*>("");
         return;
@@ -342,36 +227,31 @@ void StarBrowserDisplayItem(LPNMLVDISPINFOA nm, StarBrowser* browser)
     case 0:
         {
             Universe* u = browser->appCore->getSimulation()->getUniverse();
-            starNameString = util::UTF8ToCurrentCP(u->getStarCatalog()->getStarName(*star));
+            starNameString = util::UTF8ToCurrentCP(u->getStarCatalog()->getStarName(*record->star, true));
             nm->item.pszText = const_cast<char*>(starNameString.c_str());
         }
         break;
 
     case 1:
-        {
-            Vector3d r = star->getPosition(tdb).offsetFromKm(browser->ucPos);
-            sprintf(callbackScratch, "%.4g", astro::kilometersToLightYears(r.norm()));
-            nm->item.pszText = callbackScratch;
-        }
+        std::snprintf(callbackScratch, sizeof(callbackScratch) - 1, "%.4g", record->distance);
+        callbackScratch[sizeof(callbackScratch) - 1] = '\0';
+        nm->item.pszText = callbackScratch;
         break;
 
     case 2:
-        {
-            Vector3d r = star->getPosition(tdb).offsetFromKm(browser->ucPos);
-            float appMag = star->getApparentMagnitude(astro::kilometersToLightYears(r.norm()));
-            sprintf(callbackScratch, "%.2f", appMag);
-            nm->item.pszText = callbackScratch;
-        }
+        std::snprintf(callbackScratch, sizeof(callbackScratch) - 1, "%.2f", record->appMag);
+        callbackScratch[sizeof(callbackScratch) - 1] = '\0';
+        nm->item.pszText = callbackScratch;
         break;
 
     case 3:
-        sprintf(callbackScratch, "%.2f", star->getAbsoluteMagnitude());
+        std::snprintf(callbackScratch, sizeof(callbackScratch) - 1, "%.2f", record->star->getAbsoluteMagnitude());
+        callbackScratch[sizeof(callbackScratch) - 1] = '\0';
         nm->item.pszText = callbackScratch;
         break;
 
     case 4:
-        strncpy(callbackScratch, star->getSpectralType(),
-                sizeof(callbackScratch));
+        std::strncpy(callbackScratch, record->star->getSpectralType(), sizeof(callbackScratch)); /* Flawfinder: ignore */
         callbackScratch[sizeof(callbackScratch) - 1] = '\0';
         nm->item.pszText = callbackScratch;
         break;
@@ -382,9 +262,6 @@ void RefreshItems(HWND hDlg, StarBrowser* browser)
 {
     SetMouseCursor(IDC_WAIT);
 
-    Simulation* sim = browser->appCore->getSimulation();
-    browser->ucPos = sim->getObserver().getPosition();
-    browser->pos = browser->ucPos.toLy().cast<float>();
     HWND hwnd = GetDlgItem(hDlg, IDC_STARBROWSER_LIST);
     if (hwnd != 0)
     {
@@ -419,15 +296,15 @@ BOOL APIENTRY StarBrowserProc(HWND hDlg,
             //Initialize Max Stars edit box
             char val[16];
             hwnd = GetDlgItem(hDlg, IDC_MAXSTARS_EDIT);
-            sprintf(val, "%d", DefaultListStars);
+            sprintf(val, "%d", browser->starBrowser.size());
             SetWindowText(hwnd, val);
             SendMessage(hwnd, EM_LIMITTEXT, 3, 0);
 
             //Initialize Max Stars Slider control
             SendDlgItemMessage(hDlg, IDC_MAXSTARS_SLIDER, TBM_SETRANGE,
-                (WPARAM)TRUE, (LPARAM)MAKELONG(MinListStars, MaxListStars));
+                (WPARAM)TRUE, (LPARAM)MAKELONG(engine::StarBrowser::MinListStars, engine::StarBrowser::MaxListStars));
             SendDlgItemMessage(hDlg, IDC_MAXSTARS_SLIDER, TBM_SETPOS,
-                (WPARAM)TRUE, (LPARAM)DefaultListStars);
+                (WPARAM)TRUE, (LPARAM)browser->starBrowser.size());
 
             return(TRUE);
         }
@@ -462,17 +339,20 @@ BOOL APIENTRY StarBrowserProc(HWND hDlg,
             break;
 
         case IDC_RADIO_BRIGHTEST:
-            browser->predicate = BrightestStars;
+            browser->starBrowser.setComparison(engine::StarBrowser::Comparison::ApparentMagnitude);
+            browser->starBrowser.setFilter(engine::StarBrowser::Filter::Visible);
             RefreshItems(hDlg, browser);
             break;
 
         case IDC_RADIO_NEAREST:
-            browser->predicate = NearestStars;
+            browser->starBrowser.setComparison(engine::StarBrowser::Comparison::Nearest);
+            browser->starBrowser.setFilter(engine::StarBrowser::Filter::Visible);
             RefreshItems(hDlg, browser);
             break;
 
         case IDC_RADIO_WITHPLANETS:
-            browser->predicate = StarsWithPlanets;
+            browser->starBrowser.setComparison(engine::StarBrowser::Comparison::Nearest);
+            browser->starBrowser.setFilter(engine::StarBrowser::Filter::WithPlanets);
             RefreshItems(hDlg, browser);
             break;
 
@@ -492,7 +372,7 @@ BOOL APIENTRY StarBrowserProc(HWND hDlg,
 
                 // Check if new value is different from old. Don't want to
                 // cause a refresh to occur if not necessary.
-                if (nNewStars != browser->nStars)
+                if (nNewStars != browser->starBrowser.size())
                 {
                     minRange = SendDlgItemMessage(hDlg, IDC_MAXSTARS_SLIDER, TBM_GETRANGEMIN, 0, 0);
                     maxRange = SendDlgItemMessage(hDlg, IDC_MAXSTARS_SLIDER, TBM_GETRANGEMAX, 0, 0);
@@ -510,14 +390,14 @@ BOOL APIENTRY StarBrowserProc(HWND hDlg,
                     }
 
                     // Recheck value if different from original.
-                    if (nNewStars != browser->nStars)
+                    if (nNewStars != browser->starBrowser.size())
                     {
-                        browser->nStars = nNewStars;
+                        browser->starBrowser.setSize(nNewStars);
                         SendDlgItemMessage(hDlg,
                                            IDC_MAXSTARS_SLIDER,
                                            TBM_SETPOS,
                                            (WPARAM) TRUE,
-                                           (LPARAM) browser->nStars);
+                                           (LPARAM) browser->starBrowser.size());
                         RefreshItems(hDlg, browser);
                     }
                 }
@@ -543,9 +423,9 @@ BOOL APIENTRY StarBrowserProc(HWND hDlg,
                         if ((nm->uNewState & LVIS_SELECTED) != 0)
                         {
                             Simulation* sim = browser->appCore->getSimulation();
-                            Star* star = reinterpret_cast<Star*>(nm->lParam);
-                            if (star != NULL)
-                                sim->setSelection(Selection(star));
+                            auto record = reinterpret_cast<const engine::StarBrowserRecord*>(nm->lParam);
+                            if (record != nullptr)
+                                sim->setSelection(Selection(const_cast<Star*>(record->star)));
                         }
                         break;
                     }
@@ -555,12 +435,20 @@ BOOL APIENTRY StarBrowserProc(HWND hDlg,
                         if (hwnd != 0)
                         {
                             LPNMLISTVIEW nm = (LPNMLISTVIEW) lParam;
-                            StarBrowserSortInfo sortInfo;
-                            sortInfo.subItem = nm->iSubItem;
-                            sortInfo.ucPos = browser->ucPos;
-                            sortInfo.pos = browser->pos;
-                            ListView_SortItems(hwnd, StarBrowserCompareFunc,
-                                               reinterpret_cast<LPARAM>(&sortInfo));
+                            if (auto subItem = nm->iSubItem;
+                                subItem >= 0 && subItem < static_cast<int>(compareFuncs.size()))
+                            {
+                                if (subItem == browser->sortColumn)
+                                    browser->sortColumnReverse = !browser->sortColumnReverse;
+                                else
+                                    browser->sortColumnReverse = false;
+                                browser->sortColumn = subItem;
+                                StarBrowserSortInfo info{
+                                    browser->starBrowser.universe()->getStarCatalog(),
+                                    browser->sortColumnReverse,
+                                };
+                                ListView_SortItems(hwnd, compareFuncs[subItem], reinterpret_cast<LPARAM>(&info));
+                            }
                         }
                     }
 
@@ -584,7 +472,7 @@ BOOL APIENTRY StarBrowserProc(HWND hDlg,
                 }
                 case SB_THUMBPOSITION:
                 {
-                    browser->nStars = (int)HIWORD(wParam);
+                    browser->starBrowser.setSize(HIWORD(wParam));
                     RefreshItems(hDlg, browser);
                     break;
                 }
@@ -601,14 +489,9 @@ StarBrowser::StarBrowser(HINSTANCE appInstance,
                          HWND _parent,
                          CelestiaCore* _appCore) :
     appCore(_appCore),
-    parent(_parent)
+    parent(_parent),
+    starBrowser(_appCore->getSimulation()->getUniverse())
 {
-    ucPos = appCore->getSimulation()->getObserver().getPosition();
-    pos = ucPos.toLy().cast<float>();
-
-    predicate = NearestStars;
-    nStars = DefaultListStars;
-
     hwnd = CreateDialogParam(appInstance,
                              MAKEINTRESOURCE(IDD_STARBROWSER),
                              parent,

--- a/src/celestia/win32/winstarbrowser.h
+++ b/src/celestia/win32/winstarbrowser.h
@@ -11,28 +11,29 @@
 
 #pragma once
 
-#include "celestia/celestiacore.h"
+#include <vector>
+
+#include <celengine/starbrowser.h>
 
 #include <windows.h>
 
+class CelestiaCore;
+class Star;
 
 class StarBrowser
 {
- public:
+public:
     StarBrowser(HINSTANCE, HWND, CelestiaCore*);
     ~StarBrowser();
 
- public:
+public:
     CelestiaCore* appCore;
     HWND parent;
     HWND hwnd;
 
-    // The star browser data is valid for a particular point
-    // in space, and for performance issues is not continuously
-    // updated.
-    Eigen::Vector3f pos;
-    UniversalCoord ucPos;
+    int sortColumn{-1};
+    bool sortColumnReverse{false};
 
-    int predicate;
-    int nStars;
+    celestia::engine::StarBrowser starBrowser;
+    std::vector<celestia::engine::StarBrowserRecord> stars;
 };


### PR DESCRIPTION
* Support sorting by name/reverse column sorting in the Windows front-end. Use of `CompareStringEx` requires Vista or later.
* Use localized names in the Qt front-end

(re-raised since the agents want to recompile the Windows dependencies again)