### PR TITLE
Revert "[qt] Hold the CelestiaCore in a unique_ptr"

### DIFF
--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -281,7 +281,7 @@ CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
 
     initAppDataDirectory();
 
-    m_appCore = std::make_unique<CelestiaCore>();
+    m_appCore = new CelestiaCore();
 
     auto* progress = new AppProgressNotifier(this);
     alerter = new AppAlerter(this);
@@ -325,7 +325,7 @@ CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
     }
     QSurfaceFormat::setDefaultFormat(glformat);
 
-    glWidget = new CelestiaGlWidget(nullptr, "Celestia", m_appCore.get());
+    glWidget = new CelestiaGlWidget(nullptr, "Celestia", m_appCore);
 
     m_appCore->setCursorHandler(glWidget);
     m_appCore->setContextMenuHandler(this);
@@ -334,7 +334,7 @@ CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
 
     setWindowTitle("Celestia");
 
-    actions = new CelestiaActions(this, m_appCore.get());
+    actions = new CelestiaActions(this, m_appCore);
 
     createMenus();
 
@@ -346,27 +346,27 @@ CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
     toolsDock->setAllowedAreas(static_cast<Qt::DockWidgetAreas>(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea));
 
     // Info browser for a selected object
-    infoPanel = new InfoPanel(m_appCore.get(), _("Info Browser"), this);
+    infoPanel = new InfoPanel(m_appCore, _("Info Browser"), this);
     infoPanel->setObjectName("info-panel");
     infoPanel->setAllowedAreas(static_cast<Qt::DockWidgetAreas>(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea));
     infoPanel->setVisible(false);
 
     // Create the various browser widgets
-    celestialBrowser = new CelestialBrowser(m_appCore.get(), nullptr, infoPanel);
+    celestialBrowser = new CelestialBrowser(m_appCore, nullptr, infoPanel);
     celestialBrowser->setObjectName("celestia-browser");
     connect(celestialBrowser,
             SIGNAL(selectionContextMenuRequested(const QPoint&, Selection&)),
             this,
             SLOT(slotShowSelectionContextMenu(const QPoint&, Selection&)));
 
-    DeepSkyBrowser* deepSkyBrowser = new DeepSkyBrowser(m_appCore.get(), nullptr, infoPanel);
+    DeepSkyBrowser* deepSkyBrowser = new DeepSkyBrowser(m_appCore, nullptr, infoPanel);
     deepSkyBrowser->setObjectName("deepsky-browser");
     connect(deepSkyBrowser,
             SIGNAL(selectionContextMenuRequested(const QPoint&, Selection&)),
             this,
             SLOT(slotShowSelectionContextMenu(const QPoint&, Selection&)));
 
