### PR TITLE
Use smart pointers in octree classes

### DIFF
--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -36,7 +36,7 @@ class DSODatabase
 {
  public:
     DSODatabase() = default;
-    ~DSODatabase();
+    ~DSODatabase() = default;
 
     DeepSkyObject* getDSO(const std::uint32_t) const;
     std::uint32_t size() const;
@@ -73,25 +73,23 @@ private:
     void buildOctree();
     void calcAvgAbsMag();
 
-    int              nDSOs{ 0 };
-    int              capacity{ 0 };
-    DeepSkyObject**  DSOs{ nullptr };
+    std::vector<std::unique_ptr<DeepSkyObject>> DSOs;
     std::unique_ptr<NameDatabase> namesDB;
-    DeepSkyObject**  catalogNumberIndex{ nullptr };
-    DSOOctree*       octreeRoot{ nullptr };
+    std::vector<std::uint32_t> catalogNumberIndex;
+    std::unique_ptr<DSOOctree> octreeRoot;
     AstroCatalog::IndexNumber nextAutoCatalogNumber{ 0xfffffffe };
 
-    float            avgAbsMag{ 0.0f };
+    float avgAbsMag{ 0.0f };
 };
 
 inline DeepSkyObject*
 DSODatabase::getDSO(const std::uint32_t n) const
 {
-    return *(DSOs + n);
+    return DSOs[n].get();
 }
 
 inline std::uint32_t
 DSODatabase::size() const
 {
-    return nDSOs;
+    return static_cast<std::uint32_t>(DSOs.size());
 }

--- a/src/celengine/dsooctree.cpp
+++ b/src/celengine/dsooctree.cpp
@@ -10,11 +10,13 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <celengine/dsooctree.h>
+#include "dsooctree.h"
 
-using namespace Eigen;
+#include <celastro/astro.h>
+#include <celcompat/numbers.h>
 
 namespace astro = celestia::astro;
+namespace numbers = celestia::numbers;
 
 // The octree node into which a dso is placed is dependent on two properties:
 // its obsPosition and its luminosity--the fainter the dso, the deeper the node
@@ -22,57 +24,54 @@ namespace astro = celestia::astro;
 // of the node is allowed contain a dso brighter than this value, making it
 // possible to determine quickly whether or not to cull subtrees.
 
-bool dsoAbsoluteMagnitudePredicate(DeepSkyObject* const & _dso, const float absMag)
+template<>
+bool
+DynamicDSOOctree::exceedsBrightnessThreshold(const std::unique_ptr<DeepSkyObject>& dso, //NOSONAR
+                                             float absMag)
 {
-    return _dso->getAbsoluteMagnitude() <= absMag;
+    return dso->getAbsoluteMagnitude() <= absMag;
 }
 
-
-bool dsoStraddlesNodesPredicate(const Vector3d& cellCenterPos, DeepSkyObject* const & _dso, const float /*unused*/)
+template<>
+bool
+DynamicDSOOctree::isStraddling(const Eigen::Vector3d& cellCenterPos,
+                               const std::unique_ptr<DeepSkyObject>& dso) //NOSONAR
 {
     //checks if this dso's radius straddles child nodes
-    float dsoRadius    = _dso->getBoundingSphereRadius();
-
-    return (_dso->getPosition() - cellCenterPos).cwiseAbs().minCoeff() < dsoRadius;
+    float dsoRadius    = dso->getBoundingSphereRadius();
+    return (dso->getPosition() - cellCenterPos).cwiseAbs().minCoeff() < dsoRadius;
 }
 
-
-double dsoAbsoluteMagnitudeDecayFunction(const double excludingFactor)
+template<>
+float
+DynamicDSOOctree::applyDecay(float excludingFactor)
 {
     return excludingFactor + 0.5f;
 }
 
-
-template <>
-DynamicDSOOctree* DynamicDSOOctree::getChild(DeepSkyObject* const & _obj, const PointType& cellCenterPos)
+template<>
+DynamicDSOOctree*
+DynamicDSOOctree::getChild(const std::unique_ptr<DeepSkyObject>& obj, //NOSONAR
+                           const PointType& cellCenterPos) const
 {
-    PointType objPos = _obj->getPosition();
+    PointType objPos = obj->getPosition();
 
     int child = 0;
-    child     |= objPos.x() < cellCenterPos.x() ? 0 : XPos;
-    child     |= objPos.y() < cellCenterPos.y() ? 0 : YPos;
-    child     |= objPos.z() < cellCenterPos.z() ? 0 : ZPos;
+    child |= objPos.x() < cellCenterPos.x() ? 0 : XPos;
+    child |= objPos.y() < cellCenterPos.y() ? 0 : YPos;
+    child |= objPos.z() < cellCenterPos.z() ? 0 : ZPos;
 
-    return _children[child];
+    return (*m_children)[child].get();
 }
