### PR TITLE
Update binaryread, binarywrite to depend on celcompat/bit.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,9 +494,6 @@ else()
   message(WARNING "C++ charconv is unusable!\nWill use own implementation.")
 endif()
 
-include(TestBigEndian)
-test_big_endian(WORDS_BIGENDIAN)
-
 configure_file("config.h.in" "config.h")
 configure_file("celestia.cfg.in" "celestia.cfg")
 

--- a/config.h.in
+++ b/config.h.in
@@ -8,7 +8,6 @@
 #cmakedefine HAVE_SINCOS
 #cmakedefine HAVE_APPLE_SINCOS
 #cmakedefine HAVE_CONSTEXPR_EMPTY_ARRAY
-#cmakedefine WORDS_BIGENDIAN
 
 #ifdef HAVE_CONSTEXPR_CMATH
 #define CELESTIA_CMATH_CONSTEXPR constexpr

--- a/src/celutil/binarywrite.h
+++ b/src/celutil/binarywrite.h
@@ -1,113 +1,71 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstring>
 #include <ostream>
 #include <type_traits>
 #include <utility>
 
-#include <config.h>
-
+#include <celcompat/bit.h>
 
 namespace celestia::util
 {
 
 /*! Write a value to an output stream in machine-native byte order.
  */
-template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
-inline bool writeNative(std::ostream& out, T value)
+template<typename T, std::enable_if_t<std::is_trivially_copyable_v<T>, int> = 0>
+inline bool
+writeNative(std::ostream& out, T value)
 {
-    char data[sizeof(T)];
-    std::memcpy(data, &value, sizeof(T));
-    return out.write(data, sizeof(T)).good();
+    return out.write(reinterpret_cast<const char*>(&value), sizeof(T)).good(); //NOSONAR
 }
-
-template<>
-inline bool writeNative<char>(std::ostream& out, char value)
-{
-    return out.put(value).good();
-}
-
-template<>
-inline bool writeNative<signed char>(std::ostream& out, signed char value)
-{
-    return out.put(static_cast<char>(value)).good();
-}
-
-template<>
-inline bool writeNative<unsigned char>(std::ostream& out, unsigned char value)
-{
-    return out.put(static_cast<unsigned char>(value)).good();
-}
-
 
 /*! Write a value to an output stream with the opposite of machine-native byte order.
  */
-template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
-inline bool writeReversed(std::ostream& out, T value)
+template<typename T, std::enable_if_t<std::is_trivially_copyable_v<T>, int> = 0>
+inline bool
+writeReversed(std::ostream& out, T value)
 {
-    char data[sizeof(T)];
-    std::memcpy(data, &value, sizeof(T));
-    for (std::size_t i = 0; i < sizeof(T) / 2; ++i)
+    if constexpr (sizeof(T) == 1)
+        return writeNative(out, value);
+
+    std::array<char, sizeof(T)> temp;
+    std::memcpy(temp.data(), &value, sizeof(T));
+
+    constexpr auto halfSize = sizeof(T) / 2;
+    for (std::size_t i = 0; i < halfSize; ++i)
     {
-        std::swap(data[i], data[sizeof(T) - i - 1]);
+        std::swap(temp[i], temp[sizeof(T) - i - 1]);
     }
-    return out.write(data, sizeof(T)).good();
-}
 
-template<>
-inline bool writeReversed<char>(std::ostream& out, char value)
-{
-    return writeNative(out, value);
+    return out.write(temp.data(), sizeof(T)).good();
 }
-
-template<>
-inline bool writeReversed<signed char>(std::ostream& out, signed char value)
-{
-    return writeNative(out, value);
-}
-
-template<>
-inline bool writeReversed<unsigned char>(std::ostream& out, unsigned char value)
-{
-    return writeNative(out, value);
-}
-
-#ifdef WORDS_BIGENDIAN
 
 /*! Write a value to an output stream in little-endian byte order
  */
-template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
-inline bool writeLE(std::ostream& out, T value)
+template<typename T, std::enable_if_t<std::is_trivially_copyable_v<T>, int> = 0>
+inline bool
+writeLE(std::ostream& out, T value)
 {
-    return writeReversed(out, value);
+    using celestia::compat::endian;
+    if constexpr (endian::native == endian::little)
+        return writeNative(out, value);
+    else
+        return writeReversed(out, value);
 }
 
 /*! Write a value to an output stream in big-endian byte order
  */
-template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
-inline bool writeBE(std::ostream& out, T value)
+template<typename T, std::enable_if_t<std::is_trivially_copyable_v<T>, int> = 0>
+inline bool
+writeBE(std::ostream& out, T value)
 {
-    return writeNative(out, value);
+    using celestia::compat::endian;
+    if constexpr (endian::native == endian::little)
+        return writeReversed(out, value);
+    else
+        return writeNative(out, value);
 }
-
-#else
-
-/*! Write a value to an output stream in little-endian byte order
- */
-template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
-inline bool writeLE(std::ostream& out, T value)
-{
-    return writeNative(out, value);
-}
-
-/*! Write a value to an output stream in big-endian byte order
- */
-template<typename T, typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
-inline bool writeBE(std::ostream& out, T value)
-{
-    return writeReversed(out, value);
-}
-
-#endif
 
 } // end namespace celestia::util


### PR DESCRIPTION
- Add fromMemory* methods for buffered read support
- Use new fromMemory* methods in stardb.cpp