### PR TITLE
Remove some unnecessary usage of Selection

### DIFF
--- a/src/celengine/axisarrow.cpp
+++ b/src/celengine/axisarrow.cpp
@@ -387,7 +387,7 @@ Eigen::Vector3d
 SunDirectionArrow::getDirection(double tdb) const
 {
     const Body* b = &body;
-    Star* sun = nullptr;
+    const Star* sun = nullptr;
     while (b != nullptr)
     {
         Selection center = b->getOrbitFrame(tdb)->getCenter();
@@ -397,7 +397,7 @@ SunDirectionArrow::getDirection(double tdb) const
     }
 
     if (sun != nullptr)
-        return Selection(sun).getPosition(tdb).offsetFromKm(body.getPosition(tdb));
+        return sun->getPosition(tdb).offsetFromKm(body.getPosition(tdb));
 
     return Eigen::Vector3d::Zero();
 }

--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -599,7 +599,7 @@ Vector3d Body::getVelocity(double tdb) const
 
     if (!orbitFrame->isInertial())
     {
-        Vector3d r = Selection(const_cast<Body*>(this)).getPosition(tdb).offsetFromKm(orbitFrame->getCenter().getPosition(tdb));
+        Vector3d r = getPosition(tdb).offsetFromKm(orbitFrame->getCenter().getPosition(tdb));
         v += orbitFrame->getAngularVelocity(tdb).cross(r);
     }
 

--- a/src/celengine/selection.h
+++ b/src/celengine/selection.h
@@ -29,7 +29,6 @@ enum class SelectionType
     Location,
 };
 
