### PR TITLE
Package Windows artifacts from install target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=${{matrix.platform}}-windows `
             -DCMAKE_GENERATOR_PLATFORM="$GeneratorPlatform" `
+            -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/install" `
             -DENABLE_SPICE=ON     `
             -DENABLE_TOOLS=ON     `
             -DENABLE_TESTS=ON     `
@@ -131,23 +132,52 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{env.BUILD_TYPE}}
 
-    - name: Run winqtdeploy
+    - name: Install Windows
       shell: pwsh
-      working-directory: ${{github.workspace}}/build/src/celestia
       run: |
-        & "$env:VCPKG_INSTALLATION_ROOT/installed/${{matrix.platform}}-windows/tools/Qt6/bin/windeployqt.exe" qt6\${{env.BUILD_TYPE}}\celestia-qt6.exe
+        cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --component core
+        cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --component wingui
+        Rename-Item -Path "install" -NewName "install-wingui"
 
-    - name: Upload artifacts
+    - name: Upload Windows GUI
       uses: actions/upload-artifact@v4
       if: success()
       with:
-        name: celestia-windows-${{matrix.platform}}
+        name: celestia-windows-${{matrix.platform}}-wingui
+        if-no-files-found: error
         path: |
-          ${{github.workspace}}/build/src/**/*.exe
-          ${{github.workspace}}/build/src/**/*.dll
-          ${{github.workspace}}/build/po/**/*.gmo
-          ${{github.workspace}}/build/tools/**/*.exe
-          ${{github.workspace}}/shaders/*.glsl
+          ${{github.workspace}}/install-wingui/
+
+    - name: Install Qt6
+      shell: pwsh
+      run: |
+        cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --component core
+        cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --component qt6gui
+        Rename-Item -Path "install" -NewName "install-qt6gui"
+
+    - name: Upload Qt6 GUI
+      uses: actions/upload-artifact@v4
+      if: success()
+      with:
+        name: celestia-windows-${{matrix.platform}}-qt6gui
+        if-no-files-found: error
+        path: |
+          ${{github.workspace}}/install-qt6gui/
+
+    - name: Install tools
+      shell: pwsh
+      run: |
+        cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --component tools
+        Rename-Item -Path "install" -NewName "install-tools"
+
+    - name: Upload tools
+      uses: actions/upload-artifact@v4
+      if: success()
+      with:
+        name: celestia-windows-${{matrix.platform}}-tools
+        if-no-files-found: error
+        path: |
+          ${{github.workspace}}/install-tools/
 
   build-posix:
     name: "${{matrix.config.os}}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 3.9)
+if(WIN32)
+  # Require more recent CMake on Windows because DLLs are a pain
+  cmake_minimum_required(VERSION 3.19)
+else()
+  cmake_minimum_required(VERSION 3.9)
+endif()
 
 option(LEGACY_OPENGL_LIBS "Use legacy OpenGL libraries instead of glvnd library (Default: off)" OFF)
 

--- a/src/celestia/qt6/CMakeLists.txt
+++ b/src/celestia/qt6/CMakeLists.txt
@@ -36,11 +36,23 @@ if(APPLE)
   set_property(TARGET celestia-qt6 APPEND_STRING PROPERTY LINK_FLAGS " -framework CoreServices")
 endif()
 
-install(
-  TARGETS celestia-qt6
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  COMPONENT qt6gui
-)
+if(WIN32)
+  install(
+    TARGETS celestia-qt6
+    RUNTIME_DEPENDENCIES
+      PRE_EXCLUDE_REGEXES "^api-ms" "^ext-ms-"
+      POST_EXCLUDE_REGEXES ".*system32/.*\\.dll$"
+      DIRECTORIES $<TARGET_FILE_DIR:celestia>
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT qt6gui
+  )
+else()
+  install(
+    TARGETS celestia-qt6
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT qt6gui
+  )
+endif()
 
 if(ENABLE_LTO)
   set_target_properties(celestia-qt6 PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
@@ -50,10 +62,11 @@ if(WIN32)
   qt6_generate_deploy_app_script(TARGET celestia-qt6
     OUTPUT_SCRIPT deploy-celestia-qt6
     NO_UNSUPPORTED_PLATFORM_ERROR
+    NO_COMPILER_RUNTIME
     NO_TRANSLATIONS
   )
   install(
-    SCRIPT "${deploy-celestia-qt6}"
+    SCRIPT ${deploy-celestia-qt6}
     COMPONENT qt6gui
   )
 endif()


### PR DESCRIPTION
Experiment to see if this is a more useful format for packaging. Artifacts now contain the install layout, so the only thing required is to copy the content files into the extracted directory, then run the executable.

Alternative to #2203 