### PR TITLE
Add support for backing framebuffer object with renderbuffer

### DIFF
--- a/src/celengine/framebuffer.cpp
+++ b/src/celengine/framebuffer.cpp
@@ -10,42 +10,46 @@
 
 #include "framebuffer.h"
 
-FramebufferObject::FramebufferObject(GLuint width, GLuint height, unsigned int attachments) :
+FramebufferObject::FramebufferObject(GLuint width, GLuint height, AttachmentType colorAttachment, AttachmentType depthAttachment) :
     m_width(width),
     m_height(height),
-    m_colorTexId(0),
-    m_depthTexId(0),
-    m_fboId(0),
-    m_status(GL_FRAMEBUFFER_UNSUPPORTED)
+    m_colorAttachmentType(colorAttachment),
+    m_depthAttachmentType(depthAttachment)
 {
-    if (attachments != 0)
-    {
-        generateFbo(attachments);
-    }
+    if (colorAttachment != AttachmentType::None || depthAttachment != AttachmentType::None)
+        generateFbo();
 }
 
 FramebufferObject::FramebufferObject(FramebufferObject &&other) noexcept:
     m_width(other.m_width),
     m_height(other.m_height),
-    m_colorTexId(other.m_colorTexId),
-    m_depthTexId(other.m_depthTexId),
+    m_colorAttachmentType(other.m_colorAttachmentType),
+    m_depthAttachmentType(other.m_depthAttachmentType),
+    m_colorAttachmentId(other.m_colorAttachmentId),
+    m_depthAttachmentId(other.m_depthAttachmentId),
     m_fboId(other.m_fboId),
     m_status(other.m_status)
 {
     other.m_fboId  = 0;
+    other.m_colorAttachmentId = 0;
+    other.m_depthAttachmentId = 0;
     other.m_status = GL_FRAMEBUFFER_UNSUPPORTED;
 }
 
 FramebufferObject& FramebufferObject::operator=(FramebufferObject &&other) noexcept
 {
-    m_width        = other.m_width;
-    m_height       = other.m_height;
-    m_colorTexId   = other.m_colorTexId;
-    m_depthTexId   = other.m_depthTexId;
-    m_fboId        = other.m_fboId;
-    m_status       = other.m_status;
+    m_width                 = other.m_width;
+    m_height                = other.m_height;
+    m_colorAttachmentType   = other.m_colorAttachmentType;
+    m_depthAttachmentType   = other.m_depthAttachmentType;
+    m_colorAttachmentId     = other.m_colorAttachmentId;
+    m_depthAttachmentId     = other.m_depthAttachmentId;
+    m_fboId                 = other.m_fboId;
+    m_status                = other.m_status;
 
     other.m_fboId  = 0;
+    other.m_colorAttachmentId = 0;
+    other.m_depthAttachmentId = 0;
     other.m_status = GL_FRAMEBUFFER_UNSUPPORTED;
     return *this;
 }
@@ -62,23 +66,35 @@ FramebufferObject::isValid() const
 }
 
 GLuint
-FramebufferObject::colorTexture() const
+FramebufferObject::colorAttachment() const
 {
-    return m_colorTexId;
+    return m_colorAttachmentId;
 }
 
 GLuint
