### PR TITLE
Fix build issues arising from syntax error in acinclude.m4

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2630,8 +2630,8 @@ AC_TRY_LINK(
 LIBS="$ac_save_LIBS"
 CXXFLAGS="$ac_save_CXXFLAGS"
 AC_LANG_RESTORE
-fi
 ])
+fi
 
 if eval "test ! \"`echo $kde_cv_qt_jpeg`\" = no"; then
   AC_MSG_RESULT(yes)


### PR DESCRIPTION
The acinclude.m4 file places the closing `fi` in the wrong location, resulting in builds on some systems failing, e.g. Arch Linux: https://aur.archlinux.org/packages/celestia

The `fi` belongs where it is placed by this commit because there is no `if` inside the `AC_CACHE_VAL`. Rather, the statement is intended to close the conditional `if test -n "$LIBJPEG"`.