### PR TITLE
[win32] Update buffer handling to re-check length after populating content

### DIFF
--- a/src/celestia/win32/datetimehelpers.cpp
+++ b/src/celestia/win32/datetimehelpers.cpp
@@ -74,7 +74,11 @@ CreateLocalizedMonthNames()
 
 #ifdef _UNICODE
         std::wstring& name = months.emplace_back(static_cast<std::size_t>(length), L'\0');
-        GetCalendarInfoEx(LOCALE_NAME_USER_DEFAULT, CAL_GREGORIAN, nullptr, calType, name.data(), length, nullptr);
+        length = GetCalendarInfoEx(LOCALE_NAME_USER_DEFAULT, CAL_GREGORIAN, nullptr, calType, name.data(), length, nullptr);
+        if (length > 1)
+            name.resize(static_cast<std::size_t>(length - 1));
+        else
+            name = defaultMonthNames[i];
 #else
         buffer.resize(static_cast<std::size_t>(length));
         GetCalendarInfoEx(LOCALE_NAME_USER_DEFAULT, CAL_GREGORIAN, nullptr, calType, buffer.data(), length, nullptr);

--- a/src/celestia/win32/tstring.cpp
+++ b/src/celestia/win32/tstring.cpp
@@ -11,6 +11,8 @@
 
 #include "tstring.h"
 
+#include <algorithm>
+
 namespace celestia::win32
 {
 
@@ -36,18 +38,14 @@ UTF8ToTChar(std::string_view str, tstring::value_type* dest, int destSize)
         return 0;
     const auto srcLength = static_cast<int>(str.size());
 #ifdef _UNICODE
-    return MultiByteToWideChar(CP_UTF8, 0, str.data(), srcLength, dest, destSize);
+    return std::max(MultiByteToWideChar(CP_UTF8, 0, str.data(), srcLength, dest, destSize), 0);
 #else
     fmt::basic_memory_buffer<wchar_t> wbuffer;
     int wideLength = AppendUTF8ToWide(str, wbuffer);
     if (wideLength <= 0)
-        return wideLength;
+        return 0;
 
-    wbuffer.resize(static_cast<std::size_t>(wideLength));
-
-    MultiByteToWideChar(CP_UTF8, 0, str.data(), srcLength, wbuffer.data(), wideLength);
-
-    return WideCharToMultiByte(CP_ACP, 0, wbuffer.data(), wideLength, dest, destSize, nullptr, nullptr);
+    return std::max(WideCharToMultiByte(CP_ACP, 0, wbuffer.data(), wideLength, dest, destSize, nullptr, nullptr), 0);
 #endif
 }
 

--- a/src/celestia/win32/winmainwindow.cpp
+++ b/src/celestia/win32/winmainwindow.cpp
@@ -97,7 +97,7 @@ setMenuItemCheck(HMENU menuBar, int menuItem, bool checked)
     CheckMenuItem(menuBar, menuItem, checked ? MF_CHECKED : MF_UNCHECKED);
 }
 
-// Version of the function from tstring. h with smaller intermediate buffer
+// Version of the function from tstring.h with smaller intermediate buffer
 // suitable for char event processing
 template<typename T, std::enable_if_t<std::is_same_v<typename T::value_type, char>, int> = 0>
 void
@@ -115,17 +115,20 @@ AppendTCharCodeToUTF8(TCHAR* tch, int nch, T& destination)
         return;
 
     wbuffer.resize(static_cast<std::size_t>(wlength));
-    MultiByteToWideChar(CP_ACP, 0, tch, nch, wbuffer.data(), wlength);
+    wlength = MultiByteToWideChar(CP_ACP, 0, tch, nch, wbuffer.data(), wlength);
+    if (wlength <= 0)
+        return;
 
     int length = WideCharToMultiByte(CP_UTF8, 0, wbuffer.data(), wlength, nullptr, 0, nullptr, nullptr);
     if (length <= 0)
         return;
 
     const auto existingSize = destination.size();
-    destination.resize(existingSize + static_cast<std::size_t>(existingSize));
-    WideCharToMultiByte(CP_UTF8, 0, wbuffer.data(), wlength,
-                        destination.data() + existingSize, length,
-                        nullptr, nullptr);
+    destination.resize(existingSize + static_cast<std::size_t>(length));
+    length = WideCharToMultiByte(CP_UTF8, 0, wbuffer.data(), wlength,
+                                 destination.data() + existingSize, length,
+                                 nullptr, nullptr);
+    destination.resize(length >= 0 ? (existingSize + static_cast<std::size_t>(length)) : existingSize);
 #endif
 }
 

--- a/src/celutil/winutil.cpp
+++ b/src/celutil/winutil.cpp
@@ -25,12 +25,16 @@ WideToUTF8(std::wstring_view ws)
 
     // get a converted string length
     const auto srcLen = static_cast<int>(ws.size());
-    const auto len = WideCharToMultiByte(CP_UTF8, 0, ws.data(), srcLen, nullptr, 0, nullptr, nullptr);
+    int len = WideCharToMultiByte(CP_UTF8, 0, ws.data(), srcLen, nullptr, 0, nullptr, nullptr);
     if (len <= 0)
         return {};
 
     std::string out(static_cast<std::string::size_type>(len), '\0');
-    WideCharToMultiByte(CP_UTF8, 0, ws.data(), srcLen, out.data(), len, nullptr, nullptr);
+    len = WideCharToMultiByte(CP_UTF8, 0, ws.data(), srcLen, out.data(), len, nullptr, nullptr);
+    if (len <= 0)
+        return {};
+
+    out.resize(static_cast<std::size_t>(len));
     return out;
 }
 


### PR DESCRIPTION
Various functions in the Windows API follow the pattern: get length of buffer, allocate buffer, populate buffer. The populate buffer step could potentially return a shorter length, so always re-check this.