### PR TITLE
Use smart pointers to track orbits and rotation models

### DIFF
--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -200,7 +200,7 @@ const ReferenceFrame::SharedConstPtr& Body::getOrbitFrame(double tdb) const
 
 const celestia::ephem::Orbit* Body::getOrbit(double tdb) const
 {
-    return timeline->findPhase(tdb)->orbit();
+    return timeline->findPhase(tdb)->orbit().get();
 }
 
 
@@ -213,7 +213,7 @@ const ReferenceFrame::SharedConstPtr& Body::getBodyFrame(double tdb) const
 const celestia::ephem::RotationModel*
 Body::getRotationModel(double tdb) const
 {
-    return timeline->findPhase(tdb)->rotationModel();
+    return timeline->findPhase(tdb)->rotationModel().get();
 }
 
 

--- a/src/celengine/category.cpp
+++ b/src/celengine/category.cpp
@@ -6,11 +6,10 @@
 
 #include <celutil/gettext.h>
 #include "hash.h"
-
+#include "value.h"
 
 UserCategoryManager::UserCategoryManager() = default;
 UserCategoryManager::~UserCategoryManager() = default;
-
 
 UserCategoryId
 UserCategoryManager::create(const std::string& name,
@@ -44,7 +43,6 @@ UserCategoryManager::create(const std::string& name,
 
     return createNew(id, name, parent, domain);
 }
-
 
 bool
 UserCategoryManager::destroy(UserCategoryId category)
@@ -91,7 +89,6 @@ UserCategoryManager::destroy(UserCategoryId category)
     return true;
 }
 
-
 const UserCategory*
 UserCategoryManager::get(UserCategoryId category) const
 {
@@ -100,7 +97,6 @@ UserCategoryManager::get(UserCategoryId category) const
         return nullptr;
     return m_categories[categoryIndex].get();
 }
-
 
 UserCategoryId
 UserCategoryManager::find(std::string_view name) const
@@ -111,7 +107,6 @@ UserCategoryManager::find(std::string_view name) const
         : it->second;
 }
 
