### PR TITLE
Add support for zooming with a focus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ option(ENABLE_TESTS                 "Enable unit tests? (Default: off)" OFF)
 option(ENABLE_GLES                  "Build for OpenGL ES 2.0 instead of OpenGL 2.1 (Default: off)" OFF)
 option(ENABLE_LTO                   "Enable link time optimizations (Default: off)" OFF)
 option(ENABLE_RAY_BASED_DRAGGING    "Enable the dragging behavior that based on change of pick rays instead of screen coordinates (Default: off)" OFF)
+option(ENABLE_FOCUS_ZOOMING         "Enable the zooming behavior where the focus location on screen is kept (Default: off)" OFF)
 option(USE_GTKGLEXT                 "Use libgtkglext1 for GTK2 frontend (Default: on)" ON)
 option(USE_GTK3                     "Use Gtk3 in GTK2 frontend (Default: off)" OFF)
 option(USE_WAYLAND                  "Use Wayland in Qt frontend (Default: off)" OFF)
@@ -242,6 +243,10 @@ endif()
 
 if (ENABLE_RAY_BASED_DRAGGING)
   add_definitions(-DENABLE_RAY_BASED_DRAGGING)
+endif()
+
+if (ENABLE_FOCUS_ZOOMING)
+  add_definitions(-DENABLE_FOCUS_ZOOMING)
 endif()
 
 if(_UNIX)

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -402,18 +402,12 @@ public:
     void setLayoutDirection(celestia::LayoutDirection);
 
 private:
-    struct MouseLocation
-    {
-        float x;
-        float y;
-    };
-
     void charEnteredAutoComplete(const char*);
     void updateSelectionFromInput();
     bool readStars(const CelestiaConfig&, ProgressNotifier*);
     void renderOverlay();
     Eigen::Vector3f getPickRay(float x, float y, const celestia::View *view);
-    void updateFOV(float fov, std::optional<MouseLocation> focus, const celestia::View *view);
+    void updateFOV(float fov, std::optional<Eigen::Vector2f> focus, const celestia::View *view);
 #ifdef CELX
     bool initLuaHook(ProgressNotifier*);
 #endif // CELX
@@ -504,12 +498,12 @@ private:
     float pickTolerance { 4.0f };
 
 #ifdef ENABLE_RAY_BASED_DRAGGING
-    std::optional<MouseLocation> dragLocation { std::nullopt };
+    std::optional<Eigen::Vector2f> dragLocation { std::nullopt };
     std::optional<bool> dragStartFromSurface { std::nullopt };
 #endif
 
 #ifdef ENABLE_FOCUS_ZOOMING
-    std::optional<MouseLocation> dragStart{ std::nullopt };
+    std::optional<Eigen::Vector2f> dragStart{ std::nullopt };
 #endif
 
     std::unique_ptr<ViewportEffect> viewportEffect { nullptr };

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -221,6 +221,7 @@ public:
     void mouseMove(float, float);
     void joystickAxis(int axis, float amount);
     void joystickButton(int button, bool down);
+    void pinchUpdate(float focusX, float focusY, float scale);
     void resize(GLsizei w, GLsizei h);
     void draw();
     void draw(celestia::View*);
@@ -401,11 +402,18 @@ public:
     void setLayoutDirection(celestia::LayoutDirection);
 
 private:
+    struct MouseLocation
+    {
+        float x;
+        float y;
+    };
+
     void charEnteredAutoComplete(const char*);
     void updateSelectionFromInput();
     bool readStars(const CelestiaConfig&, ProgressNotifier*);
     void renderOverlay();
     Eigen::Vector3f getPickRay(float x, float y, const celestia::View *view);
+    void updateFOV(float fov, std::optional<MouseLocation> focus, const celestia::View *view);
 #ifdef CELX
     bool initLuaHook(ProgressNotifier*);
 #endif // CELX
@@ -495,13 +503,6 @@ private:
 
     float pickTolerance { 4.0f };
 
-#if defined(ENABLE_RAY_BASED_DRAGGING) || defined(ENABLE_FOCUS_ZOOMING)
-    struct MouseLocation
-    {
-        float x;
-        float y;
-    };
-
 #ifdef ENABLE_RAY_BASED_DRAGGING
     std::optional<MouseLocation> dragLocation { std::nullopt };
     std::optional<bool> dragStartFromSurface { std::nullopt };
@@ -509,7 +510,6 @@ private:
 
 #ifdef ENABLE_FOCUS_ZOOMING
     std::optional<MouseLocation> dragStart{ std::nullopt };
-#endif
 #endif
 
     std::unique_ptr<ViewportEffect> viewportEffect { nullptr };

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -495,14 +495,21 @@ private:
 
     float pickTolerance { 4.0f };
 
-#ifdef ENABLE_RAY_BASED_DRAGGING
+#if defined(ENABLE_RAY_BASED_DRAGGING) || defined(ENABLE_FOCUS_ZOOMING)
     struct MouseLocation
     {
         float x;
         float y;
     };
+
+#ifdef ENABLE_RAY_BASED_DRAGGING
     std::optional<MouseLocation> dragLocation { std::nullopt };
     std::optional<bool> dragStartFromSurface { std::nullopt };
+#endif
+
+#ifdef ENABLE_FOCUS_ZOOMING
+    std::optional<MouseLocation> dragStart{ std::nullopt };
+#endif
 #endif
 
     std::unique_ptr<ViewportEffect> viewportEffect { nullptr };


### PR DESCRIPTION
Add an option ENABLE_FOCUS_ZOOMING to support zooming (shift + left drag) with a focus by changing orientation during zooming so that the focus location (where the drag started) is kept where it was.

Also adding support for mobile pinch gesture based on this. Pinch on mobile is basically a focus and scale so it can be easily translated in to zooming with focus.