-
 class Selection
 {
  public:

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -551,11 +551,9 @@ displayPlanetInfo(const util::NumberFormatter& formatter,
     while (parent.body() != nullptr)
         parent = parent.parent();
 
-    if (parent.star() != nullptr)
+    if (const Star* sun = parent.star(); sun != nullptr)
     {
         bool showPhaseAngle = false;
-
-        Star* sun = parent.star();
         if (sun->getVisibility())
         {
             showPhaseAngle = true;
@@ -573,7 +571,7 @@ displayPlanetInfo(const util::NumberFormatter& formatter,
 
         if (showPhaseAngle)
         {
-            Eigen::Vector3d sunVec = Selection(&body).getPosition(t).offsetFromKm(Selection(sun).getPosition(t));
+            Eigen::Vector3d sunVec = body.getPosition(t).offsetFromKm(sun->getPosition(t));
             sunVec.normalize();
             double cosPhaseAngle = std::clamp(sunVec.dot(viewVec.normalized()), -1.0, 1.0);
             double phaseAngle = acos(cosPhaseAngle);
@@ -1162,14 +1160,12 @@ Hud::renderSelectionInfo(const WindowMetrics& metrics,
 
     // Display RA/Dec for the selection, but only when the observer is near
     // the Earth.
-    if (Selection refObject = sim->getFrame()->getRefObject();
-        refObject.body() && refObject.body()->getName() == "Earth")
+    if (const Body* refObject = sim->getFrame()->getRefObject().body();
+        refObject != nullptr && refObject->getName() == "Earth")
     {
-        Body* earth = refObject.body();
-
         UniversalCoord observerPos = sim->getObserver().getPosition();
-        double distToEarthCenter = observerPos.offsetFromKm(refObject.getPosition(sim->getTime())).norm();
-        double altitude = distToEarthCenter - earth->getRadius();
+        double distToEarthCenter = observerPos.offsetFromKm(refObject->getPosition(sim->getTime())).norm();
+        double altitude = distToEarthCenter - refObject->getRadius();
         if (altitude < 1000.0 && (sel.getType() == SelectionType::Star || sel.getType() == SelectionType::DeepSky))
         {
             // Code to show the geocentric RA/Dec
@@ -1177,7 +1173,7 @@ Hud::renderSelectionInfo(const WindowMetrics& metrics,
             // Only show the coordinates for stars and deep sky objects, where
             // the geocentric values will match the apparent values for observers
             // near the Earth.
-            Eigen::Vector3d vEarth = sel.getPosition(sim->getTime()).offsetFromKm(Selection(earth).getPosition(sim->getTime()));
+            Eigen::Vector3d vEarth = sel.getPosition(sim->getTime()).offsetFromKm(refObject->getPosition(sim->getTime()));
             vEarth = math::XRotation(astro::J2000Obliquity) * vEarth;
             displayRADec(*m_overlay, vEarth, loc);
         }

--- a/src/celestia/qt/qteventfinder.cpp
+++ b/src/celestia/qt/qteventfinder.cpp
@@ -497,13 +497,13 @@ EventFinder::slotViewNearEclipsed()
         slotSetEclipseTime();
     now = sim->getTime();
 
-    Selection receiver(activeEclipse->receiver);
-    Selection caster(activeEclipse->occulter);
-    Selection sun(activeEclipse->receiver->getSystem()->getStar());
+    Body* const receiver = activeEclipse->receiver;
+    const Body* const caster = activeEclipse->occulter;
+    const Star* const sun = activeEclipse->receiver->getSystem()->getStar();
 
-    Eigen::Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Eigen::Vector3d toReceiver = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Eigen::Vector3d maxEclipsePoint = findMaxEclipsePoint(toCasterDir, toReceiver, receiver.radius());
+    Eigen::Vector3d toCasterDir = caster->getPosition(now).offsetFromKm(sun->getPosition(now));
+    Eigen::Vector3d toReceiver = receiver->getPosition(now).offsetFromKm(sun->getPosition(now));
+    Eigen::Vector3d maxEclipsePoint = findMaxEclipsePoint(toCasterDir, toReceiver, receiver->getRadius());
 
     Eigen::Vector3d up = activeEclipse->receiver->getEclipticToBodyFixed(now).conjugate() * Eigen::Vector3d::UnitY();
     Eigen::Vector3d viewerPos = maxEclipsePoint * 4.0; // 4 radii from center
@@ -526,13 +526,13 @@ EventFinder::slotViewEclipsedSurface()
         slotSetEclipseTime();
     now = sim->getTime();
 
-    Selection receiver(activeEclipse->receiver);
-    Selection caster(activeEclipse->occulter);
-    Selection sun(activeEclipse->receiver->getSystem()->getStar());
+    Body* const receiver = activeEclipse->receiver;
+    const Body* const caster = activeEclipse->occulter;
+    const Star* const sun = activeEclipse->receiver->getSystem()->getStar();
 
-    Eigen::Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Eigen::Vector3d toReceiver = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
-    Eigen::Vector3d maxEclipsePoint = findMaxEclipsePoint(toCasterDir, toReceiver, receiver.radius());
+    Eigen::Vector3d toCasterDir = caster->getPosition(now).offsetFromKm(sun->getPosition(now));
+    Eigen::Vector3d toReceiver = receiver->getPosition(now).offsetFromKm(sun->getPosition(now));
+    Eigen::Vector3d maxEclipsePoint = findMaxEclipsePoint(toCasterDir, toReceiver, receiver->getRadius());
 
     Eigen::Vector3d up = maxEclipsePoint.normalized();
     // TODO: Select alternate up direction when eclipse is directly overhead
@@ -556,15 +556,15 @@ EventFinder::slotViewOccluderSurface()
         slotSetEclipseTime();
     now = sim->getTime();
 
-    Selection receiver(activeEclipse->receiver);
-    Selection caster(activeEclipse->occulter);
-    Selection sun(activeEclipse->receiver->getSystem()->getStar());
+    const Body* const receiver = activeEclipse->receiver;
+    Body* const caster = activeEclipse->occulter;
+    const Star* const sun = activeEclipse->receiver->getSystem()->getStar();
 
-    Eigen::Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d toCasterDir = caster->getPosition(now).offsetFromKm(sun->getPosition(now));
     Eigen::Vector3d up = activeEclipse->receiver->getEclipticToBodyFixed(now).conjugate() * Eigen::Vector3d::UnitY();
-    Eigen::Vector3d toReceiverDir = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d toReceiverDir = receiver->getPosition(now).offsetFromKm(sun->getPosition(now));
 
-    Eigen::Vector3d surfacePoint = toCasterDir * caster.radius() / toCasterDir.norm() * 1.0001;
+    Eigen::Vector3d surfacePoint = toCasterDir * caster->getRadius() / toCasterDir.norm() * 1.0001;
     Eigen::Quaterniond viewOrientation = math::LookAt<double>(surfacePoint, toReceiverDir, up);
 
     sim->setFrame(ObserverFrame::Ecliptical, caster);
@@ -585,15 +585,15 @@ EventFinder::slotViewBehindOccluder()
         slotSetEclipseTime();
     now = sim->getTime();
 
-    Selection receiver(activeEclipse->receiver);
-    Selection caster(activeEclipse->occulter);
-    Selection sun(activeEclipse->receiver->getSystem()->getStar());
+    const Body* const receiver = activeEclipse->receiver;
+    Body* const caster = activeEclipse->occulter;
+    const Star* const sun = activeEclipse->receiver->getSystem()->getStar();
 
-    Eigen::Vector3d toCasterDir = caster.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d toCasterDir = caster->getPosition(now).offsetFromKm(sun->getPosition(now));
     Eigen::Vector3d up = activeEclipse->receiver->getEclipticToBodyFixed(now).conjugate() * Eigen::Vector3d::UnitY();
-    Eigen::Vector3d toReceiverDir = receiver.getPosition(now).offsetFromKm(sun.getPosition(now));
+    Eigen::Vector3d toReceiverDir = receiver->getPosition(now).offsetFromKm(sun->getPosition(now));
 
-    Eigen::Vector3d surfacePoint = toCasterDir * caster.radius() / toCasterDir.norm() * 20.0;
+    Eigen::Vector3d surfacePoint = toCasterDir * caster->getRadius() / toCasterDir.norm() * 20.0;
     Eigen::Quaterniond viewOrientation = math::LookAt<double>(surfacePoint, toReceiverDir, up);
 
     sim->setFrame(ObserverFrame::Ecliptical, caster);


### PR DESCRIPTION
Simpler to call the relevant methods directly rather than constructing a Selection for an object of statically known type.