-
 UserCategoryId
 UserCategoryManager::findOrAdd(const std::string& name, const std::string& domain)
 {
@@ -121,7 +116,6 @@ UserCategoryManager::findOrAdd(const std::string& name, const std::string& domai
 
     return createNew(id, name, UserCategoryId::Invalid, domain);
 }
-
 
 UserCategoryId
 UserCategoryManager::createNew(UserCategoryId id,
@@ -151,7 +145,6 @@ UserCategoryManager::createNew(UserCategoryId id,
     return id;
 }
 
-
 bool
 UserCategoryManager::addObject(Selection selection, UserCategoryId category)
 {
@@ -168,7 +161,6 @@ UserCategoryManager::addObject(Selection selection, UserCategoryId category)
         it->second.push_back(category);
     return true;
 }
-
 
 bool
 UserCategoryManager::removeObject(Selection selection, UserCategoryId category)
@@ -198,7 +190,6 @@ UserCategoryManager::removeObject(Selection selection, UserCategoryId category)
     return true;
 }
 
-
 void
 UserCategoryManager::clearCategories(Selection selection)
 {
@@ -214,7 +205,6 @@ UserCategoryManager::clearCategories(Selection selection)
     m_objectMap.erase(selection);
 }
 
-
 bool
 UserCategoryManager::isInCategory(Selection selection, UserCategoryId category) const
 {
@@ -226,7 +216,6 @@ UserCategoryManager::isInCategory(Selection selection, UserCategoryId category) 
     return members.find(selection) != members.end();
 }
 
-
 const std::vector<UserCategoryId>*
 UserCategoryManager::getCategories(Selection selection) const
 {
@@ -235,7 +224,6 @@ UserCategoryManager::getCategories(Selection selection) const
         ? nullptr
         : &it->second;
 }
-
 
 UserCategory::UserCategory(UserCategoryManager::ConstructorToken,
                            const std::string& name,
@@ -246,13 +234,11 @@ UserCategory::UserCategory(UserCategoryManager::ConstructorToken,
     m_i18nName(std::move(i18nName))
 {}
 
-
 const std::string&
 UserCategory::getName(bool i18n) const
 {
     return i18n ? m_i18nName : m_name;
 }
-
 
 bool
 UserCategory::hasChild(UserCategoryId child) const
@@ -261,13 +247,11 @@ UserCategory::hasChild(UserCategoryId child) const
     return it != m_children.end();
 }
 
-
 const UserCategory*
 UserCategory::get(UserCategoryId category)
 {
     return manager.get(category);
 }
-
 
 void
 UserCategory::loadCategories(Selection selection,

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -72,8 +72,8 @@ class CachingFrame : public ReferenceFrame
     explicit CachingFrame(Selection _center);
     ~CachingFrame() override = default;
 
-    Eigen::Quaterniond getOrientation(double tjd) const;
-    Eigen::Vector3d getAngularVelocity(double tjd) const;
+    Eigen::Quaterniond getOrientation(double tjd) const override;
+    Eigen::Vector3d getAngularVelocity(double tjd) const override;
     virtual Eigen::Quaterniond computeOrientation(double tjd) const = 0;
     virtual Eigen::Vector3d computeAngularVelocity(double tjd) const;
 
@@ -95,7 +95,7 @@ class J2000EclipticFrame : public ReferenceFrame
     explicit J2000EclipticFrame(Selection center);
     ~J2000EclipticFrame() override = default;
 
-    Eigen::Quaterniond getOrientation(double /* tjd */) const
+    Eigen::Quaterniond getOrientation(double /* tjd */) const override
     {
         return Eigen::Quaterniond::Identity();
     }
@@ -234,7 +234,7 @@ class TwoVectorFrame : public CachingFrame
                    int secAxis);
     ~TwoVectorFrame() override = default;
 
-    Eigen::Quaterniond computeOrientation(double tjd) const;
+    Eigen::Quaterniond computeOrientation(double tjd) const override;
     bool isInertial() const override;
     unsigned int nestingDepth(unsigned int depth,
                               unsigned int maxDepth,

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -11,41 +11,59 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <algorithm>
 #include "parseobject.h"
-#include "body.h"
-#include "frame.h"
-#include "trajmanager.h"
-#include "rotationmanager.h"
-#include "universe.h"
+
+#include <cassert>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
 #include <celastro/astro.h>
 #include <celastro/date.h>
 #include <celcompat/numbers.h>
 #include <celephem/customorbit.h>
 #include <celephem/customrotation.h>
+#include <celephem/orbit.h>
+#include <celephem/rotation.h>
+#include <celephem/samporbit.h>
+#include <celmath/geomutil.h>
+#include <celmath/mathlib.h>
+#include <celutil/fsutils.h>
+#include <celutil/logger.h>
+#include <celutil/stringutils.h>
+#include "body.h"
+#include "hash.h"
+#include "rotationmanager.h"
+#include "selection.h"
+#include "trajmanager.h"
+#include "universe.h"
+#include "value.h"
+
+#ifdef CELX
+#include <celephem/scriptorbit.h>
+#include <celephem/scriptrotation.h>
+#endif
+
 #ifdef USE_SPICE
 #include <celephem/spiceorbit.h>
 #include <celephem/spicerotation.h>
 #endif
-#include <celephem/scriptorbit.h>
-#include <celephem/scriptrotation.h>
-#include <celmath/geomutil.h>
-#include <celutil/fsutils.h>
-#include <celutil/logger.h>
-#include <celutil/stringutils.h>
-#include <cassert>
 
-using namespace Eigen;
-using namespace std;
 using celestia::ephem::TrajectoryInterpolation;
 using celestia::ephem::TrajectoryPrecision;
 using celestia::util::GetLogger;
 
 namespace astro = celestia::astro;
+namespace engine = celestia::engine;
 namespace ephem = celestia::ephem;
 namespace math = celestia::math;
 namespace numbers = celestia::numbers;
 namespace util = celestia::util;
+
+namespace
+{
 
 /**
  * Returns the default units scale for orbits.
@@ -58,7 +76,7 @@ namespace util = celestia::util;
  * @param[out] distanceScale The default distance scale in kilometers.
  * @param[out] timeScale The default time scale in days.
  */
-static void
+void
 GetDefaultUnits(bool usePlanetUnits, double& distanceScale, double& timeScale)
 {
     if(usePlanetUnits)
@@ -73,7 +91,6 @@ GetDefaultUnits(bool usePlanetUnits, double& distanceScale, double& timeScale)
     }
 }
 
-
 /**
  * Returns the default distance scale for orbits.
  *
@@ -83,36 +100,11 @@ GetDefaultUnits(bool usePlanetUnits, double& distanceScale, double& timeScale)
  * @param[in] usePlanetUnits Controls whether to return planet units or satellite units.
  * @param[out] distanceScale The default distance scale in kilometers.
  */
-static void
+void
 GetDefaultUnits(bool usePlanetUnits, double& distanceScale)
 {
     distanceScale = usePlanetUnits ? astro::KM_PER_AU<double> : 1.0;
 }
-
-
-bool
-ParseDate(const Hash* hash, const string& name, double& jd)
-{
-    // Check first for a number value representing a Julian date
-    if (auto jdVal = hash->getNumber<double>(name); jdVal.has_value())
-    {
-        jd = *jdVal;
-        return true;
-    }
-
-    if (const std::string* dateString = hash->getString(name); dateString != nullptr)
-    {
-        astro::Date date(1, 1, 1);
-        if (astro::parseDate(*dateString, date))
-        {
-            jd = (double) date;
-            return true;
-        }
-    }
-
-    return false;
-}
-
 
 /*!
  * Create a new Keplerian orbit from an ssc property table:
@@ -148,7 +140,7 @@ ParseDate(const Hash* hash, const string& name, double& jd)
  *     Period is in Julian days
  *     SemiMajorAxis or PericenterDistance is in kilometers.
  */
-static std::unique_ptr<ephem::Orbit>
+std::shared_ptr<const ephem::Orbit>
 CreateKeplerianOrbit(const Hash* orbitData,
                      bool usePlanetUnits)
 {
@@ -234,12 +226,11 @@ CreateKeplerianOrbit(const Hash* orbitData,
 
     if (elements.eccentricity < 1.0)
     {
-        return std::make_unique<ephem::EllipticalOrbit>(elements, epoch);
+        return std::make_shared<ephem::EllipticalOrbit>(elements, epoch);
     }
 
-    return std::make_unique<ephem::HyperbolicOrbit>(elements, epoch);
+    return std::make_shared<ephem::HyperbolicOrbit>(elements, epoch);
 }
-
 
 /*!
  * Create a new sampled orbit from an ssc property table:
@@ -254,7 +245,7 @@ CreateKeplerianOrbit(const Hash* orbitData,
  * Source is the only required field. Interpolation defaults to cubic, and
  * DoublePrecision defaults to true.
  */
-static ephem::Orbit*
+std::shared_ptr<const ephem::Orbit>
 CreateSampledTrajectory(const Hash* trajData, const fs::path& path)
 {
     const std::string* source = trajData->getString("Source");
@@ -289,16 +280,12 @@ CreateSampledTrajectory(const Hash* trajData, const fs::path& path)
     TrajectoryPrecision precision = useDoublePrecision ? TrajectoryPrecision::Double : TrajectoryPrecision::Single;
 
     GetLogger()->verbose("Attempting to load sampled trajectory from source '{}'\n", *source);
-    ResourceHandle orbitHandle = GetTrajectoryManager()->getHandle(TrajectoryInfo(*sourceFile, path, interpolation, precision));
-    ephem::Orbit* orbit = GetTrajectoryManager()->find(orbitHandle);
+    auto orbit = engine::trajectoryManager.find(*sourceFile, path, interpolation, precision);
     if (orbit == nullptr)
-    {
         GetLogger()->error("Could not load sampled trajectory from '{}'\n", *source);
-    }
 
     return orbit;
 }
-
 
 /** Create a new FixedPosition trajectory.
  *
@@ -313,18 +300,18 @@ CreateSampledTrajectory(const Hash* trajData, const fs::path& path)
  * and planetocentric coordinates are only practical when the coordinate system
  * is BodyFixed.
  */
-static std::unique_ptr<ephem::Orbit>
+std::shared_ptr<const ephem::Orbit>
 CreateFixedPosition(const Hash* trajData, const Selection& centralObject, bool usePlanetUnits)
 {
     double distanceScale;
     GetDefaultUnits(usePlanetUnits, distanceScale);
 
-    Vector3d position = Vector3d::Zero();
+    Eigen::Vector3d position = Eigen::Vector3d::Zero();
 
     if (auto rectangular = trajData->getLengthVector<double>("Rectangular", 1.0, distanceScale); rectangular.has_value())
     {
         // Convert to Celestia's coordinate system
-        position = Vector3d(rectangular->x(), rectangular->z(), -rectangular->y());
+        position = Eigen::Vector3d(rectangular->x(), rectangular->z(), -rectangular->y());
     }
     else if (auto planetographic = trajData->getSphericalTuple("Planetographic"); planetographic.has_value())
     {
@@ -359,18 +346,17 @@ CreateFixedPosition(const Hash* trajData, const Selection& centralObject, bool u
         return nullptr;
     }
 
-    return std::make_unique<ephem::FixedOrbit>(position);
+    return std::make_shared<ephem::FixedOrbit>(position);
 }
-
 
 #ifdef USE_SPICE
 /**
  * Parse a string list--either a single string or an array of strings is permitted.
  */
-static bool
+bool
 ParseStringList(const Hash* table,
-                const string& propertyName,
-                list<string>& stringList)
+                std::string_view propertyName,
+                std::vector<std::string>& stringList)
 {
     const Value* v = table->getValue(propertyName);
     if (v == nullptr)
@@ -382,10 +368,9 @@ ParseStringList(const Hash* table,
         stringList.emplace_back(*str);
         return true;
     }
+
     if (const ValueArray* array = v->getArray(); array != nullptr)
     {
-        ValueArray::const_iterator iter;
-
         // Verify that all array entries are strings
 
         if (std::any_of(array->begin(), array->end(), [](const Value& val) { return val.getType() != ValueType::StringType; }))
@@ -397,12 +382,9 @@ ParseStringList(const Hash* table,
 
         return true;
     }
-    else
-    {
-        return false;
-    }
-}
 
+    return false;
+}
 
 /*! Create a new SPICE orbit. This is just a Celestia wrapper for a trajectory specified
  *  in a SPICE SPK file.
@@ -433,12 +415,12 @@ ParseStringList(const Hash* table,
  *  kernel pool. If the coverage window is noncontiguous, the first interval is
  *  used.
  */
-static std::unique_ptr<ephem::SpiceOrbit>
+std::shared_ptr<const ephem::Orbit>
 CreateSpiceOrbit(const Hash* orbitData,
                  const fs::path& path,
                  bool usePlanetUnits)
 {
-    list<string> kernelList;
+    std::vector<std::string> kernelList;
     double distanceScale;
     double timeScale;
 
@@ -502,7 +484,7 @@ CreateSpiceOrbit(const Hash* orbitData,
         return nullptr;
     }
 
-    std::unique_ptr<ephem::SpiceOrbit> orbit = nullptr;
+    std::shared_ptr<ephem::SpiceOrbit> orbit = nullptr;
     if (beginningDate != nullptr && endingDate != nullptr)
     {
         double beginningTDBJD = 0.0;
@@ -519,7 +501,7 @@ CreateSpiceOrbit(const Hash* orbitData,
             return nullptr;
         }
 
-        orbit = std::make_unique<ephem::SpiceOrbit>(*targetBodyName,
+        orbit = std::make_shared<ephem::SpiceOrbit>(*targetBodyName,
                                                     *originName,
                                                     period,
                                                     boundingRadius,
@@ -530,7 +512,7 @@ CreateSpiceOrbit(const Hash* orbitData,
     {
         // No time interval given; we'll use whatever coverage window is given
         // in the SPICE kernel.
-        orbit = std::make_unique<ephem::SpiceOrbit>(*targetBodyName,
+        orbit = std::make_shared<ephem::SpiceOrbit>(*targetBodyName,
                                                     *originName,
                                                     period,
                                                     boundingRadius);
@@ -545,7 +527,6 @@ CreateSpiceOrbit(const Hash* orbitData,
 
     return orbit;
 }
-
 
 /*! Create a new rotation model based on a SPICE frame.
  *
@@ -575,11 +556,11 @@ CreateSpiceOrbit(const Hash* orbitData,
  *  period; it is only used by Celestia for displaying object information such
  *  as sidereal day length.
  */
-static std::unique_ptr<ephem::SpiceRotation>
+std::shared_ptr<ephem::SpiceRotation>
 CreateSpiceRotation(const Hash* rotationData,
                     const fs::path& path)
 {
-    std::list<std::string> kernelList;
+    std::vector<std::string> kernelList;
 
     if (rotationData->getValue("Kernel") != nullptr)
     {
@@ -630,7 +611,7 @@ CreateSpiceRotation(const Hash* rotationData,
         return nullptr;
     }
 
-    std::unique_ptr<ephem::SpiceRotation> rotation = nullptr;
+    std::shared_ptr<ephem::SpiceRotation> rotation = nullptr;
     if (beginningDate != nullptr && endingDate != nullptr)
     {
         double beginningTDBJD = 0.0;
@@ -647,7 +628,7 @@ CreateSpiceRotation(const Hash* rotationData,
             return nullptr;
         }
 
-        rotation = std::make_unique<ephem::SpiceRotation>(*frameName,
+        rotation = std::make_shared<ephem::SpiceRotation>(*frameName,
                                                           baseFrameName,
                                                           period,
                                                           beginningTDBJD,
@@ -656,7 +637,7 @@ CreateSpiceRotation(const Hash* rotationData,
     else
     {
         // No time interval given; rotation is valid at any time.
-        rotation = std::make_unique<ephem::SpiceRotation>(*frameName,
+        rotation = std::make_shared<ephem::SpiceRotation>(*frameName,
                                                           baseFrameName,
                                                           period);
     }
@@ -671,16 +652,11 @@ CreateSpiceRotation(const Hash* rotationData,
 }
 #endif
 
-
-static ephem::Orbit*
+std::shared_ptr<const ephem::Orbit>
 CreateScriptedOrbit(const Hash* orbitData,
                     const fs::path& path)
 {
-#if !defined(CELX)
-    GetLogger()->warn("ScriptedOrbit not usable without scripting support.\n");
-    return nullptr;
-#else
-
+#ifdef CELX
     // Function name is required
     const std::string* funcName = orbitData->getString("Function");
     if (funcName == nullptr)
@@ -695,183 +671,26 @@ CreateScriptedOrbit(const Hash* orbitData,
     //Value* pathValue = new Value(path.string());
     //orbitData->addValue("AddonPath", *pathValue);
 
-    return ephem::CreateScriptedOrbit(moduleName, *funcName, *orbitData, path).release();
-#endif
-}
-
-
-ephem::Orbit*
-CreateOrbit(const Selection& centralObject,
-            const Hash* planetData,
-            const fs::path& path,
-            bool usePlanetUnits)
-{
-    if (const std::string* customOrbitName = planetData->getString("CustomOrbit"); customOrbitName != nullptr)
-    {
-        if (auto orbit = ephem::GetCustomOrbit(*customOrbitName); orbit != nullptr)
-            return orbit.release();
-        GetLogger()->error("Could not find custom orbit named '{}'\n", *customOrbitName);
-    }
-
-    if (const Value* spiceOrbitDataValue = planetData->getValue("SpiceOrbit"); spiceOrbitDataValue != nullptr)
-    {
-#ifdef USE_SPICE
-        const Hash* spiceOrbitData = spiceOrbitDataValue->getHash();
-        if (spiceOrbitData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect spice orbit syntax.\n");
-            return nullptr;
-        }
-        else
-        {
-            auto orbit = CreateSpiceOrbit(spiceOrbitData, path, usePlanetUnits);
-            if (orbit != nullptr)
-            {
-                return orbit.release();
-            }
-            GetLogger()->error("Bad spice orbit\n");
-            GetLogger()->error("Could not load SPICE orbit\n");
-        }
+    return ephem::CreateScriptedOrbit(moduleName, *funcName, *orbitData, path);
 #else
-        GetLogger()->warn("Spice support is not enabled, ignoring SpiceOrbit definition\n");
-#endif
-    }
-
-    // Trajectory calculated by Lua script
-    if (const Value* scriptedOrbitValue = planetData->getValue("ScriptedOrbit"); scriptedOrbitValue != nullptr)
-    {
-        const Hash* scriptedOrbitData = scriptedOrbitValue->getHash();
-        if (scriptedOrbitData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect scripted orbit syntax.\n");
-            return nullptr;
-        }
-
-        auto orbit = CreateScriptedOrbit(scriptedOrbitData, path);
-        if (orbit != nullptr)
-            return orbit;
-    }
-
-    // New 1.5.0 style for sampled trajectories. Permits specification of
-    // precision and interpolation type.
-    if (const Value* sampledTrajDataValue = planetData->getValue("SampledTrajectory"); sampledTrajDataValue != nullptr)
-    {
-        const Hash* sampledTrajData = sampledTrajDataValue->getHash();
-        if (sampledTrajData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect syntax for SampledTrajectory.\n");
-            return nullptr;
-        }
-
-        return CreateSampledTrajectory(sampledTrajData, path);
-    }
-
-    // Old style for sampled trajectories. Assumes cubic interpolation and
-    // single precision.
-    if (const std::string* sampOrbitFile = planetData->getString("SampledOrbit"); sampOrbitFile != nullptr)
-    {
-        if (auto sampOrbitFileName = util::U8FileName(*sampOrbitFile); sampOrbitFileName.has_value())
-        {
-            GetLogger()->verbose("Attempting to load sampled orbit file '{}'\n", *sampOrbitFile);
-            ResourceHandle orbitHandle =
-                GetTrajectoryManager()->getHandle(TrajectoryInfo(*sampOrbitFileName,
-                                                                path,
-                                                                TrajectoryInterpolation::Cubic,
-                                                                TrajectoryPrecision::Single));
-            if (auto orbit = GetTrajectoryManager()->find(orbitHandle); orbit != nullptr)
-                return orbit;
-
-            GetLogger()->error("Could not load sampled orbit file '{}'\n", *sampOrbitFile);
-        }
-        else
-        {
-            GetLogger()->error("Invalid filename in SampledOrbit\n");
-        }
-    }
-
-    if (const Value* orbitDataValue = planetData->getValue("EllipticalOrbit"); orbitDataValue != nullptr)
-    {
-        const Hash* orbitData = orbitDataValue->getHash();
-        if (orbitData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect elliptical orbit syntax.\n");
-            return nullptr;
-        }
-
-        return CreateKeplerianOrbit(orbitData, usePlanetUnits).release();
-    }
-
-    // Create an 'orbit' that places the object at a fixed point in its
-    // reference frame. There are two forms for FixedPosition: a simple
-    // form with an 3-vector value, and complex form with a properlist
-    // value. The simple form:
-    //
-    // FixedPosition [ x y z ]
-    //
-    // is a shorthand for:
-    //
-    // FixedPosition { Rectangular [ x y z ] }
-    //
-    // In addition to Rectangular, other coordinate types for fixed position are
-    // Planetographic and Planetocentric.
-    if (const Value* fixedPositionValue = planetData->getValue("FixedPosition"); fixedPositionValue != nullptr)
-    {
-        double distanceScale;
-        GetDefaultUnits(usePlanetUnits, distanceScale);
-
-        if (auto fixed = planetData->getLengthVector<double>("FixedPosition", 1.0, distanceScale); fixed.has_value())
-        {
-            // Convert to Celestia's coordinate system
-            Eigen::Vector3d fixedPosition(fixed->x(), fixed->z(), -fixed->y());
-            return new ephem::FixedOrbit(fixedPosition);
-        }
-
-        if (auto fixedPositionData = fixedPositionValue->getHash(); fixedPositionData != nullptr)
-        {
-            return CreateFixedPosition(fixedPositionData, centralObject, usePlanetUnits).release();
-        }
-
-        GetLogger()->error("Object has incorrect FixedPosition syntax.\n");
-    }
-
-    // LongLat will make an object fixed relative to the surface of its center
-    // object. This is done by creating an orbit with a period equal to the
-    // rotation rate of the parent object. A body-fixed reference frame is a
-    // much better way to accomplish this.
-    if (auto longlat = planetData->getSphericalTuple("LongLat"); longlat.has_value())
-    {
-        Body* centralBody = centralObject.body();
-        if (centralBody != nullptr)
-        {
-#if 0 // TODO: This should be enabled after #542 is fixed
-            Vector3d pos = centralBody->geodeticToCartesian(*longlat);
-#else
-            Vector3d pos = centralBody->planetocentricToCartesian(longlat->x(), longlat->y(), longlat->z());
-#endif
-            return new ephem::SynchronousOrbit(*centralBody, pos);
-        }
-        // TODO: Allow fixing objects to the surface of stars.
-        return nullptr;
-    }
-
+    GetLogger()->warn("ScriptedOrbit not usable without scripting support.\n");
     return nullptr;
+#endif
 }
 
-
-static std::unique_ptr<ephem::ConstantOrientation>
+std::shared_ptr<const ephem::ConstantOrientation>
 CreateFixedRotationModel(double offset,
                          double inclination,
                          double ascendingNode)
 {
-    Quaterniond q = math::YRotation(-numbers::pi - offset) *
-                    math::XRotation(-inclination) *
-                    math::YRotation(-ascendingNode);
+    Eigen::Quaterniond q = math::YRotation(-numbers::pi - offset) *
+                           math::XRotation(-inclination) *
+                           math::YRotation(-ascendingNode);
 
-    return std::make_unique<ephem::ConstantOrientation>(q);
+    return std::make_shared<ephem::ConstantOrientation>(q);
 }
 
-
-static std::unique_ptr<ephem::RotationModel>
+std::shared_ptr<const ephem::RotationModel>
 CreateUniformRotationModel(const Hash* rotationData,
                            double syncRotationPeriod)
 {
@@ -891,51 +710,44 @@ CreateUniformRotationModel(const Hash* rotationData,
     // doesn't have a periodic orbit. Default to a constant
     // orientation instead.
     if (period == 0.0)
-    {
         return CreateFixedRotationModel(offset, inclination, ascendingNode);
-    }
-    else
-    {
-        return std::make_unique<ephem::UniformRotationModel>(period,
-                                                             static_cast<float>(offset),
-                                                             epoch,
-                                                             static_cast<float>(inclination),
-                                                             static_cast<float>(ascendingNode));
-    }
+
+    return std::make_shared<ephem::UniformRotationModel>(period,
+                                                         static_cast<float>(offset),
+                                                         epoch,
+                                                         static_cast<float>(inclination),
+                                                         static_cast<float>(ascendingNode));
 }
 
-
-static std::unique_ptr<ephem::ConstantOrientation>
+std::shared_ptr<const ephem::RotationModel>
 CreateFixedRotationModel(const Hash* rotationData)
 {
     auto offset = math::degToRad(rotationData->getAngle<double>("MeridianAngle").value_or(0.0));
     auto inclination = math::degToRad(rotationData->getAngle<double>("Inclination").value_or(0.0));
     auto ascendingNode = math::degToRad(rotationData->getAngle<double>("AscendingNode").value_or(0.0));
 
-    Quaterniond q = math::YRotation(-numbers::pi - offset) *
-                    math::XRotation(-inclination) *
-                    math::YRotation(-ascendingNode);
+    Eigen::Quaterniond q = math::YRotation(-numbers::pi - offset) *
+                           math::XRotation(-inclination) *
+                           math::YRotation(-ascendingNode);
 
-    return std::make_unique<ephem::ConstantOrientation>(q);
+    return std::make_shared<ephem::ConstantOrientation>(q);
 }
 
-
-static std::unique_ptr<ephem::ConstantOrientation>
+std::shared_ptr<const ephem::RotationModel>
 CreateFixedAttitudeRotationModel(const Hash* rotationData)
 {
     auto heading = math::degToRad(rotationData->getAngle<double>("Heading").value_or(0.0));
     auto tilt = math::degToRad(rotationData->getAngle<double>("Tilt").value_or(0.0));
     auto roll = math::degToRad(rotationData->getAngle<double>("Roll").value_or(0.0));
 
-    Quaterniond q = math::YRotation(-numbers::pi - heading) *
-                    math::XRotation(-tilt) *
-                    math::ZRotation(-roll);
+    Eigen::Quaterniond q = math::YRotation(-numbers::pi - heading) *
+                           math::XRotation(-tilt) *
+                           math::ZRotation(-roll);
 
-    return std::make_unique<ephem::ConstantOrientation>(q);
+    return std::make_shared<ephem::ConstantOrientation>(q);
 }
 
-
-static std::unique_ptr<ephem::RotationModel>
+std::shared_ptr<const ephem::RotationModel>
 CreatePrecessingRotationModel(const Hash* rotationData,
                               double syncRotationPeriod)
 {
@@ -954,7 +766,6 @@ CreatePrecessingRotationModel(const Hash* rotationData,
     // that there's no precession.
     auto precessionPeriod = rotationData->getTime<double>("PrecessionPeriod", 1.0, astro::DAYS_PER_YEAR).value_or(0.0);
 
-
     // No period was specified, and the default synchronous
     // rotation period is zero, indicating that the object
     // doesn't have a periodic orbit. Default to a constant
@@ -963,26 +774,20 @@ CreatePrecessingRotationModel(const Hash* rotationData,
     {
         return CreateFixedRotationModel(offset, inclination, ascendingNode);
     }
-    else
-    {
-        return std::make_unique<ephem::PrecessingRotationModel>(period,
-                                                                static_cast<float>(offset),
-                                                                epoch,
-                                                                static_cast<float>(inclination),
-                                                                static_cast<float>(ascendingNode),
-                                                                precessionPeriod);
-    }
+
+    return std::make_shared<ephem::PrecessingRotationModel>(period,
+                                                            static_cast<float>(offset),
+                                                            epoch,
+                                                            static_cast<float>(inclination),
+                                                            static_cast<float>(ascendingNode),
+                                                            precessionPeriod);
 }
 
-
-static std::unique_ptr<ephem::RotationModel>
+std::shared_ptr<const ephem::RotationModel>
 CreateScriptedRotation(const Hash* rotationData,
                        const fs::path& path)
 {
-#if !defined(CELX)
-    GetLogger()->warn("ScriptedRotation not usable without scripting support.\n");
-    return nullptr;
-#else
+#ifdef CELX
 
     // Function name is required
     const std::string* funcName = rotationData->getString("Function");
@@ -999,257 +804,17 @@ CreateScriptedRotation(const Hash* rotationData,
     //rotationData->addValue("AddonPath", *pathValue);
 
     return ephem::CreateScriptedRotation(moduleName, *funcName, *rotationData, path);
-#endif
-}
-
-
-/**
- * Parse rotation information. Unfortunately, Celestia didn't originally have
- * RotationModel objects, so information about the rotation of the object isn't
- * grouped into a single subobject--the ssc fields relevant for rotation just
- * appear in the top level structure.
- */
-ephem::RotationModel*
-CreateRotationModel(const Hash* planetData,
-                    const fs::path& path,
-                    double syncRotationPeriod)
-{
-    // If more than one rotation model is specified, the following precedence
-    // is used to determine which one should be used:
-    //   CustomRotation
-    //   SPICE C-Kernel
-    //   SampledOrientation
-    //   PrecessingRotation
-    //   UniformRotation
-    //   legacy rotation parameters
-    if (const std::string* customRotationModelName = planetData->getString("CustomRotation"); customRotationModelName != nullptr)
-    {
-        if (auto rotationModel = ephem::GetCustomRotationModel(*customRotationModelName);
-            rotationModel != nullptr)
-        {
-            return rotationModel;
-        }
-        GetLogger()->error("Could not find custom rotation model named '{}'\n",
-                           *customRotationModelName);
-    }
-
-    if (const Value* spiceRotationDataValue = planetData->getValue("SpiceRotation"); spiceRotationDataValue != nullptr)
-    {
-#ifdef USE_SPICE
-        const Hash* spiceRotationData = spiceRotationDataValue->getHash();
-        if (spiceRotationData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect spice rotation syntax.\n");
-            return nullptr;
-        }
-        else
-        {
-            if (auto rotationModel = CreateSpiceRotation(spiceRotationData, path); rotationModel != nullptr)
-            {
-                return rotationModel.release();
-            }
-            GetLogger()->error("Bad spice rotation model\nCould not load SPICE rotation model\n");
-        }
 #else
-        GetLogger()->warn("Spice support is not enabled, ignoring SpiceRotation definition\n");
+    GetLogger()->warn("ScriptedRotation not usable without scripting support.\n");
+    return nullptr;
 #endif
-    }
-
-    if (const Value* scriptedRotationValue = planetData->getValue("ScriptedRotation"); scriptedRotationValue != nullptr)
-    {
-        const Hash* scriptedRotationData = scriptedRotationValue->getHash();
-        if (scriptedRotationData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect scripted rotation syntax.\n");
-            return nullptr;
-        }
-
-        if (auto rotationModel = CreateScriptedRotation(scriptedRotationData, path); rotationModel != nullptr)
-            return rotationModel.release();
-
-    }
-
-    if (const std::string* sampOrientationFile = planetData->getString("SampledOrientation"); sampOrientationFile != nullptr)
-    {
-        if (auto sampOrientationFileName = util::U8FileName(*sampOrientationFile); sampOrientationFileName.has_value())
-        {
-            GetLogger()->verbose("Attempting to load orientation file '{}'\n", *sampOrientationFile);
-            ResourceHandle orientationHandle =
-                GetRotationModelManager()->getHandle(RotationModelInfo(*sampOrientationFileName, path));
-            if (auto rotationModel = GetRotationModelManager()->find(orientationHandle); rotationModel != nullptr)
-            {
-                return rotationModel;
-            }
-
-            GetLogger()->error("Could not load rotation model file '{}'\n", *sampOrientationFile);
-        }
-        else
-        {
-            GetLogger()->error("Invalid filename in SampledOrientation\n");
-        }
-    }
-
-    if (const Value* precessingRotationValue = planetData->getValue("PrecessingRotation"); precessingRotationValue != nullptr)
-    {
-        const Hash* precessingRotationData = precessingRotationValue->getHash();
-        if (precessingRotationData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect syntax for precessing rotation.\n");
-            return nullptr;
-        }
-
-        return CreatePrecessingRotationModel(precessingRotationData,
-                                             syncRotationPeriod).release();
-    }
-
-    if (const Value* uniformRotationValue = planetData->getValue("UniformRotation"); uniformRotationValue != nullptr)
-    {
-        const Hash* uniformRotationData = uniformRotationValue->getHash();
-        if (uniformRotationData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect UniformRotation syntax.\n");
-            return nullptr;
-        }
-        return CreateUniformRotationModel(uniformRotationData,
-                                          syncRotationPeriod).release();
-    }
-
-    if (const Value* fixedRotationValue = planetData->getValue("FixedRotation"); fixedRotationValue != nullptr)
-    {
-        const Hash* fixedRotationData = fixedRotationValue->getHash();
-        if (fixedRotationData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect FixedRotation syntax.\n");
-            return nullptr;
-        }
-
-        return CreateFixedRotationModel(fixedRotationData).release();
-    }
-
-    if (const Value* fixedAttitudeValue = planetData->getValue("FixedAttitude"); fixedAttitudeValue != nullptr)
-    {
-        const Hash* fixedAttitudeData = fixedAttitudeValue->getHash();
-        if (fixedAttitudeData == nullptr)
-        {
-            GetLogger()->error("Object has incorrect FixedAttitude syntax.\n");
-            return nullptr;
-        }
-
-        return CreateFixedAttitudeRotationModel(fixedAttitudeData).release();
-    }
-
-    // For backward compatibility we need to support rotation parameters
-    // that appear in the main block of the object definition.
-    // Default to synchronous rotation
-    bool specified = false;
-    double period = syncRotationPeriod;
-    if (auto periodVal = planetData->getNumber<double>("RotationPeriod"); periodVal.has_value())
-    {
-        specified = true;
-        period = *periodVal / 24.0;
-    }
-
-    float offset = 0.0f;
-    if (auto offsetVal = planetData->getNumber<float>("RotationOffset"); offsetVal.has_value())
-    {
-        specified = true;
-        offset = math::degToRad(*offsetVal);
-    }
-
-    double epoch = astro::J2000;
-    if (ParseDate(planetData, "RotationEpoch", epoch))
-    {
-        specified = true;
-    }
-
-    float inclination = 0.0f;
-    if (auto inclinationVal = planetData->getNumber<float>("Obliquity"); inclinationVal.has_value())
-    {
-        specified = true;
-        inclination = math::degToRad(*inclinationVal);
-    }
-
-    float ascendingNode = 0.0f;
-    if (auto ascendingNodeVal = planetData->getNumber<float>("EquatorAscendingNode"); ascendingNodeVal.has_value())
-    {
-        specified = true;
-        ascendingNode = math::degToRad(*ascendingNodeVal);
-    }
-
-    double precessionRate = 0.0f;
-    if (auto precessionVal = planetData->getNumber<double>("PrecessionRate"); precessionVal.has_value())
-    {
-        specified = true;
-        precessionRate = *precessionVal;
-    }
-
-    if (specified)
-    {
-        std::unique_ptr<ephem::RotationModel> rm = nullptr;
-        if (period == 0.0)
-        {
-            // No period was specified, and the default synchronous
-            // rotation period is zero, indicating that the object
-            // doesn't have a periodic orbit. Default to a constant
-            // orientation instead.
-            rm = CreateFixedRotationModel(offset, inclination, ascendingNode);
-        }
-        else if (precessionRate == 0.0)
-        {
-            rm = std::make_unique<ephem::UniformRotationModel>(period,
-                                                               offset,
-                                                               epoch,
-                                                               inclination,
-                                                               ascendingNode);
-        }
-        else
-        {
-            rm = std::make_unique<ephem::PrecessingRotationModel>(period,
-                                                                  offset,
-                                                                  epoch,
-                                                                  inclination,
-                                                                  ascendingNode,
-                                                                  -360.0 / precessionRate);
-        }
-
-        return rm.release();
-    }
-    else
-    {
-        // No rotation fields specified
-        return nullptr;
-    }
 }
-
-
-ephem::RotationModel*
-CreateDefaultRotationModel(double syncRotationPeriod)
-{
-    std::unique_ptr<ephem::RotationModel> rotation;
-    if (syncRotationPeriod == 0.0)
-    {
-        // If syncRotationPeriod is 0, the orbit of the object is
-        // aperiodic and we'll just return a FixedRotation.
-        rotation = std::make_unique<ephem::ConstantOrientation>(Quaterniond::Identity());
-    }
-    else
-    {
-        rotation = std::make_unique<ephem::UniformRotationModel>(syncRotationPeriod,
-                                                                 0.0f,
-                                                                 astro::J2000,
-                                                                 0.0f,
-                                                                 0.0f);
-    }
-
-    return rotation.release();
-}
-
 
 /**
  * Get the center object of a frame definition. Return an empty selection
  * if it's missing or refers to an object that doesn't exist.
  */
-static Selection
+Selection
 getFrameCenter(const Universe& universe, const Hash* frameData, const Selection& defaultCenter)
 {
     const std::string* centerName = frameData->getString("Center");
@@ -1274,8 +839,7 @@ getFrameCenter(const Universe& universe, const Hash* frameData, const Selection&
     return centerObject;
 }
 
-
-static BodyFixedFrame::SharedConstPtr
+BodyFixedFrame::SharedConstPtr
 CreateBodyFixedFrame(const Universe& universe,
                      const Hash* frameData,
                      const Selection& defaultCenter)
@@ -1284,11 +848,10 @@ CreateBodyFixedFrame(const Universe& universe,
     if (center.empty())
         return nullptr;
 
-    return shared_ptr<BodyFixedFrame>(new BodyFixedFrame(center, center));
+    return std::make_shared<BodyFixedFrame>(center, center);
 }
 
-
-static BodyMeanEquatorFrame::SharedConstPtr
+BodyMeanEquatorFrame::SharedConstPtr
 CreateMeanEquatorFrame(const Universe& universe,
                        const Hash* frameData,
                        const Selection& defaultCenter)
@@ -1310,26 +873,18 @@ CreateMeanEquatorFrame(const Universe& universe,
 
     GetLogger()->debug("CreateMeanEquatorFrame {}, {}\n", center.getName(), obj.getName());
 
-    double freezeEpoch = 0.0;
-    BodyMeanEquatorFrame *ptr;
-    if (ParseDate(frameData, "Freeze", freezeEpoch))
-    {
-        ptr = new BodyMeanEquatorFrame(center, obj, freezeEpoch);
-    }
-    else
-    {
-        ptr = new BodyMeanEquatorFrame(center, obj);
-    }
-    return shared_ptr<BodyMeanEquatorFrame>(ptr);
-}
+    if (double freezeEpoch = 0.0; ParseDate(frameData, "Freeze", freezeEpoch))
+        return std::make_shared<BodyMeanEquatorFrame>(center, obj, freezeEpoch);
 
+    return std::make_shared<BodyMeanEquatorFrame>(center, obj);
+}
 
 /**
  * Convert a string to an axis label. Permitted axis labels are
  * x, y, z, -x, -y, and -z. +x, +y, and +z are allowed as synonyms for
  * x, y, z. Case is ignored.
  */
-static int
+int
 parseAxisLabel(const std::string& label)
 {
     if (compareIgnoringCase(label, "x") == 0 ||
@@ -1368,8 +923,7 @@ parseAxisLabel(const std::string& label)
     return 0;
 }
 
-
-static int
+int
 getAxis(const Hash* vectorData)
 {
     const std::string* axisLabel = vectorData->getString("Axis");
@@ -1404,12 +958,11 @@ getAxis(const Hash* vectorData)
     return axis;
 }
 
-
 /**
  * Get the target object of a direction vector definition. Return an
  * empty selection if it's missing or refers to an object that doesn't exist.
  */
-static Selection
+Selection
 getVectorTarget(const Universe& universe, const Hash* vectorData)
 {
     const std::string* targetName = vectorData->getString("Target");
@@ -1430,12 +983,11 @@ getVectorTarget(const Universe& universe, const Hash* vectorData)
     return targetObject;
 }
 
-
 /**
  * Get the observer object of a direction vector definition. Return an
  * empty selection if it's missing or refers to an object that doesn't exist.
  */
-static Selection
+Selection
 getVectorObserver(const Universe& universe, const Hash* vectorData)
 {
     const std::string* obsName = vectorData->getString("Observer");
@@ -1457,8 +1009,7 @@ getVectorObserver(const Universe& universe, const Hash* vectorData)
     return obsObject;
 }
 
-
-static std::unique_ptr<FrameVector>
+std::unique_ptr<FrameVector>
 CreateFrameVector(const Universe& universe,
                   const Selection& center,
                   const Hash* vectorData)
@@ -1501,14 +1052,14 @@ CreateFrameVector(const Universe& universe,
     {
         if (const Hash* constVecData = value->getHash(); constVecData != nullptr)
         {
-            auto vec = constVecData->getVector3<double>("Vector").value_or(Vector3d::UnitZ());
+            auto vec = constVecData->getVector3<double>("Vector").value_or(Eigen::Vector3d::UnitZ());
             if (vec.norm() == 0.0)
             {
                 GetLogger()->error("Bad two-vector frame: constant vector has length zero\n");
                 return nullptr;
             }
             vec.normalize();
-            vec = Vector3d(vec.x(), vec.z(), -vec.y());
+            vec = Eigen::Vector3d(vec.x(), vec.z(), -vec.y());
 
             // The frame for the vector is optional; a nullptr frame indicates
             // J2000 ecliptic.
@@ -1528,8 +1079,7 @@ CreateFrameVector(const Universe& universe,
     return nullptr;
 }
 
-
-static shared_ptr<const TwoVectorFrame>
+std::shared_ptr<const TwoVectorFrame>
 CreateTwoVectorFrame(const Universe& universe,
                      const Hash* frameData,
                      const Selection& defaultCenter)
@@ -1571,25 +1121,21 @@ CreateTwoVectorFrame(const Universe& universe,
     int primaryAxis = getAxis(primaryData);
     int secondaryAxis = getAxis(secondaryData);
 
-    assert(abs(primaryAxis) <= 3);
-    assert(abs(secondaryAxis) <= 3);
+    assert(std::abs(primaryAxis) <= 3);
+    assert(std::abs(secondaryAxis) <= 3);
     if (primaryAxis == 0 || secondaryAxis == 0)
     {
         return nullptr;
     }
 
-    if (abs(primaryAxis) == abs(secondaryAxis))
+    if (std::abs(primaryAxis) == std::abs(secondaryAxis))
     {
         GetLogger()->error("Bad two-vector frame: axes for vectors are collinear.\n");
         return nullptr;
     }
 
-    std::unique_ptr<FrameVector> primaryVector = CreateFrameVector(universe,
-                                                                   center,
-                                                                   primaryData);
-    std::unique_ptr<FrameVector> secondaryVector = CreateFrameVector(universe,
-                                                                     center,
-                                                                     secondaryData);
+    auto primaryVector = CreateFrameVector(universe, center, primaryData);
+    auto secondaryVector = CreateFrameVector(universe, center, secondaryData);
 
     if (primaryVector != nullptr && secondaryVector != nullptr)
     {
@@ -1603,8 +1149,7 @@ CreateTwoVectorFrame(const Universe& universe,
     return nullptr;
 }
 
-
-static shared_ptr<const J2000EclipticFrame>
+std::shared_ptr<const J2000EclipticFrame>
 CreateJ2000EclipticFrame(const Universe& universe,
                          const Hash* frameData,
                          const Selection& defaultCenter)
@@ -1614,11 +1159,10 @@ CreateJ2000EclipticFrame(const Universe& universe,
     if (center.empty())
         return nullptr;
 
-    return shared_ptr<J2000EclipticFrame>(new J2000EclipticFrame(center));
+    return std::make_shared<J2000EclipticFrame>(center);
 }
 
-
-static shared_ptr<const J2000EquatorFrame>
+std::shared_ptr<const J2000EquatorFrame>
 CreateJ2000EquatorFrame(const Universe& universe,
                         const Hash* frameData,
                         const Selection& defaultCenter)
@@ -1628,26 +1172,8 @@ CreateJ2000EquatorFrame(const Universe& universe,
     if (center.empty())
         return nullptr;
 
-    return shared_ptr<J2000EquatorFrame>(new J2000EquatorFrame(center));
+    return std::make_shared<J2000EquatorFrame>(center);
 }
-
-
-/**
- * Helper function for CreateTopocentricFrame().
- * Creates a two-vector frame with the specified center, target, and observer.
- */
-shared_ptr<const TwoVectorFrame>
-CreateTopocentricFrame(const Selection& center,
-                       const Selection& target,
-                       const Selection& observer)
-{
-    auto eqFrame = shared_ptr<BodyMeanEquatorFrame>(new BodyMeanEquatorFrame(target, target));
-    FrameVector north = FrameVector::createConstantVector(Vector3d::UnitY(), eqFrame);
-    FrameVector up = FrameVector::createRelativePositionVector(observer, target);
-
-    return shared_ptr<TwoVectorFrame>(new TwoVectorFrame(center, up, -2, north, -3));
-}
-
 
 /**
  * Create a new Topocentric frame. The topocentric frame is designed to make it easy
@@ -1689,7 +1215,7 @@ CreateTopocentricFrame(const Selection& center,
  *     ...
  * } </pre>
  */
-static shared_ptr<const TwoVectorFrame>
+std::shared_ptr<const TwoVectorFrame>
 CreateTopocentricFrame(const Universe& universe,
                        const Hash* frameData,
                        const Selection& defaultTarget,
@@ -1767,8 +1293,7 @@ CreateTopocentricFrame(const Universe& universe,
     return CreateTopocentricFrame(center, target, observer);
 }
 
-
-static ReferenceFrame::SharedConstPtr
+ReferenceFrame::SharedConstPtr
 CreateComplexFrame(const Universe& universe, const Hash* frameData, const Selection& defaultCenter, Body* defaultObserver)
 {
     if (const Value* value = frameData->getValue("BodyFixed"); value != nullptr)
@@ -1848,6 +1373,433 @@ CreateComplexFrame(const Universe& universe, const Hash* frameData, const Select
     return nullptr;
 }
 
+} // end unnamed namespace
+
+bool
+ParseDate(const Hash* hash, std::string_view name, double& jd)
+{
+    // Check first for a number value representing a Julian date
+    if (auto jdVal = hash->getNumber<double>(name); jdVal.has_value())
+    {
+        jd = *jdVal;
+        return true;
+    }
+
+    if (const std::string* dateString = hash->getString(name); dateString != nullptr)
+    {
+        astro::Date date(1, 1, 1);
+        if (astro::parseDate(*dateString, date))
+        {
+            jd = (double) date;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+std::shared_ptr<const ephem::Orbit>
+CreateOrbit(const Selection& centralObject,
+            const Hash* planetData,
+            const fs::path& path,
+            bool usePlanetUnits)
+{
+    if (const std::string* customOrbitName = planetData->getString("CustomOrbit"); customOrbitName != nullptr)
+    {
+        if (auto orbit = ephem::GetCustomOrbit(*customOrbitName); orbit != nullptr)
+            return orbit;
+        GetLogger()->error("Could not find custom orbit named '{}'\n", *customOrbitName);
+    }
+
+    if (const Value* spiceOrbitDataValue = planetData->getValue("SpiceOrbit"); spiceOrbitDataValue != nullptr)
+    {
+#ifdef USE_SPICE
+        const Hash* spiceOrbitData = spiceOrbitDataValue->getHash();
+        if (spiceOrbitData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect spice orbit syntax.\n");
+            return nullptr;
+        }
+        else
+        {
+            auto orbit = CreateSpiceOrbit(spiceOrbitData, path, usePlanetUnits);
+            if (orbit != nullptr)
+                return orbit;
+
+            GetLogger()->error("Bad spice orbit\n");
+            GetLogger()->error("Could not load SPICE orbit\n");
+        }
+#else
+        GetLogger()->warn("Spice support is not enabled, ignoring SpiceOrbit definition\n");
+#endif
+    }
+
+    // Trajectory calculated by Lua script
+    if (const Value* scriptedOrbitValue = planetData->getValue("ScriptedOrbit"); scriptedOrbitValue != nullptr)
+    {
+        const Hash* scriptedOrbitData = scriptedOrbitValue->getHash();
+        if (scriptedOrbitData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect scripted orbit syntax.\n");
+            return nullptr;
+        }
+
+        auto orbit = CreateScriptedOrbit(scriptedOrbitData, path);
+        if (orbit != nullptr)
+            return orbit;
+    }
+
+    // New 1.5.0 style for sampled trajectories. Permits specification of
+    // precision and interpolation type.
+    if (const Value* sampledTrajDataValue = planetData->getValue("SampledTrajectory"); sampledTrajDataValue != nullptr)
+    {
+        const Hash* sampledTrajData = sampledTrajDataValue->getHash();
+        if (sampledTrajData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect syntax for SampledTrajectory.\n");
+            return nullptr;
+        }
+
+        return CreateSampledTrajectory(sampledTrajData, path);
+    }
+
+    // Old style for sampled trajectories. Assumes cubic interpolation and
+    // single precision.
+    if (const std::string* sampOrbitFile = planetData->getString("SampledOrbit"); sampOrbitFile != nullptr)
+    {
+        if (auto sampOrbitFileName = util::U8FileName(*sampOrbitFile); sampOrbitFileName.has_value())
+        {
+            GetLogger()->verbose("Attempting to load sampled orbit file '{}'\n", *sampOrbitFile);
+            if (auto orbit = engine::trajectoryManager.find(*sampOrbitFileName,
+                                                            path,
+                                                            TrajectoryInterpolation::Cubic,
+                                                            TrajectoryPrecision::Single);
+                orbit != nullptr)
+            {
+                return orbit;
+            }
+
+            GetLogger()->error("Could not load sampled orbit file '{}'\n", *sampOrbitFile);
+        }
+        else
+        {
+            GetLogger()->error("Invalid filename in SampledOrbit\n");
+        }
+    }
+
+    if (const Value* orbitDataValue = planetData->getValue("EllipticalOrbit"); orbitDataValue != nullptr)
+    {
+        const Hash* orbitData = orbitDataValue->getHash();
+        if (orbitData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect elliptical orbit syntax.\n");
+            return nullptr;
+        }
+
+        return CreateKeplerianOrbit(orbitData, usePlanetUnits);
+    }
+
+    // Create an 'orbit' that places the object at a fixed point in its
+    // reference frame. There are two forms for FixedPosition: a simple
+    // form with an 3-vector value, and complex form with a properlist
+    // value. The simple form:
+    //
+    // FixedPosition [ x y z ]
+    //
+    // is a shorthand for:
+    //
+    // FixedPosition { Rectangular [ x y z ] }
+    //
+    // In addition to Rectangular, other coordinate types for fixed position are
+    // Planetographic and Planetocentric.
+    if (const Value* fixedPositionValue = planetData->getValue("FixedPosition"); fixedPositionValue != nullptr)
+    {
+        double distanceScale;
+        GetDefaultUnits(usePlanetUnits, distanceScale);
+
+        if (auto fixed = planetData->getLengthVector<double>("FixedPosition", 1.0, distanceScale); fixed.has_value())
+        {
+            // Convert to Celestia's coordinate system
+            Eigen::Vector3d fixedPosition(fixed->x(), fixed->z(), -fixed->y());
+            return std::make_shared<ephem::FixedOrbit>(fixedPosition);
+        }
+
+        if (auto fixedPositionData = fixedPositionValue->getHash(); fixedPositionData != nullptr)
+        {
+            return CreateFixedPosition(fixedPositionData, centralObject, usePlanetUnits);
+        }
+
+        GetLogger()->error("Object has incorrect FixedPosition syntax.\n");
+    }
+
+    // LongLat will make an object fixed relative to the surface of its center
+    // object. This is done by creating an orbit with a period equal to the
+    // rotation rate of the parent object. A body-fixed reference frame is a
+    // much better way to accomplish this.
+    if (auto longlat = planetData->getSphericalTuple("LongLat"); longlat.has_value())
+    {
+        Body* centralBody = centralObject.body();
+        if (centralBody != nullptr)
+        {
+#if 0 // TODO: This should be enabled after #542 is fixed
+            Eigen::Vector3d pos = centralBody->geodeticToCartesian(*longlat);
+#else
+            Eigen::Vector3d pos = centralBody->planetocentricToCartesian(longlat->x(), longlat->y(), longlat->z());
+#endif
+            return std::make_shared<ephem::SynchronousOrbit>(*centralBody, pos);
+        }
+        // TODO: Allow fixing objects to the surface of stars.
+        return nullptr;
+    }
+
+    return nullptr;
+}
+
+/**
+ * Parse rotation information. Unfortunately, Celestia didn't originally have
+ * RotationModel objects, so information about the rotation of the object isn't
+ * grouped into a single subobject--the ssc fields relevant for rotation just
+ * appear in the top level structure.
+ */
+std::shared_ptr<const ephem::RotationModel>
+CreateRotationModel(const Hash* planetData,
+                    const fs::path& path,
+                    double syncRotationPeriod)
+{
+    // If more than one rotation model is specified, the following precedence
+    // is used to determine which one should be used:
+    //   CustomRotation
+    //   SPICE C-Kernel
+    //   SampledOrientation
+    //   PrecessingRotation
+    //   UniformRotation
+    //   legacy rotation parameters
+    if (const std::string* customRotationModelName = planetData->getString("CustomRotation"); customRotationModelName != nullptr)
+    {
+        if (auto rotationModel = ephem::GetCustomRotationModel(*customRotationModelName);
+            rotationModel != nullptr)
+        {
+            return rotationModel;
+        }
+        GetLogger()->error("Could not find custom rotation model named '{}'\n",
+                           *customRotationModelName);
+    }
+
+    if (const Value* spiceRotationDataValue = planetData->getValue("SpiceRotation"); spiceRotationDataValue != nullptr)
+    {
+#ifdef USE_SPICE
+        const Hash* spiceRotationData = spiceRotationDataValue->getHash();
+        if (spiceRotationData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect spice rotation syntax.\n");
+            return nullptr;
+        }
+        else
+        {
+            if (auto rotationModel = CreateSpiceRotation(spiceRotationData, path); rotationModel != nullptr)
+                return rotationModel;
+
+            GetLogger()->error("Bad spice rotation model\nCould not load SPICE rotation model\n");
+        }
+#else
+        GetLogger()->warn("Spice support is not enabled, ignoring SpiceRotation definition\n");
+#endif
+    }
+
+    if (const Value* scriptedRotationValue = planetData->getValue("ScriptedRotation"); scriptedRotationValue != nullptr)
+    {
+        const Hash* scriptedRotationData = scriptedRotationValue->getHash();
+        if (scriptedRotationData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect scripted rotation syntax.\n");
+            return nullptr;
+        }
+
+        if (auto rotationModel = CreateScriptedRotation(scriptedRotationData, path); rotationModel != nullptr)
+            return rotationModel;
+
+    }
+
+    if (const std::string* sampOrientationFile = planetData->getString("SampledOrientation"); sampOrientationFile != nullptr)
+    {
+        if (auto sampOrientationFileName = util::U8FileName(*sampOrientationFile); sampOrientationFileName.has_value())
+        {
+            GetLogger()->verbose("Attempting to load orientation file '{}'\n", *sampOrientationFile);
+
+            if (auto rotationModel = engine::rotationModelManager.find(*sampOrientationFile, path);
+                rotationModel != nullptr)
+            {
+                return rotationModel;
+            }
+
+            GetLogger()->error("Could not load rotation model file '{}'\n", *sampOrientationFile);
+        }
+        else
+        {
+            GetLogger()->error("Invalid filename in SampledOrientation\n");
+        }
+    }
+
+    if (const Value* precessingRotationValue = planetData->getValue("PrecessingRotation"); precessingRotationValue != nullptr)
+    {
+        const Hash* precessingRotationData = precessingRotationValue->getHash();
+        if (precessingRotationData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect syntax for precessing rotation.\n");
+            return nullptr;
+        }
+
+        return CreatePrecessingRotationModel(precessingRotationData,
+                                             syncRotationPeriod);
+    }
+
+    if (const Value* uniformRotationValue = planetData->getValue("UniformRotation"); uniformRotationValue != nullptr)
+    {
+        const Hash* uniformRotationData = uniformRotationValue->getHash();
+        if (uniformRotationData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect UniformRotation syntax.\n");
+            return nullptr;
+        }
+        return CreateUniformRotationModel(uniformRotationData,
+                                          syncRotationPeriod);
+    }
+
+    if (const Value* fixedRotationValue = planetData->getValue("FixedRotation"); fixedRotationValue != nullptr)
+    {
+        const Hash* fixedRotationData = fixedRotationValue->getHash();
+        if (fixedRotationData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect FixedRotation syntax.\n");
+            return nullptr;
+        }
+
+        return CreateFixedRotationModel(fixedRotationData);
+    }
+
+    if (const Value* fixedAttitudeValue = planetData->getValue("FixedAttitude"); fixedAttitudeValue != nullptr)
+    {
+        const Hash* fixedAttitudeData = fixedAttitudeValue->getHash();
+        if (fixedAttitudeData == nullptr)
+        {
+            GetLogger()->error("Object has incorrect FixedAttitude syntax.\n");
+            return nullptr;
+        }
+
+        return CreateFixedAttitudeRotationModel(fixedAttitudeData);
+    }
+
+    // For backward compatibility we need to support rotation parameters
+    // that appear in the main block of the object definition.
+    // Default to synchronous rotation
+    bool specified = false;
+    double period = syncRotationPeriod;
+    if (auto periodVal = planetData->getNumber<double>("RotationPeriod"); periodVal.has_value())
+    {
+        specified = true;
+        period = *periodVal / 24.0;
+    }
+
+    float offset = 0.0f;
+    if (auto offsetVal = planetData->getNumber<float>("RotationOffset"); offsetVal.has_value())
+    {
+        specified = true;
+        offset = math::degToRad(*offsetVal);
+    }
+
+    double epoch = astro::J2000;
+    if (ParseDate(planetData, "RotationEpoch", epoch))
+    {
+        specified = true;
+    }
+
+    float inclination = 0.0f;
+    if (auto inclinationVal = planetData->getNumber<float>("Obliquity"); inclinationVal.has_value())
+    {
+        specified = true;
+        inclination = math::degToRad(*inclinationVal);
+    }
+
+    float ascendingNode = 0.0f;
+    if (auto ascendingNodeVal = planetData->getNumber<float>("EquatorAscendingNode"); ascendingNodeVal.has_value())
+    {
+        specified = true;
+        ascendingNode = math::degToRad(*ascendingNodeVal);
+    }
+
+    double precessionRate = 0.0f;
+    if (auto precessionVal = planetData->getNumber<double>("PrecessionRate"); precessionVal.has_value())
+    {
+        specified = true;
+        precessionRate = *precessionVal;
+    }
+
+    if (specified)
+    {
+        if (period == 0.0)
+        {
+            // No period was specified, and the default synchronous
+            // rotation period is zero, indicating that the object
+            // doesn't have a periodic orbit. Default to a constant
+            // orientation instead.
+            return CreateFixedRotationModel(offset, inclination, ascendingNode);
+        }
+
+        if (precessionRate == 0.0)
+        {
+            return std::make_shared<ephem::UniformRotationModel>(period,
+                                                                 offset,
+                                                                 epoch,
+                                                                 inclination,
+                                                                 ascendingNode);
+        }
+
+        return std::make_shared<ephem::PrecessingRotationModel>(period,
+                                                                offset,
+                                                                epoch,
+                                                                inclination,
+                                                                ascendingNode,
+                                                                -360.0 / precessionRate);
+    }
+    else
+    {
+        // No rotation fields specified
+        return nullptr;
+    }
+}
+
+std::shared_ptr<const ephem::RotationModel>
+CreateDefaultRotationModel(double syncRotationPeriod)
+{
+    if (syncRotationPeriod == 0.0)
+    {
+        // If syncRotationPeriod is 0, the orbit of the object is
+        // aperiodic and we'll just return a FixedRotation.
+        return ephem::ConstantOrientation::identity();
+    }
+
+    return std::make_shared<ephem::UniformRotationModel>(syncRotationPeriod,
+                                                         0.0f,
+                                                         astro::J2000,
+                                                         0.0f,
+                                                         0.0f);
+}
+
+/**
+ * Helper function for CreateTopocentricFrame().
+ * Creates a two-vector frame with the specified center, target, and observer.
+ */
+std::shared_ptr<const TwoVectorFrame>
+CreateTopocentricFrame(const Selection& center,
+                       const Selection& target,
+                       const Selection& observer)
+{
+    auto eqFrame = std::make_shared<BodyMeanEquatorFrame>(target, target);
+    FrameVector north = FrameVector::createConstantVector(Eigen::Vector3d::UnitY(), eqFrame);
+    FrameVector up = FrameVector::createRelativePositionVector(observer, target);
+
+    return std::make_shared<TwoVectorFrame>(center, up, -2, north, -3);
+}
 
 ReferenceFrame::SharedConstPtr CreateReferenceFrame(const Universe& universe,
                                                     const Value* frameValue,

--- a/src/celengine/parseobject.h
+++ b/src/celengine/parseobject.h
@@ -12,18 +12,23 @@
 
 #pragma once
 
-#include <string>
 #include <memory>
-#include <celephem/orbit.h>
-#include <celephem/rotation.h>
+#include <string_view>
+
 #include <celcompat/filesystem.h>
 #include "frame.h"
-#include "parser.h"
 
+class AssociativeArray;
 class Body;
-class Star;
 class Universe;
+class Value;
 class Selection;
+
+namespace celestia::ephem
+{
+class Orbit;
+class RotationModel;
+}
 
 enum class DataDisposition
 {
@@ -32,25 +37,30 @@ enum class DataDisposition
     Replace
 };
 
+bool
+ParseDate(const AssociativeArray* hash, std::string_view name, double& jd);
 
-bool ParseDate(const Hash* hash, const std::string& name, double& jd);
+std::shared_ptr<const celestia::ephem::Orbit>
+CreateOrbit(const Selection& centralObject,
+            const AssociativeArray* planetData,
+            const fs::path& path,
+            bool usePlanetUnits);
 
-celestia::ephem::Orbit* CreateOrbit(const Selection& centralObject,
-                                    const Hash* planetData,
-                                    const fs::path& path,
-                                    bool usePlanetUnits);
+std::shared_ptr<const celestia::ephem::RotationModel>
+CreateRotationModel(const AssociativeArray* rotationData,
+                    const fs::path& path,
+                    double syncRotationPeriod);
 
-celestia::ephem::RotationModel* CreateRotationModel(const Hash* rotationData,
-                                                    const fs::path& path,
-                                                    double syncRotationPeriod);
+std::shared_ptr<const celestia::ephem::RotationModel>
+CreateDefaultRotationModel(double syncRotationPeriod);
 
-celestia::ephem::RotationModel* CreateDefaultRotationModel(double syncRotationPeriod);
+ReferenceFrame::SharedConstPtr
+CreateReferenceFrame(const Universe& universe,
+                     const Value* frameValue,
+                     const Selection& defaultCenter,
+                     Body* defaultObserver);
 
-ReferenceFrame::SharedConstPtr CreateReferenceFrame(const Universe& universe,
-                                                    const Value* frameValue,
-                                                    const Selection& defaultCenter,
-                                                    Body* defaultObserver);
-
-std::shared_ptr<const TwoVectorFrame> CreateTopocentricFrame(const Selection& center,
-                                                             const Selection& target,
-                                                             const Selection& observer);
+std::shared_ptr<const TwoVectorFrame>
+CreateTopocentricFrame(const Selection& center,
+                       const Selection& target,
+                       const Selection& observer);

--- a/src/celengine/rotationmanager.cpp
+++ b/src/celengine/rotationmanager.cpp
@@ -9,41 +9,36 @@
 
 #include "rotationmanager.h"
 
-#include <fstream>
-
 #include <celephem/samporient.h>
 #include <celutil/logger.h>
 
 using celestia::util::GetLogger;
 
-
-RotationModelManager* GetRotationModelManager()
+namespace celestia::engine
 {
-    static RotationModelManager* rotationModelManager = nullptr;
-    if (rotationModelManager == nullptr)
-        rotationModelManager = std::make_unique<RotationModelManager>("data").release();
-    return rotationModelManager;
-}
 
-
-fs::path RotationModelInfo::resolve(const fs::path& baseDir) const
+std::shared_ptr<const ephem::RotationModel>
+RotationModelManager::find(const fs::path& source,
+                           const fs::path& path)
 {
-    if (!path.empty())
+    auto filename = path.empty()
+        ? "data" / source
+        : path / "data" / source;
+
+    auto it = rotationModels.try_emplace(filename).first;
+    if (auto cachedModel = it->second.lock(); cachedModel != nullptr)
+        return cachedModel;
+
+    GetLogger()->verbose("Loading rotation model: {}\n", filename);
+    auto model = ephem::LoadSampledOrientation(filename);
+    if (model == nullptr)
     {
-        fs::path filename = path / "data" / source;
-        std::ifstream in(filename);
-        if (in.good())
-            return filename;
+        rotationModels.erase(it);
+        return nullptr;
     }
 
-    return baseDir / source;
+    it->second = model;
+    return model;
 }
 
-
-std::unique_ptr<celestia::ephem::RotationModel>
-RotationModelInfo::load(const fs::path& filename) const
-{
-    GetLogger()->verbose("Loading rotation model: {}\n", filename);
-
-    return celestia::ephem::LoadSampledOrientation(filename);
-}
+} // end namespace celestia::engine

--- a/src/celengine/rotationmanager.h
+++ b/src/celengine/rotationmanager.h
@@ -10,40 +10,32 @@
 #pragma once
 
 #include <memory>
-#include <string>
 #include <tuple>
+#include <unordered_map>
 
 #include <celcompat/filesystem.h>
 #include <celephem/rotation.h>
-#include <celutil/resmanager.h>
+#include <celutil/fsutils.h>
 
-
-class RotationModelInfo
+namespace celestia::engine
 {
- private:
-    fs::path source;
-    fs::path path;
 
-    friend bool operator<(const RotationModelInfo&, const RotationModelInfo&);
+class RotationModelManager
+{
+public:
+    RotationModelManager() = default;
+    ~RotationModelManager() = default;
 
- public:
-    using ResourceType = celestia::ephem::RotationModel;
-    using ResourceKey = fs::path;
+    RotationModelManager(const RotationModelManager&) = delete;
+    RotationModelManager& operator=(const RotationModelManager&) = delete;
 
-    RotationModelInfo(const fs::path& _source,
-                      const fs::path& _path = "") :
-        source(_source), path(_path) {};
+    std::shared_ptr<const ephem::RotationModel> find(const fs::path& source,
+                                                     const fs::path& path);
 
-    fs::path resolve(const fs::path&) const;
-    std::unique_ptr<celestia::ephem::RotationModel> load(const fs::path&) const;
+private:
+    std::unordered_map<fs::path, std::weak_ptr<const ephem::RotationModel>, util::PathHasher> rotationModels;
 };
 
-inline bool operator<(const RotationModelInfo& ti0,
-                      const RotationModelInfo& ti1)
-{
-    return std::tie(ti0.source, ti0.path) < std::tie(ti1.source, ti1.path);
-}
+inline RotationModelManager rotationModelManager;
 
-typedef ResourceManager<RotationModelInfo> RotationModelManager;
-
-extern RotationModelManager* GetRotationModelManager();
+} // end namespace celestia::engine

--- a/src/celengine/star.cpp
+++ b/src/celengine/star.cpp
@@ -28,6 +28,7 @@ using namespace std::string_view_literals;
 using celestia::util::IntrusivePtr;
 
 namespace astro = celestia::astro;
+namespace ephem = celestia::ephem;
 namespace math = celestia::math;
 
 namespace
@@ -576,11 +577,11 @@ CreateStandardStarType(std::string_view specTypeName,
     details->setTemperature(_temperature);
     details->setSpectralType(specTypeName);
 
-    details->setRotationModel(new celestia::ephem::UniformRotationModel(_rotationPeriod,
-                                                                        0.0f,
-                                                                        astro::J2000,
-                                                                        0.0f,
-                                                                        0.0f));
+    details->setRotationModel(std::make_shared<ephem::UniformRotationModel>(_rotationPeriod,
+                                                                            0.0f,
+                                                                            astro::J2000,
+                                                                            0.0f,
+                                                                            0.0f));
 
     return details;
 }
@@ -1007,7 +1008,7 @@ StarDetails::setGeometry(ResourceHandle rh)
 
 
 void
-StarDetails::setOrbit(celestia::ephem::Orbit* o)
+StarDetails::setOrbit(const std::shared_ptr<const ephem::Orbit>& o)
 {
     orbit = o;
     computeOrbitalRadius();
@@ -1054,7 +1055,7 @@ StarDetails::setVisibility(bool b)
 
 
 void
-StarDetails::setRotationModel(const celestia::ephem::RotationModel* rm)
+StarDetails::setRotationModel(const std::shared_ptr<const ephem::RotationModel>& rm)
 {
     rotationModel = rm;
 }
@@ -1119,7 +1120,7 @@ StarDetails::addOrbitingStar(Star* star)
 UniversalCoord
 Star::getPosition(double t) const
 {
-    const celestia::ephem::Orbit* orbit = getOrbit();
+    const ephem::Orbit* orbit = getOrbit();
     if (orbit == nullptr)
     {
         return UniversalCoord::CreateLy(position.cast<double>());
@@ -1162,7 +1163,7 @@ Star::getOrbitBarycenterPosition(double t) const
 Eigen::Vector3d
 Star::getVelocity(double t) const
 {
-    const celestia::ephem::Orbit* orbit = getOrbit();
+    const ephem::Orbit* orbit = getOrbit();
     if (orbit == nullptr)
     {
         // The star doesn't have a defined orbit, so the velocity is just
@@ -1277,12 +1278,6 @@ void Star::setOrbitBarycenter(Star* s)
 void Star::computeOrbitalRadius()
 {
     details->computeOrbitalRadius();
-}
-
-void
-Star::setRotationModel(const celestia::ephem::RotationModel* rm)
-{
-    details->setRotationModel(rm);
 }
 
 void

--- a/src/celengine/star.h
+++ b/src/celengine/star.h
@@ -59,13 +59,13 @@ class StarDetails
     float getTemperature() const;
     ResourceHandle getGeometry() const;
     MultiResTexture getTexture() const;
-    celestia::ephem::Orbit* getOrbit() const;
+    const celestia::ephem::Orbit* getOrbit() const;
     float getOrbitalRadius() const;
     const char* getSpectralType() const;
     float getBolometricCorrection() const;
     Star* getOrbitBarycenter() const;
     bool getVisibility() const;
-    const celestia::ephem::RotationModel* getRotationModel() const;
+    const std::shared_ptr<const celestia::ephem::RotationModel>& getRotationModel() const;
     Eigen::Vector3f getEllipsoidSemiAxes() const;
     const std::string& getInfoURL() const;
 
@@ -75,12 +75,12 @@ class StarDetails
     void setBolometricCorrection(float);
     void setTexture(const MultiResTexture&);
     void setGeometry(ResourceHandle);
-    void setOrbit(celestia::ephem::Orbit*);
+    void setOrbit(const std::shared_ptr<const celestia::ephem::Orbit>&);
     void setOrbitBarycenter(Star*);
     void setOrbitalRadius(float);
     void computeOrbitalRadius();
     void setVisibility(bool);
-    void setRotationModel(const celestia::ephem::RotationModel*);
+    void setRotationModel(const std::shared_ptr<const celestia::ephem::RotationModel>&);
     void setEllipsoidSemiAxes(const Eigen::Vector3f&);
     void setInfoURL(std::string_view _infoURL);
 
@@ -131,11 +131,11 @@ class StarDetails
     MultiResTexture texture{ InvalidResource };
     ResourceHandle geometry{ InvalidResource };
 
-    celestia::ephem::Orbit* orbit{ nullptr };
+    std::shared_ptr<const celestia::ephem::Orbit> orbit;
     float orbitalRadius{ 0.0f };
     Star* barycenter{ nullptr };
 
-    const celestia::ephem::RotationModel* rotationModel{ nullptr };
+    std::shared_ptr<const celestia::ephem::RotationModel> rotationModel;
 
     Eigen::Vector3f semiAxes{ Eigen::Vector3f::Ones() };
 
@@ -170,10 +170,10 @@ StarDetails::getTexture() const
     return texture;
 }
 
-inline celestia::ephem::Orbit*
+inline const celestia::ephem::Orbit*
 StarDetails::getOrbit() const
 {
-    return orbit;
+    return orbit.get();
 }
 
 inline float
@@ -218,7 +218,7 @@ StarDetails::getVisibility() const
     return visible;
 }
 
-inline const celestia::ephem::RotationModel*
+inline const std::shared_ptr<const celestia::ephem::RotationModel>&
 StarDetails::getRotationModel() const
 {
     return rotationModel;
@@ -284,8 +284,6 @@ public:
     void setOrbitBarycenter(Star*);
     void computeOrbitalRadius();
 
-    void setRotationModel(const celestia::ephem::RotationModel*);
-
     void addOrbitingStar(Star*);
     const std::vector<Star*>* getOrbitingStars() const;
 
@@ -299,7 +297,7 @@ public:
     float getBolometricMagnitude() const;
     MultiResTexture getTexture() const;
     ResourceHandle getGeometry() const;
-    celestia::ephem::Orbit* getOrbit() const;
+    const celestia::ephem::Orbit* getOrbit() const;
     float getOrbitalRadius() const;
     Star* getOrbitBarycenter() const;
     bool getVisibility() const;
@@ -337,7 +335,7 @@ Star::getBolometricMagnitude() const
     return absMag + details->getBolometricCorrection();
 }
 
-inline celestia::ephem::Orbit*
+inline const celestia::ephem::Orbit*
 Star::getOrbit() const
 {
     return details->getOrbit();
@@ -364,7 +362,7 @@ Star::getVisibility() const
 inline const celestia::ephem::RotationModel*
 Star::getRotationModel() const
 {
-    return details->getRotationModel();
+    return details->getRotationModel().get();
 }
 
 inline Eigen::Vector3f

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -57,8 +57,8 @@ struct StarDatabaseBuilder::CustomStarDetails
     bool hasCustomDetails{false};
     fs::path modelName;
     fs::path textureName;
-    celestia::ephem::Orbit* orbit{nullptr};
-    celestia::ephem::RotationModel* rm{nullptr};
+    std::shared_ptr<const celestia::ephem::Orbit> orbit;
+    std::shared_ptr<const celestia::ephem::RotationModel> rm;
     std::optional<Eigen::Vector3d> semiAxes{std::nullopt};
     std::optional<float> radius{std::nullopt};
     double temperature{0.0};
@@ -1530,7 +1530,6 @@ StarDatabaseBuilder::applyOrbit(AstroCatalog::IndexNumber catalogNumber,
                 GetLogger()->error(_("Barycenter {} does not exist.\n"), barycenterCatNo);
             else
                 GetLogger()->error(_("Barycenter {} does not exist.\n"), *barycenterName);
-            delete customDetails.rm;
             return false;
         }
     }

--- a/src/celengine/timelinephase.cpp
+++ b/src/celengine/timelinephase.cpp
@@ -27,9 +27,9 @@ TimelinePhase::TimelinePhase(CreateToken,
                              double _startTime,
                              double _endTime,
                              const ReferenceFrame::SharedConstPtr& _orbitFrame,
-                             celestia::ephem::Orbit* _orbit,
+                             const std::shared_ptr<const celestia::ephem::Orbit>& _orbit,
                              const ReferenceFrame::SharedConstPtr& _bodyFrame,
-                             celestia::ephem::RotationModel* _rotationModel,
+                             const std::shared_ptr<const celestia::ephem::RotationModel>& _rotationModel,
                              FrameTree* _owner) :
     m_body(_body),
     m_startTime(_startTime),
@@ -51,9 +51,9 @@ TimelinePhase::CreateTimelinePhase(Universe& universe,
                                    double startTime,
                                    double endTime,
                                    const ReferenceFrame::SharedConstPtr& orbitFrame,
-                                   celestia::ephem::Orbit& orbit,
+                                   const std::shared_ptr<const celestia::ephem::Orbit>& orbit,
                                    const ReferenceFrame::SharedConstPtr& bodyFrame,
-                                   celestia::ephem::RotationModel& rotationModel)
+                                   const std::shared_ptr<const celestia::ephem::RotationModel>& rotationModel)
 {
     // Validate the time range.
     if (endTime <= startTime)
@@ -83,9 +83,9 @@ TimelinePhase::CreateTimelinePhase(Universe& universe,
                                                  startTime,
                                                  endTime,
                                                  orbitFrame,
-                                                 &orbit,
+                                                 orbit,
                                                  bodyFrame,
-                                                 &rotationModel,
+                                                 rotationModel,
                                                  frameTree);
 
     frameTree->addChild(phase);

--- a/src/celengine/timelinephase.h
+++ b/src/celengine/timelinephase.h
@@ -54,7 +54,7 @@ public:
         return m_orbitFrame;
     }
 
-    celestia::ephem::Orbit* orbit() const
+    const std::shared_ptr<const celestia::ephem::Orbit>& orbit() const
     {
         return m_orbit;
     }
@@ -64,7 +64,7 @@ public:
         return m_bodyFrame;
     }
 
-    celestia::ephem::RotationModel* rotationModel() const
+    const std::shared_ptr<const celestia::ephem::RotationModel>& rotationModel() const
     {
         return m_rotationModel;
     }
@@ -90,18 +90,18 @@ public:
                                                              double startTime,
                                                              double endTime,
                                                              const ReferenceFrame::SharedConstPtr& orbitFrame,
-                                                             celestia::ephem::Orbit& orbit,
+                                                             const std::shared_ptr<const celestia::ephem::Orbit>& orbit,
                                                              const ReferenceFrame::SharedConstPtr& bodyFrame,
-                                                             celestia::ephem::RotationModel& rotationModel);
+                                                             const std::shared_ptr<const celestia::ephem::RotationModel>& rotationModel);
 
     TimelinePhase(CreateToken,
                   Body* _body,
                   double _startTime,
                   double _endTime,
                   const ReferenceFrame::SharedConstPtr& _orbitFrame,
-                  celestia::ephem::Orbit* _orbit,
+                  const std::shared_ptr<const celestia::ephem::Orbit>& _orbit,
                   const ReferenceFrame::SharedConstPtr& _bodyFrame,
-                  celestia::ephem::RotationModel* _rotationModel,
+                  const std::shared_ptr<const celestia::ephem::RotationModel>& _rotationModel,
                   FrameTree* _owner);
     ~TimelinePhase() = default;
 
@@ -115,9 +115,9 @@ private:
     double m_endTime;
 
     ReferenceFrame::SharedConstPtr m_orbitFrame;
-    celestia::ephem::Orbit* m_orbit;
+    std::shared_ptr<const celestia::ephem::Orbit> m_orbit;
     ReferenceFrame::SharedConstPtr m_bodyFrame;
-    celestia::ephem::RotationModel* m_rotationModel;
+    std::shared_ptr<const celestia::ephem::RotationModel> m_rotationModel;
 
     FrameTree* m_owner;
 };

--- a/src/celephem/customorbit.cpp
+++ b/src/celephem/customorbit.cpp
@@ -60,7 +60,6 @@ constexpr double BoundingRadiusSlack = 1.2;
 using PlanetElements = std::array<double, 9>;
 using StaticElements = std::array<double, 23>;
 
-
 constexpr std::array<StaticElements, 8> gElements{
     StaticElements{
         /*     mercury... */
@@ -143,7 +142,6 @@ constexpr std::array<StaticElements, 8> gElements{
     }
 };
 
-
 class PlanetOrbitMixin
 {
 protected:
@@ -210,21 +208,22 @@ PlanetOrbitMixin::computePlanetCoords(int p, double map, double da, double dhl, 
     distance *= astro::KM_PER_AU<double>;
 }
 
-
 // Useful version of trig functions which operate on values in degrees instead
 // of radians.
-double sinD(double theta)
+double
+sinD(double theta)
 {
     return std::sin(math::degToRad(theta));
 }
 
-double cosD(double theta)
+double
+cosD(double theta)
 {
     return std::cos(math::degToRad(theta));
 }
 
-
-inline Eigen::Vector3d from_polar(double lon, double lat, double distance)
+inline Eigen::Vector3d
+from_polar(double lon, double lat, double distance)
 {
     double sLon;
     double cLon;
@@ -237,8 +236,8 @@ inline Eigen::Vector3d from_polar(double lon, double lat, double distance)
                            -sLon * sLat * distance);
 }
 
-
-double Obliquity(double t)
+double
+Obliquity(double t)
 {
     // Parameter t represents the Julian centuries elapsed since 1900.
     // In other words, t = (jd - 2415020.0) / 36525.0
@@ -246,7 +245,8 @@ double Obliquity(double t)
     return math::degToRad(2.345229444E1 - ((((-1.81E-3*t)+5.9E-3)*t+4.6845E1)*t)/3600.0);
 }
 
-void Nutation(double t, double &deps, double& dpsi)
+void
+Nutation(double t, double &deps, double& dpsi)
 {
     // Parameter t represents the Julian centuries elapsed since 1900.
     // In other words, t = (jd - 2415020.0) / 36525.0
@@ -304,8 +304,9 @@ void Nutation(double t, double &deps, double& dpsi)
     deps = math::degToRad(deps/3600);
 }
 
-void EclipticToEquatorial(double fEclLat, double fEclLon,
-                          double& RA, double& dec)
+void
+EclipticToEquatorial(double fEclLat, double fEclLon,
+                     double& RA, double& dec)
 {
     // Parameter t represents the Julian centuries elapsed since 1900.
     // In other words, t = (jd - 2415020.0) / 36525.0
@@ -335,12 +336,12 @@ void EclipticToEquatorial(double fEclLat, double fEclLon,
     RA = math::pfmod(RA, TWOPI);
 }
 
-
 // Convert equatorial coordinates from one epoch to another.  Method is from
 // Chapter 21 of Meeus's _Astronomical Algorithms_
-void EpochConvert(double jdFrom, double jdTo,
-                  double a0, double d0,
-                  double& a, double& d)
+void
+EpochConvert(double jdFrom, double jdTo,
+             double a0, double d0,
+             double& a, double& d)
 {
     double T = (jdFrom - astro::J2000) / 36525.0;
     double t = (jdTo - jdFrom) / 36525.0;
@@ -365,8 +366,8 @@ void EpochConvert(double jdFrom, double jdTo,
     d = std::asin(C);
 }
 
-
-double meanAnomalySun(double t)
+double
+meanAnomalySun(double t)
 {
     double t2, a, b;
 
@@ -377,8 +378,9 @@ double meanAnomalySun(double t)
     return math::degToRad(3.5847583e2 - (1.5e-4 + 3.3e-6*t)*t2 + b);
 }
 
-void auxJSun(double t, double* x1, double* x2, double* x3, double* x4,
-             double* x5, double* x6)
+void
+auxJSun(double t, double* x1, double* x2, double* x3, double* x4,
+        double* x5, double* x6)
 {
     *x1 = t/5+0.1;
     *x2 = math::pfmod(4.14473+5.29691e1*t, TWOPI);
@@ -388,13 +390,13 @@ void auxJSun(double t, double* x1, double* x2, double* x3, double* x4,
     *x6 = 2 * *x2 - 6 * *x3 + 3 * *x4;
 }
 
-
-void ComputeGalileanElements(double t,
-                             double& l1, double& l2, double& l3, double& l4,
-                             double& p1, double& p2, double& p3, double& p4,
-                             double& w1, double& w2, double& w3, double& w4,
-                             double& gamma, double& phi, double& psi,
-                             double& G, double& Gp)
+void
+ComputeGalileanElements(double t,
+                        double& l1, double& l2, double& l3, double& l4,
+                        double& p1, double& p2, double& p3, double& p4,
+                        double& w1, double& w2, double& w3, double& w4,
+                        double& gamma, double& phi, double& psi,
+                        double& G, double& Gp)
 {
     // Parameter t is Julian days, epoch 1950.0.
     l1 = 1.8513962 + 3.551552269981*t;
@@ -419,17 +421,15 @@ void ComputeGalileanElements(double t,
     Gp = 0.5581306 + 5.83982523e-4*t;
 }
 
-
-
 //////////////////////////////////////////////////////////////////////////////
 
 class MercuryOrbit : public CachingOrbit, private PlanetOrbitMixin
 {
- private:
+private:
     // Specify which planets we must compute elements for
     static constexpr std::array<int, 3> pList{0, 1, 3};
 
- public:
+public:
     ~MercuryOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -487,10 +487,10 @@ class MercuryOrbit : public CachingOrbit, private PlanetOrbitMixin
 
 class VenusOrbit : public CachingOrbit, private PlanetOrbitMixin
 {
- private:
+private:
     //Specify which planets we must compute elements for
     static constexpr std::array<int, 2> pList{1, 3};
- public:
+public:
     ~VenusOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -557,7 +557,7 @@ class VenusOrbit : public CachingOrbit, private PlanetOrbitMixin
 
 class EarthOrbit : public CachingOrbit
 {
- public:
+public:
     ~EarthOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -626,10 +626,9 @@ class EarthOrbit : public CachingOrbit
     };
 };
 
-
 class LunarOrbit : public CachingOrbit
 {
- public:
+public:
     ~LunarOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -789,11 +788,11 @@ class LunarOrbit : public CachingOrbit
 
 class MarsOrbit : public CachingOrbit, private PlanetOrbitMixin
 {
- private:
+private:
     // Specify which planets we must compute elements for
     static constexpr std::array<int, 3> pList{1, 2, 3};
 
- public:
+public:
     ~MarsOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -870,10 +869,10 @@ class MarsOrbit : public CachingOrbit, private PlanetOrbitMixin
 
 class JupiterOrbit : public CachingOrbit, private PlanetOrbitMixin
 {
- private:
+private:
     static constexpr std::array<int, 1> pList{3};
 
- public:
+public:
     ~JupiterOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -974,10 +973,10 @@ class JupiterOrbit : public CachingOrbit, private PlanetOrbitMixin
 
 class SaturnOrbit : public CachingOrbit, private PlanetOrbitMixin
 {
- private:
+private:
     static constexpr std::array<int, 1> pList{4};
 
- public:
+public:
     ~SaturnOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1101,10 +1100,10 @@ class SaturnOrbit : public CachingOrbit, private PlanetOrbitMixin
 
 class UranusOrbit : public CachingOrbit, private PlanetOrbitMixin
 {
- private:
+private:
     static constexpr std::array<int, 1> pList{5};
 
- public:
+public:
     ~UranusOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1189,10 +1188,10 @@ class UranusOrbit : public CachingOrbit, private PlanetOrbitMixin
 
 class NeptuneOrbit : public CachingOrbit, private PlanetOrbitMixin
 {
- private:
+private:
     static constexpr std::array<int, 1> pList{6};
 
- public:
+public:
     ~NeptuneOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1268,10 +1267,10 @@ class NeptuneOrbit : public CachingOrbit, private PlanetOrbitMixin
 
 class PlutoOrbit : public CachingOrbit, private PlanetOrbitMixin
 {
- private:
+private:
     static constexpr std::array<int, 1> pList{7};
 
- public:
+public:
     ~PlutoOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1311,12 +1310,12 @@ class PlutoOrbit : public CachingOrbit, private PlanetOrbitMixin
     };
 };
 
-
 // Compute for mean anomaly M the point on the ellipse with
 // semimajor axis a and eccentricity e.  This helper function assumes
 // a low eccentricity; orbit.cpp has functions appropriate for solving
 // Kepler's equation for larger values of e.
-Eigen::Vector3d ellipsePosition(double a, double e, double M)
+Eigen::Vector3d
+ellipsePosition(double a, double e, double M)
 {
     // Solve Kepler's equation--for a low eccentricity orbit, just a few
     // iterations is enough.
@@ -1329,10 +1328,9 @@ Eigen::Vector3d ellipsePosition(double a, double e, double M)
                            a * std::sqrt(1 - math::square(e)) * -std::sin(E));
 }
 
-
 class PhobosOrbit : public CachingOrbit
 {
- public:
+public:
     ~PhobosOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1398,10 +1396,9 @@ class PhobosOrbit : public CachingOrbit
     }
 };
 
-
 class DeimosOrbit : public CachingOrbit
 {
- public:
+public:
     ~DeimosOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1537,12 +1534,11 @@ class DeimosOrbit : public CachingOrbit
     }
 };
 
-
 constexpr double JupAscendingNode = math::degToRad(22.203);
 
 class IoOrbit : public CachingOrbit
 {
- public:
+public:
     ~IoOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1621,7 +1617,7 @@ class IoOrbit : public CachingOrbit
 
 class EuropaOrbit : public CachingOrbit
 {
- public:
+public:
     ~EuropaOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1711,7 +1707,7 @@ class EuropaOrbit : public CachingOrbit
 
 class GanymedeOrbit : public CachingOrbit
 {
- public:
+public:
     ~GanymedeOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1804,7 +1800,7 @@ class GanymedeOrbit : public CachingOrbit
 
 class CallistoOrbit : public CachingOrbit
 {
- public:
+public:
     ~CallistoOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -1940,7 +1936,6 @@ class CallistoOrbit : public CachingOrbit
     };
 };
 
-
 constexpr double SatAscendingNode = 168.8112;
 constexpr double SatTilt = 28.0817;
 
@@ -1948,14 +1943,15 @@ constexpr double SatTilt = 28.0817;
 // Titan, Hyperion, and Iapetus are from Jean Meeus's Astronomical Algorithms,
 // and were originally derived by Gerard Dourneau.
 
-void ComputeSaturnianElements(double t,
-                              double& t1, double& t2, double& t3,
-                              double& t4, double& t5, double& t6,
-                              double& t7, double& t8, double& t9,
-                              double& t10, double& t11,
-                              double& W0, double& W1, double& W2,
-                              double& W3, double& W4, double& W5,
-                              double& W6, double& W7, double& W8)
+void
+ComputeSaturnianElements(double t,
+                         double& t1, double& t2, double& t3,
+                         double& t4, double& t5, double& t6,
+                         double& t7, double& t8, double& t9,
+                         double& t10, double& t11,
+                         double& W0, double& W1, double& W2,
+                         double& W3, double& W4, double& W5,
+                         double& W6, double& W7, double& W8)
 {
     t1 = t - 2411093.0;
     t2 = t1 / 365.25;
@@ -1980,8 +1976,8 @@ void ComputeSaturnianElements(double t,
     W8 = 113.35 - 0.2597 * t7;
 }
 
-
-Eigen::Vector3d SaturnMoonPosition(double lam, double gam, double Om, double r)
+Eigen::Vector3d
+SaturnMoonPosition(double lam, double gam, double Om, double r)
 {
     double u = lam - Om;
     double w = Om - SatAscendingNode;
@@ -2012,11 +2008,11 @@ Eigen::Vector3d SaturnMoonPosition(double lam, double gam, double Om, double r)
     return Eigen::Vector3d(x, y, z);
 }
 
-
-void OuterSaturnMoonParams(double a, double e, double i,
-                           double Om_, double M, double lam_,
-                           double& lam, double& gam,
-                           double& r, double& w)
+void
+OuterSaturnMoonParams(double a, double e, double i,
+                      double Om_, double M, double lam_,
+                      double& lam, double& gam,
+                      double& r, double& w)
 {
     double s1 = sinD(SatTilt);
     double c1 = cosD(SatTilt);
@@ -2042,10 +2038,9 @@ void OuterSaturnMoonParams(double a, double e, double i,
     w = SatAscendingNode + u;
 }
 
-
 class MimasOrbit : public CachingOrbit
 {
- public:
+public:
     ~MimasOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2084,10 +2079,9 @@ class MimasOrbit : public CachingOrbit
     };
 };
 
-
 class EnceladusOrbit : public CachingOrbit
 {
- public:
+public:
     ~EnceladusOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2125,10 +2119,9 @@ class EnceladusOrbit : public CachingOrbit
     };
 };
 
-
 class TethysOrbit : public CachingOrbit
 {
- public:
+public:
     ~TethysOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2162,10 +2155,9 @@ class TethysOrbit : public CachingOrbit
     };
 };
 
-
 class DioneOrbit : public CachingOrbit
 {
- public:
+public:
     ~DioneOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2204,10 +2196,9 @@ class DioneOrbit : public CachingOrbit
     };
 };
 
-
 class RheaOrbit : public CachingOrbit
 {
- public:
+public:
     ~RheaOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2253,10 +2244,9 @@ class RheaOrbit : public CachingOrbit
     };
 };
 
-
 class TitanOrbit : public CachingOrbit
 {
- public:
+public:
     ~TitanOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2321,10 +2311,9 @@ class TitanOrbit : public CachingOrbit
     };
 };
 
-
 class HyperionOrbit : public CachingOrbit
 {
- public:
+public:
     ~HyperionOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2404,10 +2393,9 @@ class HyperionOrbit : public CachingOrbit
     };
 };
 
-
 class IapetusOrbit : public CachingOrbit
 {
- public:
+public:
     ~IapetusOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2496,10 +2484,9 @@ class IapetusOrbit : public CachingOrbit
     };
 };
 
-
 class PhoebeOrbit : public CachingOrbit
 {
- public:
+public:
     ~PhoebeOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2532,14 +2519,13 @@ class PhoebeOrbit : public CachingOrbit
     };
 };
 
-
 using LTerms = std::array<double, 3>;
 using ZTerms = std::array<double, 5>;
 using ZetaTerms = std::array<double, 2>;
 
 class UranianSatelliteOrbit : public CachingOrbit
 {
- private:
+private:
     double a;
     double n;
     double L0;
@@ -2548,7 +2534,7 @@ class UranianSatelliteOrbit : public CachingOrbit
     const ZTerms &z_k, &z_theta, &z_phi;
     const ZetaTerms &zeta_k, &zeta_theta, &zeta_phi;
 
- public:
+public:
     UranianSatelliteOrbit(double _a,
                           double _n,
                           double _L0, double _L1,
@@ -2635,7 +2621,6 @@ class UranianSatelliteOrbit : public CachingOrbit
     }
 };
 
-
 constexpr std::array<double, 5> uran_n
 { 4.44352267, 2.49254257, 1.51595490, 0.72166316, 0.46658054 };
 constexpr std::array<double, 5> uran_a
@@ -2708,12 +2693,13 @@ constexpr std::array<ZetaTerms, 5> uran_zeta_phi{
     ZetaTerms{ 1.75, 4.21 },
 };
 
-std::unique_ptr<Orbit> CreateUranianSatelliteOrbit(int n)
+std::shared_ptr<const Orbit>
+CreateUranianSatelliteOrbit(int n)
 {
     assert(n >= 1 && n <= 5);
     --n;
 
-    return std::make_unique<UranianSatelliteOrbit>(uran_a[n], uran_n[n],
+    return std::make_shared<UranianSatelliteOrbit>(uran_a[n], uran_n[n],
                                                    uran_L0[n], uran_L1[n],
                                                    uran_L_k[n], uran_L_theta[n],
                                                    uran_L_phi[n], uran_z_k[n],
@@ -2722,7 +2708,6 @@ std::unique_ptr<Orbit> CreateUranianSatelliteOrbit(int n)
                                                    uran_zeta_phi[n]);
 }
 
-
 /*! Orbit of Triton, from Seidelmann, _Explanatory Supplement to the
  *  Astronomical Almanac_ (1992), p.373-374. The position of Triton
  *  is calculated in Neptunocentric coordinates referred to the
@@ -2730,7 +2715,7 @@ std::unique_ptr<Orbit> CreateUranianSatelliteOrbit(int n)
  */
 class TritonOrbit : public CachingOrbit
 {
- public:
+public:
     ~TritonOrbit() override = default;
 
     Eigen::Vector3d computePosition(double jd) const override
@@ -2791,7 +2776,6 @@ class TritonOrbit : public CachingOrbit
     }
 };
 
-
 /*! Ephemeris for Helene, Telesto, and Calypso, from
  *  "An upgraded theory for Helene, Telesto, and Calypso"
  *  Oberti P., Vienne A., 2002, A&A
@@ -2849,7 +2833,6 @@ constexpr std::array<double, 24 * 6> HeleneAmps
      -0.000003,0.,0.,0.,0.,0.,-0.000003,0.,0.,0.,0.,0.,0.,0.000005,
      0.000010,0.,0.,0.,0.,0.000003,0.,0.,0.,0.,0.,0.000003,0.
 };
-
 
 constexpr std::array<double, 12 * 5> TelestoTerms
 {
@@ -2943,7 +2926,6 @@ struct HTC20Angles
     double theta;
 };
 
-
 constexpr HTC20Angles HeleneAngles =
 {
     2.29427177,
@@ -2982,7 +2964,7 @@ constexpr HTC20Angles CalypsoAngles =
 
 class HTC20Orbit : public CachingOrbit
 {
- public:
+public:
     HTC20Orbit(int _nTerms, const double* _args, const double* _amplitudes,
                const HTC20Angles& _angles,
                double _period, double /*_boundingRadius*/) :
@@ -3027,7 +3009,7 @@ class HTC20Orbit : public CachingOrbit
         return 354800 * BoundingRadiusSlack;
     }
 
- private:
+private:
     int nTerms;
     const double* args;
     const double* amplitudes;
@@ -3035,10 +3017,9 @@ class HTC20Orbit : public CachingOrbit
     double period;
 };
 
-
 class JPLEphOrbit : public CachingOrbit
 {
- public:
+public:
     JPLEphOrbit(const JPLEphemeris& e,
                 JPLEphemItem _target,
                 JPLEphemItem _center,
@@ -3100,7 +3081,7 @@ class JPLEphOrbit : public CachingOrbit
         return Eigen::Vector3d(pos.x(), pos.z(), -pos.y());
     }
 
- private:
+private:
     const JPLEphemeris& ephem;
     JPLEphemItem target;
     JPLEphemItem center;
@@ -3108,11 +3089,11 @@ class JPLEphOrbit : public CachingOrbit
     double boundingRadius;
 };
 
-
-std::unique_ptr<Orbit> CreateJPLEphOrbit(JPLEphemItem target,
-                                         JPLEphemItem center,
-                                         double period,
-                                         double boundingRadius)
+std::shared_ptr<const Orbit>
+CreateJPLEphOrbit(JPLEphemItem target,
+                  JPLEphemItem center,
+                  double period,
+                  double boundingRadius)
 {
     static bool jplephInitialized = false;
     static JPLEphemeris* jpleph = nullptr;
@@ -3142,455 +3123,572 @@ std::unique_ptr<Orbit> CreateJPLEphOrbit(JPLEphemItem target,
     if (jpleph == nullptr)
         return nullptr;
 
-    auto o = std::make_unique<JPLEphOrbit>(*jpleph, target, center, period, boundingRadius);
-    return std::make_unique<MixedOrbit>(std::move(o),
+    auto o = std::make_shared<JPLEphOrbit>(*jpleph, target, center, period, boundingRadius);
+    return std::make_shared<MixedOrbit>(std::move(o),
                                         jpleph->getStartDate(),
                                         jpleph->getEndDate(),
                                         astro::SolarMass);
 }
 
-
-double yearToJD(int year)
+double
+yearToJD(int year)
 {
     return static_cast<double>(astro::Date(year, 1, 1));
 }
 
+enum class CustomOrbitType
+{
+    Mercury = 0,
+    Venus,
+    Earth,
+    Moon,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune,
+    Pluto,
+    JplMercurySun,
+    JplVenusSun,
+    JplEarthSun,
+    JplMarsSun,
+    JplJupiterSun,
+    JplSaturnSun,
+    JplUranusSun,
+    JplNeptuneSun,
+    JplPlutoSun,
+    JplMercurySsb,
+    JplVenusSsb,
+    JplEarthSsb,
+    JplMarsSsb,
+    JplJupiterSsb,
+    JplSaturnSsb,
+    JplUranusSsb,
+    JplNeptuneSsb,
+    JplPlutoSsb,
+    JplEmbSun,
+    JplEmbSsb,
+    JplMoonEmb,
+    JplMoonEarth,
+    JplEarthEmb,
+    JplSunSsb,
+    Helene,
+    Telesto,
+    Calypso,
+    Phobos,
+    Deimos,
+    Io,
+    Europa,
+    Ganymede,
+    Callisto,
+    Mimas,
+    Enceladus,
+    Tethys,
+    Dione,
+    Rhea,
+    Titan,
+    Hyperion,
+    Iapetus,
+    Phoebe,
+    Miranda,
+    Ariel,
+    Umbriel,
+    Titania,
+    Oberon,
+    Triton,
+    VSOP87Mercury,
+    VSOP87Venus,
+    VSOP87Earth,
+    VSOP87Mars,
+    VSOP87Jupiter,
+    VSOP87Saturn,
+    VSOP87Uranus,
+    VSOP87Neptune,
+    VSOP87Sun,
+    _Count,
+};
 
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateMercuryOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<MercuryOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<MercuryOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVenusOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<VenusOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<VenusOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateEarthOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<EarthOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<EarthOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateMoonOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<LunarOrbit>(), yearToJD(-2000), yearToJD(4000), astro::EarthMass + astro::LunarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<LunarOrbit>(), yearToJD(-2000), yearToJD(4000), astro::EarthMass + astro::LunarMass);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateMarsOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<MarsOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<MarsOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJupiterOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<JupiterOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<JupiterOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateSaturnOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<SaturnOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<SaturnOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
 }
 
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateUranusOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<UranusOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<UranusOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateNeptuneOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<NeptuneOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<NeptuneOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreatePlutoOrbit()
 {
-    return std::make_unique<MixedOrbit>(std::make_unique<PlutoOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
+    return std::make_shared<MixedOrbit>(std::make_shared<PlutoOrbit>(), yearToJD(-4000), yearToJD(4000), astro::SolarMass);
 }
-
 
 // JPL ephemerides for planets (relative to the Sun)
 
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplMercurySunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Mercury, JPLEphemItem::Sun, 0.2408 * 365.25, 6.0e7);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplVenusSunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Venus, JPLEphemItem::Sun, 0.6152 * 365.25, 1.0e8);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplEarthSunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Earth, JPLEphemItem::Sun, 365.25, 1.6e8);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplMarsSunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Mars, JPLEphemItem::Sun, 1.8809 * 365.25, 2.4e8);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplJupiterSunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Jupiter, JPLEphemItem::Sun, 11.86 * 365.25, 8.0e8);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplSaturnSunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Saturn, JPLEphemItem::Sun, 29.4577 * 365.25, 1.5e9);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplUranusSunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Uranus, JPLEphemItem::Sun, 84.0139 * 365.25, 3.0e9);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplNeptuneSunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Neptune, JPLEphemItem::Sun, 164.793 * 365.25, 4.7e9);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplPlutoSunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Pluto, JPLEphemItem::Sun, 248.54 * 365.25, 6.0e9);
 }
 
-
 // JPL ephemerides for planets (relative to Solar System barycenter)
 
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplMercurySsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Mercury, JPLEphemItem::SSB, 0.2408 * 365.25, 6.0e7);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplVenusSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Venus, JPLEphemItem::SSB, 0.6152 * 365.25, 1.0e8);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplEarthSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Earth, JPLEphemItem::SSB, 365.25, 1.6e8);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplMarsSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Mars, JPLEphemItem::SSB, 1.8809 * 365.25, 2.4e8);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplJupiterSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Jupiter, JPLEphemItem::SSB, 11.86   * 365.25, 8.0e8);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplSaturnSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Saturn, JPLEphemItem::SSB, 29.4577 * 365.25, 1.5e9);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplUranusSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Uranus, JPLEphemItem::SSB, 84.0139 * 365.25, 3.0e9);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplNeptuneSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Neptune, JPLEphemItem::SSB, 164.793 * 365.25, 4.7e9);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplPlutoSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Pluto, JPLEphemItem::SSB, 248.54 * 365.25, 6.0e9);
 }
 
-
 // JPL ephemerides for Earth-Moon system
 
 // Earth-Moon barycenter, heliocentric
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplEmbSunOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::EarthMoonBary, JPLEphemItem::Sun, 365.25, 1.6e8);
 }
 
-
 // Earth-Moon barycenter, relative to ssb
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplEmbSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::EarthMoonBary, JPLEphemItem::SSB, 365.25, 1.6e8);
 }
 
-
 // Moon, barycentric
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplMoonEmbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Moon, JPLEphemItem::EarthMoonBary, 27.321661, 5.0e5);
 }
 
-
 // Moon, geocentric
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplMoonEarthOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Moon, JPLEphemItem::Earth, 27.321661, 5.0e5);
 }
 
-
 // Earth, barycentric
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplEarthEmbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Earth, JPLEphemItem::EarthMoonBary, 27.321, 1.0e5);
 }
 
-
 // Position of Sun relative to SSB
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateJplSunSsbOrbit()
 {
     return CreateJPLEphOrbit(JPLEphemItem::Sun, JPLEphemItem::SSB, 11.861773 * 365.25, 2000000);
 }
 
-
 // HTC2.0 ephemerides for Saturnian satellites in Lagrange points of Tethys and Dione
 
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateHeleneOrbit()
 {
-    return std::make_unique<HTC20Orbit>(24, HeleneTerms.data(), HeleneAmps.data(), HeleneAngles, 2.736915, 380000);
+    return std::make_shared<HTC20Orbit>(24, HeleneTerms.data(), HeleneAmps.data(), HeleneAngles, 2.736915, 380000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateTelestoOrbit()
 {
-    return std::make_unique<HTC20Orbit>(12, TelestoTerms.data(), TelestoAmps.data(), TelestoAngles, 1.887802, 300000);
+    return std::make_shared<HTC20Orbit>(12, TelestoTerms.data(), TelestoAmps.data(), TelestoAngles, 1.887802, 300000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateCalypsoOrbit()
 {
-    return std::make_unique<HTC20Orbit>(24, CalypsoTerms.data(), CalypsoAmps.data(), CalypsoAngles, 1.887803, 300000);
+    return std::make_shared<HTC20Orbit>(24, CalypsoTerms.data(), CalypsoAmps.data(), CalypsoAngles, 1.887803, 300000);
 }
-
 
 // various planetary satellite orbits
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreatePhobosOrbit()
 {
-    return std::make_unique<PhobosOrbit>();
+    return std::make_shared<PhobosOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateDeimosOrbit()
 {
-    return std::make_unique<DeimosOrbit>();
+    return std::make_shared<DeimosOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateIoOrbit()
 {
-    return std::make_unique<IoOrbit>();
+    return std::make_shared<IoOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateEuropaOrbit()
 {
-    return std::make_unique<EuropaOrbit>();
+    return std::make_shared<EuropaOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateGanymedeOrbit()
 {
-    return std::make_unique<GanymedeOrbit>();
+    return std::make_shared<GanymedeOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateCallistoOrbit()
 {
-    return std::make_unique<CallistoOrbit>();
+    return std::make_shared<CallistoOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateMimasOrbit()
 {
-    return std::make_unique<MimasOrbit>();
+    return std::make_shared<MimasOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateEnceladusOrbit()
 {
-    return std::make_unique<EnceladusOrbit>();
+    return std::make_shared<EnceladusOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateTethysOrbit()
 {
-    return std::make_unique<TethysOrbit>();
+    return std::make_shared<TethysOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateDioneOrbit()
 {
-    return std::make_unique<DioneOrbit>();
+    return std::make_shared<DioneOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateRheaOrbit()
 {
-    return std::make_unique<RheaOrbit>();
+    return std::make_shared<RheaOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateTitanOrbit()
 {
-    return std::make_unique<TitanOrbit>();
+    return std::make_shared<TitanOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateHyperionOrbit()
 {
-    return std::make_unique<HyperionOrbit>();
+    return std::make_shared<HyperionOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateIapetusOrbit()
 {
-    return std::make_unique<IapetusOrbit>();
+    return std::make_shared<IapetusOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreatePhoebeOrbit()
 {
-    return std::make_unique<PhoebeOrbit>();
+    return std::make_shared<PhoebeOrbit>();
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateMirandaOrbit()
 {
     return CreateUranianSatelliteOrbit(1);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateArielOrbit()
 {
     return CreateUranianSatelliteOrbit(2);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateUmbrielOrbit()
 {
     return CreateUranianSatelliteOrbit(3);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateTitaniaOrbit()
 {
     return CreateUranianSatelliteOrbit(4);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateOberonOrbit()
 {
     return CreateUranianSatelliteOrbit(5);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateTritonOrbit()
 {
-    return std::make_unique<TritonOrbit>();
+    return std::make_shared<TritonOrbit>();
 }
 
+using CustomOrbitFactory = std::shared_ptr<const Orbit> (*)();
 
-using CustomOrbitFactory = std::unique_ptr<Orbit> (*)();
+constexpr auto OrbitTypeCount = static_cast<std::size_t>(CustomOrbitType::_Count);
+
+constexpr std::array<CustomOrbitFactory, OrbitTypeCount> factories
+{
+    &CreateMercuryOrbit,
+    &CreateVenusOrbit,
+    &CreateEarthOrbit,
+    &CreateMoonOrbit,
+    &CreateMarsOrbit,
+    &CreateJupiterOrbit,
+    &CreateSaturnOrbit,
+    &CreateUranusOrbit,
+    &CreateNeptuneOrbit,
+    &CreatePlutoOrbit,
+    &CreateJplMercurySunOrbit,
+    &CreateJplVenusSunOrbit,
+    &CreateJplEarthSunOrbit,
+    &CreateJplMarsSunOrbit,
+    &CreateJplJupiterSunOrbit,
+    &CreateJplSaturnSunOrbit,
+    &CreateJplUranusSunOrbit,
+    &CreateJplNeptuneSunOrbit,
+    &CreateJplPlutoSunOrbit,
+    &CreateJplMercurySsbOrbit,
+    &CreateJplVenusSsbOrbit,
+    &CreateJplEarthSsbOrbit,
+    &CreateJplMarsSsbOrbit,
+    &CreateJplJupiterSsbOrbit,
+    &CreateJplSaturnSsbOrbit,
+    &CreateJplUranusSsbOrbit,
+    &CreateJplNeptuneSsbOrbit,
+    &CreateJplPlutoSsbOrbit,
+    &CreateJplEmbSunOrbit,
+    &CreateJplEmbSsbOrbit,
+    &CreateJplMoonEmbOrbit,
+    &CreateJplMoonEarthOrbit,
+    &CreateJplEarthEmbOrbit,
+    &CreateJplSunSsbOrbit,
+    &CreateHeleneOrbit,
+    &CreateTelestoOrbit,
+    &CreateCalypsoOrbit,
+    &CreatePhobosOrbit,
+    &CreateDeimosOrbit,
+    &CreateIoOrbit,
+    &CreateEuropaOrbit,
+    &CreateGanymedeOrbit,
+    &CreateCallistoOrbit,
+    &CreateMimasOrbit,
+    &CreateEnceladusOrbit,
+    &CreateTethysOrbit,
+    &CreateDioneOrbit,
+    &CreateRheaOrbit,
+    &CreateTitanOrbit,
+    &CreateHyperionOrbit,
+    &CreateIapetusOrbit,
+    &CreatePhoebeOrbit,
+    &CreateMirandaOrbit,
+    &CreateArielOrbit,
+    &CreateUmbrielOrbit,
+    &CreateTitaniaOrbit,
+    &CreateOberonOrbit,
+    &CreateTritonOrbit,
+    &CreateVSOP87MercuryOrbit,
+    &CreateVSOP87VenusOrbit,
+    &CreateVSOP87EarthOrbit,
+    &CreateVSOP87MarsOrbit,
+    &CreateVSOP87JupiterOrbit,
+    &CreateVSOP87SaturnOrbit,
+    &CreateVSOP87UranusOrbit,
+    &CreateVSOP87NeptuneOrbit,
+    &CreateVSOP87SunOrbit,
+};
 
 // lookup table generated by gperf (customorbit.gperf)
 #include "customorbit.inc"
 
+class CustomOrbitsManager
+{
+public:
+    CustomOrbitsManager() = default;
+    ~CustomOrbitsManager() = default;
+
+    CustomOrbitsManager(const CustomOrbitsManager&) = delete;
+    CustomOrbitsManager& operator=(const CustomOrbitsManager&) = delete;
+
+    std::shared_ptr<const Orbit> getOrbit(CustomOrbitType type);
+
+private:
+    std::array<std::weak_ptr<const Orbit>, OrbitTypeCount> models;
+};
+
+std::shared_ptr<const Orbit>
+CustomOrbitsManager::getOrbit(CustomOrbitType type)
+{
+    auto index = static_cast<std::size_t>(type);
+    auto& weak_ptr = models[index];
+    if (auto cachedOrbit = weak_ptr.lock(); cachedOrbit != nullptr)
+        return cachedOrbit;
+
+    auto orbit = factories[index]();
+    weak_ptr = orbit;
+    return orbit;
+}
+
 } // end unnamed namespace
 
-
-std::unique_ptr<Orbit> GetCustomOrbit(std::string_view name)
+std::shared_ptr<const Orbit>
+GetCustomOrbit(std::string_view name)
 {
     auto ptr = CustomOrbitMap::getOrbitType(name.data(), name.size());
     if (ptr == nullptr)
         return nullptr;
 
-    return ptr->factory();
+    static CustomOrbitsManager manager;
+
+    return manager.getOrbit(ptr->orbitType);
 }
 
 } // end namespace celestia::ephem

--- a/src/celephem/customorbit.gperf
+++ b/src/celephem/customorbit.gperf
@@ -5,95 +5,95 @@
 %compare-strncmp
 %readonly-tables
 %enum
-struct CustomOrbitEntry { const char* name; CustomOrbitFactory factory; };
+struct CustomOrbitEntry { const char* name; CustomOrbitType orbitType; };
 %%
-"mercury",         &CreateMercuryOrbit
-"venus",           &CreateVenusOrbit
-"earth",           &CreateEarthOrbit
-"moon",            &CreateMoonOrbit
-"mars",            &CreateMarsOrbit
-"jupiter",         &CreateJupiterOrbit
-"saturn",          &CreateSaturnOrbit
-"uranus",          &CreateUranusOrbit
-"neptune",         &CreateNeptuneOrbit
-"pluto",           &CreatePlutoOrbit
+"mercury",         CustomOrbitType::Mercury
+"venus",           CustomOrbitType::Venus
+"earth",           CustomOrbitType::Earth
+"moon",            CustomOrbitType::Moon
+"mars",            CustomOrbitType::Mars
+"jupiter",         CustomOrbitType::Jupiter
+"saturn",          CustomOrbitType::Saturn
+"uranus",          CustomOrbitType::Uranus
+"neptune",         CustomOrbitType::Neptune
+"pluto",           CustomOrbitType::Pluto
 #
 # Two styles of custom orbit name are permitted for JPL ephemeris
 # orbits. The preferred is <ephemeris>-<object>, e.g.
 # jpl-mercury-sun. But the reverse form is still supported for
 # backward compatibility.
 #
-"jpl-mercury-sun", &CreateJplMercurySunOrbit
-"jpl-venus-sun",   &CreateJplVenusSunOrbit
-"jpl-earth-sun",   &CreateJplEarthSunOrbit
-"jpl-mars-sun",    &CreateJplMarsSunOrbit
-"jpl-jupiter-sun", &CreateJplJupiterSunOrbit
-"jpl-saturn-sun",  &CreateJplSaturnSunOrbit
-"jpl-uranus-sun",  &CreateJplUranusSunOrbit
-"jpl-neptune-sun", &CreateJplNeptuneSunOrbit
-"jpl-pluto-sun",   &CreateJplPlutoSunOrbit
-"mercury-jpl",     &CreateJplMercurySunOrbit
-"venus-jpl",       &CreateJplVenusSunOrbit
-"earth-sun",       &CreateJplEarthSunOrbit
-"mars-sun",        &CreateJplMarsSunOrbit
-"jupiter-sun",     &CreateJplJupiterSunOrbit
-"saturn-sun",      &CreateJplSaturnSunOrbit
-"uranus-sun",      &CreateJplUranusSunOrbit
-"neptune-sun",     &CreateJplNeptuneSunOrbit
-"pluto-sun",       &CreateJplPlutoSunOrbit
+"jpl-mercury-sun", CustomOrbitType::JplMercurySun
+"jpl-venus-sun",   CustomOrbitType::JplVenusSun
+"jpl-earth-sun",   CustomOrbitType::JplEarthSun
+"jpl-mars-sun",    CustomOrbitType::JplMarsSun
+"jpl-jupiter-sun", CustomOrbitType::JplJupiterSun
+"jpl-saturn-sun",  CustomOrbitType::JplSaturnSun
+"jpl-uranus-sun",  CustomOrbitType::JplUranusSun
+"jpl-neptune-sun", CustomOrbitType::JplNeptuneSun
+"jpl-pluto-sun",   CustomOrbitType::JplPlutoSun
+"mercury-jpl",     CustomOrbitType::JplMercurySun
+"venus-jpl",       CustomOrbitType::JplVenusSun
+"earth-sun",       CustomOrbitType::JplEarthSun
+"mars-sun",        CustomOrbitType::JplMarsSun
+"jupiter-sun",     CustomOrbitType::JplJupiterSun
+"saturn-sun",      CustomOrbitType::JplSaturnSun
+"uranus-sun",      CustomOrbitType::JplUranusSun
+"neptune-sun",     CustomOrbitType::JplNeptuneSun
+"pluto-sun",       CustomOrbitType::JplPlutoSun
 #
-"jpl-mercury-ssb", &CreateJplMercurySsbOrbit
-"jpl-venus-ssb",   &CreateJplVenusSsbOrbit
-"jpl-earth-ssb",   &CreateJplEarthSsbOrbit
-"jpl-mars-ssb",    &CreateJplMarsSsbOrbit
-"jpl-jupiter-ssb", &CreateJplJupiterSsbOrbit
-"jpl-saturn-ssb",  &CreateJplSaturnSsbOrbit
-"jpl-uranus-ssb",  &CreateJplUranusSsbOrbit
-"jpl-neptune-ssb", &CreateJplNeptuneSsbOrbit
-"jpl-pluto-ssb",   &CreateJplPlutoSsbOrbit
+"jpl-mercury-ssb", CustomOrbitType::JplMercurySsb
+"jpl-venus-ssb",   CustomOrbitType::JplVenusSsb
+"jpl-earth-ssb",   CustomOrbitType::JplEarthSsb
+"jpl-mars-ssb",    CustomOrbitType::JplMarsSsb
+"jpl-jupiter-ssb", CustomOrbitType::JplJupiterSsb
+"jpl-saturn-ssb",  CustomOrbitType::JplSaturnSsb
+"jpl-uranus-ssb",  CustomOrbitType::JplUranusSsb
+"jpl-neptune-ssb", CustomOrbitType::JplNeptuneSsb
+"jpl-pluto-ssb",   CustomOrbitType::JplPlutoSsb
 #
-"jpl-emb-sun",     &CreateJplEmbSunOrbit
-"jpl-emb-ssb",     &CreateJplEmbSsbOrbit
-"jpl-moon-emb",    &CreateJplMoonEmbOrbit
-"jpl-moon-earth",  &CreateJplMoonEarthOrbit
-"jpl-earth-emb",   &CreateJplEarthEmbOrbit
+"jpl-emb-sun",     CustomOrbitType::JplEmbSun
+"jpl-emb-ssb",     CustomOrbitType::JplEmbSsb
+"jpl-moon-emb",    CustomOrbitType::JplMoonEmb
+"jpl-moon-earth",  CustomOrbitType::JplMoonEarth
+"jpl-earth-emb",   CustomOrbitType::JplEarthEmb
 #
-"jpl-sun-ssb",     &CreateJplSunSsbOrbit
+"jpl-sun-ssb",     CustomOrbitType::JplSunSsb
 #
-"htc20-helene",    &CreateHeleneOrbit
-"htc20-telesto",   &CreateTelestoOrbit
-"htc20-calypso",   &CreateCalypsoOrbit
+"htc20-helene",    CustomOrbitType::Helene
+"htc20-telesto",   CustomOrbitType::Telesto
+"htc20-calypso",   CustomOrbitType::Calypso
 #
-"phobos",          &CreatePhobosOrbit
-"deimos",          &CreateDeimosOrbit
-"io",              &CreateIoOrbit
-"europa",          &CreateEuropaOrbit
-"ganymede",        &CreateGanymedeOrbit
-"callisto",        &CreateCallistoOrbit
-"mimas",           &CreateMimasOrbit
-"enceladus",       &CreateEnceladusOrbit
-"tethys",          &CreateTethysOrbit
-"dione",           &CreateDioneOrbit
-"rhea",            &CreateRheaOrbit
-"titan",           &CreateTitanOrbit
-"hyperion",        &CreateHyperionOrbit
-"iapetus",         &CreateIapetusOrbit
-"phoebe",          &CreatePhoebeOrbit
-"miranda",         &CreateMirandaOrbit
-"ariel",           &CreateArielOrbit
-"umbriel",         &CreateUmbrielOrbit
-"titania",         &CreateTitaniaOrbit
-"oberon",          &CreateOberonOrbit
-"triton",          &CreateTritonOrbit
+"phobos",          CustomOrbitType::Phobos
+"deimos",          CustomOrbitType::Deimos
+"io",              CustomOrbitType::Io
+"europa",          CustomOrbitType::Europa
+"ganymede",        CustomOrbitType::Ganymede
+"callisto",        CustomOrbitType::Callisto
+"mimas",           CustomOrbitType::Mimas
+"enceladus",       CustomOrbitType::Enceladus
+"tethys",          CustomOrbitType::Tethys
+"dione",           CustomOrbitType::Dione
+"rhea",            CustomOrbitType::Rhea
+"titan",           CustomOrbitType::Titan
+"hyperion",        CustomOrbitType::Hyperion
+"iapetus",         CustomOrbitType::Iapetus
+"phoebe",          CustomOrbitType::Phoebe
+"miranda",         CustomOrbitType::Miranda
+"ariel",           CustomOrbitType::Ariel
+"umbriel",         CustomOrbitType::Umbriel
+"titania",         CustomOrbitType::Titania
+"oberon",          CustomOrbitType::Oberon
+"triton",          CustomOrbitType::Triton
 #
 # VSOP orbits
 #
-"vsop87-mercury",  &CreateVSOP87MercuryOrbit
-"vsop87-venus",    &CreateVSOP87VenusOrbit
-"vsop87-earth",    &CreateVSOP87EarthOrbit
-"vsop87-mars",     &CreateVSOP87MarsOrbit
-"vsop87-jupiter",  &CreateVSOP87JupiterOrbit
-"vsop87-saturn",   &CreateVSOP87SaturnOrbit
-"vsop87-uranus",   &CreateVSOP87UranusOrbit
-"vsop87-neptune",  &CreateVSOP87NeptuneOrbit
-"vsop87-sun",      &CreateVSOP87SunOrbit
+"vsop87-mercury",  CustomOrbitType::VSOP87Mercury
+"vsop87-venus",    CustomOrbitType::VSOP87Venus
+"vsop87-earth",    CustomOrbitType::VSOP87Earth
+"vsop87-mars",     CustomOrbitType::VSOP87Mars
+"vsop87-jupiter",  CustomOrbitType::VSOP87Jupiter
+"vsop87-saturn",   CustomOrbitType::VSOP87Saturn
+"vsop87-uranus",   CustomOrbitType::VSOP87Uranus
+"vsop87-neptune",  CustomOrbitType::VSOP87Neptune
+"vsop87-sun",      CustomOrbitType::VSOP87Sun

--- a/src/celephem/customorbit.h
+++ b/src/celephem/customorbit.h
@@ -17,6 +17,6 @@ namespace celestia::ephem
 
 class Orbit;
 
-std::unique_ptr<Orbit> GetCustomOrbit(std::string_view name);
+std::shared_ptr<const Orbit> GetCustomOrbit(std::string_view name);
 
 }

--- a/src/celephem/customrotation.cpp
+++ b/src/celephem/customrotation.cpp
@@ -936,8 +936,6 @@ public:
     }
 };
 
-
-
 enum class CustomRotationModelType
 {
     EarthP03lp = 0,
@@ -981,154 +979,167 @@ enum class CustomRotationModelType
     IAUUmbriel,
     IAUTitania,
     IAUOberon,
-    RotationModelsCount,
+    _Count,
 };
 
 class CustomRotationsManager
 {
-private:
-    static constexpr auto ArraySize = static_cast<std::size_t>(CustomRotationModelType::RotationModelsCount);
-    static std::unique_ptr<RotationModel> createModel(CustomRotationModelType);
-    std::array<std::unique_ptr<RotationModel>, ArraySize> models{ nullptr };
-
 public:
-    RotationModel* getModel(CustomRotationModelType type)
-    {
-        auto index = static_cast<std::size_t>(type);
-        auto& model = models[index];
-        if (model == nullptr)
-            model = createModel(type);
-        return model.get();
-    }
+    CustomRotationsManager() = default;
+    ~CustomRotationsManager() = default;
+
+    CustomRotationsManager(const CustomRotationsManager&) = delete;
+    CustomRotationsManager& operator=(const CustomRotationsManager&) = delete;
+
+    std::shared_ptr<const RotationModel> getModel(CustomRotationModelType type);
+
+private:
+    static constexpr auto ArraySize = static_cast<std::size_t>(CustomRotationModelType::_Count);
+    static std::shared_ptr<const RotationModel> createModel(CustomRotationModelType);
+    std::array<std::weak_ptr<const RotationModel>, ArraySize> models;
 };
 
-std::unique_ptr<RotationModel>
+std::shared_ptr<const RotationModel>
+CustomRotationsManager::getModel(CustomRotationModelType type)
+{
+    auto index = static_cast<std::size_t>(type);
+    auto model = models[index].lock();
+    if (model == nullptr)
+    {
+        model = createModel(type);
+        models[index] = model;
+    }
+
+    return model;
+}
+
+std::shared_ptr<const RotationModel>
 CustomRotationsManager::createModel(CustomRotationModelType type)
 {
     switch (type)
     {
     case CustomRotationModelType::EarthP03lp:
-        return std::make_unique<EarthRotationModel>();
+        return std::make_shared<EarthRotationModel>();
 
     // IAU rotation elements for the planets
     case CustomRotationModelType::IAUMercury:
-        return std::make_unique<IAUPrecessingRotationModel>(281.01, -0.033,
+        return std::make_shared<IAUPrecessingRotationModel>(281.01, -0.033,
                                                             61.45, -0.005,
                                                             329.548, 6.1385025);
     case CustomRotationModelType::IAUVenus:
-        return std::make_unique<IAUPrecessingRotationModel>(272.76, 0.0,
+        return std::make_shared<IAUPrecessingRotationModel>(272.76, 0.0,
                                                             67.16, 0.0,
                                                             160.20, -1.4813688);
     case CustomRotationModelType::IAUEarth:
-        return std::make_unique<IAUPrecessingRotationModel>(0.0, -0.641,
+        return std::make_shared<IAUPrecessingRotationModel>(0.0, -0.641,
                                                             90.0, -0.557,
                                                             190.147, 360.9856235);
     case CustomRotationModelType::IAUMars:
-        return std::make_unique<IAUPrecessingRotationModel>(317.68143, -0.1061,
+        return std::make_shared<IAUPrecessingRotationModel>(317.68143, -0.1061,
                                                             52.88650, -0.0609,
                                                             176.630, 350.89198226);
     case CustomRotationModelType::IAUJupiter:
-        return std::make_unique<IAUPrecessingRotationModel>(268.05, -0.009,
+        return std::make_shared<IAUPrecessingRotationModel>(268.05, -0.009,
                                                             64.49, -0.003,
                                                             284.95, 870.5366420);
     case CustomRotationModelType::IAUSaturn:
-        return std::make_unique<IAUPrecessingRotationModel>(40.589, -0.036,
+        return std::make_shared<IAUPrecessingRotationModel>(40.589, -0.036,
                                                             83.537, -0.004,
                                                             38.90, 810.7939024);
     case CustomRotationModelType::IAUUranus:
-        return std::make_unique<IAUPrecessingRotationModel>(257.311, 0.0,
+        return std::make_shared<IAUPrecessingRotationModel>(257.311, 0.0,
                                                             -15.175, 0.0,
                                                             203.81, -501.1600928);
     case CustomRotationModelType::IAUNeptune:
-        return std::make_unique<IAUNeptuneRotationModel>();
+        return std::make_shared<IAUNeptuneRotationModel>();
     case CustomRotationModelType::IAUPluto:
-        return std::make_unique<IAUPrecessingRotationModel>(313.02, 0.0,
+        return std::make_shared<IAUPrecessingRotationModel>(313.02, 0.0,
                                                             9.09, 0.0,
                                                             236.77, -56.3623195);
 
     // IAU rotation elements for the Moon
     case CustomRotationModelType::IAUMoon:
-        return std::make_unique<IAULunarRotationModel>();
+        return std::make_shared<IAULunarRotationModel>();
 
     // IAU rotation elements for satellites of Mars
     case CustomRotationModelType::IAUPhobos:
-        return std::make_unique<IAUPhobosRotationModel>();
+        return std::make_shared<IAUPhobosRotationModel>();
     case CustomRotationModelType::IAUDeimos:
-        return std::make_unique<IAUDeimosRotationModel>();
+        return std::make_shared<IAUDeimosRotationModel>();
 
     // IAU rotation elements for satellites of Jupiter
     case CustomRotationModelType::IAUMetis:
-        return std::make_unique<IAUPrecessingRotationModel>(268.05, -0.009,
+        return std::make_shared<IAUPrecessingRotationModel>(268.05, -0.009,
                                                             64.49, 0.003,
                                                             346.09, 1221.2547301);
     case CustomRotationModelType::IAUAdrastea:
-        return std::make_unique<IAUPrecessingRotationModel>(268.05, -0.009,
+        return std::make_shared<IAUPrecessingRotationModel>(268.05, -0.009,
                                                             64.49, 0.003,
                                                             33.29, 1206.9986602);
     case CustomRotationModelType::IAUAmalthea:
-        return std::make_unique<IAUAmaltheaRotationModel>();
+        return std::make_shared<IAUAmaltheaRotationModel>();
     case CustomRotationModelType::IAUThebe:
-        return std::make_unique<IAUThebeRotationModel>();
+        return std::make_shared<IAUThebeRotationModel>();
     case CustomRotationModelType::IAUIo:
-        return std::make_unique<IAUIoRotationModel>();
+        return std::make_shared<IAUIoRotationModel>();
     case CustomRotationModelType::IAUEuropa:
-        return std::make_unique<IAUEuropaRotationModel>();
+        return std::make_shared<IAUEuropaRotationModel>();
     case CustomRotationModelType::IAUGanymede:
-        return std::make_unique<IAUGanymedeRotationModel>();
+        return std::make_shared<IAUGanymedeRotationModel>();
     case CustomRotationModelType::IAUCallisto:
-        return std::make_unique<IAUCallistoRotationModel>();
+        return std::make_shared<IAUCallistoRotationModel>();
 
     // IAU rotation elements for satellites of Saturn
     case CustomRotationModelType::IAUPan:
-        return std::make_unique<IAUPrecessingRotationModel>(40.6, -0.036,
+        return std::make_shared<IAUPrecessingRotationModel>(40.6, -0.036,
                                                             83.5, -0.004,
                                                             48.8, 626.0440000);
     case CustomRotationModelType::IAUAtlas:
-        return std::make_unique<IAUPrecessingRotationModel>(40.6, -0.036,
+        return std::make_shared<IAUPrecessingRotationModel>(40.6, -0.036,
                                                             83.5, -0.004,
                                                             137.88, 598.3060000);
     case CustomRotationModelType::IAUPrometheus:
-        return std::make_unique<IAUPrecessingRotationModel>(40.6, -0.036,
+        return std::make_shared<IAUPrecessingRotationModel>(40.6, -0.036,
                                                             83.5, -0.004,
                                                             296.14, 587.289000);
     case CustomRotationModelType::IAUPandora:
-        return std::make_unique<IAUPrecessingRotationModel>(40.6, -0.036,
+        return std::make_shared<IAUPrecessingRotationModel>(40.6, -0.036,
                                                             83.5, -0.004,
                                                             162.92, 572.7891000);
     case CustomRotationModelType::IAUMimas:
-        return std::make_unique<IAUMimasRotationModel>();
+        return std::make_shared<IAUMimasRotationModel>();
     case CustomRotationModelType::IAUEnceladus:
-        return std::make_unique<IAUEnceladusRotationModel>();
+        return std::make_shared<IAUEnceladusRotationModel>();
     case CustomRotationModelType::IAUTethys:
-        return std::make_unique<IAUTethysRotationModel>();
+        return std::make_shared<IAUTethysRotationModel>();
     case CustomRotationModelType::IAUTelesto:
-        return std::make_unique<IAUTelestoRotationModel>();
+        return std::make_shared<IAUTelestoRotationModel>();
     case CustomRotationModelType::IAUCalypso:
-        return std::make_unique<IAUCalypsoRotationModel>();
+        return std::make_shared<IAUCalypsoRotationModel>();
     case CustomRotationModelType::IAUDione:
-        return std::make_unique<IAUDioneRotationModel>();
+        return std::make_shared<IAUDioneRotationModel>();
     case CustomRotationModelType::IAUHelene:
-        return std::make_unique<IAUHeleneRotationModel>();
+        return std::make_shared<IAUHeleneRotationModel>();
     case CustomRotationModelType::IAURhea:
-        return std::make_unique<IAURheaRotationModel>();
+        return std::make_shared<IAURheaRotationModel>();
     case CustomRotationModelType::IAUTitan:
-        return std::make_unique<IAUTitanRotationModel>();
+        return std::make_shared<IAUTitanRotationModel>();
     case CustomRotationModelType::IAUIapetus:
-        return std::make_unique<IAUIapetusRotationModel>();
+        return std::make_shared<IAUIapetusRotationModel>();
     case CustomRotationModelType::IAUPhoebe:
-        return std::make_unique<IAUPhoebeRotationModel>();
+        return std::make_shared<IAUPhoebeRotationModel>();
 
     // IAU rotation elements for satellites of Uranus
     case CustomRotationModelType::IAUMiranda:
-        return std::make_unique<IAUMirandaRotationModel>();
+        return std::make_shared<IAUMirandaRotationModel>();
     case CustomRotationModelType::IAUAriel:
-        return std::make_unique<IAUArielRotationModel>();
+        return std::make_shared<IAUArielRotationModel>();
     case CustomRotationModelType::IAUUmbriel:
-        return std::make_unique<IAUUmbrielRotationModel>();
+        return std::make_shared<IAUUmbrielRotationModel>();
     case CustomRotationModelType::IAUTitania:
-        return std::make_unique<IAUTitaniaRotationModel>();
+        return std::make_shared<IAUTitaniaRotationModel>();
     case CustomRotationModelType::IAUOberon:
-        return std::make_unique<IAUOberonRotationModel>();
+        return std::make_shared<IAUOberonRotationModel>();
     default:
         return nullptr;
     }
@@ -1139,16 +1150,15 @@ CustomRotationsManager::createModel(CustomRotationModelType type)
 
 } // end unnamed namespace
 
-
-RotationModel*
+std::shared_ptr<const RotationModel>
 GetCustomRotationModel(std::string_view name)
 {
     auto ptr = CustomRotationMap::getModelType(name.data(), name.size());
     if (ptr == nullptr)
         return nullptr;
 
-    static CustomRotationsManager* manager = std::make_unique<CustomRotationsManager>().release();
-    return manager->getModel(ptr->modelType);
+    static CustomRotationsManager manager;
+    return manager.getModel(ptr->modelType);
 }
 
 } // end namespace celestia::ephem

--- a/src/celephem/customrotation.h
+++ b/src/celephem/customrotation.h
@@ -12,13 +12,15 @@
 
 #pragma once
 
+#include <memory>
 #include <string_view>
-
 
 namespace celestia::ephem
 {
 
 class RotationModel;
-RotationModel* GetCustomRotationModel(std::string_view name);
+
+std::shared_ptr<const RotationModel>
+GetCustomRotationModel(std::string_view name);
 
 }

--- a/src/celephem/orbit.cpp
+++ b/src/celephem/orbit.cpp
@@ -555,8 +555,8 @@ Eigen::Vector3d CachingOrbit::computeVelocity(double jd) const
 }
 
 
-MixedOrbit::MixedOrbit(std::unique_ptr<Orbit>&& orbit, double t0, double t1, double mass) :
-    primary(std::move(orbit)),
+MixedOrbit::MixedOrbit(const std::shared_ptr<const Orbit>& orbit, double t0, double t1, double mass) :
+    primary(orbit),
     begin(t0),
     end(t1),
     boundingRadius(0.0)

--- a/src/celephem/orbit.h
+++ b/src/celephem/orbit.h
@@ -174,7 +174,7 @@ class CachingOrbit : public Orbit
 class MixedOrbit : public Orbit
 {
  public:
-    MixedOrbit(std::unique_ptr<Orbit>&& orbit, double t0, double t1, double mass);
+    MixedOrbit(const std::shared_ptr<const Orbit>& orbit, double t0, double t1, double mass);
     ~MixedOrbit() override = default;
 
     Eigen::Vector3d positionAtTime(double jd) const override;
@@ -184,9 +184,9 @@ class MixedOrbit : public Orbit
     void sample(double startTime, double endTime, OrbitSampleProc& proc) const override;
 
  private:
-    std::unique_ptr<Orbit> primary;
-    std::unique_ptr<Orbit> afterApprox;
-    std::unique_ptr<Orbit> beforeApprox;
+    std::shared_ptr<const Orbit> primary;
+    std::shared_ptr<const Orbit> afterApprox;
+    std::shared_ptr<const Orbit> beforeApprox;
     double begin;
     double end;
     double boundingRadius;

--- a/src/celephem/rotation.cpp
+++ b/src/celephem/rotation.cpp
@@ -159,13 +159,11 @@ ConstantOrientation::ConstantOrientation(const Eigen::Quaterniond& q) :
 {
 }
 
-
 Eigen::Quaterniond
 ConstantOrientation::spin(double /*unused*/) const
 {
     return orientation;
 }
-
 
 Eigen::Vector3d
 ConstantOrientation::angularVelocityAtTime(double /* tdb */) const
@@ -173,6 +171,12 @@ ConstantOrientation::angularVelocityAtTime(double /* tdb */) const
     return Eigen::Vector3d::Zero();
 }
 
+std::shared_ptr<const RotationModel>
+ConstantOrientation::identity()
+{
+    static auto identity = std::make_shared<ConstantOrientation>();
+    return identity;
+}
 
 /***** UniformRotationModel implementation *****/
 

--- a/src/celephem/rotation.h
+++ b/src/celephem/rotation.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
@@ -113,6 +115,7 @@ private:
 class ConstantOrientation : public RotationModel
 {
  public:
+    ConstantOrientation() = default;
     ConstantOrientation(const Eigen::Quaterniond& q);
     ~ConstantOrientation() override = default;
 
@@ -122,8 +125,10 @@ class ConstantOrientation : public RotationModel
     double getPeriod() const override { return 0.0; }
     bool isPeriodic() const override { return false; }
 
+    static std::shared_ptr<const RotationModel> identity();
+
  private:
-    Eigen::Quaterniond orientation;
+    Eigen::Quaterniond orientation{ Eigen::Quaterniond::Identity() };
 };
 
 

--- a/src/celephem/samporbit.h
+++ b/src/celephem/samporbit.h
@@ -27,14 +27,11 @@ enum class TrajectoryInterpolation
 enum class TrajectoryPrecision
 {
     Single,
-    Double
+    Double,
 };
 
-std::unique_ptr<Orbit> LoadSampledTrajectoryDoublePrec(const fs::path& filename, TrajectoryInterpolation interpolation);
-std::unique_ptr<Orbit> LoadSampledTrajectorySinglePrec(const fs::path& filename, TrajectoryInterpolation interpolation);
-std::unique_ptr<Orbit> LoadXYZVTrajectoryDoublePrec(const fs::path& filename, TrajectoryInterpolation interpolation);
-std::unique_ptr<Orbit> LoadXYZVTrajectorySinglePrec(const fs::path& filename, TrajectoryInterpolation interpolation);
-std::unique_ptr<Orbit> LoadXYZVBinarySinglePrec(const fs::path& filename, TrajectoryInterpolation interpolation);
-std::unique_ptr<Orbit> LoadXYZVBinaryDoublePrec(const fs::path& filename, TrajectoryInterpolation interpolation);
+std::shared_ptr<const Orbit> LoadSampledTrajectory(const fs::path&,
+                                                   TrajectoryInterpolation,
+                                                   TrajectoryPrecision);
 
 } // end namespace celestia::ephem

--- a/src/celephem/samporient.cpp
+++ b/src/celephem/samporient.cpp
@@ -151,7 +151,7 @@ SampledOrientation::getOrientation(double tjd) const
 
 } // end unnamed namespace
 
-std::unique_ptr<RotationModel>
+std::shared_ptr<const RotationModel>
 LoadSampledOrientation(const fs::path& filename)
 {
     std::vector<double> sampleTimes;
@@ -166,7 +166,7 @@ LoadSampledOrientation(const fs::path& filename)
         return nullptr;
     }
 
-    return std::make_unique<SampledOrientation>(std::move(sampleTimes),
+    return std::make_shared<SampledOrientation>(std::move(sampleTimes),
                                                 std::move(samples));
 }
 

--- a/src/celephem/samporient.h
+++ b/src/celephem/samporient.h
@@ -18,6 +18,6 @@ namespace celestia::ephem
 
 class RotationModel;
 
-std::unique_ptr<RotationModel> LoadSampledOrientation(const fs::path& filename);
+std::shared_ptr<const RotationModel> LoadSampledOrientation(const fs::path& filename);
 
 }

--- a/src/celephem/scriptorbit.cpp
+++ b/src/celephem/scriptorbit.cpp
@@ -172,10 +172,11 @@ ScriptedOrbit::getBoundingRadius() const
  *         (TDB Julian day) and returns three values which are the x, y, and
  *         z coordinates. Units for the position are kilometers.
  */
-std::unique_ptr<Orbit> CreateScriptedOrbit(const std::string* moduleName,
-                                           const std::string& funcName,
-                                           const AssociativeArray& parameters,
-                                           const fs::path& path)
+std::shared_ptr<const Orbit>
+CreateScriptedOrbit(const std::string* moduleName,
+                    const std::string& funcName,
+                    const AssociativeArray& parameters,
+                    const fs::path& path)
 {
     lua_State* luaState = GetScriptedObjectContext();
     if (luaState == nullptr)
@@ -287,7 +288,7 @@ std::unique_ptr<Orbit> CreateScriptedOrbit(const std::string* moduleName,
         return nullptr;
     }
 
-    return std::make_unique<ScriptedOrbit>(luaState,
+    return std::make_shared<ScriptedOrbit>(luaState,
                                            std::move(luaOrbitObjectName),
                                            boundingRadius,
                                            period,

--- a/src/celephem/scriptorbit.h
+++ b/src/celephem/scriptorbit.h
@@ -23,9 +23,10 @@ namespace celestia::ephem
 
 class Orbit;
 
-std::unique_ptr<Orbit> CreateScriptedOrbit(const std::string* moduleName,
-                                           const std::string& funcName,
-                                           const AssociativeArray& parameters,
-                                           const fs::path& path);
+std::shared_ptr<const Orbit>
+CreateScriptedOrbit(const std::string* moduleName,
+                    const std::string& funcName,
+                    const AssociativeArray& parameters,
+                    const fs::path& path);
 
 }

--- a/src/celephem/scriptrotation.cpp
+++ b/src/celephem/scriptrotation.cpp
@@ -171,7 +171,7 @@ ScriptedRotation::getValidRange(double& begin, double& end) const
  *         input (TDB Julian day) and returns three values which are the the
  *         quaternion (w, x, y, z).
  */
-std::unique_ptr<RotationModel>
+std::shared_ptr<const RotationModel>
 CreateScriptedRotation(const std::string* moduleName,
                             const std::string& funcName,
                             const AssociativeArray& parameters,
@@ -266,7 +266,7 @@ CreateScriptedRotation(const std::string* moduleName,
         return nullptr;
     }
 
-    return std::make_unique<ScriptedRotation>(luaState,
+    return std::make_shared<ScriptedRotation>(luaState,
                                               std::move(luaRotationObjectName),
                                               period,
                                               validRangeBegin,

--- a/src/celephem/scriptrotation.h
+++ b/src/celephem/scriptrotation.h
@@ -23,7 +23,7 @@ namespace celestia::ephem
 
 class RotationModel;
 
-std::unique_ptr<RotationModel>
+std::shared_ptr<const RotationModel>
 CreateScriptedRotation(const std::string* moduleName,
                        const std::string& funcName,
                        const AssociativeArray& parameters,

--- a/src/celephem/vsop87.cpp
+++ b/src/celephem/vsop87.cpp
@@ -11000,7 +11000,6 @@ constexpr std::array sun_Z {
     VSOPSeries(sun_Z0), VSOPSeries(sun_Z1), VSOPSeries(sun_Z2),
 };
 
-
 double
 SumSeries(const VSOPSeries& series, double t)
 {
@@ -11014,7 +11013,6 @@ SumSeries(const VSOPSeries& series, double t)
 
     return x;
 }
-
 
 class VSOP87Orbit : public CachingOrbit
 {
@@ -11129,7 +11127,6 @@ class VSOP87Orbit : public CachingOrbit
     }
 };
 
-
 // VSOP87 orbit with rectangular variables
 class VSOP87OrbitRect : public CachingOrbit
 {
@@ -11220,19 +11217,16 @@ class VSOP87OrbitRect : public CachingOrbit
     }
 };
 
-
-
 double
 yearToJD(int year)
 {
     return static_cast<double>(astro::Date(year, 1, 1));
 }
 
-
-std::unique_ptr<Orbit>
-MakeVSOP87Orbit(std::unique_ptr<Orbit>&& orbit, int t0, int t1)
+std::shared_ptr<const Orbit>
+MakeVSOP87Orbit(const std::shared_ptr<Orbit>& orbit, int t0, int t1)
 {
-    return std::make_unique<MixedOrbit>(std::move(orbit),
+    return std::make_unique<MixedOrbit>(orbit,
                                         yearToJD(t0),
                                         yearToJD(t1),
                                         astro::SolarMass);
@@ -11240,91 +11234,82 @@ MakeVSOP87Orbit(std::unique_ptr<Orbit>&& orbit, int t0, int t1)
 
 } // end unnamed namespace
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVSOP87MercuryOrbit()
 {
-    return MakeVSOP87Orbit(std::make_unique<VSOP87Orbit>(mercury_L, mercury_B, mercury_R,
+    return MakeVSOP87Orbit(std::make_shared<VSOP87Orbit>(mercury_L, mercury_B, mercury_R,
                                                          0.2408 * 365.25,
                                                          60000000.0),
                            -4000, 4000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVSOP87VenusOrbit()
 {
-    return MakeVSOP87Orbit(std::make_unique<VSOP87Orbit>(venus_L, venus_B, venus_R,
+    return MakeVSOP87Orbit(std::make_shared<VSOP87Orbit>(venus_L, venus_B, venus_R,
                                                          0.6152 * 365.25,
                                                          100000000.0),
                            -4000, 4000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVSOP87EarthOrbit()
 {
-    return MakeVSOP87Orbit(std::make_unique<VSOP87Orbit>(earth_L, earth_B, earth_R,
+    return MakeVSOP87Orbit(std::make_shared<VSOP87Orbit>(earth_L, earth_B, earth_R,
                                                          365.25,
                                                          160000000.0),
                            -4000, 4000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVSOP87MarsOrbit()
 {
-    return MakeVSOP87Orbit(std::make_unique<VSOP87Orbit>(mars_L, mars_B, mars_R,
+    return MakeVSOP87Orbit(std::make_shared<VSOP87Orbit>(mars_L, mars_B, mars_R,
                                                          1.8809 * 365.25,
                                                          240000000),
                            -4000, 4000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVSOP87JupiterOrbit()
 {
-    return MakeVSOP87Orbit(std::make_unique<VSOP87Orbit>(jupiter_L, jupiter_B, jupiter_R,
+    return MakeVSOP87Orbit(std::make_shared<VSOP87Orbit>(jupiter_L, jupiter_B, jupiter_R,
                                                          11.86 * 365.25,
                                                          800000000.0),
                            -4000, 4000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVSOP87SaturnOrbit()
 {
-    return MakeVSOP87Orbit(std::make_unique<VSOP87Orbit>(saturn_L, saturn_B, saturn_R,
+    return MakeVSOP87Orbit(std::make_shared<VSOP87Orbit>(saturn_L, saturn_B, saturn_R,
                                                          29.4577 * 365.25,
                                                          1.5e9),
                            -4000, 4000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVSOP87UranusOrbit()
 {
-    return MakeVSOP87Orbit(std::make_unique<VSOP87Orbit>(uranus_L, uranus_B, uranus_R,
+    return MakeVSOP87Orbit(std::make_shared<VSOP87Orbit>(uranus_L, uranus_B, uranus_R,
                                                          84.0139 * 365.25,
                                                          3.0e9),
                            -4000, 4000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVSOP87NeptuneOrbit()
 {
-    return MakeVSOP87Orbit(std::make_unique<VSOP87Orbit>(neptune_L, neptune_B, neptune_R,
+    return MakeVSOP87Orbit(std::make_shared<VSOP87Orbit>(neptune_L, neptune_B, neptune_R,
                                                          164.793 * 365.25,
                                                          4.7e9),
                            -4000, 4000);
 }
 
-
-std::unique_ptr<Orbit>
+std::shared_ptr<const Orbit>
 CreateVSOP87SunOrbit()
 {
-    return MakeVSOP87Orbit(std::make_unique<VSOP87OrbitRect>(sun_X, sun_Y, sun_Z,
+    return MakeVSOP87Orbit(std::make_shared<VSOP87OrbitRect>(sun_X, sun_Y, sun_Z,
                                                              0.0,
                                                              2000000),
                            -4000, 6000);

--- a/src/celephem/vsop87.h
+++ b/src/celephem/vsop87.h
@@ -16,14 +16,14 @@ namespace celestia::ephem
 
 class Orbit;
 
-std::unique_ptr<Orbit> CreateVSOP87MercuryOrbit();
-std::unique_ptr<Orbit> CreateVSOP87VenusOrbit();
-std::unique_ptr<Orbit> CreateVSOP87EarthOrbit();
-std::unique_ptr<Orbit> CreateVSOP87MarsOrbit();
-std::unique_ptr<Orbit> CreateVSOP87JupiterOrbit();
-std::unique_ptr<Orbit> CreateVSOP87SaturnOrbit();
-std::unique_ptr<Orbit> CreateVSOP87UranusOrbit();
-std::unique_ptr<Orbit> CreateVSOP87NeptuneOrbit();
-std::unique_ptr<Orbit> CreateVSOP87SunOrbit();
+std::shared_ptr<const Orbit> CreateVSOP87MercuryOrbit();
+std::shared_ptr<const Orbit> CreateVSOP87VenusOrbit();
+std::shared_ptr<const Orbit> CreateVSOP87EarthOrbit();
+std::shared_ptr<const Orbit> CreateVSOP87MarsOrbit();
+std::shared_ptr<const Orbit> CreateVSOP87JupiterOrbit();
+std::shared_ptr<const Orbit> CreateVSOP87SaturnOrbit();
+std::shared_ptr<const Orbit> CreateVSOP87UranusOrbit();
+std::shared_ptr<const Orbit> CreateVSOP87NeptuneOrbit();
+std::shared_ptr<const Orbit> CreateVSOP87SunOrbit();
 
 }

--- a/src/celutil/fsutils.h
+++ b/src/celutil/fsutils.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <optional>
 #include <string_view>
 
@@ -20,6 +21,16 @@
 
 namespace celestia::util
 {
+
+// Since std::hash<std::filesystem::path> was not in the original C++17 standard
+// we need to implement a custom hasher for older compilers.
+struct PathHasher
+{
+    std::size_t operator()(const fs::path& path) const noexcept
+    {
+        return fs::hash_value(path);
+    }
+};
 
 std::optional<fs::path> U8FileName(std::string_view source,
                                    bool allowWildcardExtension = true);


### PR DESCRIPTION
More changes that may eventually let us do re-loads of data...

- Cache custom orbits
- Use separate samples and trajectory caches to reduce duplication of samples at different interpolation/precision
- Use custom classes for trajectory/rotation model caches as resource handles aren't used