### PR TITLE
Remove getName method on Selection, create getPath on Body/Location

### DIFF
--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -19,6 +19,7 @@
 #include "body.h"
 #include "atmosphere.h"
 #include "frame.h"
+#include "stardb.h"
 #include "timeline.h"
 #include "timelinephase.h"
 #include "frametree.h"
@@ -111,11 +112,35 @@ const vector<string>& Body::getNames() const
 /*! Return the primary name for the body; if i18n, return the
  *  localized name of the body.
  */
-string Body::getName(bool i18n) const
+std::string
+Body::getName(bool i18n) const
 {
     if (i18n && hasLocalizedName())
         return localizedName;
     return names[0];
+}
+
+std::string
+Body::getPath(const StarDatabase* starDB, char delimiter) const
+{
+    std::string name = names[0];
+    const PlanetarySystem* planetarySystem = system;
+    while (planetarySystem != nullptr)
+    {
+        if (const Body* parent = planetarySystem->getPrimaryBody(); parent != nullptr)
+        {
+            name = parent->getName() + delimiter + name;
+            planetarySystem = parent->getSystem();
+        }
+        else
+        {
+            if (const Star* parentStar = system->getStar(); parentStar != nullptr)
+                name = starDB->getStarName(*parentStar) + delimiter + name;
+            break;
+        }
+    }
+
+    return name;
 }
 
 /*! Get the localized name for the body. If no localized name

--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -39,6 +39,7 @@ class Body;
 class FrameTree;
 class ReferenceMark;
 class Atmosphere;
+class StarDatabase;
 
 class PlanetarySystem
 {
@@ -199,6 +200,7 @@ public:
     PlanetarySystem* getSystem() const;
     const std::vector<std::string>& getNames() const;
     std::string getName(bool i18n = false) const;
+    std::string getPath(const StarDatabase*, char delimiter = '/') const;
     std::string getLocalizedName() const;
     bool hasLocalizedName() const;
     void addAlias(const std::string& alias);

--- a/src/celengine/location.cpp
+++ b/src/celengine/location.cpp
@@ -21,7 +21,6 @@
 using std::size_t;
 using std::strncmp;
 
-
 namespace
 {
 
@@ -30,13 +29,11 @@ namespace
 
 } // end unnamed namespace
 
-
 const std::string&
 Location::getName(bool i18n) const
 {
     return i18n && !i18nName.empty() ? i18nName : name;
 }
-
 
 void
 Location::setName(const std::string& _name)
@@ -47,6 +44,14 @@ Location::setName(const std::string& _name)
         i18nName = {};
 }
 
+std::string
+Location::getPath(const StarDatabase* starDB, char delimiter) const
+{
+    if (parent)
+        return parent->getPath(starDB, delimiter) + delimiter + name;
+    else
+        return name;
+}
 
 Eigen::Vector3f
 Location::getPosition() const
@@ -54,13 +59,11 @@ Location::getPosition() const
     return position;
 }
 
-
 void
 Location::setPosition(const Eigen::Vector3f& _position)
 {
     position = _position;
 }
-
 
 float
 Location::getSize() const
@@ -68,13 +71,11 @@ Location::getSize() const
     return size;
 }
 
-
 void
 Location::setSize(float _size)
 {
     size = _size;
 }
-
 
 float
 Location::getImportance() const
@@ -82,13 +83,11 @@ Location::getImportance() const
     return importance;
 }
 
-
 void
 Location::setImportance(float _importance)
 {
     importance = _importance;
 }
-
 
 const std::string&
 Location::getInfoURL() const
@@ -96,20 +95,17 @@ Location::getInfoURL() const
     return infoURL;
 }
 
-
 Location::FeatureType
 Location::getFeatureType() const
 {
     return featureType;
 }
 
-
 void
 Location::setFeatureType(Location::FeatureType _featureType) // cppcheck-suppress passedByValue
 {
     featureType = _featureType;
 }
-
 
 Location::FeatureType
 Location::parseFeatureType(std::string_view s)
@@ -120,20 +116,17 @@ Location::parseFeatureType(std::string_view s)
         : ptr->featureType;
 }
 
-
 Body*
 Location::getParentBody() const
 {
     return parent;
 }
 
-
 void
 Location::setParentBody(Body* _parent)
 {
     parent = _parent;
 }
-
 
 /*! Get the position of the location relative to its body in
  *  the J2000 ecliptic coordinate system.
@@ -147,7 +140,6 @@ Location::getPlanetocentricPosition(double t) const
     Eigen::Quaterniond q = parent->getEclipticToBodyFixed(t);
     return q.conjugate() * position.cast<double>();
 }
-
 
 Eigen::Vector3d
 Location::getHeliocentricPosition(double t) const

--- a/src/celengine/location.h
+++ b/src/celengine/location.h
@@ -18,13 +18,15 @@
 #include <celutil/color.h>
 
 class Body;
-
+class StarDatabase;
 
 class Location
 {
 public:
     const std::string& getName(bool i18n = false) const;
     void setName(const std::string&);
+
+    std::string getPath(const StarDatabase*, char delimiter = '/') const;
 
     Eigen::Vector3f getPosition() const;
     void setPosition(const Eigen::Vector3f&);

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -871,8 +871,6 @@ CreateMeanEquatorFrame(const Universe& universe,
         }
     }
 
-    GetLogger()->debug("CreateMeanEquatorFrame {}, {}\n", center.getName(), obj.getName());
-
     if (double freezeEpoch = 0.0; ParseDate(frameData, "Freeze", freezeEpoch))
         return std::make_shared<BodyMeanEquatorFrame>(center, obj, freezeEpoch);
 
@@ -1002,7 +1000,7 @@ getVectorObserver(const Universe& universe, const Hash* vectorData)
     if (obsObject.empty())
     {
         GetLogger()->warn("Bad two-vector frame: observer object '{}' of vector not found.\n",
-                          obsObject.getName());
+                          *obsName);
         return Selection();
     }
 

--- a/src/celengine/selection.cpp
+++ b/src/celengine/selection.cpp
@@ -27,7 +27,6 @@ namespace
 // are Julian days.
 constexpr double VELOCITY_DIFF_DELTA = 1.0 / 1440.0;
 
-
 UniversalCoord locationPosition(const Location* location, double t)
 {
     if (const Body* body = location->getParentBody(); body != nullptr)
@@ -38,31 +37,7 @@ UniversalCoord locationPosition(const Location* location, double t)
     return UniversalCoord::Zero();
 }
 
-
-std::string bodyName(const Body* body, bool i18n)
-{
-    std::string name = body->getName(i18n);
-    const PlanetarySystem* system = body->getSystem();
-    while (system != nullptr)
-    {
-        if (const Body* parent = system->getPrimaryBody(); parent != nullptr)
-        {
-            name = parent->getName(i18n) + '/' + name;
-            system = parent->getSystem();
-        }
-        else
-        {
-            if (const Star* parentStar = system->getStar(); parentStar != nullptr)
-                name = fmt::format("#{}/{}", parentStar->getIndex(), name);
-            system = nullptr;
-        }
-    }
-
-    return name;
-}
-
 } // end unnamed namespace
-
 
 double
 Selection::radius() const
@@ -82,7 +57,6 @@ Selection::radius() const
         return 0.0;
     }
 }
-
 
 UniversalCoord
 Selection::getPosition(double t) const
@@ -111,7 +85,6 @@ Selection::getPosition(double t) const
     }
 }
 
-
 Eigen::Vector3d
 Selection::getVelocity(double t) const
 {
@@ -139,37 +112,8 @@ Selection::getVelocity(double t) const
     }
 }
 
-
-std::string
-Selection::getName(bool i18n) const
-{
-    switch (type)
-    {
-    case SelectionType::Star:
-        return fmt::format("#{}", static_cast<const Star*>(obj)->getIndex());
-
-    case SelectionType::Body:
-        return bodyName(static_cast<const Body*>(obj), i18n);
-
-    case SelectionType::DeepSky:
-        return fmt::format("#{}", static_cast<const DeepSkyObject*>(obj)->getIndex());
-
-    case SelectionType::Location:
-        {
-            auto location = static_cast<const Location*>(obj);
-            if (auto parentBody = location->getParentBody(); parentBody == nullptr)
-                return location->getName(i18n);
-            else
-                return fmt::format("{}/{}", bodyName(parentBody, i18n), location->getName(i18n));
-        }
-
-    default:
-        return {};
-    }
-}
-
-
-Selection Selection::parent() const
+Selection
+Selection::parent() const
 {
     switch (type)
     {
@@ -199,9 +143,9 @@ Selection Selection::parent() const
     }
 }
 
-
 /*! Return true if the selection's visibility flag is set. */
