### PR TITLE
Various name handling updates

### DIFF
--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -87,30 +87,31 @@ DSODatabase::getCompletion(std::vector<std::string>& completion, std::string_vie
 }
 
 std::string
-DSODatabase::getDSOName(const DeepSkyObject* const & dso, bool i18n) const
+DSODatabase::getDSOName(const DeepSkyObject* dso, [[maybe_unused]] bool i18n) const
 {
+    if (namesDB == nullptr)
+        return {};
+
     AstroCatalog::IndexNumber catalogNumber = dso->getIndex();
 
-    if (namesDB != nullptr)
-    {
-        auto iter = namesDB->getFirstNameIter(catalogNumber);
-        if (iter != namesDB->getFinalNameIter() && iter->first == catalogNumber)
-        {
-            if (i18n)
-            {
-                const char *local = D_(iter->second.c_str());
-                if (iter->second != local)
-                    return local;
-            }
-            return iter->second;
-        }
-    }
+    auto iter = namesDB->getFirstNameIter(catalogNumber);
+    if (iter == namesDB->getFinalNameIter())
+        return {};
 
-    return {};
+#ifdef ENABLE_NLS
+    if (i18n)
+    {
+        const char* local = D_(iter->second.c_str());
+        if (iter->second != local)
+            return local;
+    }
+#endif
+
+    return iter->second;
 }
 
 std::string
-DSODatabase::getDSONameList(const DeepSkyObject* const & dso, const unsigned int maxNames) const
+DSODatabase::getDSONameList(const DeepSkyObject* dso, const unsigned int maxNames) const
 {
     std::string dsoNames;
 

--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -57,8 +57,8 @@ class DSODatabase
                        const Eigen::Vector3d& obsPosition,
                        float radius) const;
 
-    std::string getDSOName    (const DeepSkyObject* const &, bool i18n = false) const;
-    std::string getDSONameList(const DeepSkyObject* const &, const unsigned int maxNames = MAX_DSO_NAMES) const;
+    std::string getDSOName    (const DeepSkyObject*, bool i18n = false) const;
+    std::string getDSONameList(const DeepSkyObject*, const unsigned int maxNames = MAX_DSO_NAMES) const;
 
     NameDatabase* getNameDatabase() const;
     void setNameDatabase(std::unique_ptr<NameDatabase>&&);

--- a/src/celengine/name.cpp
+++ b/src/celengine/name.cpp
@@ -1,15 +1,13 @@
+#include "name.h"
+
+#include <utility>
+
 #ifdef DEBUG
 #include <celutil/logger.h>
 #endif
 #include <celutil/gettext.h>
 #include <celutil/greek.h>
 #include <celutil/utf8.h>
-#include "name.h"
-
-std::uint32_t NameDatabase::getNameCount() const
-{
-    return nameIndex.size();
-}
 
 void
 NameDatabase::add(const AstroCatalog::IndexNumber catalogNumber, std::string_view name)
@@ -21,15 +19,17 @@ NameDatabase::add(const AstroCatalog::IndexNumber catalogNumber, std::string_vie
     if (AstroCatalog::IndexNumber tmp = getCatalogNumberByName(name, false); tmp != AstroCatalog::InvalidIndex)
         celestia::util::GetLogger()->debug("Duplicated name '{}' on object with catalog numbers: {} and {}\n", name, tmp, catalogNumber);
 #endif
-    // Add the new name
-    //nameIndex.insert(NameIndex::value_type(name, catalogNumber));
-    std::string fname = ReplaceGreekLetterAbbr(name);
 
+    std::string fname = ReplaceGreekLetterAbbr(name);
     nameIndex[fname] = catalogNumber;
-    std::string lname = D_(fname.c_str());
+
+#ifdef ENABLE_NLS
+    std::string_view lname = D_(fname.c_str());
     if (lname != fname)
-        localizedNameIndex[lname] = catalogNumber;
-    numberIndex.insert(NumberIndex::value_type(catalogNumber, fname));
+        localizedNameIndex[std::string(lname)] = catalogNumber;
+#endif
+
+    numberIndex.emplace(catalogNumber, std::move(fname));
 }
 
 void NameDatabase::erase(const AstroCatalog::IndexNumber catalogNumber)
@@ -37,21 +37,21 @@ void NameDatabase::erase(const AstroCatalog::IndexNumber catalogNumber)
     numberIndex.erase(catalogNumber);
 }
 