-
-
-template<> unsigned int DynamicDSOOctree::SPLIT_THRESHOLD = 10;
-template<> DynamicDSOOctree::LimitingFactorPredicate*
-           DynamicDSOOctree::limitingFactorPredicate = dsoAbsoluteMagnitudePredicate;
-template<> DynamicDSOOctree::StraddlingPredicate*
-           DynamicDSOOctree::straddlingPredicate = dsoStraddlesNodesPredicate;
-template<> DynamicDSOOctree::ExclusionFactorDecayFunction*
-           DynamicDSOOctree::decayFunction = dsoAbsoluteMagnitudeDecayFunction;
-
 
 // total specialization of the StaticOctree template process*() methods for DSOs:
 template<>
-void DSOOctree::processVisibleObjects(DSOHandler&    processor,
-                                      const PointType& obsPosition,
-                                      const Hyperplane<double, 3>*  frustumPlanes,
-                                      float          limitingFactor,
-                                      double         scale) const
+void
+DSOOctree::processVisibleObjects(DSOHandler& processor,
+                                 const PointType& obsPosition,
+                                 const PlaneType* frustumPlanes,
+                                 float limitingFactor,
+                                 double scale) const
 {
     // See if this node lies within the view frustum
 
@@ -80,63 +79,61 @@ void DSOOctree::processVisibleObjects(DSOHandler&    processor,
     // planes that define the infinite view frustum.
     for (unsigned int i = 0; i < 5; ++i)
     {
-        const Hyperplane<double, 3>& plane = frustumPlanes[i];
+        const PlaneType& plane = frustumPlanes[i];
 
         double r = scale * plane.normal().cwiseAbs().sum();
-        if (plane.signedDistance(cellCenterPos) < -r)
+        if (plane.signedDistance(m_cellCenterPos) < -r)
             return;
     }
 
     // Compute the distance to node; this is equal to the distance to
     // the cellCenterPos of the node minus the boundingRadius of the node, scale * SQRT3.
-    double minDistance = (obsPosition - cellCenterPos).norm() - scale * DSOOctree::SQRT3;
+    double minDistance = (obsPosition - m_cellCenterPos).norm() - scale * numbers::sqrt3;
 
     // Process the objects in this node
     double dimmest = minDistance > 0.0 ? astro::appToAbsMag((double) limitingFactor, minDistance) : 1000.0;
 
-    for (unsigned int i=0; i<nObjects; ++i)
+    for (std::uint32_t i = 0; i < m_nObjects; ++i)
     {
-        DeepSkyObject* _obj = _firstObject[i];
-        float  absMag      = _obj->getAbsoluteMagnitude();
+        const auto& obj = m_firstObject[i];
+        float absMag = obj->getAbsoluteMagnitude();
         if (absMag < dimmest)
         {
-            double distance    = (obsPosition - _obj->getPosition()).norm() - _obj->getBoundingSphereRadius();
-            float appMag = (float) ((distance >= 32.6167) ? astro::absToAppMag((double) absMag, distance) : absMag);
+            double distance = (obsPosition - obj->getPosition()).norm() - obj->getBoundingSphereRadius();
+            auto appMag = static_cast<float>((distance >= 32.6167) ? astro::absToAppMag(static_cast<double>(absMag), distance) : absMag);
 
             if (appMag < limitingFactor)
-                processor.process(_obj, distance, absMag);
+                processor.process(obj, distance, absMag);
         }
     }
 
     // See if any of the objects in child nodes are potentially included
     // that we need to recurse deeper.
-    if (minDistance <= 0.0 || astro::absToAppMag((double) exclusionFactor, minDistance) <= limitingFactor)
+    if (m_children != nullptr &&
+        (minDistance <= 0.0 || astro::absToAppMag(static_cast<double>(m_exclusionFactor), minDistance) <= limitingFactor))
     {
         // Recurse into the child nodes
-        if (_children != nullptr)
+        for (int i = 0; i < 8; ++i)
         {
-            for (int i = 0; i < 8; ++i)
-            {
-                _children[i]->processVisibleObjects(processor,
+            (*m_children)[i]->processVisibleObjects(processor,
                                                     obsPosition,
                                                     frustumPlanes,
                                                     limitingFactor,
                                                     scale * 0.5f);
-            }
         }
     }
 }
 
-
 template<>
-void DSOOctree::processCloseObjects(DSOHandler&    processor,
-                                    const PointType& obsPosition,
-                                    double         boundingRadius,
-                                    double         scale) const
+void
+DSOOctree::processCloseObjects(DSOHandler& processor,
+                               const PointType& obsPosition,
+                               double boundingRadius,
+                               double scale) const
 {
     // Compute the distance to node; this is equal to the distance to
     // the cellCenterPos of the node minus the boundingRadius of the node, scale * SQRT3.
-    double nodeDistance    = (obsPosition - cellCenterPos).norm() - scale * DSOOctree::SQRT3;    //
+    double nodeDistance = (obsPosition - m_cellCenterPos).norm() - scale * numbers::sqrt3;
 
     if (nodeDistance > boundingRadius)
         return;
@@ -146,31 +143,30 @@ void DSOOctree::processCloseObjects(DSOHandler&    processor,
 
     // Compute distance squared to avoid having to sqrt for distance
     // comparison.
-    double radiusSquared    = boundingRadius * boundingRadius;    //
+    double radiusSquared = boundingRadius * boundingRadius;
 
     // Check all the objects in the node.
-    for (unsigned int i=0; i<nObjects; ++i)
+    for (std::uint32_t i = 0; i < m_nObjects; ++i)
     {
-        DeepSkyObject* _obj = _firstObject[i];        //
-
-        if ((obsPosition - _obj->getPosition()).squaredNorm() < radiusSquared)    //
+        const auto& obj = m_firstObject[i];
+        PointType offset = obsPosition - obj->getPosition();
+        if (offset.squaredNorm() < radiusSquared)
         {
-            float  absMag      = _obj->getAbsoluteMagnitude();
-            double distance    = (obsPosition - _obj->getPosition()).norm() - _obj->getBoundingSphereRadius();
-
-            processor.process(_obj, distance, absMag);
+            float  absMag   = obj->getAbsoluteMagnitude();
+            double distance = offset.norm() - obj->getBoundingSphereRadius();
+            processor.process(obj, distance, absMag);
         }
     }
 
     // Recurse into the child nodes
-    if (_children != nullptr)
+    if (m_children != nullptr)
     {
         for (int i = 0; i < 8; ++i)
         {
-            _children[i]->processCloseObjects(processor,
-                                              obsPosition,
-                                              boundingRadius,
-                                              scale * 0.5f);
+            (*m_children)[i]->processCloseObjects(processor,
+                                                  obsPosition,
+                                                  boundingRadius,
+                                                  scale * 0.5f);
         }
     }
 }

--- a/src/celengine/dsooctree.h
+++ b/src/celengine/dsooctree.h
@@ -12,10 +12,40 @@
 
 #pragma once
 
-#include <celengine/deepskyobj.h>
-#include <celengine/octree.h>
+#include <cstdint>
+#include <memory>
 
+#include "deepskyobj.h"
+#include "octree.h"
 
-using DynamicDSOOctree = DynamicOctree<DeepSkyObject*, double>;
-using DSOOctree = StaticOctree<DeepSkyObject*, double>;
-using DSOHandler = OctreeProcessor<DeepSkyObject*, double>;
+using DynamicDSOOctree = DynamicOctree<std::unique_ptr<DeepSkyObject>, double>;
+using DSOOctree = StaticOctree<std::unique_ptr<DeepSkyObject>, double>;
+using DSOHandler = OctreeProcessor<std::unique_ptr<DeepSkyObject>, double>;
+
+template<>
+const inline std::uint32_t DynamicDSOOctree::SPLIT_THRESHOLD = 10;
+
+template<>
+bool DynamicDSOOctree::exceedsBrightnessThreshold(const std::unique_ptr<DeepSkyObject>&, float); //NOSONAR
+
+template<>
+bool DynamicDSOOctree::isStraddling(const Eigen::Vector3d&, const std::unique_ptr<DeepSkyObject>&); //NOSONAR
+
+template<>
+float DynamicDSOOctree::applyDecay(float);
+
+template<>
+DynamicDSOOctree* DynamicDSOOctree::getChild(const std::unique_ptr<DeepSkyObject>&, const PointType&) const; //NOSONAR
+
+template<>
+void DSOOctree::processVisibleObjects(DSOHandler&,
+                                      const PointType&,
+                                      const PlaneType*,
+                                      float,
+                                      double) const;
+
+template<>
+void DSOOctree::processCloseObjects(DSOHandler&,
+                                    const PointType&,
+                                    double,
+                                    double) const;

--- a/src/celengine/dsorenderer.cpp
+++ b/src/celengine/dsorenderer.cpp
@@ -55,12 +55,11 @@ brightness(float avgAbsMag, float absMag, float appMag, float brightnessCorr, fl
 
 } // anonymous namespace
 
-DSORenderer::DSORenderer() :
-    ObjectRenderer<DeepSkyObject*, double>(DSO_OCTREE_ROOT_SIZE)
+DSORenderer::DSORenderer() : ObjectRenderer(DSO_OCTREE_ROOT_SIZE)
 {
 }
 
-void DSORenderer::process(DeepSkyObject* const &dso,
+void DSORenderer::process(const std::unique_ptr<DeepSkyObject>& dso, //NOSONAR
                           double distanceToDSO,
                           float absMag)
 {
@@ -111,20 +110,20 @@ void DSORenderer::process(DeepSkyObject* const &dso,
         case DeepSkyObjectType::Galaxy:
             // -19.04f == average over 10937 galaxies in galaxies.dsc.
             b = brightness(-19.04f, absMag, appMag, b, faintestMag);
-            galaxyRenderer->add(static_cast<const Galaxy*>(dso), relPos, b, nearZ, farZ);
+            galaxyRenderer->add(static_cast<const Galaxy*>(dso.get()), relPos, b, nearZ, farZ);
             break;
         case DeepSkyObjectType::Globular:
             // -6.86f == average over 150 globulars in globulars.dsc.
             b = brightness(-6.86f, absMag, appMag, b, faintestMag);
-            globularRenderer->add(static_cast<const Globular*>(dso), relPos, b, nearZ, farZ);
+            globularRenderer->add(static_cast<const Globular*>(dso.get()), relPos, b, nearZ, farZ);
             break;
         case DeepSkyObjectType::Nebula:
             b = brightness(avgAbsMag, absMag, appMag, b, faintestMag);
-            nebulaRenderer->add(static_cast<const Nebula*>(dso), relPos, b, nearZ, farZ);
+            nebulaRenderer->add(static_cast<const Nebula*>(dso.get()), relPos, b, nearZ, farZ);
             break;
         case DeepSkyObjectType::OpenCluster:
             b = brightness(avgAbsMag, absMag, appMag, b, faintestMag);
-            openClusterRenderer->add(static_cast<const OpenCluster*>(dso), relPos, b, nearZ, farZ);
+            openClusterRenderer->add(static_cast<const OpenCluster*>(dso.get()), relPos, b, nearZ, farZ);
             break;
         default:
             // Unsupported DSO
@@ -188,7 +187,7 @@ void DSORenderer::process(DeepSkyObject* const &dso,
             labelColor.alpha(distr * labelColor.alpha());
 
             renderer->addBackgroundAnnotation(rep,
-                                              dsoDB->getDSOName(dso, true),
+                                              dsoDB->getDSOName(dso.get(), true),
                                               labelColor,
                                               relPos,
                                               Renderer::LabelHorizontalAlignment::Start,

--- a/src/celengine/dsorenderer.h
+++ b/src/celengine/dsorenderer.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 
 #include <Eigen/Core>
 
@@ -23,12 +24,12 @@
 class DeepSkyObject;
 class DSODatabase;
 
-class DSORenderer : public ObjectRenderer<DeepSkyObject *, double>
+class DSORenderer : public ObjectRenderer<std::unique_ptr<DeepSkyObject>, double>
 {
 public:
     DSORenderer();
 
-    void process(DeepSkyObject *const &, double, float) override;
+    void process(const std::unique_ptr<DeepSkyObject>&, double, float) override; //NOSONAR
 
     celestia::math::InfiniteFrustum frustum{ celestia::math::degToRad(celestia::engine::standardFOV),
                                              1.0f,

--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -19,8 +19,8 @@
 #include <celrender/gl/vertexobject.h>
 #include <celrender/linerenderer.h>
 #include "marker.h"
+#include "observer.h"
 #include "render.h"
-
 
 using namespace celestia;
 using celestia::render::LineRenderer;

--- a/src/celengine/objectrenderer.h
+++ b/src/celengine/objectrenderer.h
@@ -10,20 +10,17 @@
 
 #pragma once
 
-#include <Eigen/Core>
+#include <cstdint>
+
 #include "octree.h"
 
 class Observer;
 class Renderer;
 
-template <class OBJ, class PREC> class ObjectRenderer : public OctreeProcessor<OBJ, PREC>
+template<class OBJ, class PREC>
+class ObjectRenderer : public OctreeProcessor<OBJ, PREC>
 {
- public:
-    ObjectRenderer(PREC _distanceLimit) :
-        distanceLimit((float) _distanceLimit)
-    {
-    };
-
+public:
     const Observer* observer    { nullptr };
     Renderer*  renderer         { nullptr };
 
@@ -34,6 +31,12 @@ template <class OBJ, class PREC> class ObjectRenderer : public OctreeProcessor<O
     // Objects brighter than labelThresholdMag will be labeled
     float labelThresholdMag     { 0.0f };
 
-    uint64_t renderFlags        { 0 };
+    std::uint64_t renderFlags   { 0 };
     int labelMode               { 0 };
+
+protected:
+    explicit ObjectRenderer(PREC _distanceLimit) :
+        distanceLimit(static_cast<float>(_distanceLimit))
+    {
+    }
 };

--- a/src/celengine/pointstarrenderer.cpp
+++ b/src/celengine/pointstarrenderer.cpp
@@ -8,12 +8,14 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include "pointstarrenderer.h"
+
 #include <celengine/starcolors.h>
 #include <celengine/star.h>
 #include <celengine/univcoord.h>
+#include "observer.h"
 #include "pointstarvertexbuffer.h"
 #include "render.h"
-#include "pointstarrenderer.h"
 
 using namespace std;
 using namespace Eigen;
@@ -30,7 +32,7 @@ static Vector3d astrocentricPosition(const UniversalCoord& pos,
 }
 
 PointStarRenderer::PointStarRenderer() :
-    ObjectRenderer<Star, float>(StarDistanceLimit)
+    ObjectRenderer(StarDistanceLimit)
 {
 }
 

--- a/src/celengine/pointstarrenderer.h
+++ b/src/celengine/pointstarrenderer.h
@@ -10,8 +10,10 @@
 
 #pragma once
 
-#include <Eigen/Core>
 #include <vector>
+
+#include <Eigen/Core>
+
 #include "objectrenderer.h"
 #include "renderlistentry.h"
 
@@ -30,15 +32,7 @@ constexpr inline float GlareOpacity          = 0.65f;
 
 class PointStarRenderer : public ObjectRenderer<Star, float>
 {
- public:
-#if 0
-    static constexpr const float StarDistanceLimit     = 1.0e6f;
-    // Star disc size in pixels
-    static constexpr const float BaseStarDiscSize      = 5.0f;
-    static constexpr const float MaxScaledDiscStarSize = 8.0f;
-    static constexpr const float GlareOpacity          = 0.65f;
-#endif
-
+public:
     PointStarRenderer();
     void process(const Star &star, float distance, float appMag) override;
 

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -77,7 +77,7 @@ private:
     std::unique_ptr<Star[]>           stars; //NOSONAR
     std::unique_ptr<StarNameDatabase> namesDB;
     std::vector<std::uint32_t>        catalogNumberIndex;
-    StarOctree*                       octreeRoot;
+    std::unique_ptr<StarOctree>       octreeRoot;
 
     friend class StarDatabaseBuilder;
 };

--- a/src/celengine/stardbbuilder.cpp
+++ b/src/celengine/stardbbuilder.cpp
@@ -1018,13 +1018,13 @@ StarDatabaseBuilder::buildOctree()
                                       StarDatabase::STAR_OCTREE_ROOT_SIZE * celestia::numbers::sqrt3_v<float>);
     auto root = std::make_unique<DynamicStarOctree>(Eigen::Vector3f(1000.0f, 1000.0f, 1000.0f),
                                                     absMag);
-    for (const Star& star : unsortedStars)
+    for (Star& star : unsortedStars)
         root->insertObject(star, StarDatabase::STAR_OCTREE_ROOT_SIZE);
 
     GetLogger()->debug("Spatially sorting stars for improved locality of reference . . .\n");
-    auto sortedStars = std::make_unique<Star[]>(unsortedStars.size());
+    auto sortedStars = std::make_unique<Star[]>(unsortedStars.size()); //NOSONAR
     Star* firstStar = sortedStars.get();
-    root->rebuildAndSort(starDB->octreeRoot, firstStar);
+    starDB->octreeRoot = root->rebuildAndSort(firstStar);
 
     GetLogger()->debug("{} stars total\nOctree has {} nodes and {} stars.\n",
                        firstStar - sortedStars.get(),

--- a/src/celengine/staroctree.cpp
+++ b/src/celengine/staroctree.cpp
@@ -10,11 +10,16 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <celengine/staroctree.h>
+#include "staroctree.h"
 
-using namespace Eigen;
+#include <celastro/astro.h>
+#include <celcompat/numbers.h>
 
 namespace astro = celestia::astro;
+namespace numbers = celestia::numbers;
+
+namespace
+{
 
 // Maximum permitted orbital radius for stars, in light years. Orbital
 // radii larger than this value are not guaranteed to give correct
@@ -24,74 +29,64 @@ namespace astro = celestia::astro;
 // star is very faint, this estimate may not work when the star is
 // far from the barycenter. Thus, the star octree traversal will always
 // render stars with orbits that are closer than MAX_STAR_ORBIT_RADIUS.
-static const float MAX_STAR_ORBIT_RADIUS = 1.0f;
+constexpr float MAX_STAR_ORBIT_RADIUS = 1.0f;
 
+} // end unnamed namespace
 
 // The octree node into which a star is placed is dependent on two properties:
 // its obsPosition and its luminosity--the fainter the star, the deeper the node
 // in which it will reside.  Each node stores an absolute magnitude; no child
 // of the node is allowed contain a star brighter than this value, making it
 // possible to determine quickly whether or not to cull subtrees.
-
-bool starAbsoluteMagnitudePredicate(const Star& star, const float absMag)
+template<>
+bool
+DynamicStarOctree::exceedsBrightnessThreshold(const Star& star, float absMag)
 {
     return star.getAbsoluteMagnitude() <= absMag;
 }
 
-
-bool starOrbitStraddlesNodesPredicate(const Vector3f& cellCenterPos, const Star& star, const float /*unused*/)
+template<>
+bool
+DynamicStarOctree::isStraddling(const Eigen::Vector3f& cellCenterPos, const Star& star)
 {
     //checks if this star's orbit straddles child nodes
     float orbitalRadius    = star.getOrbitalRadius();
     if (orbitalRadius == 0.0f)
         return false;
 
-    Vector3f starPos    = star.getPosition();
-
+    Eigen::Vector3f starPos    = star.getPosition();
     return (starPos - cellCenterPos).cwiseAbs().minCoeff() < orbitalRadius;
 }
 
-
-float starAbsoluteMagnitudeDecayFunction(const float excludingFactor)
+template<>
+float
+DynamicStarOctree::applyDecay(float excludingFactor)
 {
     return astro::lumToAbsMag(astro::absMagToLum(excludingFactor) / 4.0f);
 }
 
-
 template<>
-DynamicStarOctree* DynamicStarOctree::getChild(const Star&          obj,
-                                               const Vector3f& cellCenterPos)
+DynamicStarOctree*
+DynamicStarOctree::getChild(const Star& obj, const Eigen::Vector3f& cellCenterPos) const
 {
-    Vector3f objPos    = obj.getPosition();
+    Eigen::Vector3f objPos = obj.getPosition();
 
     int child = 0;
-    child     |= objPos.x() < cellCenterPos.x() ? 0 : XPos;
-    child     |= objPos.y() < cellCenterPos.y() ? 0 : YPos;
-    child     |= objPos.z() < cellCenterPos.z() ? 0 : ZPos;
+    child |= objPos.x() < cellCenterPos.x() ? 0 : XPos;
+    child |= objPos.y() < cellCenterPos.y() ? 0 : YPos;
+    child |= objPos.z() < cellCenterPos.z() ? 0 : ZPos;
 
-    return _children[child];
+    return (*m_children)[child].get();
 }
-
-
-// In testing, changing SPLIT_THRESHOLD from 100 to 50 nearly
-// doubled the number of nodes in the tree, but provided only between a
-// 0 to 5 percent frame rate improvement.
-template<> unsigned int DynamicStarOctree::SPLIT_THRESHOLD = 75;
-template<> DynamicStarOctree::LimitingFactorPredicate*
-           DynamicStarOctree::limitingFactorPredicate = starAbsoluteMagnitudePredicate;
-template<> DynamicStarOctree::StraddlingPredicate*
-           DynamicStarOctree::straddlingPredicate = starOrbitStraddlesNodesPredicate;
-template<> DynamicStarOctree::ExclusionFactorDecayFunction*
-           DynamicStarOctree::decayFunction = starAbsoluteMagnitudeDecayFunction;
-
 
 // total specialization of the StaticOctree template process*() methods for stars:
 template<>
-void StarOctree::processVisibleObjects(StarHandler&    processor,
-                                       const Vector3f& obsPosition,
-                                       const Hyperplane<float, 3>*   frustumPlanes,
-                                       float           limitingFactor,
-                                       float           scale) const
+void
+StarOctree::processVisibleObjects(StarHandler&    processor,
+                                  const PointType& obsPosition,
+                                  const PlaneType* frustumPlanes,
+                                  float limitingFactor,
+                                  float scale) const
 {
     // See if this node lies within the view frustum
 
@@ -99,27 +94,26 @@ void StarOctree::processVisibleObjects(StarHandler&    processor,
     // planes that define the infinite view frustum.
     for (unsigned int i = 0; i < 5; ++i)
     {
-        const Hyperplane<float, 3>& plane = frustumPlanes[i];
+        const PlaneType& plane = frustumPlanes[i];
         float r = scale * plane.normal().cwiseAbs().sum();
-        if (plane.signedDistance(cellCenterPos) < -r)
+        if (plane.signedDistance(m_cellCenterPos) < -r)
             return;
     }
 
     // Compute the distance to node; this is equal to the distance to
     // the cellCenterPos of the node minus the boundingRadius of the node, scale * SQRT3.
-    float minDistance = (obsPosition - cellCenterPos).norm() - scale * StarOctree::SQRT3;
+    float minDistance = (obsPosition - m_cellCenterPos).norm() - scale * numbers::sqrt3_v<float>;
 
     // Process the objects in this node
     float dimmest = minDistance > 0 ? astro::appToAbsMag(limitingFactor, minDistance) : 1000;
 
-    for (unsigned int i=0; i<nObjects; ++i)
+    for (std::uint32_t i = 0; i < m_nObjects; ++i)
     {
-        const Star& obj = _firstObject[i];
-
+        const Star& obj = m_firstObject[i];
         if (obj.getAbsoluteMagnitude() < dimmest)
         {
-            float distance    = (obsPosition - obj.getPosition()).norm();
-            float appMag      = obj.getApparentMagnitude(distance);
+            float distance = (obsPosition - obj.getPosition()).norm();
+            float appMag   = obj.getApparentMagnitude(distance);
 
             if (appMag < limitingFactor || (distance < MAX_STAR_ORBIT_RADIUS && obj.getOrbit()))
                 processor.process(obj, distance, appMag);
@@ -128,33 +122,31 @@ void StarOctree::processVisibleObjects(StarHandler&    processor,
 
     // See if any of the objects in child nodes are potentially included
     // that we need to recurse deeper.
-    if (minDistance <= 0 || astro::absToAppMag(exclusionFactor, minDistance) <= limitingFactor)
+    if (m_children != nullptr &&
+        (minDistance <= 0 || astro::absToAppMag(m_exclusionFactor, minDistance) <= limitingFactor))
     {
         // Recurse into the child nodes
-        if (_children != nullptr)
+        for (int i = 0; i < 8; ++i)
         {
-            for (int i=0; i<8; ++i)
-            {
-                _children[i]->processVisibleObjects(processor,
+            (*m_children)[i]->processVisibleObjects(processor,
                                                     obsPosition,
                                                     frustumPlanes,
                                                     limitingFactor,
                                                     scale * 0.5f);
-            }
         }
     }
 }
 
-
 template<>
-void StarOctree::processCloseObjects(StarHandler&    processor,
-                                     const Vector3f& obsPosition,
-                                     float           boundingRadius,
-                                     float           scale) const
+void
+StarOctree::processCloseObjects(StarHandler& processor,
+                                const PointType& obsPosition,
+                                float boundingRadius,
+                                float scale) const
 {
     // Compute the distance to node; this is equal to the distance to
     // the cellCenterPos of the node minus the boundingRadius of the node, scale * SQRT3.
-    float nodeDistance    = (obsPosition - cellCenterPos).norm() - scale * StarOctree::SQRT3;
+    float nodeDistance = (obsPosition - m_cellCenterPos).norm() - scale * numbers::sqrt3_v<float>;
 
     if (nodeDistance > boundingRadius)
         return;
@@ -167,28 +159,28 @@ void StarOctree::processCloseObjects(StarHandler&    processor,
     float radiusSquared    = boundingRadius * boundingRadius;
 
     // Check all the objects in the node.
-    for (unsigned int i = 0; i < nObjects; ++i)
+    for (std::uint32_t i = 0; i < m_nObjects; ++i)
     {
-        Star& obj = _firstObject[i];
-
-        if ((obsPosition - obj.getPosition()).squaredNorm() < radiusSquared)
+        const Star& obj = m_firstObject[i];
+        PointType offset = obsPosition - obj.getPosition();
+        if (offset.squaredNorm() < radiusSquared)
         {
-            float distance    = (obsPosition - obj.getPosition()).norm();
-            float appMag      = obj.getApparentMagnitude(distance);
+            float distance = offset.norm();
+            float appMag   = obj.getApparentMagnitude(distance);
 
             processor.process(obj, distance, appMag);
         }
     }
 
     // Recurse into the child nodes
-    if (_children != nullptr)
+    if (m_children != nullptr)
     {
         for (int i = 0; i < 8; ++i)
         {
-            _children[i]->processCloseObjects(processor,
-                                              obsPosition,
-                                              boundingRadius,
-                                              scale * 0.5f);
+            (*m_children)[i]->processCloseObjects(processor,
+                                                  obsPosition,
+                                                  boundingRadius,
+                                                  scale * 0.5f);
         }
     }
 }

--- a/src/celengine/staroctree.h
+++ b/src/celengine/staroctree.h
@@ -12,10 +12,42 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <celengine/star.h>
 #include <celengine/octree.h>
 
+using DynamicStarOctree = DynamicOctree<Star, float>;
+using StarOctree = StaticOctree<Star, float>;
+using StarHandler = OctreeProcessor<Star, float>;
 
-typedef DynamicOctree  <Star, float> DynamicStarOctree;
-typedef StaticOctree   <Star, float> StarOctree;
-typedef OctreeProcessor<Star, float> StarHandler;
+// In testing, changing SPLIT_THRESHOLD from 100 to 50 nearly
+// doubled the number of nodes in the tree, but provided only between a
+// 0 to 5 percent frame rate improvement.
+template<>
+const inline std::uint32_t DynamicStarOctree::SPLIT_THRESHOLD = 75;
+
+template<>
+bool DynamicStarOctree::exceedsBrightnessThreshold(const Star&, float);
+
+template<>
+bool DynamicStarOctree::isStraddling(const Eigen::Vector3f&, const Star&);
+
+template<>
+float DynamicStarOctree::applyDecay(float excludingFactor);
+
+template<>
+DynamicStarOctree* DynamicStarOctree::getChild(const Star&, const Eigen::Vector3f&) const;
+
+template<>
+void StarOctree::processVisibleObjects(StarHandler&,
+                                       const PointType&,
+                                       const PlaneType*,
+                                       float,
+                                       float) const;
+
+template<>
+void StarOctree::processCloseObjects(StarHandler&,
+                                     const PointType&,
+                                     float,
+                                     float) const;

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -424,7 +424,7 @@ public:
               float angle);
     ~DSOPicker() = default;
 
-    void process(DeepSkyObject* const &, double, float) override;
+    void process(const std::unique_ptr<DeepSkyObject>&, double, float) override; //NOSONAR
 
 public:
     Eigen::Vector3d pickOrigin;
@@ -450,7 +450,7 @@ DSOPicker::DSOPicker(const Eigen::Vector3d& pickOrigin,
 
 
 void
-DSOPicker::process(DeepSkyObject* const & dso, double /*unused*/, float /*unused*/)
+DSOPicker::process(const std::unique_ptr<DeepSkyObject>& dso, double, float) //NOSONAR
 {
     if (!(dso->getRenderMask() & renderFlags) || !dso->isVisible() || !dso->isClickable())
         return;
@@ -473,7 +473,7 @@ DSOPicker::process(DeepSkyObject* const & dso, double /*unused*/, float /*unused
     if (sinAngle2 <= sinAngle2Closest)
     {
         sinAngle2Closest = std::max(sinAngle2, ANGULAR_RES);
-        pickedDSO        = dso;
+        pickedDSO        = dso.get();
     }
 }
 
@@ -488,7 +488,7 @@ public:
                    float);
     ~CloseDSOPicker() = default;
 
-    void process(DeepSkyObject* const & dso, double distance, float appMag);
+    void process(const std::unique_ptr<DeepSkyObject>& dso, double distance, float appMag); //NOSONAR
 
 public:
     Eigen::Vector3d  pickOrigin;
@@ -517,7 +517,7 @@ CloseDSOPicker::CloseDSOPicker(const Eigen::Vector3d& pos,
 
 
 void
-CloseDSOPicker::process(DeepSkyObject* const & dso,
+CloseDSOPicker::process(const std::unique_ptr<DeepSkyObject>& dso, //NOSONAR
                         double distance,
                         float /*unused*/)
 {
@@ -532,7 +532,7 @@ CloseDSOPicker::process(DeepSkyObject* const & dso,
         if ((pickOrigin - dso->getPosition()).norm() > dso->getRadius() &&
             cosAngleToBoundCenter > largestCosAngle)
         {
-            closestDSO      = dso;
+            closestDSO      = dso.get();
             largestCosAngle = cosAngleToBoundCenter;
         }
     }


### PR DESCRIPTION
Use smart pointers in octree classes, modify the builder to use moves rather than copies to enable the DSOs to be held in `std::unique_ptr`.

The current data structure requires recursion (including during destruction) but I will fix that in a future pull request.