### PR TITLE
Parse paths as UTF-8

### DIFF
--- a/src/celengine/deepskyobj.h
+++ b/src/celengine/deepskyobj.h
@@ -84,7 +84,7 @@ public:
 
     virtual bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
                       double& distanceToPicker,
-                      double& cosAngleToBoundCenter) const = 0;
+                      double& cosAngleToBoundCenter) const;
     virtual bool load(const AssociativeArray*, const fs::path& resPath);
 
     virtual uint64_t getRenderMask() const { return 0; }

--- a/src/celengine/hash.cpp
+++ b/src/celengine/hash.cpp
@@ -64,7 +64,7 @@ std::optional<fs::path> AssociativeArray::getPath(std::string_view key) const
     const std::string* v = getString(key);
     if (v == nullptr) { return std::nullopt; }
 
-    return std::make_optional(util::PathExp(*v));
+    return std::make_optional(util::PathExp(fs::u8path(*v)));
 }
 
 

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -10,77 +10,80 @@
 #include <algorithm>
 #include <celmath/mathlib.h>
 #include <celmath/vecgl.h>
+#include <celutil/fsutils.h>
+#include <celutil/logger.h>
 #include <celutil/gettext.h>
 #include "meshmanager.h"
 #include "nebula.h"
 #include "rendcontext.h"
 #include "render.h"
 
+namespace util = celestia::util;
+using util::GetLogger;
 
-const char* Nebula::getType() const
+const char*
+Nebula::getType() const
 {
     return "Nebula";
 }
 
-
-void Nebula::setType(const std::string& /*typeStr*/)
+void
+Nebula::setType(const std::string& /*typeStr*/)
 {
 }
 
-
-std::string Nebula::getDescription() const
+std::string
+Nebula::getDescription() const
 {
     return _("Nebula");
 }
 
-
-ResourceHandle Nebula::getGeometry() const
+ResourceHandle
+Nebula::getGeometry() const
 {
     return geometry;
 }
 
-
-void Nebula::setGeometry(ResourceHandle _geometry)
+void
+Nebula::setGeometry(ResourceHandle _geometry)
 {
     geometry = _geometry;
 }
 
-DeepSkyObjectType Nebula::getObjType() const
+DeepSkyObjectType
+Nebula::getObjType() const
 {
     return DeepSkyObjectType::Nebula;
 }
 
-
-bool Nebula::pick(const Eigen::ParametrizedLine<double, 3>& ray,
-                  double& distanceToPicker,
-                  double& cosAngleToBoundCenter) const
-{
-    // The preconditional sphere-ray intersection test is enough for now:
-    return DeepSkyObject::pick(ray, distanceToPicker, cosAngleToBoundCenter);
-}
-
-
-bool Nebula::load(const AssociativeArray* params, const fs::path& resPath)
+bool
+Nebula::load(const AssociativeArray* params, const fs::path& resPath)
 {
     if (const std::string* t = params->getString("Mesh"); t != nullptr)
     {
-        fs::path geometryFileName(*t);
+        auto geometryFileName = util::U8FileName(*t);
+        if (!geometryFileName.has_value())
+        {
+            GetLogger()->error("Invalid filename in Mesh\n");
+            return false;
+        }
+
         ResourceHandle geometryHandle =
-            GetGeometryManager()->getHandle(GeometryInfo(geometryFileName, resPath));
+            GetGeometryManager()->getHandle(GeometryInfo(*geometryFileName, resPath));
         setGeometry(geometryHandle);
     }
 
     return DeepSkyObject::load(params, resPath);
 }
 
-
-std::uint64_t Nebula::getRenderMask() const
+std::uint64_t
+Nebula::getRenderMask() const
 {
     return Renderer::ShowNebulae;
 }
 
-
-unsigned int Nebula::getLabelMask() const
+unsigned int
+Nebula::getLabelMask() const
 {
     return Renderer::NebulaLabels;
 }

--- a/src/celengine/nebula.h
+++ b/src/celengine/nebula.h
@@ -22,9 +22,7 @@ public:
     void setType(const std::string&) override;
     std::string getDescription() const override;
 
-    bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
-              double& distanceToPicker,
-              double& cosAngleToBoundCenter) const override;
+    // pick: the preconditional sphere-ray intersection test is enough for now
     bool load(const AssociativeArray*, const fs::path&) override;
 
     uint64_t getRenderMask() const override;

