### PR TITLE
Update vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Update vcpkg
       shell: pwsh
       run: |
-        $vcpkgCommit = '72d66da23b4332533c82d797bf2f82b8d6d1bf8a'
+        $vcpkgCommit = 'a13163bfa5d7b4c814d8c929443874f676c4482c'
         pushd "$env:VCPKG_INSTALLATION_ROOT"
         git cat-file -e "${vcpkgCommit}^{commit}" 2> $null
         if (!$?) {


### PR DESCRIPTION
Update to latest version of vcpkg, so we're definitely getting packages after the recent xz/lzma downgrade. (We don't have a dependency on this currently but probably better to err on the side of caution)