### PR TITLE
Avoid throwing on invalid locale

### DIFF
--- a/src/celastro/date.cpp
+++ b/src/celastro/date.cpp
@@ -94,7 +94,7 @@ private:
 
 MonthAbbreviations::MonthAbbreviations()
 {
-    auto loc = std::locale("");
+    auto loc = std::locale();
     for (int i = 0; i < 12; ++i)
     {
         std::tm tm;
@@ -213,11 +213,11 @@ Date::toString(Format format) const
     switch(format)
     {
     case Locale:
-        return fmt::format(std::locale(""), "{:%c}"sv, cal_time);
+        return fmt::format(std::locale(), "{:%c}"sv, cal_time);
     case TZName:
-        return fmt::format(std::locale(""), "{:%Y %b %d %H:%M:%S %Z}"sv, cal_time);
+        return fmt::format(std::locale(), "{:%Y %b %d %H:%M:%S %Z}"sv, cal_time);
     default:
-        return fmt::format(std::locale(""), "{:%Y %b %d %H:%M:%S %z}"sv, cal_time);
+        return fmt::format(std::locale(), "{:%Y %b %d %H:%M:%S %z}"sv, cal_time);
     }
 #else
     switch(format)

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -426,7 +426,7 @@ private:
     Simulation* sim{ nullptr };
     Renderer* renderer{ nullptr };
 
-    std::locale loc{ "" };
+    std::locale loc;
 
     celestia::WindowMetrics metrics;
     std::unique_ptr<celestia::Hud> hud;

--- a/src/celestia/gtk/main.cpp
+++ b/src/celestia/gtk/main.cpp
@@ -38,6 +38,7 @@
 #include <celestia/celestiacore.h>
 #include <celestia/configfile.h>
 #include <celutil/gettext.h>
+#include <celutil/localeutil.h>
 
 /* Includes for the GTK front-end */
 #include "common.h"
@@ -303,10 +304,9 @@ initRealize(GtkWidget* widget, AppData* app)
 int main(int argc, char* argv[])
 {
     using namespace celestia::gtk;
+    namespace util = celestia::util;
 
-    setlocale(LC_ALL, "");
-    /* Force number displays into C locale. */
-    setlocale(LC_NUMERIC, "C");
+    util::InitLocale();
 
     #ifndef WIN32
     bindtextdomain("celestia", LOCALEDIR);

--- a/src/celestia/qt/qtmain.cpp
+++ b/src/celestia/qt/qtmain.cpp
@@ -33,6 +33,7 @@
 #include <QTranslator>
 
 #include <celutil/gettext.h>
+#include <celutil/localeutil.h>
 #include "qtappwin.h"
 #include "qtcommandline.h"
 #include "qtgettext.h"
@@ -49,8 +50,7 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
 
     // Gettext integration
-    setlocale(LC_ALL, "");
-    setlocale(LC_NUMERIC, "C");
+    celestia::util::InitLocale();
 #ifdef ENABLE_NLS
     QString localeDir = LOCALEDIR;
     bindtextdomain("celestia", localeDir.toUtf8().data());

--- a/src/celestia/sdl/sdlmain.cpp
+++ b/src/celestia/sdl/sdlmain.cpp
@@ -20,6 +20,7 @@
 #include <celestia/configfile.h>
 #include <celestia/url.h>
 #include <celutil/gettext.h>
+#include <celutil/localeutil.h>
 #include <celutil/tzutil.h>
 #include <SDL.h>
 #ifdef GL_ES
@@ -658,8 +659,7 @@ DumpGLInfo()
 int
 sdlmain(int /* argc */, char ** /* argv */)
 {
-    setlocale(LC_ALL, "");
-    setlocale(LC_NUMERIC, "C");
+    celestia::util::InitLocale();
 
 #ifdef ENABLE_NLS
     bindtextdomain("celestia", LOCALEDIR);

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -36,6 +36,7 @@
 #include <celutil/array_view.h>
 #include <celutil/fsutils.h>
 #include <celutil/gettext.h>
+#include <celutil/localeutil.h>
 #include <celutil/logger.h>
 #include <celutil/winutil.h>
 
@@ -622,8 +623,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     auto appCore = std::make_unique<CelestiaCore>();
 
     // Gettext integration
-    setlocale(LC_ALL, "");
-    setlocale(LC_NUMERIC, "C");
+    util::InitLocale();
 
 #ifdef ENABLE_NLS
     std::error_code ec;

--- a/src/celutil/CMakeLists.txt
+++ b/src/celutil/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CELUTIL_SOURCES
   greek.h
   includeicu.h
   intrusiveptr.h
+  localeutil.cpp
   localeutil.h
   logger.cpp
   logger.h

--- a/src/celutil/localeutil.cpp
+++ b/src/celutil/localeutil.cpp
@@ -1,0 +1,32 @@
+// localeutil.cpp
+//
+// Copyright (C) 2024-present, Celestia Development Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <clocale>
+#include <locale>
+#include <fmt/format.h>
+
+namespace celestia::util
+{
+
+void InitLocale()
+{
+    /* try to set locale, fallback to "classic" */
+    if (setlocale(LC_ALL, ""))
+    {
+        std::locale::global(std::locale(""));
+    }
+    else
+    {
+        fmt::print("Could not find locale, falling back to classic.\n");
+    }
+    /* Force number displays into C locale. */
+    setlocale(LC_NUMERIC, "C");
+}
+
+}

--- a/src/celutil/localeutil.h
+++ b/src/celutil/localeutil.h
@@ -14,6 +14,14 @@
 # include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
 #endif
 
+
+namespace celestia::util
+{
+
+void InitLocale();
+
+}
+
 #ifdef _MSC_VER
 typedef _locale_t locale_t;
 


### PR DESCRIPTION
This solves the issue mentioned here: https://github.com/CelestiaProject/Celestia/issues/2049#issuecomment-1963008789 where Celestia crashes if the specified locale does not exist.
I can trigger it by running `LC_ALL=C.ANSI_X3.4-1968 celestia-qt6`

This MR solves the issue as `std::locale()` does not throw.
~However it changes the behavior to return either `std::locale::classic()` or the last value entered into `std::locale::global()`.~

The original behavior has been restored by calling `std::locale::global(std::locale(""))` in the case that the user selected locale is found by `setlocale`.
~I'm not sure how to do this as the project uses `-fno-exceptions`.~

https://en.cppreference.com/w/cpp/locale/locale/locale