### PR TITLE
Normalize point source color

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2968,17 +2968,16 @@ void Renderer::renderPlanet(Body& body,
 
     if (body.isVisibleAsPoint())
     {
-        if (float maxCoeff = body.getSurface().color.toVector3().maxCoeff(); maxCoeff > 0.0f)
+        if (float maxCoeff = body.getSurface().color.toVector3().maxCoeff(); maxCoeff > 0.0f) // ignore [ 0 0 0 ]; used by old addons to make objects not get rendered as point
         {
-    {
-        renderObjectAsPoint(pos,
-                            body.getRadius(),
-                            appMag,
-                            discSizeInPixels,
-                            body.getSurface().color / maxCoeff,
-                            false, false, m);
+            renderObjectAsPoint(pos,
+                                body.getRadius(),
+                                appMag,
+                                discSizeInPixels,
+                                body.getSurface().color / maxCoeff, // normalize point color; 'darkness' is handled by size of point determined by GeomAlbedo.
+                                false, false, m);
+        }
     }
-}
 
 
 void Renderer::renderStar(const Star& star,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2978,6 +2978,7 @@ void Renderer::renderPlanet(Body& body,
                                 false, false, m);
         }
     }
+}
 
 
 void Renderer::renderStar(const Star& star,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2966,13 +2966,13 @@ void Renderer::renderPlanet(Body& body,
         }
     }
 
-    if (body.isVisibleAsPoint())
+    if (body.isVisibleAsPoint() && body.getSurface().color.toVector3().maxCoeff() > 0.0f)
     {
         renderObjectAsPoint(pos,
                             body.getRadius(),
                             appMag,
                             discSizeInPixels,
-                            body.getSurface().color,
+                            body.getSurface().color / body.getSurface().color.maxCoeff(),
                             false, false, m);
     }
 }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2972,7 +2972,7 @@ void Renderer::renderPlanet(Body& body,
                             body.getRadius(),
                             appMag,
                             discSizeInPixels,
-                            body.getSurface().color / body.getSurface().color.toVector3().maxCoeff(),
+                            body.getSurface().color / maxCoeff,
                             false, false, m);
     }
 }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2972,7 +2972,7 @@ void Renderer::renderPlanet(Body& body,
                             body.getRadius(),
                             appMag,
                             discSizeInPixels,
-                            body.getSurface().color / body.getSurface().color.maxCoeff(),
+                            body.getSurface().color / body.getSurface().color.toVector3().maxCoeff(),
                             false, false, m);
     }
 }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2974,7 +2974,7 @@ void Renderer::renderPlanet(Body& body,
                                 body.getRadius(),
                                 appMag,
                                 discSizeInPixels,
-                                body.getSurface().color / maxCoeff, // normalize point color; 'darkness' is handled by size of point determined by GeomAlbedo.
+                                body.getSurface().color * (1.0f / maxCoeff), // normalize point color; 'darkness' is handled by size of point determined by GeomAlbedo.
                                 false, false, m);
         }
     }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2966,7 +2966,10 @@ void Renderer::renderPlanet(Body& body,
         }
     }
 
-    if (body.isVisibleAsPoint() && body.getSurface().color.toVector3().maxCoeff() > 0.0f)
+    if (body.isVisibleAsPoint())
+    {
+        if (float maxCoeff = body.getSurface().color.toVector3().maxCoeff(); maxCoeff > 0.0f)
+        {
     {
         renderObjectAsPoint(pos,
                             body.getRadius(),


### PR DESCRIPTION
See Issue #2016

Pedro noted that old addons use [ 0 0 0 ] in order for object to not get rendered as points; this is handled by the condition at the beginning, which excludes such objects (and so they do not get rendered anyway).