### PR TITLE
Do not populate m_verticesTr when not drawing Lines or PREFER_SIMPLE_TRIANGLES

### DIFF
--- a/src/celrender/linerenderer.h
+++ b/src/celrender/linerenderer.h
@@ -258,7 +258,7 @@ private:
     void setup_vbo_lines();
     void create_vbo_triangles();
     void setup_vbo_triangles();
-    void triangulate();
+    void triangulate_and_segment();
     void triangulate_segments();
     void triangulate_vertices_as_segments();
     void triangulate_vertices();
@@ -287,7 +287,8 @@ private:
     VertexFormat                        m_format;
     int                                 m_hints{ 0 };
     bool                                m_useTriangles{ false };
-    bool                                m_triangulated{ false };
+    bool                                m_verticesTriangulated{ false };
+    bool                                m_segmented{ false };
     bool                                m_loopDone{ false };
     bool                                m_inUse{ false };
     CelestiaGLProgram                  *m_prog{ nullptr };


### PR DESCRIPTION
When drawing Lines or drawing with PREFER_SIMPLE_TRIANGLES, only `m_segments` is used, `m_segments` is populated with value from `m_vertices`, `m_verticesTr` is unused.

In the old implementation, when drawing Lines with triangles with m_storageType = StorageType::Static, `m_useTriangles` is set to true so only `m_verticesTr` is populated, but segmentation of triangles used only the vertices from m_vertices.