### PR TITLE
Split Frustum and InfiniteFrustum

### DIFF
--- a/src/celengine/dsorenderer.cpp
+++ b/src/celengine/dsorenderer.cpp
@@ -70,7 +70,7 @@ void DSORenderer::process(DeepSkyObject* const &dso,
     // each object (even if it's not visible) would be sent to the OpenGL
     // pipeline.
     double dsoRadius = dso->getBoundingSphereRadius();
-    if (frustum.testSphere(center, (float) dsoRadius) == math::Frustum::Outside)
+    if (frustum.testSphere(center, (float) dsoRadius) == math::FrustumAspect::Outside)
         return;
 
     float appMag;

--- a/src/celengine/dsorenderer.h
+++ b/src/celengine/dsorenderer.h
@@ -26,9 +26,9 @@ public:
 
     void process(DeepSkyObject *const &, double, float) override;
 
-    celestia::math::Frustum frustum{ celestia::math::degToRad(celestia::engine::standardFOV),
-                                     1.0f,
-                                     1.0f };
+    celestia::math::InfiniteFrustum frustum{ celestia::math::degToRad(celestia::engine::standardFOV),
+                                             1.0f,
+                                             1.0f };
 
     Eigen::Vector3d obsPos;
     Eigen::Matrix3f orientationMatrixT;

--- a/src/celengine/fisheyeprojectionmode.cpp
+++ b/src/celengine/fisheyeprojectionmode.cpp
@@ -64,6 +64,12 @@ FisheyeProjectionMode::getFrustum(float nearZ, float farZ, float zoom) const
     return math::Frustum(getFOV(zoom), width / height, nearZ, farZ);
 }
 
+math::InfiniteFrustum
+FisheyeProjectionMode::getInfiniteFrustum(float nearZ, float zoom) const
+{
+    return math::InfiniteFrustum(getFOV(zoom), width / height, nearZ);
+}
+
 double FisheyeProjectionMode::getViewConeAngleMax(float /*zoom*/) const
 {
     return std::cos(static_cast<double>(fisheyeFOV) / 2.0);
@@ -97,7 +103,12 @@ void FisheyeProjectionMode::configureShaderManager(ShaderManager *shaderManager)
     shaderManager->setFisheyeEnabled(true);
 }
 
-bool FisheyeProjectionMode::project(const Eigen::Vector3f& pos, const Eigen::Matrix4f existingModelViewMatrix, const Eigen::Matrix4f existingProjectionMatrix, const Eigen::Matrix4f /*existingMVPMatrix*/, const int viewport[4], Eigen::Vector3f& result) const
+bool FisheyeProjectionMode::project(const Eigen::Vector3f& pos,
+                                    const Eigen::Matrix4f& existingModelViewMatrix,
+                                    const Eigen::Matrix4f& existingProjectionMatrix,
+                                    const Eigen::Matrix4f& /*existingMVPMatrix*/,
+                                    const std::array<int, 4>& viewport,
+                                    Eigen::Vector3f& result) const
 {
     return math::ProjectFisheye(pos, existingModelViewMatrix, existingProjectionMatrix, viewport, result);
 }

--- a/src/celengine/fisheyeprojectionmode.h
+++ b/src/celengine/fisheyeprojectionmode.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <Eigen/Core>
+
 #include <celengine/projectionmode.h>
 
 namespace celestia::engine
@@ -33,6 +35,7 @@ public:
     float getPixelSize(float zoom) const override;
     float getFieldCorrection(float zoom) const override;
     math::Frustum getFrustum(float nearZ, float farZ, float zoom) const override;
+    math::InfiniteFrustum getInfiniteFrustum(float nearZ, float zoom) const override;
     double getViewConeAngleMax(float zoom) const override;
 
     float getNormalizedDeviceZ(float nearZ, float farZ, float z) const override;
@@ -40,7 +43,12 @@ public:
     Eigen::Vector3f getPickRay(float x, float y, float zoom) const override;
 
     void configureShaderManager(ShaderManager *) const override;
