### PR TITLE
possible fix for #559

### DIFF
--- a/src/celmodel/mesh.cpp
+++ b/src/celmodel/mesh.cpp
@@ -502,9 +502,12 @@ Mesh::pick(const Eigen::Vector3d& rayOrigin, const Eigen::Vector3d& rayDirection
                 else // primType == TriFan
                 {
                     index += 1;
-                    if (index < nIndices)
+                    if (index < nIndices - 1)
                     {
                         index += 1;
+                        i1 = i2;
+                        i2 = group.indices[index];
+                    } else if (index == nIndices - 1) {
                         i1 = i2;
                         i2 = group.indices[index];
                     }

--- a/src/celmodel/mesh.cpp
+++ b/src/celmodel/mesh.cpp
@@ -508,7 +508,8 @@ Mesh::pick(const Eigen::Vector3d& rayOrigin, const Eigen::Vector3d& rayDirection
                         i1 = i2;
                         i2 = group.indices[index];
                     }
-                    else if (index == nIndices - 1) {
+                    else if (index == nIndices - 1)
+                    {
                         i1 = i2;
                         i2 = group.indices[index];
                     }

--- a/src/celmodel/mesh.cpp
+++ b/src/celmodel/mesh.cpp
@@ -507,7 +507,8 @@ Mesh::pick(const Eigen::Vector3d& rayOrigin, const Eigen::Vector3d& rayDirection
                         index += 1;
                         i1 = i2;
                         i2 = group.indices[index];
-                    } else if (index == nIndices - 1) {
+                    }
+                    else if (index == nIndices - 1) {
                         i1 = i2;
                         i2 = group.indices[index];
                     }


### PR DESCRIPTION
check for out-of-boundary was added to TriFan branch in ```Mesh::pick(const Eigen::Vector3d& rayOrigin, const Eigen::Vector3d& rayDirection, PickResult* result)``` method from mesh.cpp; this PR is intended to fix [#559](https://github.com/CelestiaProject/Celestia/issues/559) issue