--- a/src/celengine/rotationmanager.h
+++ b/src/celengine/rotationmanager.h
@@ -21,7 +21,7 @@
 class RotationModelInfo
 {
  private:
-    std::string source;
+    fs::path source;
     fs::path path;
 
     friend bool operator<(const RotationModelInfo&, const RotationModelInfo&);
@@ -30,7 +30,7 @@ class RotationModelInfo
     using ResourceType = celestia::ephem::RotationModel;
     using ResourceKey = fs::path;
 
-    RotationModelInfo(const std::string& _source,
+    RotationModelInfo(const fs::path& _source,
                       const fs::path& _path = "") :
         source(_source), path(_path) {};
 

--- a/src/celengine/trajmanager.h
+++ b/src/celengine/trajmanager.h
@@ -41,7 +41,7 @@ class TrajectoryInfo
     };
 
  private:
-    std::string source;
+    fs::path source;
     fs::path path;
     celestia::ephem::TrajectoryInterpolation interpolation;
     celestia::ephem::TrajectoryPrecision precision;
@@ -51,7 +51,7 @@ class TrajectoryInfo
  public:
     using ResourceType = celestia::ephem::Orbit;
 
-    TrajectoryInfo(const std::string& _source,
+    TrajectoryInfo(const fs::path& _source,
                    const fs::path& _path = "",
                    celestia::ephem::TrajectoryInterpolation _interpolation = celestia::ephem::TrajectoryInterpolation::Cubic,
                    celestia::ephem::TrajectoryPrecision _precision = celestia::ephem::TrajectoryPrecision::Single) :

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -274,9 +274,12 @@ VirtualTexture::loadTileTexture(unsigned int lod, unsigned int u, unsigned int v
     lod >>= baseSplit;
     assert(lod < (unsigned)MaxResolutionLevels);
 
+    auto filename = fs::u8path(fmt::format("{}{}_{}", tilePrefix, u, v));
+    filename += tileExt;
+
     auto path = tilePath /
                 fmt::format("level{:d}", lod) /
-                fmt::format("{:s}{:d}_{:d}{:s}", tilePrefix, u, v, tileExt.string());
+                filename;
 
     auto img = Image::load(path);
     if (img == nullptr)

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -62,7 +62,7 @@ applyPath(fs::path& target, const Hash& hash, std::string_view key)
 {
     auto path = hash.getPath(key);
     if (path.has_value())
-        target = celestia::util::PathExp(*path);
+        target = *path;
 }
 
 
@@ -119,11 +119,11 @@ applyPathArray(std::vector<fs::path>& target, const Hash& hash, std::string_view
                 break;
             }
 
-            target.emplace_back(celestia::util::PathExp(*itemStr));
+            target.emplace_back(celestia::util::PathExp(fs::u8path(*itemStr)));
         }
     }
     else if (auto str = value->getString(); str != nullptr)
-        target.emplace_back(celestia::util::PathExp(*str));
+        target.emplace_back(celestia::util::PathExp(fs::u8path(*str)));
     else
         GetLogger()->error("{} must be a string or an array of strings.\n", key);
 }

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -673,7 +673,7 @@ void CommandPreloadTextures::processInstantaneous(ExecutionEnvironment& env)
 ////////////////
 // Capture command
 
-CommandCapture::CommandCapture(std::string _type, std::string _filename)
+CommandCapture::CommandCapture(std::string _type, fs::path _filename)
     : type(std::move(_type)), filename(std::move(_filename))
 {
 }
@@ -1078,8 +1078,8 @@ void CommandSetWindowBordersVisible::processInstantaneous(ExecutionEnvironment& 
 ///////////////
 // SetRingsTexture command
 CommandSetRingsTexture::CommandSetRingsTexture(std::string _object,
-                                               std::string _textureName,
-                                               std::string _path) :
+                                               fs::path _textureName,
+                                               fs::path _path) :
     object(std::move(_object)),
     textureName(std::move(_textureName)),
     path(std::move(_path))

--- a/src/celscript/legacy/command.h
+++ b/src/celscript/legacy/command.h
@@ -601,14 +601,14 @@ class CommandUnmarkAll : public InstantaneousCommand
 class CommandCapture : public InstantaneousCommand
 {
  public:
-    CommandCapture(std::string, std::string);
+    CommandCapture(std::string, fs::path);
 
  protected:
     void processInstantaneous(ExecutionEnvironment&) override;
 
  private:
     std::string type;
-    std::string filename;
+    fs::path filename;
 };
 
 
@@ -732,7 +732,12 @@ class CommandSetTextColor : public InstantaneousCommand
 class CommandPlay : public InstantaneousCommand
 {
  public:
-    CommandPlay(int channel, std::optional<float> volume, float pan, std::optional<bool> loop, const std::optional<fs::path> &filename, bool nopause);
+    CommandPlay(int channel,
+                std::optional<float> volume,
+                float pan,
+                std::optional<bool> loop,
+                const std::optional<fs::path> &filename,
+                bool nopause);
 
  protected:
     void processInstantaneous(ExecutionEnvironment&) override;
@@ -794,13 +799,15 @@ class CommandSetWindowBordersVisible : public InstantaneousCommand
 class CommandSetRingsTexture : public InstantaneousCommand
 {
  public:
-    CommandSetRingsTexture(std::string, std::string, std::string);
+    CommandSetRingsTexture(std::string, fs::path, fs::path);
 
  protected:
     void processInstantaneous(ExecutionEnvironment&) override;
 
  private:
-    std::string object, textureName, path;
+    std::string object;
+    fs::path textureName;
+    fs::path path;
 };
 
 } // end namespace celestia::scripts

