### PR TITLE
Split DSODatabaseBuilder and DynamicOctree into separate files

### DIFF
--- a/src/celengine/CMakeLists.txt
+++ b/src/celengine/CMakeLists.txt
@@ -21,6 +21,8 @@ set(CELENGINE_SOURCES
   deepskyobj.h
   dsodb.cpp
   dsodb.h
+  dsodbbuilder.cpp
+  dsodbbuilder.h
   dsooctree.cpp
   dsooctree.h
   dsorenderer.cpp
@@ -70,6 +72,7 @@ set(CELENGINE_SOURCES
   observer.cpp
   observer.h
   octree.h
+  octreebuilder.h
   opencluster.cpp
   opencluster.h
   orbitsampler.h

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -1,61 +1,54 @@
+// dsodb.cpp
 //
-// C++ Implementation: dsodb
+// Copyright (C) 2005-2024, the Celestia Development Team
 //
-// Description:
-//
-//
+// Original version:
 // Author: Toti <root@totibox>, (C) 2005
 //
-// Copyright: See COPYING file that comes with this distribution
-//
-//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "dsodb.h"
 
 #include <algorithm>
-#include <cmath>
-#include <numeric>
 #include <utility>
 
-#include <celcompat/numbers.h>
 #include <celutil/gettext.h>
 #include <celutil/logger.h>
-#include <celutil/tokenizer.h>
-#include "category.h"
-#include "galaxy.h"
-#include "globular.h"
-#include "parser.h"
-#include "dsodb.h"
-#include "nebula.h"
-#include "opencluster.h"
-#include "value.h"
+#include "name.h"
 
 using celestia::util::GetLogger;
 
-namespace astro = celestia::astro;
+DSODatabase::~DSODatabase() = default;
 
-namespace
+DSODatabase::DSODatabase(std::vector<std::unique_ptr<DeepSkyObject>>&& DSOs,
+                         std::unique_ptr<DSOOctree>&& octreeRoot,
+                         std::unique_ptr<NameDatabase>&& namesDB,
+                         std::vector<std::uint32_t>&& catalogNumberIndex,
+                         float avgAbsMag) :
+    m_DSOs(std::move(DSOs)),
+    m_octreeRoot(std::move(octreeRoot)),
+    m_namesDB(std::move(namesDB)),
+    m_catalogNumberIndex(std::move(catalogNumberIndex)),
+    m_avgAbsMag(avgAbsMag)
 {
-
-constexpr const float DSO_OCTREE_MAGNITUDE   = 8.0f;
-//constexpr const float DSO_EXTRA_ROOM         = 0.01f; // Reserve 1% capacity for extra DSOs
-                                                      // (useful as a complement of binary loaded DSOs)
-
-//constexpr char FILE_HEADER[]                 = "CEL_DSOs";
-
-} // end unnamed namespace
+}
 
 DeepSkyObject*
 DSODatabase::find(const AstroCatalog::IndexNumber catalogNumber) const
 {
-    auto it = std::lower_bound(catalogNumberIndex.begin(),
-                               catalogNumberIndex.end(),
+    auto it = std::lower_bound(m_catalogNumberIndex.begin(),
+                               m_catalogNumberIndex.end(),
                                catalogNumber,
                                [this](std::uint32_t idx, AstroCatalog::IndexNumber catNum)
                                {
-                                   return DSOs[idx]->getIndex() < catNum;
+                                   return m_DSOs[idx]->getIndex() < catNum;
                                });
 
-    return (it != catalogNumberIndex.end() && DSOs[*it]->getIndex() == catalogNumber)
-        ? DSOs[*it].get()
+    return (it != m_catalogNumberIndex.end() && m_DSOs[*it]->getIndex() == catalogNumber)
+        ? m_DSOs[*it].get()
         : nullptr;
 }
 
@@ -65,34 +58,27 @@ DSODatabase::find(std::string_view name, bool i18n) const
     if (name.empty())
         return nullptr;
 
-    if (namesDB != nullptr)
-    {
-        AstroCatalog::IndexNumber catalogNumber = namesDB->getCatalogNumberByName(name, i18n);
-        if (catalogNumber != AstroCatalog::InvalidIndex)
-            return find(catalogNumber);
-    }
-
-    return nullptr;
+    AstroCatalog::IndexNumber catalogNumber = m_namesDB->getCatalogNumberByName(name, i18n);
+    return catalogNumber == AstroCatalog::InvalidIndex
+        ? nullptr
+        : find(catalogNumber);
 }
 
 void
 DSODatabase::getCompletion(std::vector<std::string>& completion, std::string_view name) const
 {
     // only named DSOs are supported by completion.
-    if (!name.empty() && namesDB != nullptr)
-        namesDB->getCompletion(completion, name);
+    if (!name.empty())
+        m_namesDB->getCompletion(completion, name);
 }
 
 std::string
 DSODatabase::getDSOName(const DeepSkyObject* dso, [[maybe_unused]] bool i18n) const
 {
-    if (namesDB == nullptr)
-        return {};
-
     AstroCatalog::IndexNumber catalogNumber = dso->getIndex();
 
-    auto iter = namesDB->getFirstNameIter(catalogNumber);
-    if (iter == namesDB->getFinalNameIter())
+    auto iter = m_namesDB->getFirstNameIter(catalogNumber);
+    if (iter == m_namesDB->getFinalNameIter())
         return {};
 
 #ifdef ENABLE_NLS
@@ -113,10 +99,10 @@ DSODatabase::getDSONameList(const DeepSkyObject* dso, const unsigned int maxName
     std::string dsoNames;
 
     auto catalogNumber = dso->getIndex();
-    auto iter = namesDB->getFirstNameIter(catalogNumber);
+    auto iter = m_namesDB->getFirstNameIter(catalogNumber);
 
     unsigned int count = 0;
-    while (iter != namesDB->getFinalNameIter() && iter->first == catalogNumber && count < maxNames)
+    while (iter != m_namesDB->getFinalNameIter() && iter->first == catalogNumber && count < maxNames)
     {
         if (count != 0)
             dsoNames.append(" / ");
@@ -158,11 +144,11 @@ DSODatabase::findVisibleDSOs(DSOHandler& dsoHandler,
         frustumPlanes[i]   = Eigen::Hyperplane<double, 3>(planeNormals[i], obsPos);
     }
 
-    octreeRoot->processVisibleObjects(dsoHandler,
-                                      obsPos,
-                                      frustumPlanes,
-                                      limitingMag,
-                                      DSO_OCTREE_ROOT_SIZE);
+    m_octreeRoot->processVisibleObjects(dsoHandler,
+                                        obsPos,
+                                        frustumPlanes,
+                                        limitingMag,
+                                        DSO_OCTREE_ROOT_SIZE);
 }
 
 void
@@ -170,202 +156,8 @@ DSODatabase::findCloseDSOs(DSOHandler& dsoHandler,
                            const Eigen::Vector3d& obsPos,
                            float radius) const
 {
-    octreeRoot->processCloseObjects(dsoHandler,
-                                    obsPos,
-                                    radius,
-                                    DSO_OCTREE_ROOT_SIZE);
-}
-
-NameDatabase*
-DSODatabase::getNameDatabase() const
-{
-    return namesDB.get();
-}
-
-void
-DSODatabase::setNameDatabase(std::unique_ptr<NameDatabase>&& _namesDB)
-{
-    namesDB = std::move(_namesDB);
-}
-
-bool
-DSODatabase::load(std::istream& in, const fs::path& resourcePath)
-{
-    Tokenizer tokenizer(&in);
-    Parser    parser(&tokenizer);
-
-#ifdef ENABLE_NLS
-    std::string s = resourcePath.string();
-    const char *d = s.c_str();
-    bindtextdomain(d, d); // domain name is the same as resource path
-#endif
-
-    while (tokenizer.nextToken() != Tokenizer::TokenEnd)
-    {
-        std::string objType;
-        if (auto tokenValue = tokenizer.getNameValue(); tokenValue.has_value())
-        {
-            objType = *tokenValue;
-        }
-        else
-        {
-            GetLogger()->error("Error parsing deep sky catalog file.\n");
-            return false;
-        }
-
-        AstroCatalog::IndexNumber objCatalogNumber = nextAutoCatalogNumber--;
-
-        tokenizer.nextToken();
-        std::string objName;
-        if (auto tokenValue = tokenizer.getStringValue(); tokenValue.has_value())
-        {
-            objName = *tokenValue;
-        }
-        else
-        {
-            GetLogger()->error("Error parsing deep sky catalog file: bad name.\n");
-            return false;
-        }
-
-        const Value objParamsValue = parser.readValue();
-        const Hash* objParams = objParamsValue.getHash();
-        if (objParams == nullptr)
-        {
-            GetLogger()->error("Error parsing deep sky catalog entry {}\n", objName.c_str());
-            return false;
-        }
-
-        std::unique_ptr<DeepSkyObject> obj;
-        if (compareIgnoringCase(objType, "Galaxy") == 0)
-            obj = std::make_unique<Galaxy>();
-        else if (compareIgnoringCase(objType, "Globular") == 0)
-            obj = std::make_unique<Globular>();
-        else if (compareIgnoringCase(objType, "Nebula") == 0)
-            obj = std::make_unique<Nebula>();
-        else if (compareIgnoringCase(objType, "OpenCluster") == 0)
-            obj = std::make_unique<OpenCluster>();
-
-        if (obj != nullptr && obj->load(objParams, resourcePath))
-        {
-            UserCategory::loadCategories(obj.get(), *objParams, DataDisposition::Add, resourcePath.string());
-
-            obj->setIndex(objCatalogNumber);
-            DSOs.emplace_back(std::move(obj));
-
-            if (namesDB != nullptr && !objName.empty())
-            {
-                // List of names will replace any that already exist for
-                // this DSO.
-                namesDB->erase(objCatalogNumber);
-
-                // Iterate through the string for names delimited
-                // by ':', and insert them into the DSO database.
-                // Note that db->add() will skip empty names.
-                std::string::size_type startPos = 0;
-                while (startPos != std::string::npos)
-                {
-                    std::string::size_type next    = objName.find(':', startPos);
-                    std::string::size_type length  = std::string::npos;
-                    if (next != std::string::npos)
-                    {
-                        length = next - startPos;
-                        ++next;
-                    }
-                    std::string DSOName = objName.substr(startPos, length);
-                    namesDB->add(objCatalogNumber, DSOName);
-                    startPos   = next;
-                }
-            }
-        }
-        else
-        {
-            GetLogger()->warn("Bad Deep Sky Object definition--will continue parsing file.\n");
-            return false;
-        }
-    }
-
-    return true;
-}
-
-void
-DSODatabase::finish()
-{
-    buildOctree();
-    buildIndexes();
-    calcAvgAbsMag();
-
-    GetLogger()->info(_("Loaded {} deep space objects\n"), DSOs.size());
-}
-
-void
-DSODatabase::buildOctree()
-{
-    GetLogger()->debug("Sorting DSOs into octree . . .\n");
-    float absMag = astro::appToAbsMag(DSO_OCTREE_MAGNITUDE, DSO_OCTREE_ROOT_SIZE * celestia::numbers::sqrt3_v<float>);
-
-    // TODO: investigate using a different center--it's possible that more
-    // objects end up straddling the base level nodes when the center of the
-    // octree is at the origin.
-    auto root = std::make_unique<DynamicDSOOctree>(Eigen::Vector3d::Zero(), absMag);
-    for (auto& dso : DSOs)
-        root->insertObject(dso, DSO_OCTREE_ROOT_SIZE);
-
-    GetLogger()->debug("Spatially sorting DSOs for improved locality of reference . . .\n");
-    std::vector<std::unique_ptr<DeepSkyObject>> sortedDSOs;
-    sortedDSOs.resize(DSOs.size());
-    std::unique_ptr<DeepSkyObject>* firstDSO = sortedDSOs.data();
-
-    // The spatial sorting part is useless for DSOs since we
-    // are storing pointers to objects and not the objects themselves:
-    octreeRoot = root->rebuildAndSort(firstDSO);
-
-    GetLogger()->debug("{} DSOs total.\nOctree has {} nodes and {} DSOs.\n",
-                       firstDSO - sortedDSOs.data(),
-                       UINT32_C(1) + octreeRoot->countChildren(),
-                       octreeRoot->countObjects());
-
-    DSOs = std::move(sortedDSOs);
-}
-
-void
-DSODatabase::calcAvgAbsMag()
-{
-    std::uint32_t nDSOeff = size();
-    for (const auto& dso : DSOs)
-    {
-        float DSOmag = dso->getAbsoluteMagnitude();
-
-        // take only DSO's with realistic AbsMag entry
-        // (> DSO_DEFAULT_ABS_MAGNITUDE) into account
-        if (DSOmag > DSO_DEFAULT_ABS_MAGNITUDE)
-            avgAbsMag += DSOmag;
-        else if (nDSOeff > 1)
-            --nDSOeff;
-    }
-    avgAbsMag /= static_cast<float>(nDSOeff);
-}
-
-void
-DSODatabase::buildIndexes()
-{
-    // This should only be called once for the database
-    // assert(catalogNumberIndexes[0] == nullptr);
-
-    GetLogger()->debug("Building catalog number indexes . . .\n");
-
-    catalogNumberIndex.resize(DSOs.size());
-    std::iota(catalogNumberIndex.begin(), catalogNumberIndex.end(), UINT32_C(0));
-
-    std::sort(catalogNumberIndex.begin(),
-              catalogNumberIndex.end(),
-              [this](std::uint32_t idx0, std::uint32_t idx1)
-              {
-                  return DSOs[idx0]->getIndex() < DSOs[idx1]->getIndex();
-              });
-}
-
-float
-DSODatabase::getAverageAbsoluteMagnitude() const
-{
-    return avgAbsMag;
+    m_octreeRoot->processCloseObjects(dsoHandler,
+                                      obsPos,
+                                      radius,
+                                      DSO_OCTREE_ROOT_SIZE);
 }

--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -1,19 +1,18 @@
+// dsodb.h
 //
-// C++ Interface: dsodb
+// Copyright (C) 2005-2024, the Celestia Development Team
 //
-// Description:
-//
-//
+// Original version:
 // Author: Toti <root@totibox>, (C) 2005
 //
-// Copyright: See COPYING file that comes with this distribution
-//
-//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
 
 #pragma once
 
 #include <cstdint>
-#include <iosfwd>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -22,9 +21,11 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <celcompat/filesystem.h>
-#include <celengine/dsooctree.h>
-#include <celengine/name.h>
+#include "dsooctree.h"
+
+class DeepSkyObject;
+class DSODatabaseBuilder;
+class NameDatabase;
 
 constexpr inline unsigned int MAX_DSO_NAMES = 10;
 
@@ -34,9 +35,14 @@ constexpr inline float DSO_OCTREE_ROOT_SIZE = 1.0e11f;
 //NOTE: this one and starDatabase should be derived from a common base class since they share lots of code and functionality.
 class DSODatabase
 {
- public:
-    DSODatabase() = default;
-    ~DSODatabase() = default;
+public:
+    DSODatabase(std::vector<std::unique_ptr<DeepSkyObject>>&&,
+                std::unique_ptr<DSOOctree>&&,
+                std::unique_ptr<NameDatabase>&&,
+                std::vector<std::uint32_t>&&,
+                float);
+
+    ~DSODatabase();
 
     DeepSkyObject* getDSO(const std::uint32_t) const;
     std::uint32_t size() const;
@@ -60,36 +66,33 @@ class DSODatabase
     std::string getDSOName    (const DeepSkyObject*, bool i18n = false) const;
     std::string getDSONameList(const DeepSkyObject*, const unsigned int maxNames = MAX_DSO_NAMES) const;
 
-    NameDatabase* getNameDatabase() const;
-    void setNameDatabase(std::unique_ptr<NameDatabase>&&);
-
-    bool load(std::istream&, const fs::path& resourcePath = fs::path());
-    void finish();
-
     float getAverageAbsoluteMagnitude() const;
 
 private:
-    void buildIndexes();
-    void buildOctree();
-    void calcAvgAbsMag();
+    std::vector<std::unique_ptr<DeepSkyObject>> m_DSOs;
+    std::unique_ptr<DSOOctree> m_octreeRoot;
+    std::unique_ptr<NameDatabase> m_namesDB;
+    std::vector<std::uint32_t> m_catalogNumberIndex;
 
-    std::vector<std::unique_ptr<DeepSkyObject>> DSOs;
-    std::unique_ptr<NameDatabase> namesDB;
-    std::vector<std::uint32_t> catalogNumberIndex;
-    std::unique_ptr<DSOOctree> octreeRoot;
-    AstroCatalog::IndexNumber nextAutoCatalogNumber{ 0xfffffffe };
+    float m_avgAbsMag{ 0.0f };
 
-    float avgAbsMag{ 0.0f };
+    friend class DSODatabaseBuilder;
 };
 
 inline DeepSkyObject*
 DSODatabase::getDSO(const std::uint32_t n) const
 {
-    return DSOs[n].get();
+    return m_DSOs[n].get();
 }
 
 inline std::uint32_t
 DSODatabase::size() const
 {
-    return static_cast<std::uint32_t>(DSOs.size());
+    return static_cast<std::uint32_t>(m_DSOs.size());
+}
+
+inline float
+DSODatabase::getAverageAbsoluteMagnitude() const
+{
+    return m_avgAbsMag;
 }

--- a/src/celengine/dsodbbuilder.cpp
+++ b/src/celengine/dsodbbuilder.cpp
@@ -1,0 +1,297 @@
+// dsodbbuilder.cpp
+//
+// Copyright (C) 2005-2024, the Celestia Development Team
+//
+// Split from dsodb.cpp - original version:
+// Author: Toti <root@totibox>, (C) 2005
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "dsodbbuilder.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <string>
+
+#include <Eigen/Core>
+
+#include <celastro/astro.h>
+#include <celcompat/numbers.h>
+#include <celutil/logger.h>
+#include <celutil/gettext.h>
+#include <celutil/stringutils.h>
+#include <celutil/tokenizer.h>
+#include "category.h"
+#include "deepskyobj.h"
+#include "dsodb.h"
+#include "dsooctree.h"
+#include "galaxy.h"
+#include "globular.h"
+#include "hash.h"
+#include "nebula.h"
+#include "octreebuilder.h"
+#include "opencluster.h"
+#include "parser.h"
+#include "value.h"
+
+namespace astro = celestia::astro;
+
+using DynamicDSOOctree = DynamicOctree<std::unique_ptr<DeepSkyObject>, double>;
+
+using celestia::util::GetLogger;
+
+template<>
+const inline std::uint32_t DynamicDSOOctree::SPLIT_THRESHOLD = 10;
+
+// The octree node into which a dso is placed is dependent on two properties:
+// its obsPosition and its luminosity--the fainter the dso, the deeper the node
+// in which it will reside.  Each node stores an absolute magnitude; no child
+// of the node is allowed contain a dso brighter than this value, making it
+// possible to determine quickly whether or not to cull subtrees.
+
+template<>
+bool
+DynamicDSOOctree::exceedsBrightnessThreshold(const std::unique_ptr<DeepSkyObject>& dso, //NOSONAR
+                                             float absMag)
+{
+    return dso->getAbsoluteMagnitude() <= absMag;
+}
+
+template<>
+bool
+DynamicDSOOctree::isStraddling(const Eigen::Vector3d& cellCenterPos,
+                               const std::unique_ptr<DeepSkyObject>& dso) //NOSONAR
+{
+    //checks if this dso's radius straddles child nodes
+    float dsoRadius = dso->getBoundingSphereRadius();
+    return (dso->getPosition() - cellCenterPos).cwiseAbs().minCoeff() < dsoRadius;
+}
+
+template<>
+float
+DynamicDSOOctree::applyDecay(float excludingFactor)
+{
+    return excludingFactor + 0.5f;
+}
+
+template<>
+DynamicDSOOctree*
+DynamicDSOOctree::getChild(const std::unique_ptr<DeepSkyObject>& obj, //NOSONAR
+                           const PointType& cellCenterPos) const
+{
+    PointType objPos = obj->getPosition();
+
+    unsigned int child = 0U;
+    child |= objPos.x() < cellCenterPos.x() ? 0U : OctreeXPos;
+    child |= objPos.y() < cellCenterPos.y() ? 0U : OctreeYPos;
+    child |= objPos.z() < cellCenterPos.z() ? 0U : OctreeZPos;
+
+    return (*m_children)[child].get();
+}
+
+namespace
+{
+
+constexpr float DSO_OCTREE_MAGNITUDE = 8.0f;
+
+std::unique_ptr<DeepSkyObject>
+createDSO(std::string_view objType)
+{
+    if (compareIgnoringCase(objType, "Galaxy") == 0)
+        return std::make_unique<Galaxy>();
+    if (compareIgnoringCase(objType, "Globular") == 0)
+        return std::make_unique<Globular>();
+    if (compareIgnoringCase(objType, "Nebula") == 0)
+        return std::make_unique<Nebula>();
+    if (compareIgnoringCase(objType, "OpenCluster") == 0)
+        return std::make_unique<OpenCluster>();
+    return nullptr;
+}
+
+float
+calcAvgAbsMag(const std::vector<std::unique_ptr<DeepSkyObject>>& DSOs)
+{
+    auto nDSOeff = DSOs.size();
+    float avgAbsMag = 0.0f;
+    for (const auto& dso : DSOs)
+    {
+        float DSOmag = dso->getAbsoluteMagnitude();
+
+        // take only DSO's with realistic AbsMag entry
+        // (> DSO_DEFAULT_ABS_MAGNITUDE) into account
+        if (DSOmag > DSO_DEFAULT_ABS_MAGNITUDE)
+            avgAbsMag += DSOmag;
+        else if (nDSOeff > 1)
+            --nDSOeff;
+    }
+
+    return avgAbsMag / static_cast<float>(nDSOeff);
+}
+
+void
+addName(NameDatabase* namesDB, AstroCatalog::IndexNumber objCatalogNumber, std::string_view objName)
+{
+    if (objName.empty())
+        return;
+
+    // List of names will replace any that already exist for
+    // this DSO.
+    namesDB->erase(objCatalogNumber);
+
+    // Iterate through the string for names delimited
+    // by ':', and insert them into the DSO database.
+    // Note that db->add() will skip empty names.
+    while (!objName.empty())
+    {
+        auto pos = objName.find(':');
+        namesDB->add(objCatalogNumber, objName.substr(0, pos));
+        if (pos == std::string_view::npos)
+            break;
+
+        objName = objName.substr(pos + 1);
+    }
+}
+
+std::unique_ptr<DSOOctree>
+buildOctree(std::vector<std::unique_ptr<DeepSkyObject>>& DSOs)
+{
+    GetLogger()->debug("Sorting DSOs into octree . . .\n");
+    float absMag = astro::appToAbsMag(DSO_OCTREE_MAGNITUDE, DSO_OCTREE_ROOT_SIZE * celestia::numbers::sqrt3_v<float>);
+
+    auto root = std::make_unique<DynamicDSOOctree>(Eigen::Vector3d::Zero(), absMag);
+    for (auto& dso : DSOs)
+        root->insertObject(dso, DSO_OCTREE_ROOT_SIZE);
+
+    GetLogger()->debug("Spatially sorting DSOs for improved locality of reference . . .\n");
+    std::vector<std::unique_ptr<DeepSkyObject>> sortedDSOs;
+    sortedDSOs.resize(DSOs.size());
+    std::unique_ptr<DeepSkyObject>* firstDSO = sortedDSOs.data();
+
+    // The spatial sorting part is useless for DSOs since we
+    // are storing pointers to objects and not the objects themselves:
+    auto octreeRoot = root->rebuildAndSort(firstDSO);
+
+    GetLogger()->debug("{} DSOs total.\nOctree has {} nodes and {} DSOs.\n",
+                       firstDSO - sortedDSOs.data(),
+                       UINT32_C(1) + octreeRoot->countChildren(),
+                       octreeRoot->countObjects());
+
+    DSOs = std::move(sortedDSOs);
+
+    return octreeRoot;
+}
+
+std::vector<std::uint32_t>
+buildCatalogNumberIndex(const std::vector<std::unique_ptr<DeepSkyObject>>& DSOs)
+{
+    GetLogger()->debug("Building catalog number indexes . . .\n");
+
+    std::vector<std::uint32_t> catalogNumberIndex(DSOs.size(), UINT32_C(0));
+    std::iota(catalogNumberIndex.begin(), catalogNumberIndex.end(), UINT32_C(0));
+
+    std::sort(catalogNumberIndex.begin(),
+              catalogNumberIndex.end(),
+              [&DSOs](std::uint32_t idx0, std::uint32_t idx1)
+              {
+                  return DSOs[idx0]->getIndex() < DSOs[idx1]->getIndex();
+              });
+
+    return catalogNumberIndex;
+}
+
+} // end unnamed namespace
+
+DSODatabaseBuilder::~DSODatabaseBuilder() = default;
+
+bool
+DSODatabaseBuilder::load(std::istream& in, const fs::path& resourcePath)
+{
+    Tokenizer tokenizer(&in);
+    Parser    parser(&tokenizer);
+
+#ifdef ENABLE_NLS
+    std::string s = resourcePath.string();
+    const char *d = s.c_str();
+    bindtextdomain(d, d); // domain name is the same as resource path
+#endif
+
+    while (tokenizer.nextToken() != Tokenizer::TokenEnd)
+    {
+        std::string objType;
+        if (auto tokenValue = tokenizer.getNameValue(); tokenValue.has_value())
+        {
+            objType = *tokenValue;
+        }
+        else
+        {
+            GetLogger()->error("Error parsing deep sky catalog file.\n");
+            return false;
+        }
+
+        tokenizer.nextToken();
+        std::string objName;
+        if (auto tokenValue = tokenizer.getStringValue(); tokenValue.has_value())
+        {
+            objName = *tokenValue;
+        }
+        else
+        {
+            GetLogger()->error("Error parsing deep sky catalog file: bad name.\n");
+            return false;
+        }
+
+        const Value objParamsValue = parser.readValue();
+        const Hash* objParams = objParamsValue.getHash();
+        if (objParams == nullptr)
+        {
+            GetLogger()->error("Error parsing deep sky catalog entry {}\n", objName);
+            return false;
+        }
+
+        std::unique_ptr<DeepSkyObject> obj = createDSO(objType);
+
+        if (obj == nullptr || !obj->load(objParams, resourcePath))
+        {
+            GetLogger()->warn("Bad Deep Sky Object definition--will continue parsing file.\n");
+            continue;
+        }
+
+        UserCategory::loadCategories(obj.get(), *objParams, DataDisposition::Add, resourcePath.string());
+
+        if (nextAutoCatalogNumber == AstroCatalog::InvalidIndex)
+        {
+            GetLogger()->error("Exceeded maximum DSO count.\n");
+            break;
+        }
+
+        AstroCatalog::IndexNumber objCatalogNumber = nextAutoCatalogNumber;
+        ++nextAutoCatalogNumber;
+
+        obj->setIndex(objCatalogNumber);
+        DSOs.emplace_back(std::move(obj));
+
+        addName(namesDB.get(), objCatalogNumber, objName);
+    }
+
+    return true;
+}
+
+std::unique_ptr<DSODatabase>
+DSODatabaseBuilder::finish()
+{
+    auto octreeRoot = buildOctree(DSOs);
+    auto catalogNumberIndex = buildCatalogNumberIndex(DSOs);
+    float avgAbsMag = calcAvgAbsMag(DSOs);
+
+    GetLogger()->info(_("Loaded {} deep space objects\n"), DSOs.size());
+
+    return std::make_unique<DSODatabase>(std::move(DSOs),
+                                         std::move(octreeRoot),
+                                         std::move(namesDB),
+                                         std::move(catalogNumberIndex),
+                                         avgAbsMag);
+}

--- a/src/celengine/dsodbbuilder.h
+++ b/src/celengine/dsodbbuilder.h
@@ -1,0 +1,40 @@
+// dsodbbuilder.h
+//
+// Copyright (C) 2005-2024, the Celestia Development Team
+//
+// Split from dsodb.h - original version:
+// Author: Toti <root@totibox>, (C) 2005
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <iosfwd>
+#include <memory>
+#include <vector>
+
+#include <celcompat/filesystem.h>
+#include "astroobj.h"
+#include "name.h"
+
+class DeepSkyObject;
+class DSODatabase;
+class NameDatabase;
+
+class DSODatabaseBuilder
+{
+public:
+    DSODatabaseBuilder() = default;
+    ~DSODatabaseBuilder();
+
+    bool load(std::istream&, const fs::path& resourcePath = fs::path());
+    std::unique_ptr<DSODatabase> finish();
+
+private:
+    std::vector<std::unique_ptr<DeepSkyObject>> DSOs;
+    std::unique_ptr<NameDatabase> namesDB{ std::make_unique<NameDatabase>() };
+    AstroCatalog::IndexNumber nextAutoCatalogNumber{ 0 };
+};

--- a/src/celengine/dsooctree.cpp
+++ b/src/celengine/dsooctree.cpp
@@ -18,52 +18,6 @@
 namespace astro = celestia::astro;
 namespace numbers = celestia::numbers;
 
-// The octree node into which a dso is placed is dependent on two properties:
-// its obsPosition and its luminosity--the fainter the dso, the deeper the node
-// in which it will reside.  Each node stores an absolute magnitude; no child
-// of the node is allowed contain a dso brighter than this value, making it
-// possible to determine quickly whether or not to cull subtrees.
-
-template<>
-bool
-DynamicDSOOctree::exceedsBrightnessThreshold(const std::unique_ptr<DeepSkyObject>& dso, //NOSONAR
-                                             float absMag)
-{
-    return dso->getAbsoluteMagnitude() <= absMag;
-}
-
-template<>
-bool
-DynamicDSOOctree::isStraddling(const Eigen::Vector3d& cellCenterPos,
-                               const std::unique_ptr<DeepSkyObject>& dso) //NOSONAR
-{
-    //checks if this dso's radius straddles child nodes
-    float dsoRadius    = dso->getBoundingSphereRadius();
-    return (dso->getPosition() - cellCenterPos).cwiseAbs().minCoeff() < dsoRadius;
-}
-
-template<>
-float
-DynamicDSOOctree::applyDecay(float excludingFactor)
-{
-    return excludingFactor + 0.5f;
-}
-
-template<>
-DynamicDSOOctree*
-DynamicDSOOctree::getChild(const std::unique_ptr<DeepSkyObject>& obj, //NOSONAR
-                           const PointType& cellCenterPos) const
-{
-    PointType objPos = obj->getPosition();
-
-    int child = 0;
-    child |= objPos.x() < cellCenterPos.x() ? 0 : XPos;
-    child |= objPos.y() < cellCenterPos.y() ? 0 : YPos;
-    child |= objPos.z() < cellCenterPos.z() ? 0 : ZPos;
-
-    return (*m_children)[child].get();
-}
-
 // total specialization of the StaticOctree template process*() methods for DSOs:
 template<>
 void

--- a/src/celengine/dsooctree.h
+++ b/src/celengine/dsooctree.h
@@ -18,24 +18,8 @@
 #include "deepskyobj.h"
 #include "octree.h"
 
-using DynamicDSOOctree = DynamicOctree<std::unique_ptr<DeepSkyObject>, double>;
 using DSOOctree = StaticOctree<std::unique_ptr<DeepSkyObject>, double>;
 using DSOHandler = OctreeProcessor<std::unique_ptr<DeepSkyObject>, double>;
-
-template<>
-const inline std::uint32_t DynamicDSOOctree::SPLIT_THRESHOLD = 10;
-
-template<>
-bool DynamicDSOOctree::exceedsBrightnessThreshold(const std::unique_ptr<DeepSkyObject>&, float); //NOSONAR
-
-template<>
-bool DynamicDSOOctree::isStraddling(const Eigen::Vector3d&, const std::unique_ptr<DeepSkyObject>&); //NOSONAR
-
-template<>
-float DynamicDSOOctree::applyDecay(float);
-
-template<>
-DynamicDSOOctree* DynamicDSOOctree::getChild(const std::unique_ptr<DeepSkyObject>&, const PointType&) const; //NOSONAR
 
 template<>
 void DSOOctree::processVisibleObjects(DSOHandler&,

--- a/src/celengine/octree.h
+++ b/src/celengine/octree.h
@@ -2,7 +2,7 @@
 //
 // Octree-based visibility determination for objects.
 //
-// Copyright (C) 2001-2009, Celestia Development Team
+// Copyright (C) 2001-2024, Celestia Development Team
 // Original version by Chris Laurel <claurel@gmail.com>
 //
 // This program is free software; you can redistribute it and/or
@@ -15,12 +15,11 @@
 #include <array>
 #include <cstdint>
 #include <memory>
-#include <utility>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-// The DynamicOctree and StaticOctree template arguments are:
+// The StaticOctree template arguments are:
 // OBJ:  object hanging from the node,
 // PREC: floating point precision of the culling operations at node level.
 // The hierarchy of octree nodes is built using a single precision value (excludingFactor), which relates to an
@@ -128,183 +127,4 @@ StaticOctree<OBJ, PREC>::countObjects() const
             count += (*m_children)[i]->countObjects();
 
     return count;
-}
-
-// There are two classes implemented in this module: StaticOctree and
-// DynamicOctree.  The DynamicOctree is built first by inserting
-// objects from a database or catalog and is then 'compiled' into a StaticOctree.
-// In the process of building the StaticOctree, the original object database is
-// reorganized, with objects in the same octree node all placed adjacent to each
-// other.  This spatial sorting of the objects dramatically improves the
-// performance of octree operations through much more coherent memory access.
-enum
-{
-    XPos = 1,
-    YPos = 2,
-    ZPos = 4,
-};
-
-template<class OBJ, class PREC>
-class DynamicOctree
-{
-public:
-    using PointType = Eigen::Matrix<PREC, 3, 1>;
-
-    DynamicOctree(const PointType& cellCenterPos,
-                  float exclusionFactor);
-
-    void insertObject(OBJ&, const PREC);
-    std::unique_ptr<StaticOctree<OBJ, PREC>> rebuildAndSort(OBJ*&);
-
-private:
-    using ObjectList = std::vector<OBJ*>;
-
-    static const unsigned int SPLIT_THRESHOLD;
-
-    static bool exceedsBrightnessThreshold(const OBJ&, float);
-    static bool isStraddling(const PointType&, const OBJ&);
-    static float applyDecay(float);
-
-private:
-    using ChildrenType = std::array<std::unique_ptr<DynamicOctree>, 8>;
-
-    void           add(OBJ&);
-    void           split(const PREC);
-    void           sortIntoChildNodes();
-    DynamicOctree* getChild(const OBJ&, const PointType&) const;
-
-    std::unique_ptr<ChildrenType> m_children;
-    PointType m_cellCenterPos;
-    float m_exclusionFactor;
-    std::unique_ptr<ObjectList> m_objects;
-};
-
-// The SPLIT_THRESHOLD is the number of objects a node must contain before its
-// children are generated. Increasing this number will decrease the number of
-// octree nodes in the tree, which will use less memory but make culling less
-// efficient.
-template<class OBJ, class PREC>
-DynamicOctree<OBJ, PREC>::DynamicOctree(const PointType& cellCenterPos,
-                                        float exclusionFactor):
-    m_cellCenterPos(cellCenterPos),
-    m_exclusionFactor(exclusionFactor)
-{
-}
-
-template<class OBJ, class PREC>
-void
-DynamicOctree<OBJ, PREC>::insertObject(OBJ& obj, const PREC scale)
-{
-    // If the object can't be placed into this node's children, then put it here:
-    if (exceedsBrightnessThreshold(obj, m_exclusionFactor) || isStraddling(m_cellCenterPos, obj))
-    {
-        add(obj);
-        return;
-    }
-
-    // If we haven't allocated child nodes yet, try to fit
-    // the object in this node, even though it could be put
-    // in a child. Only if there are more than SPLIT_THRESHOLD
-    // objects in the node will we attempt to place the
-    // object into a child node.  This is done in order
-    // to avoid having the octree degenerate into one object
-    // per node.
-    if (m_children == nullptr)
-    {
-        if (m_objects == nullptr || m_objects->size() < SPLIT_THRESHOLD)
-        {
-            add(obj);
-            return;
-        }
-
-        split(scale * 0.5f);
-    }
-
-    // We've already allocated child nodes; place the object
-    // into the appropriate one.
-    getChild(obj, m_cellCenterPos)->insertObject(obj, scale * (PREC) 0.5);
-}
-
-template<class OBJ, class PREC>
-void
-DynamicOctree<OBJ, PREC>::add(OBJ& obj)
-{
-    if (m_objects == nullptr)
-        m_objects = std::make_unique<ObjectList>();
-
-    m_objects->push_back(&obj);
-}
-
-template<class OBJ, class PREC>
-void
-DynamicOctree<OBJ, PREC>::split(const PREC scale)
-{
-    m_children = std::make_unique<ChildrenType>();
-    for (int i = 0; i < 8; ++i)
-    {
-        PointType centerPos = m_cellCenterPos
-                            + PointType(((i & XPos) != 0) ? scale : -scale,
-                                        ((i & YPos) != 0) ? scale : -scale,
-                                        ((i & ZPos) != 0) ? scale : -scale);
-
-        (*m_children)[i] = std::make_unique<DynamicOctree>(centerPos, applyDecay(m_exclusionFactor));
-    }
-
-    sortIntoChildNodes();
-}
-
-// Sort this node's objects into objects that can remain here,
-// and objects that should be placed into one of the eight
-// child nodes.
-template<class OBJ, class PREC>
-void
-DynamicOctree<OBJ, PREC>::sortIntoChildNodes()
-{
-    auto writeIt = m_objects->begin();
-    auto endIt = m_objects->end();
-
-    for (auto readIt = writeIt; readIt != endIt; ++readIt)
-    {
-        OBJ& obj = **readIt;
-        if (exceedsBrightnessThreshold(obj, m_exclusionFactor) || isStraddling(m_cellCenterPos, obj))
-        {
-            *writeIt = *readIt;
-            ++writeIt;
-        }
-        else
-        {
-            getChild(obj, m_cellCenterPos)->add(obj);
-        }
-    }
-
-    m_objects->erase(writeIt, endIt);
-}
-
-template<class OBJ, class PREC>
-std::unique_ptr<StaticOctree<OBJ, PREC>>
-DynamicOctree<OBJ, PREC>::rebuildAndSort(OBJ*& sortedObjects)
-{
-    OBJ* firstObject = sortedObjects;
-
-    if (m_objects != nullptr)
-    {
-        for (OBJ* obj : *m_objects)
-        {
-            *sortedObjects = std::move(*obj);
-            ++sortedObjects;
-        }
-    }
-
-    auto nObjects = static_cast<std::uint32_t>(sortedObjects - firstObject);
-    auto staticNode = std::make_unique<StaticOctree<OBJ, PREC>>(m_cellCenterPos, m_exclusionFactor, firstObject, nObjects);
-
-    if (m_children != nullptr)
-    {
-        staticNode->m_children = std::make_unique<typename StaticOctree<OBJ, PREC>::ChildrenType>();
-
-        for (int i = 0; i < 8; ++i)
-            (*staticNode->m_children)[i] = (*m_children)[i]->rebuildAndSort(sortedObjects);
-    }
-
-    return staticNode;
 }

--- a/src/celengine/octreebuilder.h
+++ b/src/celengine/octreebuilder.h
@@ -1,0 +1,198 @@
+// octreebuilder.h
+//
+// Octree-based visibility determination for objects.
+//
+// Copyright (C) 2001-2024, Celestia Development Team
+//
+// Split from octree.h:
+// Original version by Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include "octree.h"
+
+constexpr inline unsigned int OctreeXPos = 1;
+constexpr inline unsigned int OctreeYPos = 2;
+constexpr inline unsigned int OctreeZPos = 4;
+
+// The DynamicOctree is built first by inserting objects from a database or
+// catalog and is then 'compiled' into a StaticOctree. In the process of
+// building the StaticOctree, the original object database is reorganized,
+// with objects in the same octree node all placed adjacent to each other.
+// This spatial sorting of the objects dramatically improves the performance
+// of octree operations through much more coherent memory access.
+template<class OBJ, class PREC>
+class DynamicOctree
+{
+public:
+    using PointType = Eigen::Matrix<PREC, 3, 1>;
+
+    DynamicOctree(const PointType& cellCenterPos,
+                  float exclusionFactor);
+
+    void insertObject(OBJ&, const PREC);
+    std::unique_ptr<StaticOctree<OBJ, PREC>> rebuildAndSort(OBJ*&);
+
+private:
+    using ObjectList = std::vector<OBJ*>;
+    using ChildrenType = std::array<std::unique_ptr<DynamicOctree>, 8>;
+
+    static const unsigned int SPLIT_THRESHOLD;
+
+    static bool exceedsBrightnessThreshold(const OBJ&, float);
+    static bool isStraddling(const PointType&, const OBJ&);
+    static float applyDecay(float);
+
+    void           add(OBJ&);
+    void           split(const PREC);
+    void           sortIntoChildNodes();
+    DynamicOctree* getChild(const OBJ&, const PointType&) const;
+
+    std::unique_ptr<ChildrenType> m_children;
+    PointType m_cellCenterPos;
+    float m_exclusionFactor;
+    std::unique_ptr<ObjectList> m_objects;
+};
+
+// The SPLIT_THRESHOLD is the number of objects a node must contain before its
+// children are generated. Increasing this number will decrease the number of
+// octree nodes in the tree, which will use less memory but make culling less
+// efficient.
+template<class OBJ, class PREC>
+DynamicOctree<OBJ, PREC>::DynamicOctree(const PointType& cellCenterPos,
+                                        float exclusionFactor):
+    m_cellCenterPos(cellCenterPos),
+    m_exclusionFactor(exclusionFactor)
+{
+}
+
+template<class OBJ, class PREC>
+void
+DynamicOctree<OBJ, PREC>::insertObject(OBJ& obj, const PREC scale)
+{
+    // If the object can't be placed into this node's children, then put it here:
+    if (exceedsBrightnessThreshold(obj, m_exclusionFactor) || isStraddling(m_cellCenterPos, obj))
+    {
+        add(obj);
+        return;
+    }
+
+    // If we haven't allocated child nodes yet, try to fit
+    // the object in this node, even though it could be put
+    // in a child. Only if there are more than SPLIT_THRESHOLD
+    // objects in the node will we attempt to place the
+    // object into a child node.  This is done in order
+    // to avoid having the octree degenerate into one object
+    // per node.
+    if (m_children == nullptr)
+    {
+        if (m_objects == nullptr || m_objects->size() < SPLIT_THRESHOLD)
+        {
+            add(obj);
+            return;
+        }
+
+        split(scale * 0.5f);
+    }
+
+    // We've already allocated child nodes; place the object
+    // into the appropriate one.
+    getChild(obj, m_cellCenterPos)->insertObject(obj, scale * PREC(0.5));
+}
+
+template<class OBJ, class PREC>
+void
+DynamicOctree<OBJ, PREC>::add(OBJ& obj)
+{
+    if (m_objects == nullptr)
+        m_objects = std::make_unique<ObjectList>();
+
+    m_objects->push_back(&obj);
+}
+
+template<class OBJ, class PREC>
+void
+DynamicOctree<OBJ, PREC>::split(const PREC scale)
+{
+    m_children = std::make_unique<ChildrenType>();
+    for (unsigned int i = 0U; i < 8U; ++i)
+    {
+        PointType centerPos = m_cellCenterPos
+                            + PointType(((i & OctreeXPos) != 0U) ? scale : -scale,
+                                        ((i & OctreeYPos) != 0U) ? scale : -scale,
+                                        ((i & OctreeZPos) != 0U) ? scale : -scale);
+
+        (*m_children)[i] = std::make_unique<DynamicOctree>(centerPos, applyDecay(m_exclusionFactor));
+    }
+
+    sortIntoChildNodes();
+}
+
+// Sort this node's objects into objects that can remain here,
+// and objects that should be placed into one of the eight
+// child nodes.
+template<class OBJ, class PREC>
+void
+DynamicOctree<OBJ, PREC>::sortIntoChildNodes()
+{
+    auto writeIt = m_objects->begin();
+    auto endIt = m_objects->end();
+
+    for (auto readIt = writeIt; readIt != endIt; ++readIt)
+    {
+        OBJ& obj = **readIt;
+        if (exceedsBrightnessThreshold(obj, m_exclusionFactor) || isStraddling(m_cellCenterPos, obj))
+        {
+            *writeIt = *readIt;
+            ++writeIt;
+        }
+        else
+        {
+            getChild(obj, m_cellCenterPos)->add(obj);
+        }
+    }
+
+    m_objects->erase(writeIt, endIt);
+}
+
+template<class OBJ, class PREC>
+std::unique_ptr<StaticOctree<OBJ, PREC>>
+DynamicOctree<OBJ, PREC>::rebuildAndSort(OBJ*& sortedObjects)
+{
+    OBJ* firstObject = sortedObjects;
+
+    if (m_objects != nullptr)
+    {
+        for (OBJ* obj : *m_objects)
+        {
+            *sortedObjects = std::move(*obj);
+            ++sortedObjects;
+        }
+    }
+
+    auto nObjects = static_cast<std::uint32_t>(sortedObjects - firstObject);
+    auto staticNode = std::make_unique<StaticOctree<OBJ, PREC>>(m_cellCenterPos, m_exclusionFactor, firstObject, nObjects);
+
+    if (m_children != nullptr)
+    {
+        staticNode->m_children = std::make_unique<typename StaticOctree<OBJ, PREC>::ChildrenType>();
+
+        for (unsigned int i = 0U; i < 8U; ++i)
+            (*staticNode->m_children)[i] = (*m_children)[i]->rebuildAndSort(sortedObjects);
+    }
+
+    return staticNode;
+}

--- a/src/celengine/staroctree.cpp
+++ b/src/celengine/staroctree.cpp
@@ -33,52 +33,6 @@ constexpr float MAX_STAR_ORBIT_RADIUS = 1.0f;
 
 } // end unnamed namespace
 
-// The octree node into which a star is placed is dependent on two properties:
-// its obsPosition and its luminosity--the fainter the star, the deeper the node
-// in which it will reside.  Each node stores an absolute magnitude; no child
-// of the node is allowed contain a star brighter than this value, making it
-// possible to determine quickly whether or not to cull subtrees.
-template<>
-bool
-DynamicStarOctree::exceedsBrightnessThreshold(const Star& star, float absMag)
-{
-    return star.getAbsoluteMagnitude() <= absMag;
-}
-
-template<>
-bool
-DynamicStarOctree::isStraddling(const Eigen::Vector3f& cellCenterPos, const Star& star)
-{
-    //checks if this star's orbit straddles child nodes
-    float orbitalRadius    = star.getOrbitalRadius();
-    if (orbitalRadius == 0.0f)
-        return false;
-
-    Eigen::Vector3f starPos    = star.getPosition();
-    return (starPos - cellCenterPos).cwiseAbs().minCoeff() < orbitalRadius;
-}
-
-template<>
-float
-DynamicStarOctree::applyDecay(float excludingFactor)
-{
-    return astro::lumToAbsMag(astro::absMagToLum(excludingFactor) / 4.0f);
-}
-
-template<>
-DynamicStarOctree*
-DynamicStarOctree::getChild(const Star& obj, const Eigen::Vector3f& cellCenterPos) const
-{
-    Eigen::Vector3f objPos = obj.getPosition();
-
-    int child = 0;
-    child |= objPos.x() < cellCenterPos.x() ? 0 : XPos;
-    child |= objPos.y() < cellCenterPos.y() ? 0 : YPos;
-    child |= objPos.z() < cellCenterPos.z() ? 0 : ZPos;
-
-    return (*m_children)[child].get();
-}
-
 // total specialization of the StaticOctree template process*() methods for stars:
 template<>
 void

--- a/src/celengine/staroctree.h
+++ b/src/celengine/staroctree.h
@@ -17,27 +17,8 @@
 #include <celengine/star.h>
 #include <celengine/octree.h>
 
-using DynamicStarOctree = DynamicOctree<Star, float>;
 using StarOctree = StaticOctree<Star, float>;
 using StarHandler = OctreeProcessor<Star, float>;
-
-// In testing, changing SPLIT_THRESHOLD from 100 to 50 nearly
-// doubled the number of nodes in the tree, but provided only between a
-// 0 to 5 percent frame rate improvement.
-template<>
-const inline std::uint32_t DynamicStarOctree::SPLIT_THRESHOLD = 75;
-
-template<>
-bool DynamicStarOctree::exceedsBrightnessThreshold(const Star&, float);
-
-template<>
-bool DynamicStarOctree::isStraddling(const Eigen::Vector3f&, const Star&);
-
-template<>
-float DynamicStarOctree::applyDecay(float excludingFactor);
-
-template<>
-DynamicStarOctree* DynamicStarOctree::getChild(const Star&, const Eigen::Vector3f&) const;
 
 template<>
 void StarOctree::processVisibleObjects(StarHandler&,

--- a/src/celestia/loaddso.cpp
+++ b/src/celestia/loaddso.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 
 #include <celengine/dsodb.h>
+#include <celengine/dsodbbuilder.h>
 #include <celestia/catalogloader.h>
 #include <celestia/configfile.h>
 #include <celestia/progressnotifier.h>
@@ -20,13 +21,12 @@
 
 namespace celestia
 {
-using DeepSkyLoader = CatalogLoader<DSODatabase>;
+using DeepSkyLoader = CatalogLoader<DSODatabaseBuilder>;
 
 std::unique_ptr<DSODatabase>
 loadDSO(const CelestiaConfig &config, ProgressNotifier *progressNotifier)
 {
-    auto dsoDB = std::make_unique<DSODatabase>();
-    dsoDB->setNameDatabase(std::make_unique<NameDatabase>());
+    auto dsoDB = std::make_unique<DSODatabaseBuilder>();
 
     // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
     const char *typeDesc = C_("catalog", "deep sky");
@@ -46,8 +46,7 @@ loadDSO(const CelestiaConfig &config, ProgressNotifier *progressNotifier)
     // Next, read all the deep sky files in the extras directories
     loader.loadExtras(config.paths.extrasDirs);
 
-    dsoDB->finish();
-    return dsoDB;
+    return dsoDB->finish();
 }
 
 } // namespace celestia


### PR DESCRIPTION
Reduces the amount of code pulled in by including the octree files. This will make later changes to the octree structure easier to contain.