-FramebufferObject::depthTexture() const
+FramebufferObject::depthAttachment() const
 {
-    return m_depthTexId;
+    return m_depthAttachmentId;
+}
+
+FramebufferObject::AttachmentType
+FramebufferObject::colorAttachmentType() const
+{
+    return m_colorAttachmentType;
+}
+
+FramebufferObject::AttachmentType
+FramebufferObject::depthAttachmentType() const
+{
+    return m_depthAttachmentType;
 }
 
 void
 FramebufferObject::generateColorTexture()
 {
     // Create and bind the texture
-    glGenTextures(1, &m_colorTexId);
-    glBindTexture(GL_TEXTURE_2D, m_colorTexId);
+    glGenTextures(1, &m_colorAttachmentId);
+    glBindTexture(GL_TEXTURE_2D, m_colorAttachmentId);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -88,7 +104,6 @@ FramebufferObject::generateColorTexture()
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     // Set the texture dimensions
-    // Do we need to set GL_DEPTH_COMPONENT24 here?
 #ifdef GL_ES
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_width, m_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 #else
@@ -109,8 +124,8 @@ void
 FramebufferObject::generateDepthTexture()
 {
     // Create and bind the texture
-    glGenTextures(1, &m_depthTexId);
-    glBindTexture(GL_TEXTURE_2D, m_depthTexId);
+    glGenTextures(1, &m_depthAttachmentId);
+    glBindTexture(GL_TEXTURE_2D, m_depthAttachmentId);
 
 #ifndef GL_ES
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
@@ -136,7 +151,27 @@ FramebufferObject::generateDepthTexture()
 }
 
 void
-FramebufferObject::generateFbo(unsigned int attachments)
+FramebufferObject::generateColorRenderbuffer()
+{
+    glGenRenderbuffers(1, &m_colorAttachmentId);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_colorAttachmentId);
+#ifdef GL_ES
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA, m_width, m_height);
+#else
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_RGB8, m_width, m_height);
+#endif
+}
+
+void
+FramebufferObject::generateDepthRenderbuffer()
+{
+    glGenRenderbuffers(1, &m_depthAttachmentId);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_depthAttachmentId);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, m_width, m_height);
+}
+
+void
+FramebufferObject::generateFbo()
 {
     // Create the FBO
     glGenFramebuffers(1, &m_fboId);
@@ -148,30 +183,28 @@ FramebufferObject::generateFbo(unsigned int attachments)
     glReadBuffer(GL_NONE);
 #endif
 
-    if ((attachments & ColorAttachment) != 0)
+    switch (m_colorAttachmentType)
     {
+    case AttachmentType::Texture:
         generateColorTexture();
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_colorTexId, 0);
-        m_status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-        if (m_status != GL_FRAMEBUFFER_COMPLETE)
-        {
-            glBindFramebuffer(GL_FRAMEBUFFER, oldFboId);
-            cleanup();
-            return;
-        }
-    }
-#ifndef GL_ES
-    else
-    {
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_colorAttachmentId, 0);
+        break;
+    case AttachmentType::Renderbuffer:
+        generateColorRenderbuffer();
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorAttachmentId);
+        break;
+#ifdef GL_ES
+    default:
+        break;
+#else
+    default:
         // Depth-only rendering; no color buffer.
         glDrawBuffer(GL_NONE);
-    }
 #endif
+    }
 
-    if ((attachments & DepthAttachment) != 0)
+    if (m_colorAttachmentType != AttachmentType::None)
     {
-        generateDepthTexture();
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_depthTexId, 0);
         m_status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
         if (m_status != GL_FRAMEBUFFER_COMPLETE)
         {
@@ -180,9 +213,29 @@ FramebufferObject::generateFbo(unsigned int attachments)
             return;
         }
     }
-    else
+
+    switch (m_depthAttachmentType) {
+    case AttachmentType::Texture:
+        generateDepthTexture();
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_depthAttachmentId, 0);
+        break;
+    case AttachmentType::Renderbuffer:
+        generateDepthRenderbuffer();
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthAttachmentId);
+        break;
+    default:
+        break;
+    }
+
+    if (m_depthAttachmentType != AttachmentType::None)
     {
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
+        m_status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        if (m_status != GL_FRAMEBUFFER_COMPLETE)
+        {
+            glBindFramebuffer(GL_FRAMEBUFFER, oldFboId);
+            cleanup();
+            return;
+        }
     }
 
     // Restore default frame buffer