-    bool project(const Eigen::Vector3f& pos, const Eigen::Matrix4f existingModelViewMatrix, const Eigen::Matrix4f existingProjectionMatrix, const Eigen::Matrix4f existingMVPMatrix, const int viewport[4], Eigen::Vector3f& result) const override;
+    bool project(const Eigen::Vector3f& pos,
+                 const Eigen::Matrix4f& existingModelViewMatrix,
+                 const Eigen::Matrix4f& existingProjectionMatrix,
+                 const Eigen::Matrix4f& existingMVPMatrix,
+                 const std::array<int, 4>& viewport,
+                 Eigen::Vector3f& result) const override;
 };
 
-}
+} // end namespace celestia::engine

--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -99,7 +99,7 @@ Renderer::renderMarker(MarkerRepresentation::Symbol symbol,
 void
 Renderer::renderSelectionPointer(const Observer& observer,
                                  double now,
-                                 const math::Frustum& viewFrustum,
+                                 const math::InfiniteFrustum& viewFrustum,
                                  const Selection& sel)
 {
     constexpr float cursorDistance = 20.0f;
@@ -108,7 +108,7 @@ Renderer::renderSelectionPointer(const Observer& observer,
 
     // Get the position of the cursor relative to the eye
     Eigen::Vector3d position = sel.getPosition(now).offsetFromKm(observer.getPosition());
-    if (viewFrustum.testSphere(position, sel.radius()) != math::Frustum::Outside)
+    if (viewFrustum.testSphere(position, sel.radius()) != math::FrustumAspect::Outside)
         return;
 
     assert(shaderManager != nullptr);

--- a/src/celengine/lodspheremesh.cpp
+++ b/src/celengine/lodspheremesh.cpp
@@ -492,30 +492,30 @@ void LODSphereMesh::render(unsigned int attributes,
         //
         // Compute the vertices of the view frustum.  These will be used for
         // culling patches.
-        ri.fp[0] = intersect3(frustum.plane(math::Frustum::Near),
-                              frustum.plane(math::Frustum::Top),
-                              frustum.plane(math::Frustum::Left));
-        ri.fp[1] = intersect3(frustum.plane(math::Frustum::Near),
-                              frustum.plane(math::Frustum::Top),
-                              frustum.plane(math::Frustum::Right));
-        ri.fp[2] = intersect3(frustum.plane(math::Frustum::Near),
-                              frustum.plane(math::Frustum::Bottom),
-                              frustum.plane(math::Frustum::Left));
-        ri.fp[3] = intersect3(frustum.plane(math::Frustum::Near),
-                              frustum.plane(math::Frustum::Bottom),
-                              frustum.plane(math::Frustum::Right));
-        ri.fp[4] = intersect3(frustum.plane(math::Frustum::Far),
-                              frustum.plane(math::Frustum::Top),
-                              frustum.plane(math::Frustum::Left));
-        ri.fp[5] = intersect3(frustum.plane(math::Frustum::Far),
-                              frustum.plane(math::Frustum::Top),
-                              frustum.plane(math::Frustum::Right));
-        ri.fp[6] = intersect3(frustum.plane(math::Frustum::Far),
-                              frustum.plane(math::Frustum::Bottom),
-                              frustum.plane(math::Frustum::Left));
-        ri.fp[7] = intersect3(frustum.plane(math::Frustum::Far),
-                              frustum.plane(math::Frustum::Bottom),
-                              frustum.plane(math::Frustum::Right));
+        ri.fp[0] = intersect3(frustum.plane(math::FrustumPlane::Near),
+                              frustum.plane(math::FrustumPlane::Top),
+                              frustum.plane(math::FrustumPlane::Left));
+        ri.fp[1] = intersect3(frustum.plane(math::FrustumPlane::Near),
+                              frustum.plane(math::FrustumPlane::Top),
+                              frustum.plane(math::FrustumPlane::Right));
+        ri.fp[2] = intersect3(frustum.plane(math::FrustumPlane::Near),
+                              frustum.plane(math::FrustumPlane::Bottom),
+                              frustum.plane(math::FrustumPlane::Left));
+        ri.fp[3] = intersect3(frustum.plane(math::FrustumPlane::Near),
+                              frustum.plane(math::FrustumPlane::Bottom),
+                              frustum.plane(math::FrustumPlane::Right));
+        ri.fp[4] = intersect3(frustum.plane(math::FrustumPlane::Far),
+                              frustum.plane(math::FrustumPlane::Top),
+                              frustum.plane(math::FrustumPlane::Left));
+        ri.fp[5] = intersect3(frustum.plane(math::FrustumPlane::Far),
+                              frustum.plane(math::FrustumPlane::Top),
+                              frustum.plane(math::FrustumPlane::Right));
+        ri.fp[6] = intersect3(frustum.plane(math::FrustumPlane::Far),
+                              frustum.plane(math::FrustumPlane::Bottom),
+                              frustum.plane(math::FrustumPlane::Left));
+        ri.fp[7] = intersect3(frustum.plane(math::FrustumPlane::Far),
+                              frustum.plane(math::FrustumPlane::Bottom),
+                              frustum.plane(math::FrustumPlane::Right));
 
         const int extent = maxDivisions / 2;
         for (int i = 0; i < 2; i++)
@@ -608,7 +608,7 @@ LODSphereMesh::renderPatches(int phi0, int theta0,
                                      (patchCenter - p1).norm(),
                                      (patchCenter - p2).norm(),
                                      (patchCenter - p3).norm()});
-        ri.frustum.testSphere(patchCenter, boundingRadius) == math::Frustum::Outside)
+        ri.frustum.testSphere(patchCenter, boundingRadius) == math::FrustumAspect::Outside)
         return;
 
     if (level == 1)

--- a/src/celengine/perspectiveprojectionmode.cpp
+++ b/src/celengine/perspectiveprojectionmode.cpp
@@ -61,6 +61,12 @@ PerspectiveProjectionMode::getFrustum(float nearZ, float farZ, float zoom) const
     return math::Frustum(getFOV(zoom), width / height, nearZ, farZ);
 }
 
