### PR TITLE
[qt] Update deep sky browser

### DIFF
--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -310,13 +310,6 @@ bool DSODatabase::load(std::istream& in, const fs::path& resourcePath)
 }
 
 
-bool DSODatabase::loadBinary(std::istream&)
-{
-    // TODO: define a binary dso file format
-    return true;
-}
-
-
 void DSODatabase::finish()
 {
     buildOctree();

--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -38,7 +38,6 @@ class DSODatabase
     DSODatabase() = default;
     ~DSODatabase();
 
-
     DeepSkyObject* getDSO(const std::uint32_t) const;
     std::uint32_t size() const;
 
@@ -65,10 +64,7 @@ class DSODatabase
     void setNameDatabase(std::unique_ptr<DSONameDatabase>&&);
 
     bool load(std::istream&, const fs::path& resourcePath = fs::path());
-    bool loadBinary(std::istream&);
     void finish();
-
-    static DSODatabase* read(std::istream&);
 
     float getAverageAbsoluteMagnitude() const;
 

--- a/src/celestia/qt/qtdeepskybrowser.h
+++ b/src/celestia/qt/qtdeepskybrowser.h
@@ -29,7 +29,6 @@ class Selection;
 class ColorSwatchWidget;
 class InfoPanel;
 
-
 class DeepSkyBrowser : public QWidget
 {
     Q_OBJECT


### PR DESCRIPTION
- Only show Type column for galaxies (irrelevant otherwise)
- Replace multiset with heap algorithms when populating the DSO list
- When building with Qt6, use QRegularExpression instead of legacy QRegExp
- Remove some unused methods from the DSO database