### PR TITLE
Add ExtrasDirectories based on configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,7 @@ include(TestBigEndian)
 test_big_endian(WORDS_BIGENDIAN)
 
 configure_file("config.h.in" "config.h")
+configure_file("celestia.cfg.in" "celestia.cfg")
 
 set(BASE_DATA_SOURCES
   demo.cel

--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -198,7 +198,7 @@ StarTextures
 # or
 #   ExtrasDirectories  [ "D:\\celestia-extras" ]
 #------------------------------------------------------------------------
-  ExtrasDirectories  [ "extras-standard" "extras" ]
+  ExtrasDirectories  [ "extras-standard" "extras" @CELCFG_EXTRAS_DIRS@]
 
 
 #------------------------------------------------------------------------


### PR DESCRIPTION
In the flatpak I'm currently using `sed` to modify the file after the fact. This change would allow me to run cmake with the option:
`-DCELCFG_EXTRAS_DIRS="\"~/.var/app/space.celestiaproject.Celestia/data/Celestia/extras\""`

I thought running `configure_file` on the config might prove useful for other things, though I'm not completely sure how useful it is.
