### PR TITLE
Reduce AtmosphereExtinctionThreshold value

### DIFF
--- a/src/celengine/atmosphere.h
+++ b/src/celengine/atmosphere.h
@@ -65,4 +65,4 @@ class Atmosphere
 // to render. The radius of the sphere is the height at which the
 // density of the atmosphere falls to the extinction threshold, i.e.
 // -H * ln(extinctionThreshold)
-constexpr inline float AtmosphereExtinctionThreshold = 0.05f;
+constexpr inline float AtmosphereExtinctionThreshold = 0.0001f;


### PR DESCRIPTION
Testing by **MinersHavenM43** on the Discord server confirms that this change produces the expected effect of making the cut-off at the top of atmospheres almost invisible, while causing no obvious issues.

Before:
![image](https://github.com/CelestiaProject/Celestia/assets/64715469/7e34562c-6e7f-4797-8d14-6badf831b949)

After (screenshot by him):
![image](https://github.com/CelestiaProject/Celestia/assets/64715469/ee1d6175-ee33-4aa9-865f-a81bfd358b4b)
