### PR TITLE
Consistent use of i18n names in GTK/Qt search/goto dialogs

### DIFF
--- a/src/celestia/gtk/actions.cpp
+++ b/src/celestia/gtk/actions.cpp
@@ -535,7 +535,7 @@ actionSearchObject(GtkAction*, AppData* app)
         const gchar* name = gtk_entry_get_text(GTK_ENTRY(entry));
         if (name != NULL)
         {
-            Selection sel = app->simulation->findObject(name);
+            Selection sel = app->simulation->findObjectFromPath(name, true);
             if (!sel.empty())
                 app->simulation->setSelection(sel);
         }

--- a/src/celestia/gtk/dialog-goto.cpp
+++ b/src/celestia/gtk/dialog-goto.cpp
@@ -79,7 +79,7 @@ GotoObject(gotoObjectData* gotoObjectDlg)
     if (objectName != nullptr)
     {
         Simulation* simulation = gotoObjectDlg->app->simulation;
-        Selection sel = simulation->findObjectFromPath(objectName);
+        Selection sel = simulation->findObjectFromPath(objectName, true);
 
         if (!sel.empty())
         {

--- a/src/celestia/qt/qteventfinder.cpp
+++ b/src/celestia/qt/qteventfinder.cpp
@@ -391,7 +391,7 @@ EventFinder::slotFindEclipses()
         eclipseTypeMask = Eclipse::Solar | Eclipse::Lunar;
 
     std::string bodyName = fmt::format("Sol/{}", planets[planetSelect->currentIndex()]);
-    Selection obj = appCore->getSimulation()->findObjectFromPath(bodyName, true);
+    Selection obj = appCore->getSimulation()->findObjectFromPath(bodyName);
 
     if (obj.body() == nullptr)
     {

--- a/src/celestia/qt/qtgotoobjectdialog.cpp
+++ b/src/celestia/qt/qtgotoobjectdialog.cpp
@@ -56,7 +56,7 @@ GoToObjectDialog::on_buttonBox_accepted()
     QString objectName = ui.objectName->text();
 
     Simulation *simulation = appCore->getSimulation();
-    Selection sel = simulation->findObjectFromPath(objectName.toStdString());
+    Selection sel = simulation->findObjectFromPath(objectName.toStdString(), true);
 
     simulation->setSelection(sel);
     simulation->follow();
@@ -114,7 +114,7 @@ GoToObjectDialog::on_objectName_textChanged(const QString &objectName)
     }
 
     // Enable OK button only if we have found the object
-    Selection sel = appCore->getSimulation()->findObjectFromPath(objectName.toStdString());
+    Selection sel = appCore->getSimulation()->findObjectFromPath(objectName.toStdString(), true);
     okButton->setEnabled(!sel.empty());
 }
 


### PR DESCRIPTION
User input boxes should use localized names
Qt event finder uses static names -> should NOT use localized name
Enable paths in GTK find dialog.