-    SolarSystemBrowser* solarSystemBrowser = new SolarSystemBrowser(m_appCore.get(), nullptr, infoPanel);
+    SolarSystemBrowser* solarSystemBrowser = new SolarSystemBrowser(m_appCore, nullptr, infoPanel);
     solarSystemBrowser->setObjectName("ssys-browser");
     connect(solarSystemBrowser,
             SIGNAL(selectionContextMenuRequested(const QPoint&, Selection&)),
@@ -383,7 +383,7 @@ CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
 
     addDockWidget(Qt::RightDockWidgetArea, infoPanel);
 
-    eventFinder = new EventFinder(m_appCore.get(), _("Event Finder"), this);
+    eventFinder = new EventFinder(m_appCore, _("Event Finder"), this);
     eventFinder->setObjectName("event-finder");
     eventFinder->setAllowedAreas(static_cast<Qt::DockWidgetAreas>(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea));
     addDockWidget(Qt::LeftDockWidgetArea, eventFinder);
@@ -391,7 +391,7 @@ CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
     //addDockWidget(Qt::DockWidgetArea, eventFinder);
 
     // Create the time toolbar
-    timeToolBar = new TimeToolBar(m_appCore.get(), _("Time"));
+    timeToolBar = new TimeToolBar(m_appCore, _("Time"));
     timeToolBar->setObjectName("time-toolbar");
     timeToolBar->setFloatable(true);
     timeToolBar->setMovable(true);
@@ -655,7 +655,7 @@ void
 CelestiaAppWindow::slotShowSelectionContextMenu(const QPoint& pos,
                                                 Selection& sel)
 {
-    SelectionPopup* menu = new SelectionPopup(sel, m_appCore.get(), this);
+    SelectionPopup* menu = new SelectionPopup(sel, m_appCore, this);
     connect(menu, SIGNAL(selectionInfoRequested(Selection&)),
             this, SLOT(slotShowObjectInfo(Selection&)));
     menu->popupAtCenter(pos);
@@ -789,7 +789,7 @@ CelestiaAppWindow::slotCopyImage()
 void
 CelestiaAppWindow::slotCopyURL()
 {
-    CelestiaState appState(m_appCore.get());
+    CelestiaState appState(m_appCore);
     appState.captureState();
 
     Url url(appState);
@@ -841,7 +841,7 @@ CelestiaAppWindow::gotoSelection()
 void
 CelestiaAppWindow::gotoObject()
 {
-    GoToObjectDialog dlg(this, m_appCore.get());
+    GoToObjectDialog dlg(this, m_appCore);
     dlg.exec();
 }
 
@@ -849,14 +849,14 @@ void
 CelestiaAppWindow::tourGuide()
 {
     // use show() to display dialog in non-modal format since exec() is automatically modal
-    TourGuideDialog *tourDialog = new TourGuideDialog(this, m_appCore.get());
+    TourGuideDialog *tourDialog = new TourGuideDialog(this, m_appCore);
     tourDialog->show();
 }
 
 void
 CelestiaAppWindow::slotPreferences()
 {
-    PreferencesDialog dlg(this, m_appCore.get());
+    PreferencesDialog dlg(this, m_appCore);
     dlg.exec();
 }
 
@@ -982,7 +982,7 @@ void
 CelestiaAppWindow::slotShowTimeDialog()
 {
     SetTimeDialog* timeDialog = new SetTimeDialog(m_appCore->getSimulation()->getTime(),
-                                                  this, m_appCore.get());
+                                                  this, m_appCore);
 
     timeDialog->show();
 }
@@ -1108,7 +1108,7 @@ CelestiaAppWindow::slotAddBookmark()
     if (defaultTitle.isEmpty())
         defaultTitle = _("New bookmark");
 
-    CelestiaState appState(m_appCore.get());
+    CelestiaState appState(m_appCore);
     appState.captureState();
 
     // Capture the current frame buffer to use as a bookmark icon.
@@ -1698,7 +1698,7 @@ void
 CelestiaAppWindow::requestContextMenu(float x, float y, Selection sel)
 {
     qreal scale = devicePixelRatioF();
-    SelectionPopup* menu = new SelectionPopup(sel, m_appCore.get(), this);
+    SelectionPopup* menu = new SelectionPopup(sel, m_appCore, this);
     connect(menu, SIGNAL(selectionInfoRequested(Selection&)),
             this, SLOT(slotShowObjectInfo(Selection&)));
     menu->popupAtCenter(centralWidget()->mapToGlobal(QPoint((int)(x / scale), (int)(y / scale))));

--- a/src/celestia/qt/qtappwin.h
+++ b/src/celestia/qt/qtappwin.h
@@ -12,8 +12,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include <QImage>
 #include <QMainWindow>
 #include <QString>
@@ -149,7 +147,7 @@ private:
     QDockWidget* toolsDock{ nullptr };
     CelestialBrowser* celestialBrowser{ nullptr };
 
-    std::unique_ptr<CelestiaCore> m_appCore;
+    CelestiaCore* m_appCore{ nullptr };
 
     CelestiaActions* actions{ nullptr };
 


### PR DESCRIPTION
This reverts commit db922ab6b8f00d71bb5378bc28c42ba6f9a613ca.

Fixes #2159 

Didn't look like there was a problem on Windows but Linux makes this more obvious. Annoyingly there isn't actually a good place to put the destructor in the Qt code as it currently stands, so rely on process teardown instead.