### PR TITLE
Get number format information from ICU

### DIFF
--- a/src/celengine/dateformatter.cpp
+++ b/src/celengine/dateformatter.cpp
@@ -10,9 +10,6 @@
 // of the License, or (at your option) any later version.
 
 #include "dateformatter.h"
-#ifdef USE_ICU
-#include <celutil/gettext.h>
-#endif
 
 namespace astro = celestia::astro;
 
@@ -83,14 +80,6 @@ UDateFormat *DateFormatter::getFormatter(bool local, astro::Date::Format format)
     if (auto formatter = formatters[index]; formatter != nullptr)
         return formatter;
 
-    static const char *locale = nullptr;
-    if (locale == nullptr)
-    {
-        const char *orig = N_("LANGUAGE");
-        const char *lang = _(orig);
-        locale = lang == orig ? "en" : lang;
-    }
-
     const UChar *pattern;
     UDateFormatStyle dateStyle;
     UDateFormatStyle timeStyle;
@@ -119,7 +108,7 @@ UDateFormat *DateFormatter::getFormatter(bool local, astro::Date::Format format)
     }
 
     UErrorCode error = U_ZERO_ERROR;
-    auto formatter = udat_open(timeStyle, dateStyle, locale, local ? nullptr : u"UTC", -1, pattern, -1, &error);
+    auto formatter = udat_open(timeStyle, dateStyle, nullptr, local ? nullptr : u"UTC", -1, pattern, -1, &error);
     if (U_FAILURE(error))
         return nullptr;
 

--- a/src/celestia/hud.h
+++ b/src/celestia/hud.h
@@ -13,7 +13,9 @@
 #pragma once
 
 #include <limits>
+#ifndef USE_ICU
 #include <locale>
+#endif
 #include <memory>
 #include <string>
 #include <string_view>
@@ -171,7 +173,11 @@ private:
     std::unique_ptr<OverlayImage> m_image;
 
     std::unique_ptr<engine::DateFormatter> m_dateFormatter{ std::make_unique<engine::DateFormatter>() };
+#ifdef USE_ICU
+    std::unique_ptr<const util::NumberFormatter> m_numberFormatter{ std::make_unique<util::NumberFormatter>() };
+#else
     std::unique_ptr<const util::NumberFormatter> m_numberFormatter{ std::make_unique<util::NumberFormatter>(std::locale("")) };
+#endif
     celestia::astro::Date::Format m_dateFormat{ celestia::astro::Date::Locale };
     int m_dateStrWidth{ 0 };
 

--- a/src/celutil/formatnum.cpp
+++ b/src/celutil/formatnum.cpp
@@ -29,7 +29,6 @@
 #include <unicode/decimfmt.h>
 #include <unicode/ustring.h>
 #endif
-#include <celutil/gettext.h>
 #endif
 
 using namespace std::string_view_literals;
@@ -192,26 +191,23 @@ bool getNumberSymbol(const UNumberFormat *numFormat, UNumberFormatSymbol symbol,
 #ifdef USE_ICU
 NumberFormatter::NumberFormatter()
 {
-    const char *orig = N_("LANGUAGE");
-    const char *lang = _(orig);
-
     UErrorCode status = U_ZERO_ERROR;
-    UNumberFormat* numFormat = unum_open(UNUM_DECIMAL, nullptr, 0, lang == orig ? "en" : lang, nullptr, &status);
+    UNumberFormat* numFormat = unum_open(UNUM_DECIMAL, nullptr, 0, nullptr, nullptr, &status);
     if (U_FAILURE(status))
         return;
 
     getNumberSymbol(numFormat, UNUM_DECIMAL_SEPARATOR_SYMBOL, m_decimal);
 
     // attribute == -1 means the attribute is missing
-    int32_t groupingUsed = unum_getAttribute(numFormat, UNUM_GROUPING_USED);
-    int32_t groupingSize = unum_getAttribute(numFormat, UNUM_GROUPING_SIZE);
+    std::int32_t groupingUsed = unum_getAttribute(numFormat, UNUM_GROUPING_USED);
+    std::int32_t groupingSize = unum_getAttribute(numFormat, UNUM_GROUPING_SIZE);
     if (groupingUsed != -1 && groupingUsed != 0 &&
         groupingSize != -1 && groupingSize != 0 &&
         getNumberSymbol(numFormat, UNUM_GROUPING_SEPARATOR_SYMBOL, m_thousands))
     {
         m_grouping.push_back(static_cast<char>(groupingSize));
 
-        int32_t secondaryGroupingSize = unum_getAttribute(numFormat, UNUM_SECONDARY_GROUPING_SIZE);
+        std::int32_t secondaryGroupingSize = unum_getAttribute(numFormat, UNUM_SECONDARY_GROUPING_SIZE);
         if (secondaryGroupingSize != -1 && secondaryGroupingSize != 0)
             m_grouping.push_back(static_cast<char>(secondaryGroupingSize));
     }

--- a/src/celutil/formatnum.h
+++ b/src/celutil/formatnum.h
@@ -13,7 +13,9 @@
 
 #include <cassert>
 #include <iterator>
+#ifndef USE_ICU
 #include <locale>
+#endif
 #include <string_view>
 #include <type_traits>
 
@@ -61,7 +63,11 @@ private:
 class NumberFormatter
 {
 public:
+#ifdef USE_ICU
+    NumberFormatter();
+#else
     explicit NumberFormatter(const std::locale& loc);
+#endif
 
     template<typename T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
     inline FormattedFloat<T> format(T value,

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -3,7 +3,6 @@ set(UNIT_TEST_SOURCES
   arrayvector_test.cpp
   category_test.cpp
   constellation_test.cpp
-  formatnum_test.cpp
   greek_test.cpp
   hash_test.cpp
   intrusiveptr_test.cpp
@@ -20,6 +19,8 @@ set(UNIT_TEST_SOURCES
 
 if(USE_ICU)
   list(APPEND UNIT_TEST_SOURCES unicode_test.cpp)
+else()
+  list(APPEND UNIT_TEST_SOURCES formatnum_test.cpp)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
symbol and attributes for number formatting based on std::locale seems to be inaccurate on certain platforms.

for example: de_DE locale on Mac says grouping is not used. value returned from grouping() is 0x7F.