### PR TITLE
Use empty mesh in case of invalid filenames in Mesh declarations

### DIFF
--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -30,6 +30,7 @@ using namespace Eigen;
 using namespace std;
 
 namespace astro = celestia::astro;
+namespace engine = celestia::engine;
 namespace math = celestia::math;
 
 Body::Body(PlanetarySystem* _system, const std::string& _name) :
@@ -985,7 +986,7 @@ void Body::computeLocations()
     // No work to do if there's no mesh, or if the mesh cannot be loaded
     if (geometry == InvalidResource)
         return;
-    const Geometry* g = GetGeometryManager()->find(geometry);
+    const Geometry* g = engine::GetGeometryManager()->find(geometry);
     if (g == nullptr)
         return;
 

--- a/src/celengine/geometry.h
+++ b/src/celengine/geometry.h
@@ -52,3 +52,10 @@ public:
     {
     }
 };
+
+class EmptyGeometry : public Geometry
+{
+    void render(RenderContext&, double _t = 0.0) override { /* no-op */ }
+    bool pick(const Eigen::ParametrizedLine<double, 3>&, double&) const override { return false; }
+    bool isOpaque() const override { return true; }
+};

--- a/src/celengine/meshmanager.h
+++ b/src/celengine/meshmanager.h
@@ -19,10 +19,14 @@
 #include <celutil/resmanager.h>
 #include "geometry.h"
 
+namespace celestia::engine
+{
 
 class GeometryInfo
 {
- public:
+public:
+    using ResourceType = Geometry;
+
     // Ensure that models with different centers get resolved to different objects by
     // encoding the center, scale and normalization state in the key.
     struct ResourceKey
@@ -46,26 +50,12 @@ class GeometryInfo
         {}
     };
 
- private:
-    fs::path source;
-    fs::path path;
-    Eigen::Vector3f center;
-    float scale;
-    bool isNormalized;
-
-    friend bool operator<(const GeometryInfo&, const GeometryInfo&);
-
- public:
-    using ResourceType = Geometry;
-
     GeometryInfo(const fs::path& _source,
                  const fs::path& _path = "") :
         source(_source),
-        path(_path),
-        center(Eigen::Vector3f::Zero()),
-        scale(1.0f),
-        isNormalized(true)
-        {}
+        path(_path)
+    {
+    }
 
     GeometryInfo(const fs::path& _source,
                  const fs::path& _path,
@@ -77,10 +67,20 @@ class GeometryInfo
         center(_center),
         scale(_scale),
         isNormalized(_isNormalized)
-        {}
+    {
+    }
 
     ResourceKey resolve(const fs::path&) const;
     std::unique_ptr<Geometry> load(const ResourceKey&) const;
+
+private:
+    fs::path source;
+    fs::path path;
+    Eigen::Vector3f center{ Eigen::Vector3f::Zero() };
+    float scale{ 1.0f };
+    bool isNormalized{ true };
+
+    friend bool operator<(const GeometryInfo&, const GeometryInfo&);
 };
 
 inline bool operator<(const GeometryInfo& g0, const GeometryInfo& g1)
@@ -99,4 +99,6 @@ inline bool operator<(const GeometryInfo::ResourceKey& k0,
 
 using GeometryManager = ResourceManager<GeometryInfo>;
 
-extern GeometryManager* GetGeometryManager();
+GeometryManager* GetGeometryManager();
+
+} // end namespace celestia::engine

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -18,6 +18,7 @@
 #include "rendcontext.h"
 #include "render.h"
 
+namespace engine = celestia::engine;
 namespace util = celestia::util;
 using util::GetLogger;
 
@@ -69,7 +70,7 @@ Nebula::load(const AssociativeArray* params, const fs::path& resPath)
         }
 
         ResourceHandle geometryHandle =
