### PR TITLE
Update vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           'boost-smart-ptr',
           'cspice',
           'eigen3',
-          'ffmpeg[x264]',
+          'ffmpeg[core,avcodec,avformat,gpl,swscale,x264]',
           'fmt',
           'freetype',
           'gettext[tools]',
@@ -75,7 +75,7 @@ jobs:
           'libjpeg-turbo',
           'libpng',
           'luajit',
-          'qtbase[core,opengl,widgets,freetype,harfbuzz,icu,jpeg,png]'
+          'qtbase[core,opengl,widgets,freetype,harfbuzz,jpeg,png]'
         )
 
         # We treat x86 builds as native, other builds keep host as x64-windows.
@@ -120,7 +120,7 @@ jobs:
             -DENABLE_MINIAUDIO=ON `
             -DENABLE_LTO=ON       `
             -DUSE_ICU=ON          `
-            -DUSE_WIN_ICU=OFF
+            -DUSE_WIN_ICU=ON
 
     - name: Build
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Update vcpkg
       shell: pwsh
       run: |
-        $vcpkgCommit = '326d8b43e365352ba3ccadf388d989082fe0f2a6'
+        $vcpkgCommit = '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
         pushd "$env:VCPKG_INSTALLATION_ROOT"
         git cat-file -e "${vcpkgCommit}^{commit}" 2> $null
         if (!$?) {


### PR DESCRIPTION
- Update Qt to 6.7
- Temporarily switch Windows builds to use Windows ICU as the vcpkg build fails on GitHub runners (https://github.com/microsoft/vcpkg/issues/39171) - this drops support for Windows versions earlier than Windows 10 1903, we should revert this once the underlying issue is resolved
- Remove some components of ffmpeg