--- a/src/celutil/fsutils.cpp
+++ b/src/celutil/fsutils.cpp
@@ -11,6 +11,8 @@
 // of the License, or (at your option) any later version.
 
 #include <config.h> // HAVE_WORDEXP
+#include <array>
+#include <cctype>
 #include <fstream>
 #include <utility>
 #include <fmt/format.h>
@@ -37,6 +39,60 @@
 
 namespace celestia::util
 {
+
+std::optional<fs::path>
+U8FileName(std::string_view source, bool allowWildcardExtension)
+{
+    using namespace std::string_view_literals;
+
+    // Windows: filenames cannot end with . or space
+    if (source.empty() || source.back() == '.' || source.back() == ' ')
+        return std::nullopt;
+
+    // Various characters disallowed in Windows filenames
+    constexpr std::string_view badChars = R"("/:<>?\|)"sv;
+    const auto lastPos = source.size() - 1;
+    for (std::string_view::size_type i = 0; i < source.size(); ++i)
+    {
+        char ch = source[i];
+        // Windows (and basic politeness) disallows all control characters
+        // Only allow * as extension .* at the end of the name
+        if (ch < ' ' || badChars.find(ch) != std::string_view::npos ||
+            (ch == '*' && !(allowWildcardExtension && i == lastPos && i > 0 && source[i - 1] == '.')))
+        {
+            return std::nullopt;
+        }
+    }
+
+    // Disallow reserved Windows device names
+    if (std::string_view stem = source.substr(0, source.rfind('.'));
+        stem.size() >= 3 && stem.size() <= 5)
+    {
+        std::array<char, 5> buffer{ '\0', '\0', '\0', '\0', '\0' };
+        stem.copy(buffer.data(), 5);
+        for (std::size_t i = 0; i < stem.size(); ++i)
+        {
+            buffer[i] = static_cast<char>(std::toupper(static_cast<unsigned char>(buffer[i])));
+        }
+
+        stem = std::string_view(buffer.data(), stem.size());
+        if (stem == "CON"sv || stem == "PRN"sv || stem == "AUX"sv || stem == "NUL"sv)
+            return std::nullopt;
+
+        constexpr std::string_view superscriptTrailBytes = "\xb2\xb3\xb9"sv;
+
+        // COM or LPT followed by digits 0-9 or superscript digits 1-3
+        if ((stem.substr(0, 3) == "COM"sv || stem.substr(0, 3) == "LPT"sv) &&
+            ((stem.size() == 4 && stem[3] >= '0' && stem[3] <= '9') ||
+             (stem.size() == 5 && stem[3] == '\xc2' &&
+              superscriptTrailBytes.find(stem[4]) != std::string_view::npos)))
+        {
+            return std::nullopt;
+        }
+    }
+
+    return fs::u8path(source);
+}
 
 fs::path LocaleFilename(const fs::path &p)
 {

--- a/src/celutil/fsutils.h
+++ b/src/celutil/fsutils.h
@@ -21,7 +21,7 @@ namespace celestia::util
 {
 
 fs::path LocaleFilename(const fs::path& filename);
-fs::path PathExp(const fs::path& filename);
+fs::path PathExp(fs::path&& filename);
 fs::path ResolveWildcard(const fs::path& wildcard,
                          array_view<std::string_view> extensions);
 bool IsValidDirectory(const fs::path &dir);

--- a/src/celutil/fsutils.h
+++ b/src/celutil/fsutils.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string_view>
 
 #include <celcompat/filesystem.h>
@@ -20,6 +21,8 @@
 namespace celestia::util
 {
 
+std::optional<fs::path> U8FileName(std::string_view source,
+                                   bool allowWildcardExtension = true);
 fs::path LocaleFilename(const fs::path& filename);
 fs::path PathExp(fs::path&& filename);
 fs::path ResolveWildcard(const fs::path& wildcard,


### PR DESCRIPTION
The path constructor from `char` strings uses the system's current narrow character encoding, which on Windows will depend on the locale. Therefore we should construct paths from UTF-8 via `u8path`.

Also validate filenames in a cross-platform manner, to avoid illegal path sequences, Windows reserved device names, or breaking out of the directory structure.