### PR TITLE
Replace reinterpret_cast with static_cast in DSORenderer

### DIFF
--- a/src/celengine/dsorenderer.cpp
+++ b/src/celengine/dsorenderer.cpp
@@ -8,14 +8,19 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <celengine/dsodb.h>
-#include <celengine/deepskyobj.h>
+#include "dsorenderer.h"
+
 #include <celrender/galaxyrenderer.h>
 #include <celrender/globularrenderer.h>
 #include <celrender/nebularenderer.h>
 #include <celrender/openclusterrenderer.h>
+#include "dsodb.h"
+#include "deepskyobj.h"
+#include "galaxy.h"
+#include "globular.h"
+#include "nebula.h"
+#include "opencluster.h"
 #include "render.h"
-#include "dsorenderer.h"
 
 namespace astro = celestia::astro;
 namespace math = celestia::math;
@@ -106,20 +111,20 @@ void DSORenderer::process(DeepSkyObject* const &dso,
         case DeepSkyObjectType::Galaxy:
             // -19.04f == average over 10937 galaxies in galaxies.dsc.
             b = brightness(-19.04f, absMag, appMag, b, faintestMag);
-            galaxyRenderer->add(reinterpret_cast<Galaxy*>(dso), relPos, b, nearZ, farZ);
+            galaxyRenderer->add(static_cast<const Galaxy*>(dso), relPos, b, nearZ, farZ);
             break;
         case DeepSkyObjectType::Globular:
             // -6.86f == average over 150 globulars in globulars.dsc.
             b = brightness(-6.86f, absMag, appMag, b, faintestMag);
-            globularRenderer->add(reinterpret_cast<Globular*>(dso), relPos, b, nearZ, farZ);
+            globularRenderer->add(static_cast<const Globular*>(dso), relPos, b, nearZ, farZ);
             break;
         case DeepSkyObjectType::Nebula:
             b = brightness(avgAbsMag, absMag, appMag, b, faintestMag);
-            nebulaRenderer->add(reinterpret_cast<Nebula*>(dso), relPos, b, nearZ, farZ);
+            nebulaRenderer->add(static_cast<const Nebula*>(dso), relPos, b, nearZ, farZ);
             break;
         case DeepSkyObjectType::OpenCluster:
             b = brightness(avgAbsMag, absMag, appMag, b, faintestMag);
-            openClusterRenderer->add(reinterpret_cast<OpenCluster*>(dso), relPos, b, nearZ, farZ);
+            openClusterRenderer->add(static_cast<const OpenCluster*>(dso), relPos, b, nearZ, farZ);
             break;
         default:
             // Unsupported DSO

--- a/src/celengine/dsorenderer.h
+++ b/src/celengine/dsorenderer.h
@@ -10,14 +10,18 @@
 
 #pragma once
 
-#include "objectrenderer.h"
+#include <cstdint>
 
 #include <Eigen/Core>
-#include <celengine/projectionmode.h>
+
 #include <celmath/frustum.h>
+#include <celmath/mathlib.h>
 #include <celrender/rendererfwd.h>
+#include "objectrenderer.h"
+#include "projectionmode.h"
 
 class DeepSkyObject;
+class DSODatabase;
 
 class DSORenderer : public ObjectRenderer<DeepSkyObject *, double>
 {
@@ -34,8 +38,8 @@ public:
     Eigen::Matrix3f orientationMatrixT;
     DSODatabase    *dsoDB{ nullptr };
 
-    float    avgAbsMag{ 0.0f };
-    uint32_t dsosProcessed{ 0 };
+    float         avgAbsMag{ 0.0f };
+    std::uint32_t dsosProcessed{ 0 };
 
     celestia::render::GalaxyRenderer      *galaxyRenderer{ nullptr };
     celestia::render::GlobularRenderer    *globularRenderer{ nullptr };


### PR DESCRIPTION
Downcast can be done via static_cast provided the types are complete.