### PR TITLE
Updates for intrusive_ptr refcounting

### DIFF
--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -278,17 +278,17 @@ private:
     friend void
     intrusive_ptr_add_ref(Sh_ExpressionContents* p)
     {
-        ++p->m_refCount;
+        ++(p->m_refCount);
     }
 
     friend void
     intrusive_ptr_release(Sh_ExpressionContents* p)
     {
-        if (--p->m_refCount == 0)
+        if (--(p->m_refCount) == 0)
             delete p;
     }
 
-    std::uint32_t m_refCount{0};
+    std::uint32_t m_refCount{ 1 };
 };
 
 
@@ -323,7 +323,7 @@ public:
     {}
 
     Sh_Expression(float f) :
-        m_contents(new Sh_ConstantExpression(f))
+        m_contents(new Sh_ConstantExpression(f), false)
     {}
 
     ~Sh_Expression() = default;
@@ -354,7 +354,7 @@ private:
 template<typename T, typename... Args>
 Sh_Expression makeExpression(Args&&... args)
 {
-    return Sh_Expression(boost::intrusive_ptr<T>(new T(std::forward<Args>(args)...)));
+    return Sh_Expression(boost::intrusive_ptr(new T(std::forward<Args>(args)...), false));
 }
 
 

--- a/src/celengine/star.cpp
+++ b/src/celengine/star.cpp
@@ -892,7 +892,7 @@ StarDetails::StarDetails()
 boost::intrusive_ptr<StarDetails>
 StarDetails::create()
 {
-    return boost::intrusive_ptr<StarDetails>(new StarDetails);
+    return boost::intrusive_ptr(new StarDetails, false);
 }
 
 boost::intrusive_ptr<StarDetails>

--- a/src/celengine/star.h
+++ b/src/celengine/star.h
@@ -115,17 +115,17 @@ class StarDetails
     friend void
     intrusive_ptr_add_ref(StarDetails* p)
     {
-        p->refCount.fetch_add(1);
+        p->refCount.fetch_add(1, std::memory_order_relaxed);
     }
 
     friend void
     intrusive_ptr_release(StarDetails* p)
     {
-        if (p->refCount.fetch_sub(1) == 1)
+        if (p->refCount.fetch_sub(1, std::memory_order_acq_rel) == 1)
             delete p;
     }
 
-    std::atomic_uint32_t refCount{ 0 };
+    std::atomic_uint32_t refCount{ 1 };
 
     float radius{ 0.0f };
     float temperature{ 0.0f };


### PR DESCRIPTION
- Initialize the refcounts with 1
- Use memory orderings that match the implementation of shared_ptr refcounting in libc++/Windows STL

Latter also matches the example in [Herb Sutter's `atomic<>` weapons talk](https://www.youtube.com/watch?v=KeLBd2EJLOU) (discussion starts at 1:19:51), should be a little better on ARM.