### PR TITLE
Fix version check for `throw_format_error`

### DIFF
--- a/src/celutil/formatnum.cpp
+++ b/src/celutil/formatnum.cpp
@@ -65,7 +65,7 @@ struct fmt::formatter<ExtendedSubstring>
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}')
         {
-#if FMT_VERSION >= 100000
+#if FMT_VERSION >= 100100
             throw_format_error("invalid format");
 #else
             assert(0);

--- a/src/celutil/formatnum.h
+++ b/src/celutil/formatnum.h
@@ -121,7 +121,7 @@ struct fmt::formatter<celestia::util::FormattedFloat<T>>
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}')
         {
-#if FMT_VERSION >= 100000
+#if FMT_VERSION >= 100100
             throw_format_error("invalid format");
 #else
             assert(0);


### PR DESCRIPTION
Method was added to the public API in 10.1.0, not 10.0.0

Resolves #2043 