### PR TITLE
Use apt-get instead of apt in translations workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           qtbase qt5compat[core]
 
     - name: Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -174,7 +174,7 @@ jobs:
         fi
 
     - name: 'Checkout source code'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -279,7 +279,7 @@ jobs:
         fi
 
     - name: 'Checkout source code'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -339,7 +339,7 @@ jobs:
                             gcc-toolset-11-gcc-c++
 
     - name: 'Checkout source code'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -37,7 +37,7 @@ jobs:
                                 cmake
 
     - name: 'Checkout source code'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
         repository: ${{ github.event.workflow_run.head_repository.full_name }}

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
     - name: 'Install dependencies'
       run: |
-        sudo apt update
-        sudo apt install -y gettext
+        sudo apt-get update
+        sudo apt-get install -y gettext
 
     - name: 'Checkout source code'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 'Validate translations'
       working-directory: ${{github.workspace}}/po


### PR DESCRIPTION
- Fixes a warning in workflow output
- Update checkout tasks to use v4