-AstroCatalog::IndexNumber NameDatabase::getCatalogNumberByName(std::string_view name, bool i18n) const
+AstroCatalog::IndexNumber
+NameDatabase::getCatalogNumberByName(std::string_view name, [[maybe_unused]] bool i18n) const
 {
-    auto iter = nameIndex.find(name);
-    if (iter != nameIndex.end())
+    if (auto iter = nameIndex.find(name); iter != nameIndex.end())
         return iter->second;
 
+#if ENABLE_NLS
     if (i18n)
     {
-        iter = localizedNameIndex.find(name);
-        if (iter != localizedNameIndex.end())
+        if (auto iter = localizedNameIndex.find(name); iter != localizedNameIndex.end())
             return iter->second;
     }
+#endif
 
-    auto replacedGreek = ReplaceGreekLetterAbbr(name);
-    if (replacedGreek != name)
+    if (auto replacedGreek = ReplaceGreekLetterAbbr(name); replacedGreek != name)
         return getCatalogNumberByName(replacedGreek, i18n);
 
     return AstroCatalog::InvalidIndex;
@@ -65,44 +65,24 @@ AstroCatalog::IndexNumber NameDatabase::getCatalogNumberByName(std::string_view 
 // preserve this order when inserting the names into the multimap
 // (not certain whether or not this behavior is in the STL spec.
 // but it works on the implementations I've tried so far.)
-std::string NameDatabase::getNameByCatalogNumber(const AstroCatalog::IndexNumber catalogNumber) const
+NameDatabase::NumberIndex::const_iterator
+NameDatabase::getFirstNameIter(const AstroCatalog::IndexNumber catalogNumber) const
 {
-    if (catalogNumber == AstroCatalog::InvalidIndex)
-        return "";
-
-    NumberIndex::const_iterator iter = numberIndex.lower_bound(catalogNumber);
-
-    if (iter != numberIndex.end() && iter->first == catalogNumber)
-        return iter->second;
-
-    return "";
-}
-
-
-// Return the first name matching the catalog number or end()
-// if there are no matching names.  The first name *should* be the
-// proper name of the OBJ, if one exists. This requires the
-// OBJ name database file to have the proper names listed before
-// other designations.  Also, the STL implementation must
-// preserve this order when inserting the names into the multimap
-// (not certain whether or not this behavior is in the STL spec.
-// but it works on the implementations I've tried so far.)
-NameDatabase::NumberIndex::const_iterator NameDatabase::getFirstNameIter(const AstroCatalog::IndexNumber catalogNumber) const
-{
-    NumberIndex::const_iterator iter = numberIndex.lower_bound(catalogNumber);
-
+    auto iter = numberIndex.lower_bound(catalogNumber);
     if (iter == numberIndex.end() || iter->first != catalogNumber)
         return getFinalNameIter();
-    else
-        return iter;
+
+    return iter;
 }
 
-NameDatabase::NumberIndex::const_iterator NameDatabase::getFinalNameIter() const
+NameDatabase::NumberIndex::const_iterator
+NameDatabase::getFinalNameIter() const
 {
     return numberIndex.end();
 }
 
-void NameDatabase::getCompletion(std::vector<std::string>& completion, std::string_view name) const
+void
+NameDatabase::getCompletion(std::vector<std::string>& completion, std::string_view name) const
 {
     std::string name2 = ReplaceGreekLetter(name);
     for (const auto &[n, _] : nameIndex)
@@ -111,9 +91,11 @@ void NameDatabase::getCompletion(std::vector<std::string>& completion, std::stri
             completion.push_back(n);
     }
 
+#ifdef ENABLE_NLS
     for (const auto &[n, _] : localizedNameIndex)
     {
         if (UTF8StartsWith(n, name2, true))
             completion.push_back(n);
     }
+#endif
 }

--- a/src/celengine/name.h
+++ b/src/celengine/name.h
@@ -25,28 +25,26 @@
 // lies the one and only need for type genericity.
 class NameDatabase
 {
- public:
+public:
     using NameIndex = std::map<std::string, AstroCatalog::IndexNumber, CompareIgnoringCasePredicate>;
     using NumberIndex = std::multimap<AstroCatalog::IndexNumber, std::string>;
 
- public:
-    std::uint32_t getNameCount() const;
-
-    void add(const AstroCatalog::IndexNumber, std::string_view);
+    void add(AstroCatalog::IndexNumber, std::string_view);
 
     // delete all names associated with the specified catalog number
-    void erase(const AstroCatalog::IndexNumber);
+    void erase(AstroCatalog::IndexNumber);
 
     AstroCatalog::IndexNumber getCatalogNumberByName(std::string_view, bool i18n) const;
-    std::string getNameByCatalogNumber(const AstroCatalog::IndexNumber) const;
 
-    NumberIndex::const_iterator getFirstNameIter(const AstroCatalog::IndexNumber catalogNumber) const;
+    NumberIndex::const_iterator getFirstNameIter(AstroCatalog::IndexNumber catalogNumber) const;
     NumberIndex::const_iterator getFinalNameIter() const;
 
     void getCompletion(std::vector<std::string>& completion, std::string_view name) const;
 
- protected:
+private:
     NameIndex   nameIndex;
+#ifdef ENABLE_NLS
     NameIndex   localizedNameIndex;
+#endif
     NumberIndex numberIndex;
 };

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -553,23 +553,23 @@ StarDatabase::getCompletion(std::vector<std::string>& completion, std::string_vi
 // of a memory allocation (though no explcit deallocation is
 // required as it's all wrapped in the string class.)
 std::string
-StarDatabase::getStarName(const Star& star, bool i18n) const
+StarDatabase::getStarName(const Star& star, [[maybe_unused]] bool i18n) const
 {
     AstroCatalog::IndexNumber catalogNumber = star.getIndex();
+    if (namesDB == nullptr)
+        return catalogNumberToString(catalogNumber);
 
-    if (namesDB != nullptr)
+    if (auto iter = namesDB->getFirstNameIter(catalogNumber); iter != namesDB->getFinalNameIter())
     {
-        StarNameDatabase::NumberIndex::const_iterator iter = namesDB->getFirstNameIter(catalogNumber);
-        if (iter != namesDB->getFinalNameIter() && iter->first == catalogNumber)
+#ifdef ENABLE_NLS
+        if (i18n)
         {
-            if (i18n)
-            {
-                const char * local = D_(iter->second.c_str());
-                if (iter->second != local)
-                    return local;
-            }
-            return iter->second;
+            const char * local = D_(iter->second.c_str());
+            if (iter->second != local)
+                return local;
         }
+#endif
+        return iter->second;
     }
 
     /*
@@ -605,8 +605,7 @@ StarDatabase::getStarNameList(const Star& star, const unsigned int maxNames) con
 
     if (namesDB != nullptr)
     {
-        StarNameDatabase::NumberIndex::const_iterator iter = namesDB->getFirstNameIter(catalogNumber);
-
+        auto iter = namesDB->getFirstNameIter(catalogNumber);
         while (iter != namesDB->getFinalNameIter() && iter->first == catalogNumber && nameSet.size() < maxNames)
         {
             append(D_(iter->second.c_str()));

--- a/src/celengine/starname.h
+++ b/src/celengine/starname.h
@@ -19,17 +19,27 @@
 
 #include <celengine/name.h>
 
-
-class StarNameDatabase: public NameDatabase
+class StarNameDatabase: private NameDatabase
 {
- public:
+public:
     StarNameDatabase() {};
 
+    using NameDatabase::add;
+    using NameDatabase::erase;
+
+    using NameDatabase::getFirstNameIter;
+    using NameDatabase::getFinalNameIter;
+
+    using NameDatabase::getCompletion;
+
+    // We don't want users to access the getCatalogMethodByName method on the
+    // NameDatabase base class, so use private inheritance to enforce usage of
+    // the below method:
     std::uint32_t findCatalogNumberByName(std::string_view, bool i18n) const;
 
     static std::unique_ptr<StarNameDatabase> readNames(std::istream&);
 
- private:
+private:
     std::uint32_t findFlamsteedOrVariable(std::string_view, std::string_view, bool) const;
     std::uint32_t findBayer(std::string_view, std::string_view, bool) const;
     std::uint32_t findBayerNoNumber(std::string_view,


### PR DESCRIPTION
- Remove unused methods on NameDatabase
- Avoid some unnecessary string creation
- Disable more code when ENABLE_NLS is not defined
- Use fmt::basic_memory_buffer to avoid length checks when canonicalizing star names