### PR TITLE
Make GL_ARB_framebuffer_object mandatory + compilation fix for GCC 7

### DIFF
--- a/src/celengine/framebuffer.h
+++ b/src/celengine/framebuffer.h
@@ -28,7 +28,6 @@ class FramebufferObject
     FramebufferObject& operator=(FramebufferObject&&) noexcept;
     ~FramebufferObject();
 
-    static inline bool isSupported();
     bool isValid() const;
     GLuint width() const
     {
@@ -60,12 +59,3 @@ class FramebufferObject
     GLuint m_fboId;
     GLenum m_status;
 };
-
-bool FramebufferObject::isSupported()
-{
-#ifdef GL_ES
-    return true;
-#else
-    return celestia::gl::ARB_framebuffer_object;
-#endif
-}

--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -1,6 +1,8 @@
 #include "glsupport.h"
 #include <algorithm>
 #include <cstring>
+#include <fmt/format.h>
+#include <celutil/gettext.h>
 
 namespace celestia::gl
 {
@@ -81,7 +83,11 @@ bool init(util::array_view<std::string> ignore) noexcept
     OES_geometry_shader            = check_extension(ignore, "GL_OES_geometry_shader") || check_extension(ignore, "GL_EXT_geometry_shader");
 #else
     ARB_vertex_array_object        = check_extension(ignore, "GL_ARB_vertex_array_object");
-    ARB_framebuffer_object         = check_extension(ignore, "GL_ARB_framebuffer_object") || check_extension(ignore, "GL_EXT_framebuffer_object");
+    if (!has_extension("GL_ARB_framebuffer_object"))
+    {
+        fmt::print(_("Mandatory extension GL_ARB_framebuffer_object is missing!\n"));
+        return false;
+    }
 #endif
     ARB_shader_texture_lod         = check_extension(ignore, "GL_ARB_shader_texture_lod");
     EXT_texture_compression_s3tc   = check_extension(ignore, "GL_EXT_texture_compression_s3tc");

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -49,7 +49,6 @@ extern CELAPI bool OES_texture_border_clamp; //NOSONAR
 extern CELAPI bool OES_geometry_shader; //NOSONAR
 #else
 extern CELAPI bool ARB_vertex_array_object; //NOSONAR
-extern CELAPI bool ARB_framebuffer_object; //NOSONAR
 #endif
 extern CELAPI GLint maxPointSize; //NOSONAR
 extern CELAPI GLint maxTextureSize; //NOSONAR

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4811,8 +4811,6 @@ Renderer::createShadowFBO()
 void
 Renderer::setShadowMapSize(unsigned size)
 {
-    if (!FramebufferObject::isSupported())
-        return;
     m_shadowMapSize = std::min(size, static_cast<unsigned>(gl::maxTextureSize));
     if (m_shadowFBO != nullptr && m_shadowMapSize == m_shadowFBO->width())
         return;

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -343,14 +343,12 @@ CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
 
     toolsDock = new QDockWidget(_("Celestial Browser"), this);
     toolsDock->setObjectName("celestia-tools-dock");
-    toolsDock->setAllowedAreas(Qt::LeftDockWidgetArea |
-                               Qt::RightDockWidgetArea);
+    toolsDock->setAllowedAreas(static_cast<Qt::DockWidgetAreas>(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea));
 
     // Info browser for a selected object
     infoPanel = new InfoPanel(m_appCore, _("Info Browser"), this);
     infoPanel->setObjectName("info-panel");
-    infoPanel->setAllowedAreas(Qt::LeftDockWidgetArea |
-                               Qt::RightDockWidgetArea);
+    infoPanel->setAllowedAreas(static_cast<Qt::DockWidgetAreas>(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea));
     infoPanel->setVisible(false);
 
     // Create the various browser widgets
@@ -387,8 +385,7 @@ CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
 
     eventFinder = new EventFinder(m_appCore, _("Event Finder"), this);
     eventFinder->setObjectName("event-finder");
-    eventFinder->setAllowedAreas(Qt::LeftDockWidgetArea |
-                                 Qt::RightDockWidgetArea);
+    eventFinder->setAllowedAreas(static_cast<Qt::DockWidgetAreas>(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea));
     addDockWidget(Qt::LeftDockWidgetArea, eventFinder);
     eventFinder->setVisible(false);
     //addDockWidget(Qt::DockWidgetArea, eventFinder);

--- a/src/celestia/qt/qtcelestialbrowser.cpp
+++ b/src/celestia/qt/qtcelestialbrowser.cpp
@@ -147,7 +147,7 @@ CelestialBrowser::StarTableModel::objectAtIndex(const QModelIndex& _index) const
 Qt::ItemFlags
 CelestialBrowser::StarTableModel::flags(const QModelIndex& /*unused*/) const
 {
-    return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    return static_cast<Qt::ItemFlags>(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 }
 
 // Override QAbstractTableModel::data()

--- a/src/celestia/qt/qtdeepskybrowser.cpp
+++ b/src/celestia/qt/qtdeepskybrowser.cpp
@@ -281,7 +281,7 @@ DeepSkyBrowser::DSOTableModel::objectAtIndex(const QModelIndex& _index) const
 Qt::ItemFlags
 DeepSkyBrowser::DSOTableModel::flags(const QModelIndex& /*unused*/) const
 {
-    return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    return static_cast<Qt::ItemFlags>(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 }
 
 // Override QAbstractTableModel::data()

--- a/src/celestia/qt/qteventfinder.cpp
+++ b/src/celestia/qt/qteventfinder.cpp
@@ -162,7 +162,7 @@ private:
 Qt::ItemFlags
 EventFinder::EventTableModel::flags(const QModelIndex& /*unused*/) const
 {
-    return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    return static_cast<Qt::ItemFlags>(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 }
 
 QVariant

--- a/src/celestia/qt/qtsolarsystembrowser.cpp
+++ b/src/celestia/qt/qtsolarsystembrowser.cpp
@@ -622,7 +622,7 @@ SolarSystemBrowser::SolarSystemTreeModel::flags(const QModelIndex& index) const
     if (!index.isValid())
         return {};
 
-    return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    return static_cast<Qt::ItemFlags>(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 }
 
 // Override QAbstractTableModel::data()

--- a/src/tools/cmod/cmodview/modelviewwidget.cpp
+++ b/src/tools/cmod/cmodview/modelviewwidget.cpp
@@ -904,9 +904,6 @@ ModelViewWidget::setAmbientLight(bool enable)
 void
 ModelViewWidget::setShadows(bool enable)
 {
-    if (!FramebufferObject::isSupported())
-        return;
-
     if (enable != m_shadowsEnabled)
     {
         m_shadowsEnabled = enable;


### PR DESCRIPTION
It's impossible to compile Celestia for systems which have GL 2.1 but not
framebuffers, because such systems (if they exist) have too old drivers,
and the only reason for this is too old OS. But such systems are not
supported by modern C++ compilers.