+math::InfiniteFrustum
+PerspectiveProjectionMode::getInfiniteFrustum(float nearZ, float zoom) const
+{
+    return math::InfiniteFrustum(getFOV(zoom), width / height, nearZ);
+}
+
 double PerspectiveProjectionMode::getViewConeAngleMax(float zoom) const
 {
     // When computing the view cone, we want the field of
@@ -92,7 +98,12 @@ void PerspectiveProjectionMode::configureShaderManager(ShaderManager *shaderMana
     shaderManager->setFisheyeEnabled(false);
 }
 
-bool PerspectiveProjectionMode::project(const Eigen::Vector3f& pos, const Eigen::Matrix4f /*existingModelViewMatrix*/, const Eigen::Matrix4f /*existingProjectionMatrix*/, const Eigen::Matrix4f existingMVPMatrix, const int viewport[4], Eigen::Vector3f& result) const
+bool PerspectiveProjectionMode::project(const Eigen::Vector3f& pos,
+                                        const Eigen::Matrix4f& /*existingModelViewMatrix*/,
+                                        const Eigen::Matrix4f& /*existingProjectionMatrix*/,
+                                        const Eigen::Matrix4f& existingMVPMatrix,
+                                        const std::array<int, 4>& viewport,
+                                        Eigen::Vector3f& result) const
 {
     return math::ProjectPerspective(pos, existingMVPMatrix, viewport, result);
 }

--- a/src/celengine/perspectiveprojectionmode.h
+++ b/src/celengine/perspectiveprojectionmode.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <Eigen/Core>
+
 #include <celengine/projectionmode.h>
 
 namespace celestia::engine
@@ -33,6 +35,7 @@ public:
     float getPixelSize(float zoom) const override;
     float getFieldCorrection(float zoom) const override;
     math::Frustum getFrustum(float nearZ, float farZ, float zoom) const override;
+    math::InfiniteFrustum getInfiniteFrustum(float nearZ, float zoom) const override;
     double getViewConeAngleMax(float zoom) const override;
 
     float getNormalizedDeviceZ(float nearZ, float farZ, float z) const override;
@@ -40,7 +43,12 @@ public:
     Eigen::Vector3f getPickRay(float x, float y, float zoom) const override;
 
     void configureShaderManager(ShaderManager *) const override;
-    bool project(const Eigen::Vector3f& pos, const Eigen::Matrix4f existingModelViewMatrix, const Eigen::Matrix4f existingProjectionMatrix, const Eigen::Matrix4f existingMVPMatrix, const int viewport[4], Eigen::Vector3f& result) const override;
+    bool project(const Eigen::Vector3f& pos,
+                 const Eigen::Matrix4f& existingModelViewMatrix,
+                 const Eigen::Matrix4f& existingProjectionMatrix,
+                 const Eigen::Matrix4f& existingMVPMatrix,
+                 const std::array<int, 4>& viewport,
+                 Eigen::Vector3f& result) const override;
 };
 