@@ -194,18 +247,36 @@ void
 FramebufferObject::cleanup()
 {
     if (m_fboId != 0)
-    {
         glDeleteFramebuffers(1, &m_fboId);
+
+    if (m_colorAttachmentId != 0)
+    {
+        switch (m_colorAttachmentType)
+        {
+        case AttachmentType::Texture:
+            glDeleteTextures(1, &m_colorAttachmentId);
+            break;
+        case AttachmentType::Renderbuffer:
+            glDeleteRenderbuffers(1, &m_colorAttachmentId);
+            break;
+        default:
+            break;
+        }
     }
 
-    if (m_colorTexId != 0)
+    if (m_depthAttachmentId != 0)
     {
-        glDeleteTextures(1, &m_colorTexId);
-    }
-
-    if (m_depthTexId != 0)
-    {
-        glDeleteTextures(1, &m_depthTexId);
+        switch (m_depthAttachmentType)
+        {
+        case AttachmentType::Texture:
+            glDeleteTextures(1, &m_depthAttachmentId);
+            break;
+        case AttachmentType::Renderbuffer:
+            glDeleteRenderbuffers(1, &m_depthAttachmentId);
+            break;
+        default:
+            break;
+        }
     }
 }
 

--- a/src/celengine/framebuffer.h
+++ b/src/celengine/framebuffer.h
@@ -15,20 +15,22 @@
 class FramebufferObject
 {
  public:
-    enum
+    enum class AttachmentType
     {
-        ColorAttachment = 0x1,
-        DepthAttachment = 0x2
+        None,
+        Texture,
+        Renderbuffer,
     };
+
     FramebufferObject() = delete;
-    FramebufferObject(GLuint width, GLuint height, unsigned int attachments);
+    FramebufferObject(GLuint width, GLuint height, AttachmentType colorAttachment, AttachmentType depthAttachment);
     FramebufferObject(const FramebufferObject&) = delete;
     FramebufferObject(FramebufferObject&&) noexcept;
     FramebufferObject& operator=(const FramebufferObject&) = delete;
     FramebufferObject& operator=(FramebufferObject&&) noexcept;
     ~FramebufferObject();
 
-    static inline bool isSupported();
+    static bool isSupported();
     bool isValid() const;
     GLuint width() const
     {
@@ -40,8 +42,11 @@ class FramebufferObject
         return m_height;
     }
 
-    GLuint colorTexture() const;
-    GLuint depthTexture() const;
+    GLuint colorAttachment() const;
+    GLuint depthAttachment() const;
+
+    AttachmentType colorAttachmentType() const;
+    AttachmentType depthAttachmentType() const;
 
     bool bind();
     bool unbind(GLint oldfboId);
@@ -49,19 +54,24 @@ class FramebufferObject
  private:
     void generateColorTexture();
     void generateDepthTexture();
-    void generateFbo(unsigned int attachments);
+    void generateColorRenderbuffer();
+    void generateDepthRenderbuffer();
+
+    void generateFbo();
     void cleanup();
 
  private:
     GLuint m_width;
     GLuint m_height;
-    GLuint m_colorTexId;
-    GLuint m_depthTexId;
-    GLuint m_fboId;
-    GLenum m_status;
+    AttachmentType m_colorAttachmentType;
+    AttachmentType m_depthAttachmentType;
+    GLuint m_colorAttachmentId  { 0 };
+    GLuint m_depthAttachmentId  { 0 };
+    GLuint m_fboId              { 0 };
+    GLenum m_status             { GL_FRAMEBUFFER_UNSUPPORTED };
 };
 
-bool FramebufferObject::isSupported()
+inline bool FramebufferObject::isSupported()
 {
 #ifdef GL_ES
     return true;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4800,7 +4800,8 @@ Renderer::createShadowFBO()
 {
     m_shadowFBO = std::make_unique<FramebufferObject>(m_shadowMapSize,
                                                       m_shadowMapSize,
-                                                      FramebufferObject::DepthAttachment);
+                                                      FramebufferObject::AttachmentType::None,
+                                                      FramebufferObject::AttachmentType::Texture);
     if (!m_shadowFBO->isValid())
     {
         GetLogger()->warn("Error creating shadow FBO.\n");

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -496,7 +496,7 @@ void renderGeometry_GLSL(Geometry* geometry,
 
         glActiveTexture(GL_TEXTURE0);
         glEnable(GL_TEXTURE_2D);
-        glBindTexture(GL_TEXTURE_2D, shadowBuffer->depthTexture());
+        glBindTexture(GL_TEXTURE_2D, shadowBuffer->depthAttachment());
 #if GL_ONLY_SHADOWS
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 #endif
@@ -533,7 +533,7 @@ void renderGeometry_GLSL(Geometry* geometry,
 
     if (shadowBuffer != nullptr && shadowBuffer->isValid())
     {
-        rc.setShadowMap(shadowBuffer->depthTexture(), shadowBuffer->width(), &lightMatrix);
+        rc.setShadowMap(shadowBuffer->depthAttachment(), shadowBuffer->width(), &lightMatrix);
     }
 
     rc.setCameraOrientation(ri.orientation);

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -10,7 +10,6 @@
 
 #include <array>
 #include "viewporteffect.h"
-#include "framebuffer.h"
 #include "render.h"
 #include "shadermanager.h"
 #include "mapmanager.h"
@@ -41,6 +40,16 @@ bool ViewportEffect::distortXY(float &x, float &y)
     return true;
 }
 
+FramebufferObject::AttachmentType ViewportEffect::colorAttachmentType() const
+{
+    return FramebufferObject::AttachmentType::Texture;
+}
+
+FramebufferObject::AttachmentType ViewportEffect::depthAttachmentType() const
+{
+    return FramebufferObject::AttachmentType::Renderbuffer;
+}
+
 PassthroughViewportEffect::PassthroughViewportEffect() :
     ViewportEffect()
 {
@@ -56,7 +65,7 @@ bool PassthroughViewportEffect::render(Renderer* renderer, FramebufferObject* fb
 
     prog->use();
     prog->samplerParam("tex") = 0;
-    glBindTexture(GL_TEXTURE_2D, fbo->colorTexture());
+    glBindTexture(GL_TEXTURE_2D, fbo->colorAttachment());
     renderer->setPipelineState(ps);
     vo.draw();
     glBindTexture(GL_TEXTURE_2D, 0);
@@ -127,8 +136,8 @@ bool WarpMeshViewportEffect::render(Renderer* renderer, FramebufferObject* fbo, 
 
     prog->use();
     prog->samplerParam("tex") = 0;
-    prog->floatParam("screenRatio") = (float)height / width;
-    glBindTexture(GL_TEXTURE_2D, fbo->colorTexture());
+    prog->floatParam("screenRatio") = static_cast<float>(height) / static_cast<float>(width);
+    glBindTexture(GL_TEXTURE_2D, fbo->colorAttachment());
     renderer->setPipelineState(ps);
     vo.draw();
     glBindTexture(GL_TEXTURE_2D, 0);

--- a/src/celengine/viewporteffect.h
+++ b/src/celengine/viewporteffect.h
@@ -12,8 +12,8 @@
 
 #include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
+#include <celengine/framebuffer.h>
 
-class FramebufferObject;
 class Renderer;
 class CelestiaGLProgram;
 class WarpMesh;
@@ -27,6 +27,9 @@ public:
     virtual bool prerender(Renderer*, FramebufferObject*);
     virtual bool render(Renderer*, FramebufferObject*, int width, int height) = 0;
     virtual bool distortXY(float& x, float& y);
+
+    virtual FramebufferObject::AttachmentType depthAttachmentType() const;
+    virtual FramebufferObject::AttachmentType colorAttachmentType() const;
 
 private:
     GLint oldFboId;

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2011,7 +2011,7 @@ void CelestiaCore::draw(View* view)
     if (viewportEffect != nullptr)
     {
         // create/update FBO for viewport effect
-        view->updateFBO(metrics.width, metrics.height);
+        view->updateFBO(metrics.width, metrics.height, viewportEffect->colorAttachmentType(), viewportEffect->depthAttachmentType());
         fbo = view->getFBO();
     }
     bool process = fbo != nullptr && viewportEffect->preprocess(renderer, fbo);
@@ -2463,8 +2463,14 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
 
     if (!config->viewportEffect.empty() && config->viewportEffect != "none")
     {
-        if (config->viewportEffect == "passthrough")
+        if (!FramebufferObject::isSupported())
+        {
+            GetLogger()->warn("Framebuffer object not supported, ignoring viewport effect\n");
+        }
+        else if (config->viewportEffect == "passthrough")
+        {
             viewportEffect = unique_ptr<ViewportEffect>(new PassthroughViewportEffect);
+        }
         else if (config->viewportEffect == "warpmesh")
         {
             if (config->paths.warpMeshFile.empty())

--- a/src/celestia/view.cpp
+++ b/src/celestia/view.cpp
@@ -9,7 +9,6 @@
 
 #include "view.h"
 
-#include <celengine/framebuffer.h>
 #include <celengine/glsupport.h>
 #include <celengine/overlay.h>
 #include <celengine/rectangle.h>
@@ -261,16 +260,15 @@ View::drawBorder(Overlay* overlay, int gWidth, int gHeight, const Color &color, 
 
 
 void
-View::updateFBO(int gWidth, int gHeight)
+View::updateFBO(int gWidth, int gHeight, FramebufferObject::AttachmentType colorAttachment, FramebufferObject::AttachmentType depthAttachment)
 {
     auto newWidth = static_cast<GLuint>(width * gWidth);
     auto newHeight = static_cast<GLuint>(height * gHeight);
-    if (fbo && fbo.get()->width() == newWidth && fbo.get()->height() == newHeight)
+    if (fbo && fbo->width() == newWidth && fbo->height() == newHeight && fbo->colorAttachmentType() == colorAttachment && fbo->depthAttachmentType() == depthAttachment)
         return;
 
     // recreate FBO when FBO not exisits or on size change
-    fbo = std::make_unique<FramebufferObject>(newWidth, newHeight,
-                                              FramebufferObject::ColorAttachment | FramebufferObject::DepthAttachment);
+    fbo = std::make_unique<FramebufferObject>(newWidth, newHeight, colorAttachment, depthAttachment);
     if (!fbo->isValid())
     {
         GetLogger()->error("Error creating view FBO.\n");

--- a/src/celestia/view.h
+++ b/src/celestia/view.h
@@ -11,9 +11,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <celengine/framebuffer.h>
 
 class Color;
-class FramebufferObject;
 class Observer;
 class Overlay;
 
@@ -49,7 +49,7 @@ public:
     void reset();
     static View* remove(View*);
     void drawBorder(Overlay*, int gWidth, int gHeight, const Color &color, float linewidth = 1.0f) const;
-    void updateFBO(int gWidth, int gHeight);
+    void updateFBO(int gWidth, int gHeight, FramebufferObject::AttachmentType colorAttachment, FramebufferObject::AttachmentType depthAttachment);
     FramebufferObject *getFBO() const;
 
     Type           type;

--- a/src/tools/cmod/cmodview/modelviewwidget.cpp
+++ b/src/tools/cmod/cmodview/modelviewwidget.cpp
@@ -837,7 +837,7 @@ ModelViewWidget::paintGL()
 
             glActiveTexture(GL_TEXTURE0);
             glEnable(GL_TEXTURE_2D);
-            glBindTexture(GL_TEXTURE_2D, shadowBuffer->depthTexture());
+            glBindTexture(GL_TEXTURE_2D, shadowBuffer->depthAttachment());
 
             // Disable texture compare temporarily--we just want to see the
             // stored depth values.
@@ -913,8 +913,8 @@ ModelViewWidget::setShadows(bool enable)
         if (m_shadowsEnabled && m_shadowBuffers.size() < 2)
         {
             makeCurrent();
-            auto* fb0 = new FramebufferObject(ShadowBufferSize, ShadowBufferSize, FramebufferObject::DepthAttachment);
-            auto* fb1 = new FramebufferObject(ShadowBufferSize, ShadowBufferSize, FramebufferObject::DepthAttachment);
+            auto* fb0 = new FramebufferObject(ShadowBufferSize, ShadowBufferSize, FramebufferObject::AttachmentType::None, FramebufferObject::AttachmentType::Texture);
+            auto* fb1 = new FramebufferObject(ShadowBufferSize, ShadowBufferSize, FramebufferObject::AttachmentType::None, FramebufferObject::AttachmentType::Texture);
             m_shadowBuffers << fb0 << fb1;
             if (!fb0->isValid() || !fb1->isValid())
             {
@@ -1057,7 +1057,7 @@ ModelViewWidget::bindMaterial(const cmod::Material* material,
 
                 glActiveTexture(GL_TEXTURE4 + i);
                 glEnable(GL_TEXTURE_2D);
-                glBindTexture(GL_TEXTURE_2D, m_shadowBuffers[i]->depthTexture());
+                glBindTexture(GL_TEXTURE_2D, m_shadowBuffers[i]->depthAttachment());
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_R_TO_TEXTURE);
                 setSampler(*shader, samplerName, 4 + i);
                 glActiveTexture(GL_TEXTURE0);


### PR DESCRIPTION
Most likely viewport effects do not need to read from depth attachment so we can use render buffers when available.