-            GetGeometryManager()->getHandle(GeometryInfo(*geometryFileName, resPath));
+            engine::GetGeometryManager()->getHandle(engine::GeometryInfo(*geometryFileName, resPath));
         setGeometry(geometryHandle);
     }
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2225,7 +2225,7 @@ void Renderer::renderObject(const Vector3f& pos,
     if (obj.geometry != InvalidResource)
     {
         // This is a model loaded from a file
-        geometry = GetGeometryManager()->find(obj.geometry);
+        geometry = engine::GetGeometryManager()->find(obj.geometry);
     }
 
     // Get the textures . . .
@@ -2764,7 +2764,7 @@ void Renderer::renderPlanet(Body& body,
         bool isNormalized = false;
         const Geometry* geometry = nullptr;
         if (rp.geometry != InvalidResource)
-            geometry = GetGeometryManager()->find(rp.geometry);
+            geometry = engine::GetGeometryManager()->find(rp.geometry);
         if (geometry == nullptr || geometry->isNormalized())
         {
             scaleFactors = rp.semiAxes * rp.radius;
@@ -3232,7 +3232,7 @@ void Renderer::addRenderListEntries(RenderListEntry& rle,
 
         if (body.getGeometry() != InvalidResource && rle.discSizeInPixels > 1)
         {
-            const Geometry* geometry = GetGeometryManager()->find(body.getGeometry());
+            const Geometry* geometry = engine::GetGeometryManager()->find(body.getGeometry());
             if (geometry == nullptr)
                 rle.isOpaque = true;
             else
@@ -4368,7 +4368,7 @@ void Renderer::loadTextures(Body* body)
 
     if (body->getGeometry() != InvalidResource)
     {
-        Geometry* geometry = GetGeometryManager()->find(body->getGeometry());
+        Geometry* geometry = engine::GetGeometryManager()->find(body->getGeometry());
         if (geometry != nullptr)
         {
             geometry->loadTextures();

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -43,6 +43,7 @@ using celestia::util::GetLogger;
 using celestia::util::IntrusivePtr;
 
 namespace astro = celestia::astro;
+namespace engine = celestia::engine;
 namespace math = celestia::math;
 namespace util = celestia::util;
 
@@ -1420,6 +1421,8 @@ StarDatabaseBuilder::applyCustomStarDetails(const Star* star,
 
     if (!customDetails.modelName.empty())
     {
+        using engine::GeometryInfo;
+        using engine::GetGeometryManager;
         ResourceHandle geometryHandle = GetGeometryManager()->getHandle(GeometryInfo(customDetails.modelName,
                                                                                      path,
                                                                                      Eigen::Vector3f::Zero(),

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -32,6 +32,7 @@
 #include "render.h"
 #include "timelinephase.h"
 
+namespace engine = celestia::engine;
 namespace math = celestia::math;
 namespace util = celestia::util;
 
@@ -191,7 +192,7 @@ ExactPlanetPickTraversal(Body* body, PlanetPickInfo& pickInfo)
         Eigen::ParametrizedLine<double, 3> r(pickInfo.pickRay.origin() - bpos, pickInfo.pickRay.direction());
         r = math::transformRay(r, m);
 
-        Geometry* geometry = GetGeometryManager()->find(body->getGeometry());
+        const Geometry* geometry = engine::GetGeometryManager()->find(body->getGeometry());
         float scaleFactor = body->getGeometryScale();
         if (geometry != nullptr && geometry->isNormalized())
             scaleFactor = radius;

--- a/src/celrender/nebularenderer.cpp
+++ b/src/celrender/nebularenderer.cpp
@@ -78,7 +78,7 @@ NebulaRenderer::renderNebula(const Object &obj) const
 {
     Geometry *g = nullptr;
     if (auto geometry = obj.nebula->getGeometry(); geometry != InvalidResource)
-        g = GetGeometryManager()->find(geometry);
+        g = engine::GetGeometryManager()->find(geometry);
     if (g == nullptr)
         return;
 


### PR DESCRIPTION
- Special case `Mesh ""` to not log errors (used in some add-ons to avoid rendering geometry while still retaining the ability to have cloud maps, etc.)

Resolves #2069