### PR TITLE
Move RayBasedDragging and FocusZooming to cfg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,6 @@ option(ENABLE_FAST_MATH             "Build with unsafe fast-math compiller optio
 option(ENABLE_TESTS                 "Enable unit tests? (Default: off)" OFF)
 option(ENABLE_GLES                  "Build for OpenGL ES 2.0 instead of OpenGL 2.1 (Default: off)" OFF)
 option(ENABLE_LTO                   "Enable link time optimizations (Default: off)" OFF)
-option(ENABLE_RAY_BASED_DRAGGING    "Enable the dragging behavior that based on change of pick rays instead of screen coordinates (Default: off)" OFF)
-option(ENABLE_FOCUS_ZOOMING         "Enable the zooming behavior where the focus location on screen is kept (Default: off)" OFF)
 option(USE_GTKGLEXT                 "Use libgtkglext1 for GTK2 frontend (Default: on)" ON)
 option(USE_GTK3                     "Use Gtk3 in GTK2 frontend (Default: off)" OFF)
 option(USE_WAYLAND                  "Use Wayland in Qt frontend (Default: off)" OFF)
@@ -238,14 +236,6 @@ if(ENABLE_LIBAVIF)
   link_libraries(libavif::libavif)
   include_directories(${LIBAVIF_INCLUDE_DIR})
   add_definitions(-DUSE_LIBAVIF)
-endif()
-
-if (ENABLE_RAY_BASED_DRAGGING)
-  add_definitions(-DENABLE_RAY_BASED_DRAGGING)
-endif()
-
-if (ENABLE_FOCUS_ZOOMING)
-  add_definitions(-DENABLE_FOCUS_ZOOMING)
 endif()
 
 if(_UNIX)

--- a/celestia.cfg
+++ b/celestia.cfg
@@ -279,8 +279,14 @@ StarTextures
 #------------------------------------------------------------------------
 # ReverseMouseWheel performs a change of command rotates
 # the mouse wheel on the opposite. The default value is false.
+# RayBasedDragging enables dragging behavior that based on change of
+# pick rays instead of screen coordinates. The default value is false.
+# FocusZooming enables the zooming behavior where the focus location on
+# screen is kept. The default value is false.
 #------------------------------------------------------------------------
 #  ReverseMouseWheel true
+#  RayBasedDragging  true
+#  FocusZooming      true
 
 
 #------------------------------------------------------------------------

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -28,6 +28,7 @@
 #include <celengine/overlayimage.h>
 #include <celengine/viewporteffect.h>
 #include <celimage/pixelformat.h>
+#include <celutil/flag.h>
 #include <celutil/tee.h>
 #include "configfile.h"
 #include "favorites.h"
@@ -179,6 +180,14 @@ public:
         Deny        = 2,
     };
 
+    enum class InteractionFlags : unsigned int
+    {
+        None                = 0x0,
+        ReverseWheel        = 0x1,
+        RayBasedDragging    = 0x2,
+        FocusZooming        = 0x4,
+    };
+
     CelestiaCore();
     ~CelestiaCore();
 
@@ -300,6 +309,9 @@ public:
     std::tuple<int, int> getWindowDimension() const;
     void setAccelerationCoefficient(float);
     void setDecelerationCoefficient(float);
+
+    InteractionFlags getInteractionFlags() const;
+    void setInteractionFlags(InteractionFlags);
 
     void setFOVFromZoom();
     void setZoomFromFOV();
@@ -489,14 +501,11 @@ private:
 
     float pickTolerance { 4.0f };
 
-#ifdef ENABLE_RAY_BASED_DRAGGING
+    InteractionFlags interactionFlags { InteractionFlags::None };
+
     std::optional<Eigen::Vector2f> dragLocation { std::nullopt };
     std::optional<bool> dragStartFromSurface { std::nullopt };
-#endif
-
-#ifdef ENABLE_FOCUS_ZOOMING
     std::optional<Eigen::Vector2f> dragStart{ std::nullopt };
-#endif
 
     std::unique_ptr<ViewportEffect> viewportEffect { nullptr };
     bool isViewportEffectUsed { false };
@@ -516,3 +525,5 @@ private:
     friend std::shared_ptr<TextureFont> getTitleFont(CelestiaCore*);
 #endif
 };
+
+ENUM_CLASS_BITWISE_OPS(CelestiaCore::InteractionFlags);

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -173,6 +173,8 @@ applyMouse(CelestiaConfig::Mouse& mouse, const Hash& hash)
     applyNumber(mouse.rotateAcceleration, hash, "RotateAcceleration"sv);
     applyNumber(mouse.rotationSensitivity, hash, "MouseRotationSensitivity"sv);
     applyBoolean(mouse.reverseWheel, hash, "ReverseMouseWheel"sv);
+    applyBoolean(mouse.rayBasedDragging, hash, "RayBasedDragging"sv);
+    applyBoolean(mouse.focusZooming, hash, "FocusZooming"sv);
 }
 
 

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -59,7 +59,9 @@ struct CelestiaConfig
         std::string cursor{ };
         float rotateAcceleration{ 120.0f };
         float rotationSensitivity{ 1.0f };
-        bool  reverseWheel{ false };
+        bool reverseWheel{ false };
+        bool rayBasedDragging{ false };
+        bool focusZooming{ false };
     };
 
     struct RenderDetails

--- a/src/celutil/flag.h
+++ b/src/celutil/flag.h
@@ -59,4 +59,13 @@ constexpr bool is_set(E f, E t)
     return (f & t) != static_cast<E>(0);
 }
 
+template<typename E, std::enable_if_t<std::is_enum_v<E>, int> = 0>
+constexpr void set_or_unset(E& f, E t, bool set)
+{
+    if (set)
+        f |= t;
+    else
+        f &= ~t;
+}
+
 }


### PR DESCRIPTION
and combined with reverseWheel in CelestiaCore::interactionFlags so that they can be changed during runtime by calling CelestiaCore::setInteractionFlags.