### PR TITLE
Fix too wide bitmask in Url which caused planets to be shown always

### DIFF
--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -206,7 +206,6 @@ class Renderer
                                   ShowMinorMoons        |
                                   ShowAsteroids         |
                                   ShowComets            |
-                                  ShowPlanetRings       |
                                   ShowSpacecrafts,
         ShowDeepSpaceObjects    = ShowGalaxies          |
                                   ShowGlobulars         |
@@ -214,6 +213,7 @@ class Renderer
                                   ShowOpenClusters,
         DefaultRenderFlags      = ShowStars             |
                                   ShowSolarSystemObjects|
+                                  ShowPlanetRings       |
                                   ShowDeepSpaceObjects  |
                                   ShowCloudMaps         |
                                   ShowNightMaps         |


### PR DESCRIPTION
Plus cleanup without functional changes

With `master`:
1.  Start Celestia, so the Earth is visible
1. Disable all bodies in display options, the Earth is invisible
1. Copy URL
1. Paste it back
1. The Earth is visible again

This was caused by too wide RF_MASK which set bit 26 used in 1.7 to set planet visibility in a 1.6-compatible way.