### PR TITLE
[qt6] Remove qt5compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         vcpkg --triplet=${{matrix.platform}}-windows install --recurse `
           cspice eigen3 ffmpeg[x264] fmt freetype gettext gperf libepoxy libjpeg-turbo libpng luajit `
-          qtbase qt5compat[core]
+          qtbase
 
     - name: Checkout source code
       uses: actions/checkout@v4
@@ -167,7 +167,7 @@ jobs:
                                 ninja-build \
                                 qtbase5-dev qtbase5-dev-tools qtbase5-private-dev
         if [ "${{matrix.config.qt6}}" = "ON" ]; then
-            sudo apt-get install -y qt6-base-dev qt6-base-dev-tools libqt6core5compat6-dev qt6-base-private-dev
+            sudo apt-get install -y qt6-base-dev qt6-base-dev-tools qt6-base-private-dev
         fi
         if [ "${{matrix.config.avif}}" = "ON" ]; then
             sudo apt-get install -y libavif-dev

--- a/src/celestia/qt6/CMakeLists.txt
+++ b/src/celestia/qt6/CMakeLists.txt
@@ -10,12 +10,7 @@ set(CMAKE_AUTOMOC ON)
 # Create code from a list of Qt designer ui files
 set(CMAKE_AUTOUIC ON)
 
-# Work around a bug in the Core5Compat cmake files which reference the
-# non-versioned Qt::Core and Qt::CorePrivate libraries
-find_package(Qt6 COMPONENTS Core CONFIG REQUIRED)
-add_library(Qt::Core ALIAS Qt6::Core)
-add_library(Qt::CorePrivate ALIAS Qt6::CorePrivate)
-find_package(Qt6 COMPONENTS Core Widgets OpenGLWidgets Core5Compat CONFIG REQUIRED)
+find_package(Qt6 COMPONENTS Core Widgets OpenGLWidgets CONFIG REQUIRED)
 qt6_add_resources(RC_SRC "../qt/icons.qrc")
 
 if(USE_WAYLAND)
@@ -26,7 +21,7 @@ endif()
 
 add_executable(celestia-qt6 WIN32 ${QT_SOURCES} ${RES} ${RC_SRC})
 add_dependencies(celestia-qt6 celestia)
-target_link_libraries(celestia-qt6 Qt6::Widgets Qt6::OpenGLWidgets Qt6::Core5Compat celestia)
+target_link_libraries(celestia-qt6 Qt6::Widgets Qt6::OpenGLWidgets celestia)
 
 if(USE_WAYLAND)
   target_link_libraries(celestia-qt6 Wayland::Client wayland-protocols-helper)

--- a/src/tools/cmod/cmodview-qt6/CMakeLists.txt
+++ b/src/tools/cmod/cmodview-qt6/CMakeLists.txt
@@ -5,12 +5,7 @@ endif()
 
 include(../cmodview/CmodviewCommon.cmake)
 
-find_package(Qt6 COMPONENTS Core CONFIG REQUIRED)
-# Work around a bug in the Core5Compat cmake files which reference the
-# non-versioned Qt::Core and Qt::CorePrivate libraries
-add_library(Qt::Core ALIAS Qt6::Core)
-add_library(Qt::CorePrivate ALIAS Qt6::CorePrivate)
-find_package(Qt6 COMPONENTS Core Widgets OpenGLWidgets Core5Compat CONFIG REQUIRED)
+find_package(Qt6 COMPONENTS Core Widgets OpenGLWidgets CONFIG REQUIRED)
 
 GetCmodviewSources()
 
@@ -20,7 +15,7 @@ set(CMAKE_AUTOMOC ON)
 build_cmod_tool(cmodview-qt6 WIN32 ${CMODVIEW_SOURCES})
 target_include_directories(cmodview-qt6 PRIVATE ${OPENGL_INCLUDE_DIRS})
 target_compile_definitions(cmodview-qt6 PRIVATE IMPORT_GLSUPPORT)
-target_link_libraries(cmodview-qt6 Qt6::Widgets Qt6::OpenGLWidgets Qt6::Core5Compat ${OPENGL_LIBRARIES})
+target_link_libraries(cmodview-qt6 Qt6::Widgets Qt6::OpenGLWidgets ${OPENGL_LIBRARIES})
 
 if(APPLE)
   set_property(TARGET cmodview-qt6 APPEND_STRING PROPERTY LINK_FLAGS " -framework CoreFoundation")


### PR DESCRIPTION
From my tests on Windows and Linux, we might not need the Qt5 compatibility module for Qt6 any more.