-bool Selection::isVisible() const
+bool
+Selection::isVisible() const
 {
     switch (type)
     {

--- a/src/celengine/selection.h
+++ b/src/celengine/selection.h
@@ -48,32 +48,31 @@ class Selection
     double radius() const;
     UniversalCoord getPosition(double t) const;
     Eigen::Vector3d getVelocity(double t) const;
-    std::string getName(bool i18n = false) const;
     Selection parent() const;
 
     bool isVisible() const;
 
-    Star* star() const
+    inline Star* star() const
     {
         return type == SelectionType::Star ? static_cast<Star*>(obj) : nullptr;
     }
 
-    Body* body() const
+    inline Body* body() const
     {
         return type == SelectionType::Body ? static_cast<Body*>(obj) : nullptr;
     }
 
-    DeepSkyObject* deepsky() const
+    inline DeepSkyObject* deepsky() const
     {
         return type == SelectionType::DeepSky ? static_cast<DeepSkyObject*>(obj) : nullptr;
     }
 
-    Location* location() const
+    inline Location* location() const
     {
         return type == SelectionType::Location ? static_cast<Location*>(obj) : nullptr;
     }
 
-    SelectionType getType() const { return type; }
+    inline SelectionType getType() const { return type; }
 
  private:
     SelectionType type { SelectionType::None };

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -92,12 +92,14 @@ class StarDatabase
 
     using CrossIndex = std::vector<CrossIndexEntry>;
 
-    AstroCatalog::IndexNumber searchCrossIndexForCatalogNumber(StarCatalog, AstroCatalog::IndexNumber number) const;
-    Star* searchCrossIndex(StarCatalog, AstroCatalog::IndexNumber number) const;
     AstroCatalog::IndexNumber crossIndex(StarCatalog, AstroCatalog::IndexNumber number) const;
 
 private:
     static constexpr auto NumCatalogs = static_cast<std::size_t>(StarCatalog::_CatalogCount);
+
+    AstroCatalog::IndexNumber searchCrossIndexForCatalogNumber(StarCatalog, AstroCatalog::IndexNumber number) const;
+    Star* searchCrossIndex(StarCatalog, AstroCatalog::IndexNumber number) const;
+
 
     std::uint32_t nStars{ 0 };
 


### PR DESCRIPTION
This method would fall back to internal catalog numbers (#nnnn) for stars/DSOs, which is less stable if additional extras are added. Instead provide a `getPath` method on `Body`/`Location` which takes the star database as a parameter (plus allow a configurable delimiter so it can be re-used in the `Url` class)