### PR TITLE
Read config from writable data path

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2304,6 +2304,10 @@ bool CelestiaCore::initSimulation(const fs::path& configFileName,
         localConfigFile = PathExp("~/.celestia-1.7.cfg");
         if (!localConfigFile.empty())
             hasConfig |= ReadCelestiaConfig(localConfigFile, *config);
+
+        localConfigFile = PathExp("~/.celestia/celestia.cfg");
+        if (!localConfigFile.empty())
+            hasConfig |= ReadCelestiaConfig(localConfigFile, *config);
     }
 
     if (!hasConfig)


### PR DESCRIPTION
This MR adds `${XDG_DATA_HOME}/Celestia/celestia.cfg` to the list of locations in which celestia looks for configs.
This option is preferable to `~/.celestia.cfg` for flapak as that would require the whole home directory to be visible inside the sandbox.

`XDG_DATA_HOME` is generally `~/.local/share` however in a flatpak it's `~/.var/app/${APP_ID}/data/`.