-}
+} // end namespace celestia::engine

--- a/src/celengine/projectionmode.h
+++ b/src/celengine/projectionmode.h
@@ -9,7 +9,9 @@
 
 #pragma once
 
+#include <array>
 #include <tuple>
+
 #include <Eigen/Core>
 
 class ShaderManager;
@@ -17,12 +19,13 @@ class ShaderManager;
 namespace celestia::math
 {
 class Frustum;
+class InfiniteFrustum;
 }
 
 namespace celestia::engine
 {
 
-constexpr float standardFOV = 45.0f;
+constexpr inline float standardFOV = 45.0f;
 
 class ProjectionMode
 {
@@ -41,6 +44,7 @@ public:
     virtual float getPixelSize(float zoom) const = 0;
     virtual float getFieldCorrection(float zoom) const = 0;
     virtual celestia::math::Frustum getFrustum(float nearZ, float farZ, float zoom) const = 0;
+    virtual celestia::math::InfiniteFrustum getInfiniteFrustum(float nearZ, float zoom) const = 0;
 
     // Calculate the cosine of half the maximum field of view. We'll use this for
     // fast testing of object visibility.
@@ -50,7 +54,12 @@ public:
 
     virtual Eigen::Vector3f getPickRay(float x, float y, float zoom) const = 0;
     virtual void configureShaderManager(ShaderManager *) const = 0;
-    virtual bool project(const Eigen::Vector3f& pos, const Eigen::Matrix4f existingModelViewMatrix, const Eigen::Matrix4f existingProjectionMatrix, const Eigen::Matrix4f existingMVPMatrix, const int viewport[4], Eigen::Vector3f& result) const = 0;
+    virtual bool project(const Eigen::Vector3f& pos,
+                         const Eigen::Matrix4f& existingModelViewMatrix,
+                         const Eigen::Matrix4f& existingProjectionMatrix,
+                         const Eigen::Matrix4f& existingMVPMatrix,
+                         const std::array<int, 4>& viewport,
+                         Eigen::Vector3f& result) const = 0;
 
     void setScreenDpi(int screenDpi);
     void setDistanceToScreen(int distanceToScreen);

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -53,6 +53,7 @@ class VertexObject;
 namespace math
 {
 class Frustum;
+class InfiniteFrustum;
 }
 }
 
@@ -497,7 +498,7 @@ class Renderer
     void renderSkyGrids(const Observer& observer);
     void renderSelectionPointer(const Observer& observer,
                                 double now,
-                                const celestia::math::Frustum& viewFrustum,
+                                const celestia::math::InfiniteFrustum& viewFrustum,
                                 const Selection& sel);
 
     void renderAsterisms(const Universe&, float, const Matrices&);
@@ -506,11 +507,11 @@ class Renderer
 
     void buildNearSystemsLists(const Universe &universe,
                                const Observer &observer,
-                               const celestia::math::Frustum &xfrustum,
+                               const celestia::math::InfiniteFrustum &xfrustum,
                                double jd);
 
     void buildRenderLists(const Eigen::Vector3d& astrocentricObserverPos,
-                          const celestia::math::Frustum& viewFrustum,
+                          const celestia::math::InfiniteFrustum& viewFrustum,
                           const Eigen::Vector3d& viewPlaneNormal,
                           const Eigen::Vector3d& frameCenter,
                           const FrameTree* tree,
@@ -518,10 +519,10 @@ class Renderer
                           double now);
     void buildOrbitLists(const Eigen::Vector3d& astrocentricObserverPos,
                          const Eigen::Quaterniond& observerOrientation,
-                         const celestia::math::Frustum& viewFrustum,
+                         const celestia::math::InfiniteFrustum& viewFrustum,
                          const FrameTree* tree,
                          double now);
-    void buildLabelLists(const celestia::math::Frustum& viewFrustum,
+    void buildLabelLists(const celestia::math::InfiniteFrustum& viewFrustum,
                          double now);
     int buildDepthPartitions();
 
@@ -534,7 +535,7 @@ class Renderer
                                   const Observer& observer,
                                   double now);
 
-    void removeInvisibleItems(const celestia::math::Frustum &frustum);
+    void removeInvisibleItems(const celestia::math::InfiniteFrustum &frustum);
 
     void renderObject(const Eigen::Vector3f& pos,
                       float distance,
@@ -652,7 +653,7 @@ class Renderer
 
     bool selectionToAnnotation(const Selection &sel,
                                const Observer &observer,
-                               const celestia::math::Frustum &xfrustum,
+                               const celestia::math::InfiniteFrustum &xfrustum,
                                double now);
 
     void adjustMagnitudeInsideAtmosphere(float &faintestMag,

--- a/src/celmath/frustum.cpp
+++ b/src/celmath/frustum.cpp
@@ -8,139 +8,203 @@
 // of the License, or (at your option) any later version.
 
 #include <cmath>
+#include <type_traits>
+#include <utility>
 
 #include <Eigen/LU>
 
+#include <celutil/array_view.h>
 #include "frustum.h"
-
 
 namespace celestia::math
 {
 
-Frustum::Frustum(float fov, float aspectRatio, float n) :
-    infinite(true)
+namespace
 {
-    init(fov, aspectRatio, n, n);
-}
 
-Frustum::Frustum(float fov, float aspectRatio, float n, float f) :
-    infinite(std::isinf(f))
-{
-    init(fov, aspectRatio, n, infinite ? n : f);
-}
-
-Frustum::Frustum(float l, float r, float t, float b, float n, float f) :
-    infinite(std::isinf(f))
-{
-    init(l, r, t, b, n, infinite ? n : f);
-}
-
-void Frustum::init(float fov, float aspectRatio, float n, float f)
-{
-    float h = std::tan(fov / 2.0f);
-    float w = h * aspectRatio;
-
-    init(-w * n, w * n, h * n, -h * n, n, f);
-}
+constexpr auto NearIdx = static_cast<std::size_t>(FrustumPlane::Near);
+constexpr auto FarIdx = static_cast<std::size_t>(FrustumPlane::Far);
 
 void
-Frustum::init(float l, float r, float t, float b, float n, float f)
+init(Frustum::PlaneType* planes, float l, float r, float t, float b, float n)
 {
-    Eigen::Vector3f normals[4];
-    normals[Bottom] = Eigen::Vector3f(0.0f,    n,  b);
-    normals[Top]    = Eigen::Vector3f(0.0f,   -n, -t);
-    normals[Left]   = Eigen::Vector3f(   n, 0.0f,  l);
-    normals[Right]  = Eigen::Vector3f(  -n, 0.0f, -r);
+    std::array<Eigen::Vector3f, 4> normals
+    {
+        Eigen::Vector3f(0.0f,    n,  b), // Bottom
+        Eigen::Vector3f(0.0f,   -n, -t), // Top
+        Eigen::Vector3f(   n, 0.0f,  l), // Left
+        Eigen::Vector3f(  -n, 0.0f, -r), // Right
+    };
+
     for (unsigned int i = 0; i < 4; i++)
     {
         planes[i] = Eigen::Hyperplane<float, 3>(normals[i].normalized(), 0.0f);
     }
 
-    planes[Near] = Eigen::Hyperplane<float, 3>(Eigen::Vector3f(0.0f, 0.0f, -1.0f), -n);
-    planes[Far]  = Eigen::Hyperplane<float, 3>(Eigen::Vector3f(0.0f, 0.0f,  1.0f),  f);
+    planes[NearIdx] = Eigen::Hyperplane<float, 3>(Eigen::Vector3f(0.0f, 0.0f, -1.0f), -n);
 }
-
-Frustum::Aspect
-Frustum::test(const Eigen::Vector3f& point) const
-{
-    unsigned int nPlanes = infinite ? 5 : 6;
-
-    for (unsigned int i = 0; i < nPlanes; i++)
-    {
-        if (planes[i].signedDistance(point) < 0.0f)
-            return Outside;
-    }
-
-    return Inside;
-}
-
-
-Frustum::Aspect
-Frustum::testSphere(const Eigen::Vector3f& center, float radius) const
-{
-    unsigned int nPlanes = infinite ? 5 : 6;
-    unsigned int intersections = 0;
-
-    for (unsigned int i = 0; i < nPlanes; i++)
-    {
-        float distanceToPlane = planes[i].signedDistance(center);
-        if (distanceToPlane < -radius)
-            return Outside;
-        if (distanceToPlane <= radius)
-            intersections |= (1 << i);
-    }
-
-    return (intersections == 0) ? Inside : Intersect;
-}
-
-
-/** Double precision version of testSphere()
-  */
-Frustum::Aspect
-Frustum::testSphere(const Eigen::Vector3d& center, double radius) const
-{
-    int nPlanes = infinite ? 5 : 6;
-    int intersections = 0;
-
-    // IMPORTANT: Celestia relies on this calculation being peformed at double
-    // precision. Simply converting center to single precision is NOT an
-    // allowable optimization.
-    for (int i = 0; i < nPlanes; i++)
-    {
-        double distanceToPlane = planes[i].cast<double>().signedDistance(center);
-        if (distanceToPlane < -radius)
-            return Outside;
-        if (distanceToPlane <= radius)
-            intersections |= (1 << i);
-    }
-
-    return (intersections == 0) ? Inside : Intersect;
-}
-
 
 void
-Frustum::transform(const Eigen::Matrix3f& m)
+init(Frustum::PlaneType* planes, float fov, float aspectRatio, float n)
 {
-    unsigned int nPlanes = infinite ? 5 : 6;
+    float h = std::tan(fov * 0.5f);
+    float w = h * aspectRatio;
 
-    for (unsigned int i = 0; i < nPlanes; i++)
+    init(planes, -w * n, w * n, h * n, -h * n, n);
+}
+
+Frustum::PlaneType
+createFarPlane(float f)
+{
+    return Frustum::PlaneType(Eigen::Vector3f(0.0f, 0.0f,  1.0f), f);
+}
+
+void
+doTransform(Frustum::PlaneType* planes, unsigned int nPlanes, const Eigen::Matrix3f& matrix)
+{
+    for (unsigned int i = 0; i < nPlanes; ++i)
     {
-        planes[i] = planes[i].transform(m, Eigen::Isometry);
+        planes[i] = planes[i].transform(matrix, Eigen::Isometry);
     }
 }
 
-
 void
-Frustum::transform(const Eigen::Matrix4f& m)
+doTransform(Frustum::PlaneType* planes, unsigned int nPlanes, const Eigen::Matrix4f& matrix)
 {
-    unsigned int nPlanes = infinite ? 5 : 6;
-    Eigen::Matrix4f invTranspose = m.inverse().transpose();
+    Eigen::Matrix4f invTranspose = matrix.inverse().transpose();
 
-    for (unsigned int i = 0; i < nPlanes; i++)
+    for (unsigned int i = 0; i < nPlanes; ++i)
     {
         planes[i].coeffs() = invTranspose * planes[i].coeffs();
         planes[i].normalize();
     }
+}
+
+FrustumAspect
+doTest(util::array_view<Frustum::PlaneType> planes, const Eigen::Vector3f& point)
+{
+    for (const auto& plane : planes)
+    {
+        if (plane.signedDistance(point) < 0.0f)
+            return FrustumAspect::Outside;
+    }
+
+    return FrustumAspect::Inside;
+}
+
+template<typename PREC>
+FrustumAspect
+doTestSphere(util::array_view<Frustum::PlaneType> planes,
+             const Eigen::Matrix<PREC, 3, 1>& center,
+             PREC radius)
+{
+    bool isIntersecting = false;
+
+    for (const auto& plane : planes)
+    {
+        PREC distanceToPlane;
+        if constexpr (std::is_same_v<PREC, float>)
+        {
+            distanceToPlane = plane.signedDistance(center);
+        }
+        else
+        {
+            // IMPORTANT: Celestia relies on this calculation being peformed at double
+            // precision. Simply converting center to single precision is NOT an
+            // allowable optimization.
+            distanceToPlane = plane.template cast<PREC>().signedDistance(center);
+        }
+
+        if (distanceToPlane < -radius)
+            return FrustumAspect::Outside;
+        if (distanceToPlane <= radius)
+            isIntersecting = true;
+    }
+
+    return isIntersecting ? FrustumAspect::Intersect : FrustumAspect::Inside;
+}
+
+} // end unnamed namespace
+
+Frustum::Frustum(float fov, float aspectRatio, float n, float f)
+{
+    init(planes.data(), fov, aspectRatio, n);
+    planes[FarIdx] = createFarPlane(f);
+}
+
+Frustum::Frustum(float l, float r, float t, float b, float n, float f)
+{
+    init(planes.data(), l, r, t, b, n);
+    planes[FarIdx] = createFarPlane(f);
+}
+
+void
+Frustum::transform(const Eigen::Matrix3f& m)
+{
+    doTransform(planes.data(), nPlanes, m);
+}
+
+void
+Frustum::transform(const Eigen::Matrix4f& m)
+{
+    doTransform(planes.data(), nPlanes, m);
+}
+
+FrustumAspect
+Frustum::test(const Eigen::Vector3f& point) const
+{
+    return doTest(planes, point);
+}
+
+FrustumAspect
+Frustum::testSphere(const Eigen::Vector3f& center, float radius) const
+{
+    return doTestSphere(planes, center, radius);
+}
+
+/** Double precision version of testSphere()
+  */
+FrustumAspect
+Frustum::testSphere(const Eigen::Vector3d& center, double radius) const
+{
+    return doTestSphere(planes, center, radius);
+}
+
+InfiniteFrustum::InfiniteFrustum(float fov, float aspectRatio, float n)
+{
+    init(planes.data(), fov, aspectRatio, n);
+}
+
+void
+InfiniteFrustum::transform(const Eigen::Matrix3f& m)
+{
+    doTransform(planes.data(), nPlanes, m);
+}
+
+void
+InfiniteFrustum::transform(const Eigen::Matrix4f& m)
+{
+    doTransform(planes.data(), nPlanes, m);
+}
+
+FrustumAspect
+InfiniteFrustum::test(const Eigen::Vector3f& point) const
+{
+    return doTest(planes, point);
+}
+
+FrustumAspect
+InfiniteFrustum::testSphere(const Eigen::Vector3f& center, float radius) const
+{
+    return doTestSphere(planes, center, radius);
+}
+
+/** Double precision version of testSphere()
+  */
+FrustumAspect
+InfiniteFrustum::testSphere(const Eigen::Vector3d& center, double radius) const
+{
+    return doTestSphere(planes, center, radius);
 }
 
 }

--- a/src/celmath/frustum.h
+++ b/src/celmath/frustum.h
@@ -9,55 +9,79 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-
 namespace celestia::math
 {
+
+enum class FrustumPlane : unsigned int
+{
+    Bottom    = 0,
+    Top       = 1,
+    Left      = 2,
+    Right     = 3,
+    Near      = 4,
+    Far       = 5,
+};
+
+enum class FrustumAspect
+{
+    Outside   = 0,
+    Inside    = 1,
+    Intersect = 2,
+};
 
 class Frustum
 {
 public:
     using PlaneType = Eigen::Hyperplane<float, 3>;
 
-    Frustum(float fov, float aspectRatio, float nearDist);
     Frustum(float fov, float aspectRatio, float nearDist, float farDist);
     Frustum(float left, float right, float top, float bottom, float nearDist, float farDist);
 
-    inline Eigen::Hyperplane<float, 3> plane(unsigned int which) const
+    inline PlaneType plane(FrustumPlane which) const
     {
-        return planes[which];
+        return planes[static_cast<std::size_t>(which)];
     }
 
     void transform(const Eigen::Matrix3f& m);
     void transform(const Eigen::Matrix4f& m);
 
-    enum {
-        Bottom    = 0,
-        Top       = 1,
-        Left      = 2,
-        Right     = 3,
-        Near      = 4,
-        Far       = 5,
-    };
-
-    enum Aspect {
-        Outside   = 0,
-        Inside    = 1,
-        Intersect = 2,
-    };
-
-    Aspect test(const Eigen::Vector3f& point) const;
-    Aspect testSphere(const Eigen::Vector3f& center, float radius) const;
-    Aspect testSphere(const Eigen::Vector3d& center, double radius) const;
+    FrustumAspect test(const Eigen::Vector3f& point) const;
+    FrustumAspect testSphere(const Eigen::Vector3f& center, float radius) const;
+    FrustumAspect testSphere(const Eigen::Vector3d& center, double radius) const;
 
 private:
-    void init(float fov, float aspectRatio, float nearDist, float farDist);
-    void init(float left, float right, float top, float bottom, float nearDist, float farDist);
+    static constexpr unsigned int nPlanes = 6;
+    std::array<PlaneType, nPlanes> planes;
+};
 
-    Eigen::Hyperplane<float, 3> planes[6];
-    bool infinite;
+class InfiniteFrustum
+{
+public:
+    using PlaneType = Frustum::PlaneType;
+
+    InfiniteFrustum(float fov, float aspectRatio, float nearDist);
+
+    inline PlaneType plane(FrustumPlane which) const
+    {
+        return planes[static_cast<std::size_t>(which)];
+    }
+
+    void transform(const Eigen::Matrix3f& m);
+    void transform(const Eigen::Matrix4f& m);
+
+    FrustumAspect test(const Eigen::Vector3f& point) const;
+    FrustumAspect testSphere(const Eigen::Vector3f& center, float radius) const;
+    FrustumAspect testSphere(const Eigen::Vector3d& center, double radius) const;
+
+private:
+    static constexpr unsigned int nPlanes = 5;
+    std::array<PlaneType, nPlanes> planes;
 };
 
 } // namespace celestia::math

--- a/src/celmath/geomutil.h
+++ b/src/celmath/geomutil.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <array>
 #include <cmath>
 
 #include <Eigen/Core>
@@ -122,7 +123,7 @@ LookAt(const Eigen::Matrix<T, 3, 1>& from, const Eigen::Matrix<T, 3, 1>& to, con
 template<class T> bool
 ProjectPerspective(const Eigen::Matrix<T, 3, 1>& from,
                    const Eigen::Matrix<T, 4, 4>& modelViewProjectionMatrix,
-                   const int viewport[4],
+                   const std::array<int, 4>& viewport,
                    Eigen::Matrix<T, 3, 1>& to)
 {
     Eigen::Matrix<T, 4, 1> in(from.x(), from.y(), from.z(), static_cast<T>(1));
@@ -142,21 +143,10 @@ ProjectPerspective(const Eigen::Matrix<T, 3, 1>& from,
 }
 
 template<class T> bool
-ProjectPerspective(const Eigen::Matrix<T, 3, 1>& from,
-                   const Eigen::Matrix<T, 4, 4>& modelViewMatrix,
-                   const Eigen::Matrix<T, 4, 4>& projMatrix,
-                   const int viewport[4],
-                   Eigen::Matrix<T, 3, 1>& to)
-{
-    Eigen::Matrix<T, 4, 4> m = projMatrix * modelViewMatrix;
-    return Project(from, m, viewport, to);
-}
-
-template<class T> bool
 ProjectFisheye(const Eigen::Matrix<T, 3, 1>& from,
                const Eigen::Matrix<T, 4, 4>& modelViewMatrix,
                const Eigen::Matrix<T, 4, 4>& projMatrix,
-               const int viewport[4],
+               const std::array<int, 4>& viewport,
                Eigen::Matrix<T, 3, 1>& to)
 {
     using std::atan2, std::hypot;

--- a/src/celrender/globularrenderer.cpp
+++ b/src/celrender/globularrenderer.cpp
@@ -470,7 +470,7 @@ CalculateSpriteSize(int w, int h, const Eigen::Matrix4f &pr, const Eigen::Matrix
      * Taking into account multiplication rules v2 becomes just 2 * viewMat.col(0) and v3 is just vec3(0, 0, 0).
      */
     auto mvp = pr * mv;
-    int viewport[] = { 0, 0, w, h };
+    std::array<int, 4> viewport{ 0, 0, w, h };
     Eigen::Vector3f ndc2;
     projectionMode->project(2.0f * viewMat.col(0), mv, pr, mvp, viewport, ndc2);
     Eigen::Vector3f ndc3;


### PR DESCRIPTION
Shrinks the object sizes and makes it clearer which type of object is being used.

- Use enum classes for FrustumPlane and FrustumAspect
- Update projection modes to pass matrices by reference
- Use std::array for viewport in projection routines
- Remove unused math::ProjectPerspective overload