### PR TITLE
[qt] Reduce set time JD value to 6 decimal places

### DIFF
--- a/src/celestia/qt/qtsettimedialog.cpp
+++ b/src/celestia/qt/qtsettimedialog.cpp
@@ -144,7 +144,7 @@ SetTimeDialog::SetTimeDialog(double currentTimeTDB,
     timeLayout->addWidget(julianDateLabel, 3, 0);
 
     julianDateSpin = new QDoubleSpinBox(this);
-    julianDateSpin->setDecimals(10);
+    julianDateSpin->setDecimals(6);
     julianDateSpin->setMinimum(-1931442.5); // -10000 Jan 01 00:00:00
     julianDateSpin->setMaximum(5373850.5); // 10000 Dec 31 23:59:59
     julianDateSpin->setAccelerated(true);


### PR DESCRIPTION
Resolves #76

This still allows setting the time to approx. 1/10 second, and should protect against cases where the value gets altered due to insufficient precision of `double`.