### PR TITLE
Linearize octree node storage

### DIFF
--- a/src/celastro/astro.h
+++ b/src/celastro/astro.h
@@ -76,10 +76,18 @@ float appMagToLum(float mag, float lyrs);
 
 template<class T>
 CELESTIA_CMATH_CONSTEXPR T
+distanceModulus(T lyrs)
+{
+    using std::log10;
+    return T(5) * log10(lyrs / LY_PER_PARSEC<T>) - T(5);
+}
+
+template<class T>
+CELESTIA_CMATH_CONSTEXPR T
 absToAppMag(T absMag, T lyrs)
 {
     using std::log10;
-    return absMag - T(5) + T(5) * log10(lyrs / LY_PER_PARSEC<T>);
+    return absMag + distanceModulus(lyrs);
 }
 
 template<class T>
@@ -87,7 +95,7 @@ CELESTIA_CMATH_CONSTEXPR T
 appToAbsMag(T appMag, T lyrs)
 {
     using std::log10;
-    return appMag + T(5) - T(5) * log10(lyrs / LY_PER_PARSEC<T>);
+    return appMag - distanceModulus(lyrs);
 }
 
 // Distance conversions

--- a/src/celengine/dsodb.cpp
+++ b/src/celengine/dsodb.cpp
@@ -19,12 +19,14 @@
 #include <celutil/logger.h>
 #include "name.h"
 
+namespace engine = celestia::engine;
+
 using celestia::util::GetLogger;
 
 DSODatabase::~DSODatabase() = default;
 
 DSODatabase::DSODatabase(std::vector<std::unique_ptr<DeepSkyObject>>&& DSOs,
-                         std::unique_ptr<DSOOctree>&& octreeRoot,
+                         std::unique_ptr<engine::DSOOctree>&& octreeRoot,
                          std::unique_ptr<NameDatabase>&& namesDB,
                          std::vector<std::uint32_t>&& catalogNumberIndex,
                          float avgAbsMag) :
@@ -116,7 +118,7 @@ DSODatabase::getDSONameList(const DeepSkyObject* dso, const unsigned int maxName
 }
 
 void
-DSODatabase::findVisibleDSOs(DSOHandler& dsoHandler,
+DSODatabase::findVisibleDSOs(engine::DSOHandler& dsoHandler,
                              const Eigen::Vector3d& obsPos,
                              const Eigen::Quaternionf& obsOrient,
                              float fovY,
@@ -152,7 +154,7 @@ DSODatabase::findVisibleDSOs(DSOHandler& dsoHandler,
 }
 
 void
-DSODatabase::findCloseDSOs(DSOHandler& dsoHandler,
+DSODatabase::findCloseDSOs(engine::DSOHandler& dsoHandler,
                            const Eigen::Vector3d& obsPos,
                            float radius) const
 {

--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -36,8 +36,7 @@ constexpr inline float DSO_OCTREE_ROOT_SIZE = 1.0e11f;
 class DSODatabase
 {
 public:
-    DSODatabase(std::vector<std::unique_ptr<DeepSkyObject>>&&,
-                std::unique_ptr<celestia::engine::DSOOctree>&&,
+    DSODatabase(std::unique_ptr<celestia::engine::DSOOctree>&&,
                 std::unique_ptr<NameDatabase>&&,
                 std::vector<std::uint32_t>&&,
                 float);
@@ -69,7 +68,6 @@ public:
     float getAverageAbsoluteMagnitude() const;
 
 private:
-    std::vector<std::unique_ptr<DeepSkyObject>> m_DSOs;
     std::unique_ptr<celestia::engine::DSOOctree> m_octreeRoot;
     std::unique_ptr<NameDatabase> m_namesDB;
     std::vector<std::uint32_t> m_catalogNumberIndex;
@@ -82,13 +80,13 @@ private:
 inline DeepSkyObject*
 DSODatabase::getDSO(const std::uint32_t n) const
 {
-    return m_DSOs[n].get();
+    return (*m_octreeRoot)[n].get();
 }
 
 inline std::uint32_t
 DSODatabase::size() const
 {
-    return static_cast<std::uint32_t>(m_DSOs.size());
+    return m_octreeRoot->size();
 }
 
 inline float

--- a/src/celengine/dsodb.h
+++ b/src/celengine/dsodb.h
@@ -37,7 +37,7 @@ class DSODatabase
 {
 public:
     DSODatabase(std::vector<std::unique_ptr<DeepSkyObject>>&&,
-                std::unique_ptr<DSOOctree>&&,
+                std::unique_ptr<celestia::engine::DSOOctree>&&,
                 std::unique_ptr<NameDatabase>&&,
                 std::vector<std::uint32_t>&&,
                 float);
@@ -52,14 +52,14 @@ public:
 
     void getCompletion(std::vector<std::string>&, std::string_view) const;
 
-    void findVisibleDSOs(DSOHandler& dsoHandler,
+    void findVisibleDSOs(celestia::engine::DSOHandler& dsoHandler,
                          const Eigen::Vector3d& obsPosition,
                          const Eigen::Quaternionf& obsOrientation,
                          float fovY,
                          float aspectRatio,
                          float limitingMag) const;
 
-    void findCloseDSOs(DSOHandler& dsoHandler,
+    void findCloseDSOs(celestia::engine::DSOHandler& dsoHandler,
                        const Eigen::Vector3d& obsPosition,
                        float radius) const;
 
@@ -70,7 +70,7 @@ public:
 
 private:
     std::vector<std::unique_ptr<DeepSkyObject>> m_DSOs;
-    std::unique_ptr<DSOOctree> m_octreeRoot;
+    std::unique_ptr<celestia::engine::DSOOctree> m_octreeRoot;
     std::unique_ptr<NameDatabase> m_namesDB;
     std::vector<std::uint32_t> m_catalogNumberIndex;
 

--- a/src/celengine/dsodbbuilder.cpp
+++ b/src/celengine/dsodbbuilder.cpp
@@ -39,8 +39,9 @@
 #include "value.h"
 
 namespace astro = celestia::astro;
+namespace engine = celestia::engine;
 
-using DynamicDSOOctree = DynamicOctree<std::unique_ptr<DeepSkyObject>, double>;
+using DynamicDSOOctree = engine::DynamicOctree<std::unique_ptr<DeepSkyObject>, double>;
 
 using celestia::util::GetLogger;
 
@@ -156,7 +157,7 @@ addName(NameDatabase* namesDB, AstroCatalog::IndexNumber objCatalogNumber, std::
     }
 }
 
-std::unique_ptr<DSOOctree>
+std::unique_ptr<engine::DSOOctree>
 buildOctree(std::vector<std::unique_ptr<DeepSkyObject>>& DSOs)
 {
     GetLogger()->debug("Sorting DSOs into octree . . .\n");

--- a/src/celengine/dsooctree.cpp
+++ b/src/celengine/dsooctree.cpp
@@ -15,8 +15,8 @@
 #include <celastro/astro.h>
 #include <celcompat/numbers.h>
 
-namespace astro = celestia::astro;
-namespace numbers = celestia::numbers;
+namespace celestia::engine
+{
 
 // total specialization of the StaticOctree template process*() methods for DSOs:
 template<>
@@ -124,3 +124,5 @@ DSOOctree::processCloseObjects(DSOHandler& processor,
         }
     }
 }
+
+} // end namespace celestia::engine

--- a/src/celengine/dsooctree.cpp
+++ b/src/celengine/dsooctree.cpp
@@ -14,114 +14,99 @@
 
 #include <celastro/astro.h>
 #include <celcompat/numbers.h>
+#include <celmath/mathlib.h>
 
 namespace celestia::engine
 {
 
-// total specialization of the StaticOctree template process*() methods for DSOs:
-template<>
-void
-DSOOctree::processVisibleObjects(DSOHandler& processor,
-                                 const PointType& obsPosition,
-                                 const PlaneType* frustumPlanes,
-                                 float limitingFactor,
-                                 double scale) const
-{
-    // See if this node lies within the view frustum
+// The version of cppcheck used by Codacy doesn't seem to detect the field initializer
 
+DSOOctreeVisibleObjectsProcessor::DSOOctreeVisibleObjectsProcessor(DSOHandler* dsoHandler, // cppcheck-suppress uninitMemberVar
+                                                                   const DSOOctree::PointType& obsPosition,
+                                                                   util::array_view<PlaneType> frustumPlanes,
+                                                                   float limitingFactor) :
+    m_dsoHandler(dsoHandler),
+    m_obsPosition(obsPosition),
+    m_frustumPlanes(frustumPlanes),
+    m_limitingFactor(limitingFactor)
+{
+}
+
+bool
+DSOOctreeVisibleObjectsProcessor::checkNode(const DSOOctree::PointType& center,
+                                            double size,
+                                            float factor)
+{
     // Test the cubic octree node against each one of the five
     // planes that define the infinite view frustum.
     for (unsigned int i = 0; i < 5; ++i)
     {
-        const PlaneType& plane = frustumPlanes[i];
+        const PlaneType& plane = m_frustumPlanes[i];
 
-        double r = scale * plane.normal().cwiseAbs().sum();
-        if (plane.signedDistance(m_cellCenterPos) < -r)
-            return;
+        double r = size * plane.normal().cwiseAbs().sum();
+        if (plane.signedDistance(center) < -r)
+            return false;
     }
 
     // Compute the distance to node; this is equal to the distance to
     // the cellCenterPos of the node minus the boundingRadius of the node, scale * SQRT3.
-    double minDistance = (obsPosition - m_cellCenterPos).norm() - scale * numbers::sqrt3;
+    double minDistance = (m_obsPosition - center).norm() - size * numbers::sqrt3;
 
-    // Process the objects in this node
-    double dimmest = minDistance > 0.0 ? astro::appToAbsMag((double) limitingFactor, minDistance) : 1000.0;
+    // Check whether the brightest object in this node is bright enough to render
+    auto distanceModulus = static_cast<float>(astro::distanceModulus(minDistance));
+    if (minDistance > 0.0 && (factor + distanceModulus) > m_limitingFactor)
+        return false;
 
-    for (std::uint32_t i = 0; i < m_nObjects; ++i)
-    {
-        const auto& obj = m_firstObject[i];
-        float absMag = obj->getAbsoluteMagnitude();
-        if (absMag < dimmest)
-        {
-            double distance = (obsPosition - obj->getPosition()).norm() - obj->getBoundingSphereRadius();
-            auto appMag = static_cast<float>((distance >= 32.6167) ? astro::absToAppMag(static_cast<double>(absMag), distance) : absMag);
+    // Dimmest absolute magnitude to process
+    m_dimmest = minDistance > 0.0 ? (m_limitingFactor - distanceModulus) : 1000.0;
 
-            if (appMag < limitingFactor)
-                processor.process(obj, distance, absMag);
-        }
-    }
-
-    // See if any of the objects in child nodes are potentially included
-    // that we need to recurse deeper.
-    if (m_children != nullptr &&
-        (minDistance <= 0.0 || astro::absToAppMag(static_cast<double>(m_exclusionFactor), minDistance) <= limitingFactor))
-    {
-        // Recurse into the child nodes
-        for (int i = 0; i < 8; ++i)
-        {
-            (*m_children)[i]->processVisibleObjects(processor,
-                                                    obsPosition,
-                                                    frustumPlanes,
-                                                    limitingFactor,
-                                                    scale * 0.5f);
-        }
-    }
+    return true;
 }
 
-template<>
 void
-DSOOctree::processCloseObjects(DSOHandler& processor,
-                               const PointType& obsPosition,
-                               double boundingRadius,
-                               double scale) const
+DSOOctreeVisibleObjectsProcessor::process(const std::unique_ptr<DeepSkyObject>& obj) const //NOSONAR
+{
+    float absMag = obj->getAbsoluteMagnitude();
+    if (absMag > m_dimmest)
+        return;
+
+    double distance = (m_obsPosition - obj->getPosition()).norm() - obj->getBoundingSphereRadius();
+    auto appMag = static_cast<float>((distance >= 32.6167) ? astro::absToAppMag(static_cast<double>(absMag), distance) : absMag);
+
+    if (appMag <= m_limitingFactor)
+        m_dsoHandler->process(obj, distance, absMag);
+}
+
+DSOOctreeCloseObjectsProcessor::DSOOctreeCloseObjectsProcessor(DSOHandler* dsoHandler,
+                                                               const DSOOctree::PointType& obsPosition,
+                                                               double boundingRadius) :
+    m_dsoHandler(dsoHandler),
+    m_obsPosition(obsPosition),
+    m_boundingRadius(boundingRadius),
+    m_radiusSquared(math::square(boundingRadius))
+{
+}
+
+bool
+DSOOctreeCloseObjectsProcessor::checkNode(const DSOOctree::PointType& center,
+                                          double size,
+                                          float /* factor */) const
 {
     // Compute the distance to node; this is equal to the distance to
     // the cellCenterPos of the node minus the boundingRadius of the node, scale * SQRT3.
-    double nodeDistance = (obsPosition - m_cellCenterPos).norm() - scale * numbers::sqrt3;
+    double nodeDistance = (m_obsPosition - center).norm() - size * numbers::sqrt3;
+    return nodeDistance <= m_boundingRadius;
+}
 
-    if (nodeDistance > boundingRadius)
-        return;
-
-    // At this point, we've determined that the cellCenterPos of the node is
-    // close enough that we must check individual objects for proximity.
-
-    // Compute distance squared to avoid having to sqrt for distance
-    // comparison.
-    double radiusSquared = boundingRadius * boundingRadius;
-
-    // Check all the objects in the node.
-    for (std::uint32_t i = 0; i < m_nObjects; ++i)
+void
+DSOOctreeCloseObjectsProcessor::process(const std::unique_ptr<DeepSkyObject>& obj) const //NOSONAR
+{
+    Eigen::Vector3d offset = m_obsPosition - obj->getPosition();
+    if (offset.squaredNorm() < m_radiusSquared)
     {
-        const auto& obj = m_firstObject[i];
-        PointType offset = obsPosition - obj->getPosition();
-        if (offset.squaredNorm() < radiusSquared)
-        {
-            float  absMag   = obj->getAbsoluteMagnitude();
-            double distance = offset.norm() - obj->getBoundingSphereRadius();
-            processor.process(obj, distance, absMag);
-        }
-    }
-
-    // Recurse into the child nodes
-    if (m_children != nullptr)
-    {
-        for (int i = 0; i < 8; ++i)
-        {
-            (*m_children)[i]->processCloseObjects(processor,
-                                                  obsPosition,
-                                                  boundingRadius,
-                                                  scale * 0.5f);
-        }
+        float  absMag   = obj->getAbsoluteMagnitude();
+        double distance = offset.norm() - obj->getBoundingSphereRadius();
+        m_dsoHandler->process(obj, distance, absMag);
     }
 }
 

--- a/src/celengine/dsooctree.h
+++ b/src/celengine/dsooctree.h
@@ -18,6 +18,9 @@
 #include "deepskyobj.h"
 #include "octree.h"
 
+namespace celestia::engine
+{
+
 using DSOOctree = StaticOctree<std::unique_ptr<DeepSkyObject>, double>;
 using DSOHandler = OctreeProcessor<std::unique_ptr<DeepSkyObject>, double>;
 
@@ -33,3 +36,5 @@ void DSOOctree::processCloseObjects(DSOHandler&,
                                     const PointType&,
                                     double,
                                     double) const;
+
+} // end namespace celestia::engine

--- a/src/celengine/dsooctree.h
+++ b/src/celengine/dsooctree.h
@@ -15,6 +15,9 @@
 #include <cstdint>
 #include <memory>
 
+#include <Eigen/Geometry>
+
+#include <celutil/array_view.h>
 #include "deepskyobj.h"
 #include "octree.h"
 
@@ -24,17 +27,50 @@ namespace celestia::engine
 using DSOOctree = StaticOctree<std::unique_ptr<DeepSkyObject>, double>;
 using DSOHandler = OctreeProcessor<std::unique_ptr<DeepSkyObject>, double>;
 
-template<>
-void DSOOctree::processVisibleObjects(DSOHandler&,
-                                      const PointType&,
-                                      const PlaneType*,
-                                      float,
-                                      double) const;
+// This class searches the octree for objects that are likely to be visible
+// to a viewer with the specified obsPosition and limitingFactor.  The
+// octreeProcessor is invoked for each potentially visible object --no object with
+// a property greater than limitingFactor will be processed, but
+// objects that are outside the view frustum may be.  Frustum tests are performed
+// only at the node level to optimize the octree traversal, so an exact test
+// (if one is required) is the responsibility of the callback method.
+class DSOOctreeVisibleObjectsProcessor
+{
+public:
+    using PlaneType = Eigen::Hyperplane<double, 3>;
 
-template<>
-void DSOOctree::processCloseObjects(DSOHandler&,
-                                    const PointType&,
-                                    double,
-                                    double) const;
+    DSOOctreeVisibleObjectsProcessor(DSOHandler*,
+                                     const DSOOctree::PointType&,
+                                     util::array_view<PlaneType>,
+                                     float);
+
+    bool checkNode(const DSOOctree::PointType&, double, float);
+    void process(const std::unique_ptr<DeepSkyObject>&) const; //NOSONAR
+
+private:
+    DSOHandler* m_dsoHandler;
+    DSOOctree::PointType m_obsPosition;
+    util::array_view<PlaneType> m_frustumPlanes;
+    float m_limitingFactor;
+
+    float m_dimmest{ 1000.0f };
+};
+
+class DSOOctreeCloseObjectsProcessor
+{
+public:
+    DSOOctreeCloseObjectsProcessor(DSOHandler*,
+                                   const DSOOctree::PointType&,
+                                   double);
+
+    bool checkNode(const DSOOctree::PointType&, double, float) const;
+    void process(const std::unique_ptr<DeepSkyObject>&) const; //NOSONAR
+
+private:
+    DSOHandler* m_dsoHandler;
+    DSOOctree::PointType m_obsPosition;
+    double m_boundingRadius;
+    double m_radiusSquared;
+};
 
 } // end namespace celestia::engine

--- a/src/celengine/objectrenderer.h
+++ b/src/celengine/objectrenderer.h
@@ -18,7 +18,7 @@ class Observer;
 class Renderer;
 
 template<class OBJ, class PREC>
-class ObjectRenderer : public OctreeProcessor<OBJ, PREC>
+class ObjectRenderer : public celestia::engine::OctreeProcessor<OBJ, PREC>
 {
 public:
     const Observer* observer    { nullptr };

--- a/src/celengine/octree.h
+++ b/src/celengine/octree.h
@@ -19,6 +19,9 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+namespace celestia::engine
+{
+
 // The StaticOctree template arguments are:
 // OBJ:  object hanging from the node,
 // PREC: floating point precision of the culling operations at node level.
@@ -128,3 +131,5 @@ StaticOctree<OBJ, PREC>::countObjects() const
 
     return count;
 }
+
+} // end namespace celestia::engine

--- a/src/celengine/octree.h
+++ b/src/celengine/octree.h
@@ -25,6 +25,7 @@ namespace celestia::engine
 
 using OctreeNodeIndex = std::uint32_t;
 using OctreeObjectIndex = std::uint32_t;
+using OctreeDepthType = std::uint32_t;
 
 constexpr inline OctreeNodeIndex InvalidOctreeNode = UINT32_MAX;
 
@@ -67,7 +68,7 @@ protected:
     OctreeProcessor() = default;
 };
 
-template<class OBJ, class PREC>
+template<class TRAITS, class STORAGE>
 class DynamicOctree;
 
 // The StaticOctree template arguments are:
@@ -106,7 +107,8 @@ private:
     std::vector<NodeType> m_nodes;
     std::vector<OBJ> m_objects;
 
-    friend class DynamicOctree<OBJ, PREC>;
+    template<class TRAITS, class STORAGE>
+    friend class DynamicOctree;
 };
 
 template<class OBJ, class PREC>

--- a/src/celengine/octreebuilder.h
+++ b/src/celengine/octreebuilder.h
@@ -24,6 +24,9 @@
 
 #include "octree.h"
 
+namespace celestia::engine
+{
+
 constexpr inline unsigned int OctreeXPos = 1;
 constexpr inline unsigned int OctreeYPos = 2;
 constexpr inline unsigned int OctreeZPos = 4;
@@ -196,3 +199,5 @@ DynamicOctree<OBJ, PREC>::rebuildAndSort(OBJ*& sortedObjects)
 
     return staticNode;
 }
+
+} // end namespace celestia::engine

--- a/src/celengine/octreebuilder.h
+++ b/src/celengine/octreebuilder.h
@@ -16,22 +16,52 @@
 
 #include <algorithm>
 #include <array>
-#include <cstdint>
+#include <cassert>
 #include <memory>
-#include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include <Eigen/Core>
 
+#include <celutil/blockarray.h>
 #include "octree.h"
 
 namespace celestia::engine
 {
 
-constexpr inline unsigned int OctreeXPos = 1;
-constexpr inline unsigned int OctreeYPos = 2;
-constexpr inline unsigned int OctreeZPos = 4;
+namespace detail
+{
+
+template<class PREC>
+struct DynamicOctreeNode
+{
+    using PointType = Eigen::Matrix<PREC, 3, 1>;
+    using ChildrenType = std::array<OctreeNodeIndex, 8>;
+
+    explicit DynamicOctreeNode(const PointType&);
+
+    bool isStraddling(const PointType&, PREC);
+
+    PointType center;
+    std::vector<OctreeObjectIndex> objIndices;
+    std::unique_ptr<ChildrenType> children;
+};
+
+template<class PREC>
+DynamicOctreeNode<PREC>::DynamicOctreeNode(const PointType& _center) :
+    center(_center)
+{
+}
+
+template<class PREC>
+bool
+DynamicOctreeNode<PREC>::isStraddling(const PointType& pos, PREC radius)
+{
+    return radius > PREC(0) && (pos - center).cwiseAbs().minCoeff() < radius;
+}
+
+} // end namespace celestia::engine::detail
 
 // The DynamicOctree is built first by inserting objects from a database or
 // catalog and is then 'compiled' into a StaticOctree. In the process of
@@ -39,62 +69,97 @@ constexpr inline unsigned int OctreeZPos = 4;
 // with objects in the same octree node all placed adjacent to each other.
 // This spatial sorting of the objects dramatically improves the performance
 // of octree operations through much more coherent memory access.
-template<class OBJ, class PREC>
+
+template<class TRAITS, class STORAGE>
 class DynamicOctree
 {
 public:
-    using PointType = Eigen::Matrix<PREC, 3, 1>;
+    using StorageType = STORAGE;
+    using ObjectType = typename TRAITS::ObjectType;
+    using PrecisionType = typename TRAITS::PrecisionType;
+    using PointType = Eigen::Matrix<PrecisionType, 3, 1>;
+    using StaticOctreeType = StaticOctree<ObjectType, PrecisionType>;
 
-    DynamicOctree(const PointType& cellCenterPos,
-                  float exclusionFactor);
+    static_assert(std::is_same_v<decltype(std::declval<StorageType>()[std::declval<OctreeObjectIndex>()]), ObjectType&>, "Incorrect element type in STORAGE");
+    static_assert(std::is_same_v<decltype(TRAITS::getPosition(std::declval<ObjectType>())), PointType>, "Incorrect return type for TRAITS::getPosition");
+    static_assert(std::is_same_v<decltype(TRAITS::getRadius(std::declval<ObjectType>())), PrecisionType>, "Incorrect return type for TRAITS::getRadius");
 
-    void insertObject(OBJ&, PREC);
-    std::unique_ptr<StaticOctree<OBJ, PREC>> rebuildAndSort(PREC, OctreeObjectIndex) const;
+    DynamicOctree(STORAGE&& objects,
+                  const PointType& rootCenter,
+                  PrecisionType rootSize,
+                  float rootExclusionFactor,
+                  OctreeObjectIndex splitThreshold);
+
+    DynamicOctree(const DynamicOctree&) = delete;
+    DynamicOctree& operator=(const DynamicOctree&) = delete;
+    DynamicOctree(DynamicOctree&&) noexcept = default;
+    DynamicOctree& operator=(DynamicOctree&&) noexcept = default;
+
+    std::unique_ptr<StaticOctreeType> build();
 
 private:
-    using ObjectList = std::vector<OBJ*>;
-    using ChildrenType = std::array<std::unique_ptr<DynamicOctree>, 8>;
+    using NodeType = detail::DynamicOctreeNode<PrecisionType>;
 
-    static const unsigned int SPLIT_THRESHOLD;
+    void insertObject(OctreeObjectIndex);
+    void splitNode(NodeType&, OctreeDepthType);
+    OctreeNodeIndex getChild(NodeType&, OctreeDepthType, const PointType&);
+    void buildNode(StaticOctreeType&,
+                   const NodeType&,
+                   OctreeDepthType,
+                   std::vector<OctreeNodeIndex>&);
 
-    static float        getMagnitude(const OBJ&);
-    static bool         isStraddling(const PointType&, const OBJ&);
-    static float        applyDecay(float);
-    static unsigned int getChildIndex(const OBJ&, const PointType&);
-
-    void           add(OBJ&);
-    void           split(PREC);
-    DynamicOctree* getChild(const OBJ&, PREC);
-
-    OctreeNodeIndex countNodes() const;
-
-    std::unique_ptr<ChildrenType> m_children;
-    PointType m_cellCenterPos;
-    float m_exclusionFactor;
-    std::unique_ptr<ObjectList> m_objects;
+    BlockArray<NodeType> m_nodes;
+    STORAGE m_objects;
+    std::vector<PrecisionType> m_sizes;
+    std::vector<float> m_factors;
+    std::vector<OctreeObjectIndex> m_excluded;
+    OctreeObjectIndex m_splitThreshold;
 };
 
-// The SPLIT_THRESHOLD is the number of objects a node must contain before its
-// children are generated. Increasing this number will decrease the number of
-// octree nodes in the tree, which will use less memory but make culling less
-// efficient.
-template<class OBJ, class PREC>
-DynamicOctree<OBJ, PREC>::DynamicOctree(const PointType& cellCenterPos,
-                                        float exclusionFactor):
-    m_cellCenterPos(cellCenterPos),
-    m_exclusionFactor(exclusionFactor)
+template<class TRAITS, class STORAGE>
+DynamicOctree<TRAITS, STORAGE>::DynamicOctree(STORAGE&& objects,
+                                              const PointType& rootCenter,
+                                              PrecisionType rootSize,
+                                              float rootExclusionFactor,
+                                              OctreeObjectIndex splitThreshold) :
+    m_objects(std::move(objects)),
+    m_splitThreshold(splitThreshold)
 {
+    m_nodes.emplace_back(rootCenter);
+    m_sizes.emplace_back(rootSize);
+    m_factors.emplace_back(rootExclusionFactor);
+
+    for (OctreeObjectIndex i = 0, end = static_cast<OctreeObjectIndex>(m_objects.size()); i < end; ++i)
+    {
+        insertObject(i);
+    }
 }
 
-template<class OBJ, class PREC>
+template<class TRAITS, class STORAGE>
 void
-DynamicOctree<OBJ, PREC>::insertObject(OBJ& obj, PREC scale)
+DynamicOctree<TRAITS, STORAGE>::insertObject(OctreeObjectIndex idx)
 {
-    for (DynamicOctree* node = this;;)
+    const ObjectType& obj = m_objects[idx];
+    PointType pos = TRAITS::getPosition(obj);
+    if ((pos - m_nodes[0].center).cwiseAbs().maxCoeff() > m_sizes[0])
     {
-        if (getMagnitude(obj) <= node->m_exclusionFactor || isStraddling(node->m_cellCenterPos, obj))
+        m_excluded.push_back(idx);
+        return;
+    }
+
+    OctreeNodeIndex nodeIdx = 0;
+    OctreeDepthType depth = 0;
+    for (;;)
+    {
+        NodeType& node = m_nodes[nodeIdx];
+
+        if (m_factors.size() <= depth)
+            m_factors.push_back(TRAITS::applyDecay(m_factors.back()));
+
+        // If the object can't be placed into this node's children, then put it here:
+        if (TRAITS::getMagnitude(obj) <= m_factors[depth] || node.isStraddling(pos, TRAITS::getRadius(obj)))
         {
-            node->add(obj);
+            node.objIndices.push_back(idx);
             return;
         }
 
@@ -105,169 +170,180 @@ DynamicOctree<OBJ, PREC>::insertObject(OBJ& obj, PREC scale)
         // object into a child node.  This is done in order
         // to avoid having the octree degenerate into one object
         // per node.
-
-        scale *= PREC(0.5);
-
-        if (node->m_children == nullptr)
+        if (node.children == nullptr)
         {
-            if (node->m_objects == nullptr || node->m_objects->size() < SPLIT_THRESHOLD)
+            if (node.objIndices.size() < m_splitThreshold)
             {
-                node->add(obj);
+                node.objIndices.push_back(idx);
                 return;
             }
 
-            node->split(scale);
+            splitNode(node, depth);
         }
 
-        node = node->getChild(obj, scale);
+        ++depth;
+        nodeIdx = getChild(node, depth, pos);
     }
 }
 
-template<class OBJ, class PREC>
+template<class TRAITS, class STORAGE>
 void
-DynamicOctree<OBJ, PREC>::add(OBJ& obj)
+DynamicOctree<TRAITS, STORAGE>::splitNode(NodeType& node, OctreeDepthType depth)
 {
-    if (m_objects == nullptr)
-        m_objects = std::make_unique<ObjectList>();
+    assert(node.children == nullptr);
+    node.children = std::make_unique<typename NodeType::ChildrenType>();
+    node.children->fill(InvalidOctreeNode);
 
-    m_objects->push_back(&obj);
-}
-
-template<class OBJ, class PREC>
-void
-DynamicOctree<OBJ, PREC>::split(PREC scale)
-{
-    assert(m_children == nullptr);
-    m_children = std::make_unique<ChildrenType>();
-
-    auto writeIt = m_objects->begin();
-    auto endIt = m_objects->end();
+    auto writeIt = node.objIndices.begin();
+    auto endIt = node.objIndices.end();
 
     for (auto readIt = writeIt; readIt != endIt; ++readIt)
     {
-        OBJ& obj = **readIt;
-        if (getMagnitude(obj) <= m_exclusionFactor || isStraddling(m_cellCenterPos, obj))
+        const ObjectType& obj = m_objects[*readIt];
+        PointType pos = TRAITS::getPosition(obj);
+        if (TRAITS::getMagnitude(obj) <= m_factors[depth] || node.isStraddling(pos, TRAITS::getRadius(obj)))
         {
             *writeIt = *readIt;
             ++writeIt;
         }
         else
         {
-            getChild(obj, scale)->add(obj);
+            NodeType& childNode = m_nodes[getChild(node, depth + 1, pos)];
+            childNode.objIndices.push_back(*readIt);
         }
     }
 
-    m_objects->erase(writeIt, endIt);
-}
-
-template<class OBJ, class PREC>
-DynamicOctree<OBJ, PREC>*
-DynamicOctree<OBJ, PREC>::getChild(const OBJ& obj, PREC scale)
-{
-    assert(m_children != nullptr);
-
-    unsigned int childIndex = getChildIndex(obj, m_cellCenterPos);
-    auto& result = (*m_children)[childIndex];
-    if (result == nullptr)
+    if (writeIt == node.objIndices.begin())
     {
-        PointType centerPos = m_cellCenterPos
-                            + PointType(((childIndex & OctreeXPos) != 0U) ? scale : -scale,
-                                        ((childIndex & OctreeYPos) != 0U) ? scale : -scale,
-                                        ((childIndex & OctreeZPos) != 0U) ? scale : -scale);
-        result = std::make_unique<DynamicOctree>(centerPos, applyDecay(m_exclusionFactor));
+        // No objects retained: release heap allocation
+        node.objIndices = std::vector<OctreeObjectIndex>();
     }
-
-    return result.get();
+    else
+    {
+        node.objIndices.erase(writeIt, endIt);
+    }
 }
 
-template<class OBJ, class PREC>
+template<class TRAITS, class STORAGE>
 OctreeNodeIndex
-DynamicOctree<OBJ, PREC>::countNodes() const
+DynamicOctree<TRAITS, STORAGE>::getChild(NodeType& node, OctreeDepthType depth, const PointType& pos)
 {
-    OctreeNodeIndex result = 0;
+    assert(node.children != nullptr);
 
-    std::vector<const DynamicOctree*> nodeStack;
-    nodeStack.push_back(this);
-    while (!nodeStack.empty())
+    auto childIndex = static_cast<unsigned int>(pos.x() >= node.center.x()) |
+                      (static_cast<unsigned int>(pos.y() >= node.center.y()) << 1U) |
+                      (static_cast<unsigned int>(pos.z() >= node.center.z()) << 2U);
+    OctreeNodeIndex& result = (*node.children)[childIndex];
+    if (result == InvalidOctreeNode)
     {
-        const DynamicOctree* node = nodeStack.back();
-        nodeStack.pop_back();
-
-        ++result;
-
-        if (node->m_children == nullptr)
-            continue;
-
-        for (const auto& child : *node->m_children)
-        {
-            if (child != nullptr)
-                nodeStack.push_back(child.get());
-        }
+        result = static_cast<OctreeNodeIndex>(m_nodes.size());
+        if (m_sizes.size() <= depth)
+            m_sizes.push_back(m_sizes.back() * PrecisionType(0.5));
+        PrecisionType scale = m_sizes[depth];
+        PointType centerPos = node.center
+                            + scale * PointType(static_cast<PrecisionType>(static_cast<int>((childIndex & 1U) << 1U) - 1),
+                                                static_cast<PrecisionType>(static_cast<int>(childIndex & 2U) - 1),
+                                                static_cast<PrecisionType>(static_cast<int>((childIndex & 4U) >> 1U) - 1));
+        m_nodes.emplace_back(centerPos);
     }
 
     return result;
 }
 
-template<class OBJ, class PREC>
-std::unique_ptr<StaticOctree<OBJ, PREC>>
-DynamicOctree<OBJ, PREC>::rebuildAndSort(PREC scale, OctreeObjectIndex objectCount) const
+template<class TRAITS, class STORAGE>
+std::unique_ptr<typename DynamicOctree<TRAITS, STORAGE>::StaticOctreeType>
+DynamicOctree<TRAITS, STORAGE>::build()
 {
-    auto staticOctree = std::make_unique<StaticOctree<OBJ, PREC>>();
-    staticOctree->m_nodes.reserve(countNodes());
-    staticOctree->m_objects.reserve(objectCount);
+    auto staticOctree = std::make_unique<StaticOctreeType>();
+    staticOctree->m_nodes.reserve(m_nodes.size());
+    staticOctree->m_objects.reserve(m_objects.size());
 
-    std::vector<std::tuple<const DynamicOctree*, PREC, OctreeNodeIndex>> nodeStack;
-    std::vector<OctreeNodeIndex> nodeIndexStack;
-    nodeStack.emplace_back(this, scale, 0);
-
+    std::vector<std::pair<OctreeNodeIndex, OctreeDepthType>> nodeStack;
+    std::vector<OctreeNodeIndex> prevByDepth;
+    nodeStack.emplace_back(0, 0);
     while (!nodeStack.empty())
     {
-        auto [node, nodeScale, depth] = nodeStack.back();
+        auto [nodeIdx, depth] = nodeStack.back();
+        const NodeType& node = m_nodes[nodeIdx];
+        buildNode(*staticOctree, node, depth, prevByDepth);
         nodeStack.pop_back();
 
-        // any nodes in the node stack with a depth greater or equal to this one
-        // will have this node as the node to jump to when skipping the subtree
-        auto nodeIndex = static_cast<OctreeNodeIndex>(staticOctree->m_nodes.size());
-        while (nodeIndexStack.size() > depth)
-        {
-            staticOctree->m_nodes[nodeIndexStack.back()].right = nodeIndex;
-            nodeIndexStack.pop_back();
-        }
-
-        nodeIndexStack.push_back(nodeIndex);
-
-        auto& staticNode = staticOctree->m_nodes.emplace_back(node->m_cellCenterPos, nodeScale);
-        if (node->m_objects != nullptr && !node->m_objects->empty())
-        {
-            staticNode.first = static_cast<OctreeObjectIndex>(staticOctree->m_objects.size());
-            staticNode.last = staticNode.first + static_cast<OctreeObjectIndex>(node->m_objects->size());
-
-            for (OBJ* obj : *node->m_objects)
-            {
-                staticNode.brightFactor = std::min(staticNode.brightFactor, getMagnitude(*obj));
-                staticOctree->m_objects.emplace_back(std::move(*obj));
-            }
-
-            // update parent node brightness factors, necessary in case they have no
-            // stars
-            for (OctreeNodeIndex parentDepth = 0; parentDepth < depth; ++parentDepth)
-            {
-                auto& parentNode = staticOctree->m_nodes[nodeIndexStack[parentDepth]];
-                parentNode.brightFactor = std::min(parentNode.brightFactor, staticNode.brightFactor);
-            }
-        }
-
-        if (node->m_children == nullptr)
+        if (node.children == nullptr)
             continue;
 
-        for (const auto& child : *node->m_children)
+        for (OctreeNodeIndex child : *node.children)
         {
-            if (child != nullptr)
-                nodeStack.emplace_back(child.get(), nodeScale * PREC(0.5), depth + 1);
+            if (child != InvalidOctreeNode)
+                nodeStack.emplace_back(child, depth + 1);
         }
     }
 
+    for (OctreeObjectIndex objIndex : m_excluded)
+        staticOctree->m_objects.emplace_back(std::move(m_objects[objIndex]));
+
     return staticOctree;
+}
+
+template<class TRAITS, class STORAGE>
+void
+DynamicOctree<TRAITS, STORAGE>::buildNode(StaticOctreeType& staticOctree,
+                                          const NodeType& node,
+                                          OctreeDepthType depth,
+                                          std::vector<OctreeNodeIndex>& prevByDepth)
+{
+    // any nodes in the node stack with a depth greater or equal to this one
+    // will have this node as the node to jump to when skipping the subtree
+    auto staticNodeIdx = static_cast<OctreeNodeIndex>(staticOctree.m_nodes.size());
+    while (prevByDepth.size() > depth)
+    {
+        staticOctree.m_nodes[prevByDepth.back()].right = staticNodeIdx;
+        prevByDepth.pop_back();
+    }
+
+    prevByDepth.push_back(staticNodeIdx);
+
+    auto& staticNode = staticOctree.m_nodes.emplace_back(node.center, m_sizes[depth]);
+
+    if (node.objIndices.empty())
+        return;
+
+    staticNode.first = static_cast<OctreeObjectIndex>(staticOctree.m_objects.size());
+    staticNode.last = staticNode.first + static_cast<OctreeObjectIndex>(node.objIndices.size());
+
+    // move the objects into the sorted octree, keep track of brightest
+    for (OctreeObjectIndex objIdx : node.objIndices)
+    {
+        ObjectType& obj = m_objects[objIdx];
+        staticNode.brightFactor = std::min(staticNode.brightFactor, TRAITS::getMagnitude(obj));
+        staticOctree.m_objects.emplace_back(std::move(obj));
+    }
+
+    // update parent node brightness factors, in case node was empty or
+    // (less likely) filled with objects straddling the center
+    for (OctreeNodeIndex parentDepth = depth; parentDepth-- > 0;)
+    {
+        auto& parentNode = staticOctree.m_nodes[prevByDepth[parentDepth]];
+        if (parentNode.brightFactor <= staticNode.brightFactor)
+            break;
+
+        parentNode.brightFactor = staticNode.brightFactor;
+    }
+}
+
+template<typename TRAITS, typename STORAGE>
+inline std::unique_ptr<DynamicOctree<TRAITS, STORAGE>>
+makeDynamicOctree(STORAGE&& objects,
+                  const Eigen::Matrix<typename TRAITS::PrecisionType, 3, 1>& rootCenter,
+                  typename TRAITS::PrecisionType rootSize,
+                  float rootExclusionFactor,
+                  OctreeObjectIndex splitThreshold)
+{
+    static_assert(!std::is_reference_v<STORAGE>, "makeDynamicOctree must be called with rvalue for objects parameter");
+    return std::make_unique<DynamicOctree<TRAITS, STORAGE>>(std::forward<STORAGE>(objects),
+                                                            rootCenter,
+                                                            rootSize,
+                                                            rootExclusionFactor,
+                                                            splitThreshold);
 }
 
 } // end namespace celestia::engine

--- a/src/celengine/stardb.cpp
+++ b/src/celengine/stardb.cpp
@@ -21,6 +21,7 @@
 using namespace std::string_view_literals;
 
 namespace compat = celestia::compat;
+namespace engine = celestia::engine;
 
 namespace
 {
@@ -197,7 +198,7 @@ StarDatabase::getStarNameList(const Star& star, unsigned int maxNames) const
 }
 
 void
-StarDatabase::findVisibleStars(StarHandler& starHandler,
+StarDatabase::findVisibleStars(engine::StarHandler& starHandler,
                                const Eigen::Vector3f& position,
                                const Eigen::Quaternionf& orientation,
                                float fovY,
@@ -232,7 +233,7 @@ StarDatabase::findVisibleStars(StarHandler& starHandler,
 }
 
 void
-StarDatabase::findCloseStars(StarHandler& starHandler,
+StarDatabase::findCloseStars(engine::StarHandler& starHandler,
                              const Eigen::Vector3f& position,
                              float radius) const
 {

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -54,14 +54,14 @@ public:
 
     void getCompletion(std::vector<std::string>&, std::string_view) const;
 
-    void findVisibleStars(StarHandler& starHandler,
+    void findVisibleStars(celestia::engine::StarHandler& starHandler,
                           const Eigen::Vector3f& obsPosition,
                           const Eigen::Quaternionf& obsOrientation,
                           float fovY,
                           float aspectRatio,
                           float limitingMag) const;
 
-    void findCloseStars(StarHandler& starHandler,
+    void findCloseStars(celestia::engine::StarHandler& starHandler,
                         const Eigen::Vector3f& obsPosition,
                         float radius) const;
 
@@ -74,10 +74,10 @@ private:
     Star* searchCrossIndex(StarCatalog, AstroCatalog::IndexNumber number) const;
 
     std::uint32_t nStars{ 0 };
-    std::unique_ptr<Star[]>           stars; //NOSONAR
-    std::unique_ptr<StarNameDatabase> namesDB;
-    std::vector<std::uint32_t>        catalogNumberIndex;
-    std::unique_ptr<StarOctree>       octreeRoot;
+    std::unique_ptr<Star[]>                       stars; //NOSONAR
+    std::unique_ptr<StarNameDatabase>             namesDB;
+    std::vector<std::uint32_t>                    catalogNumberIndex;
+    std::unique_ptr<celestia::engine::StarOctree> octreeRoot;
 
     friend class StarDatabaseBuilder;
 };

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -73,8 +73,6 @@ public:
 private:
     Star* searchCrossIndex(StarCatalog, AstroCatalog::IndexNumber number) const;
 
-    std::uint32_t nStars{ 0 };
-    std::unique_ptr<Star[]>                       stars; //NOSONAR
     std::unique_ptr<StarNameDatabase>             namesDB;
     std::vector<std::uint32_t>                    catalogNumberIndex;
     std::unique_ptr<celestia::engine::StarOctree> octreeRoot;
@@ -85,11 +83,11 @@ private:
 inline Star*
 StarDatabase::getStar(const std::uint32_t n) const
 {
-    return stars.get() + n;
+    return &(*octreeRoot)[n];
 }
 
 inline std::uint32_t
 StarDatabase::size() const
 {
-    return nStars;
+    return octreeRoot->size();
 }

--- a/src/celengine/stardbbuilder.cpp
+++ b/src/celengine/stardbbuilder.cpp
@@ -52,7 +52,7 @@ namespace ephem = celestia::ephem;
 namespace math = celestia::math;
 namespace util = celestia::util;
 
-using DynamicStarOctree = DynamicOctree<Star, float>;
+using DynamicStarOctree = engine::DynamicOctree<Star, float>;
 
 using util::GetLogger;
 

--- a/src/celengine/staroctree.cpp
+++ b/src/celengine/staroctree.cpp
@@ -14,6 +14,7 @@
 
 #include <celastro/astro.h>
 #include <celcompat/numbers.h>
+#include <celmath/mathlib.h>
 
 namespace celestia::engine
 {
@@ -33,14 +34,23 @@ constexpr float MAX_STAR_ORBIT_RADIUS = 1.0f;
 
 } // end unnamed namespace
 
-// total specialization of the StaticOctree template process*() methods for stars:
-template<>
-void
-StarOctree::processVisibleObjects(StarHandler&    processor,
-                                  const PointType& obsPosition,
-                                  const PlaneType* frustumPlanes,
-                                  float limitingFactor,
-                                  float scale) const
+// The version of cppcheck used by Codacy doesn't seem to detect the field initializer
+
+StarOctreeVisibleObjectsProcessor::StarOctreeVisibleObjectsProcessor(StarHandler* starHandler, // cppcheck-suppress uninitMemberVar
+                                                                     const StarOctree::PointType& obsPosition,
+                                                                     util::array_view<PlaneType> frustumPlanes,
+                                                                     float limitingFactor) :
+    m_starHandler(starHandler),
+    m_obsPosition(obsPosition),
+    m_frustumPlanes(frustumPlanes),
+    m_limitingFactor(limitingFactor)
+{
+}
+
+bool
+StarOctreeVisibleObjectsProcessor::checkNode(const StarOctree::PointType& center,
+                                             float size,
+                                             float factor)
 {
     // See if this node lies within the view frustum
 
@@ -48,94 +58,70 @@ StarOctree::processVisibleObjects(StarHandler&    processor,
     // planes that define the infinite view frustum.
     for (unsigned int i = 0; i < 5; ++i)
     {
-        const PlaneType& plane = frustumPlanes[i];
-        float r = scale * plane.normal().cwiseAbs().sum();
-        if (plane.signedDistance(m_cellCenterPos) < -r)
-            return;
+        const PlaneType& plane = m_frustumPlanes[i];
+        float r = size * plane.normal().cwiseAbs().sum();
+        if (plane.signedDistance(center) < -r)
+            return false;
     }
 
     // Compute the distance to node; this is equal to the distance to
     // the cellCenterPos of the node minus the boundingRadius of the node, scale * SQRT3.
-    float minDistance = (obsPosition - m_cellCenterPos).norm() - scale * numbers::sqrt3_v<float>;
+    float minDistance = (m_obsPosition - center).norm() - size * numbers::sqrt3_v<float>;
 
-    // Process the objects in this node
-    float dimmest = minDistance > 0 ? astro::appToAbsMag(limitingFactor, minDistance) : 1000;
+    float distanceModulus = astro::distanceModulus(minDistance);
+    if (minDistance > 0.0 && (factor + distanceModulus) > m_limitingFactor)
+        return false;
 
-    for (std::uint32_t i = 0; i < m_nObjects; ++i)
-    {
-        const Star& obj = m_firstObject[i];
-        if (obj.getAbsoluteMagnitude() < dimmest)
-        {
-            float distance = (obsPosition - obj.getPosition()).norm();
-            float appMag   = obj.getApparentMagnitude(distance);
+    // Dimmest absolute magnitude to process
+    m_dimmest = minDistance > 0 ? (m_limitingFactor - distanceModulus) : 1000;
 
-            if (appMag < limitingFactor || (distance < MAX_STAR_ORBIT_RADIUS && obj.getOrbit()))
-                processor.process(obj, distance, appMag);
-        }
-    }
-
-    // See if any of the objects in child nodes are potentially included
-    // that we need to recurse deeper.
-    if (m_children != nullptr &&
-        (minDistance <= 0 || astro::absToAppMag(m_exclusionFactor, minDistance) <= limitingFactor))
-    {
-        // Recurse into the child nodes
-        for (int i = 0; i < 8; ++i)
-        {
-            (*m_children)[i]->processVisibleObjects(processor,
-                                                    obsPosition,
-                                                    frustumPlanes,
-                                                    limitingFactor,
-                                                    scale * 0.5f);
-        }
-    }
+    return true;
 }
 
-template<>
 void
-StarOctree::processCloseObjects(StarHandler& processor,
-                                const PointType& obsPosition,
-                                float boundingRadius,
-                                float scale) const
+StarOctreeVisibleObjectsProcessor::process(const Star& obj) const
+{
+    if (obj.getAbsoluteMagnitude() > m_dimmest)
+        return;
+
+    float distance = (m_obsPosition - obj.getPosition()).norm();
+    float appMag   = obj.getApparentMagnitude(distance);
+
+    if (appMag <= m_limitingFactor || (distance < MAX_STAR_ORBIT_RADIUS && obj.getOrbit()))
+        m_starHandler->process(obj, distance, appMag);
+}
+
+StarOctreeCloseObjectsProcessor::StarOctreeCloseObjectsProcessor(StarHandler* starHandler,
+                                                                 const StarOctree::PointType& obsPosition,
+                                                                 float boundingRadius) :
+    m_starHandler(starHandler),
+    m_obsPosition(obsPosition),
+    m_boundingRadius(boundingRadius),
+    m_radiusSquared(math::square(boundingRadius))
+{
+}
+
+bool
+StarOctreeCloseObjectsProcessor::checkNode(const StarOctree::PointType& center,
+                                           float size,
+                                           float /* factor */) const
 {
     // Compute the distance to node; this is equal to the distance to
     // the cellCenterPos of the node minus the boundingRadius of the node, scale * SQRT3.
-    float nodeDistance = (obsPosition - m_cellCenterPos).norm() - scale * numbers::sqrt3_v<float>;
+    float nodeDistance = (m_obsPosition - center).norm() - size * numbers::sqrt3_v<float>;
+    return nodeDistance <= m_boundingRadius;
+}
 
-    if (nodeDistance > boundingRadius)
-        return;
-
-    // At this point, we've determined that the cellCenterPos of the node is
-    // close enough that we must check individual objects for proximity.
-
-    // Compute distance squared to avoid having to sqrt for distance
-    // comparison.
-    float radiusSquared    = boundingRadius * boundingRadius;
-
-    // Check all the objects in the node.
-    for (std::uint32_t i = 0; i < m_nObjects; ++i)
+void
+StarOctreeCloseObjectsProcessor::process(const Star& obj) const
+{
+    StarOctree::PointType offset = m_obsPosition - obj.getPosition();
+    if (offset.squaredNorm() < m_radiusSquared)
     {
-        const Star& obj = m_firstObject[i];
-        PointType offset = obsPosition - obj.getPosition();
-        if (offset.squaredNorm() < radiusSquared)
-        {
-            float distance = offset.norm();
-            float appMag   = obj.getApparentMagnitude(distance);
+        float distance = offset.norm();
+        float appMag   = obj.getApparentMagnitude(distance);
 
-            processor.process(obj, distance, appMag);
-        }
-    }
-
-    // Recurse into the child nodes
-    if (m_children != nullptr)
-    {
-        for (int i = 0; i < 8; ++i)
-        {
-            (*m_children)[i]->processCloseObjects(processor,
-                                                  obsPosition,
-                                                  boundingRadius,
-                                                  scale * 0.5f);
-        }
+        m_starHandler->process(obj, distance, appMag);
     }
 }
 

--- a/src/celengine/staroctree.cpp
+++ b/src/celengine/staroctree.cpp
@@ -15,8 +15,8 @@
 #include <celastro/astro.h>
 #include <celcompat/numbers.h>
 
-namespace astro = celestia::astro;
-namespace numbers = celestia::numbers;
+namespace celestia::engine
+{
 
 namespace
 {
@@ -138,3 +138,5 @@ StarOctree::processCloseObjects(StarHandler& processor,
         }
     }
 }
+
+} // end namespace celestia::engine

--- a/src/celengine/staroctree.h
+++ b/src/celengine/staroctree.h
@@ -17,6 +17,9 @@
 #include <celengine/star.h>
 #include <celengine/octree.h>
 
+namespace celestia::engine
+{
+
 using StarOctree = StaticOctree<Star, float>;
 using StarHandler = OctreeProcessor<Star, float>;
 
@@ -32,3 +35,5 @@ void StarOctree::processCloseObjects(StarHandler&,
                                      const PointType&,
                                      float,
                                      float) const;
+
+} // end namespace celestia::engine

--- a/src/celengine/staroctree.h
+++ b/src/celengine/staroctree.h
@@ -14,6 +14,8 @@
 
 #include <cstdint>
 
+#include <Eigen/Geometry>
+
 #include <celengine/star.h>
 #include <celengine/octree.h>
 
@@ -23,17 +25,50 @@ namespace celestia::engine
 using StarOctree = StaticOctree<Star, float>;
 using StarHandler = OctreeProcessor<Star, float>;
 
-template<>
-void StarOctree::processVisibleObjects(StarHandler&,
-                                       const PointType&,
-                                       const PlaneType*,
-                                       float,
-                                       float) const;
+// This class searches the octree for objects that are likely to be visible
+// to a viewer with the specified obsPosition and limitingFactor.  The
+// octreeProcessor is invoked for each potentially visible object --no object with
+// a property greater than limitingFactor will be processed, but
+// objects that are outside the view frustum may be.  Frustum tests are performed
+// only at the node level to optimize the octree traversal, so an exact test
+// (if one is required) is the responsibility of the callback method.
+class StarOctreeVisibleObjectsProcessor
+{
+public:
+    using PlaneType = Eigen::Hyperplane<float, 3>;
 
-template<>
-void StarOctree::processCloseObjects(StarHandler&,
-                                     const PointType&,
-                                     float,
-                                     float) const;
+    StarOctreeVisibleObjectsProcessor(StarHandler*,
+                                      const StarOctree::PointType&,
+                                      util::array_view<PlaneType>,
+                                      float);
+
+    bool checkNode(const StarOctree::PointType&, float, float);
+    void process(const Star&) const;
+
+private:
+    StarHandler* m_starHandler;
+    StarOctree::PointType m_obsPosition;
+    util::array_view<PlaneType> m_frustumPlanes;
+    float m_limitingFactor;
+
+    float m_dimmest{ 1000.0f };
+};
+
+class StarOctreeCloseObjectsProcessor
+{
+public:
+    StarOctreeCloseObjectsProcessor(StarHandler*,
+                                    const StarOctree::PointType&,
+                                    float);
+
+    bool checkNode(const StarOctree::PointType&, float, float) const;
+    void process(const Star&) const;
+
+private:
+    StarHandler* m_starHandler;
+    StarOctree::PointType m_obsPosition;
+    float m_boundingRadius;
+    float m_radiusSquared;
+};
 
 } // end namespace celestia::engine

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -41,8 +41,7 @@ namespace
 
 constexpr double ANGULAR_RES = 3.5e-6;
 
-
-class ClosestStarFinder : public StarHandler
+class ClosestStarFinder : public engine::StarHandler
 {
 public:
     ClosestStarFinder(float _maxDistance, const Universe* _universe);
@@ -80,8 +79,7 @@ ClosestStarFinder::process(const Star& star, float distance, float /*unused*/)
     }
 }
 
-
-class NearStarFinder : public StarHandler
+class NearStarFinder : public engine::StarHandler
 {
 public:
     NearStarFinder(float _maxDistance, std::vector<const Star*>& nearStars);
@@ -107,8 +105,6 @@ NearStarFinder::process(const Star& star, float distance, float /*unused*/)
         nearStars.push_back(&star);
 }
 
-
-
 struct PlanetPickInfo
 {
     double sinAngle2Closest;
@@ -119,7 +115,6 @@ struct PlanetPickInfo
     double jd;
     float atanTolerance;
 };
-
 
 bool
 ApproxPlanetPickTraversal(Body* body, PlanetPickInfo& pickInfo)
@@ -152,7 +147,6 @@ ApproxPlanetPickTraversal(Body* body, PlanetPickInfo& pickInfo)
 
     return true;
 }
-
 
 // Perform an intersection test between the pick ray and a body
 bool
@@ -259,9 +253,8 @@ traverseFrameTree(const FrameTree* frameTree,
     return true;
 }
 
-
 // StarPicker is a callback class for StarDatabase::findVisibleStars
-class StarPicker : public StarHandler
+class StarPicker : public engine::StarHandler
 {
 public:
     StarPicker(const Eigen::Vector3f&, const Eigen::Vector3f&, double, float);
@@ -329,8 +322,7 @@ StarPicker::process(const Star& star, float /*unused*/, float /*unused*/)
     }
 }
 
-
-class CloseStarPicker : public StarHandler
+class CloseStarPicker : public engine::StarHandler
 {
 public:
     CloseStarPicker(const UniversalCoord& pos,
@@ -350,7 +342,6 @@ public:
     float closestDistance;
     double sinAngle2Closest;
 };
-
 
 CloseStarPicker::CloseStarPicker(const UniversalCoord& pos,
                                  const Eigen::Vector3f& dir,
@@ -414,8 +405,7 @@ CloseStarPicker::process(const Star& star,
     }
 }
 
-
-class DSOPicker : public DSOHandler
+class DSOPicker : public engine::DSOHandler
 {
 public:
     DSOPicker(const Eigen::Vector3d& pickOrigin,
@@ -435,7 +425,6 @@ public:
     double  sinAngle2Closest;
 };
 
-
 DSOPicker::DSOPicker(const Eigen::Vector3d& pickOrigin,
                      const Eigen::Vector3d& pickDir,
                      std::uint64_t renderFlags,
@@ -447,7 +436,6 @@ DSOPicker::DSOPicker(const Eigen::Vector3d& pickOrigin,
     sinAngle2Closest(std::max(std::sin(angle / 2.0), ANGULAR_RES))
 {
 }
-
 
 void
 DSOPicker::process(const std::unique_ptr<DeepSkyObject>& dso, double, float) //NOSONAR
@@ -477,8 +465,7 @@ DSOPicker::process(const std::unique_ptr<DeepSkyObject>& dso, double, float) //N
     }
 }
 
-
-class CloseDSOPicker : public DSOHandler
+class CloseDSOPicker : public engine::DSOHandler
 {
 public:
     CloseDSOPicker(const Eigen::Vector3d& pos,
@@ -500,7 +487,6 @@ public:
     double largestCosAngle;
 };
 
-
 CloseDSOPicker::CloseDSOPicker(const Eigen::Vector3d& pos,
                                const Eigen::Vector3d& dir,
                                std::uint64_t renderFlags,
@@ -514,7 +500,6 @@ CloseDSOPicker::CloseDSOPicker(const Eigen::Vector3d& pos,
     largestCosAngle(-2.0)
 {
 }
-
 
 void
 CloseDSOPicker::process(const std::unique_ptr<DeepSkyObject>& dso, //NOSONAR
@@ -565,10 +550,8 @@ getLocationsCompletion(std::vector<std::string>& completion,
 
 } // end unnamed namespace
 
-
 // Needs definition of ConstellationBoundaries
 Universe::~Universe() = default;
-
 
 StarDatabase*
 Universe::getStarCatalog() const
@@ -576,13 +559,11 @@ Universe::getStarCatalog() const
     return starCatalog.get();
 }
 
-
 void
 Universe::setStarCatalog(std::unique_ptr<StarDatabase>&& catalog)
 {
     starCatalog = std::move(catalog);
 }
-
 
 SolarSystemCatalog*
 Universe::getSolarSystemCatalog() const
@@ -596,13 +577,11 @@ Universe::setSolarSystemCatalog(std::unique_ptr<SolarSystemCatalog>&& catalog)
     solarSystemCatalog = std::move(catalog);
 }
 
-
 DSODatabase*
 Universe::getDSOCatalog() const
 {
     return dsoCatalog.get();
 }
-
 
 void
 Universe::setDSOCatalog(std::unique_ptr<DSODatabase>&& catalog)
@@ -610,13 +589,11 @@ Universe::setDSOCatalog(std::unique_ptr<DSODatabase>&& catalog)
     dsoCatalog = std::move(catalog);
 }
 
-
 AsterismList*
 Universe::getAsterisms() const
 {
     return asterisms.get();
 }
-
 
 void
 Universe::setAsterisms(std::unique_ptr<AsterismList>&& _asterisms)
@@ -624,20 +601,17 @@ Universe::setAsterisms(std::unique_ptr<AsterismList>&& _asterisms)
     asterisms = std::move(_asterisms);
 }
 
-
 ConstellationBoundaries*
 Universe::getBoundaries() const
 {
     return boundaries.get();
 }
 
-
 void
 Universe::setBoundaries(std::unique_ptr<ConstellationBoundaries>&& _boundaries)
 {
     boundaries = std::move(_boundaries);
 }
-
 
 // Return the planetary system of a star, or nullptr if it has no planets.
 SolarSystem*
@@ -652,7 +626,6 @@ Universe::getSolarSystem(const Star* star) const
         ? nullptr
         : iter->second.get();
 }
-
 
 // A more general version of the method above--return the solar system
 // that contains an object, or nullptr if there is no solar sytstem.
@@ -686,7 +659,6 @@ Universe::getSolarSystem(const Selection& sel) const
     }
 }
 
-
 // Create a new solar system for a star and return a pointer to it; if it
 // already has a solar system, just return a pointer to the existing one.
 SolarSystem*
@@ -701,13 +673,11 @@ Universe::getOrCreateSolarSystem(Star* star) const
     return iter->second.get();
 }
 
-
 const celestia::MarkerList&
 Universe::getMarkers() const
 {
     return markers;
 }
-
 
 void
 Universe::markObject(const Selection& sel,
@@ -735,7 +705,6 @@ Universe::markObject(const Selection& sel,
     marker.setSizing(sizing);
 }
 
-
 void
 Universe::unmarkObject(const Selection& sel, int priority)
 {
@@ -745,13 +714,11 @@ Universe::unmarkObject(const Selection& sel, int priority)
         markers.erase(iter);
 }
 
-
 void
 Universe::unmarkAll()
 {
     markers.clear();
 }
-
 
 bool
 Universe::isMarked(const Selection& sel, int priority) const
@@ -760,7 +727,6 @@ Universe::isMarked(const Selection& sel, int priority) const
                              [&sel](const auto& m) { return m.object() == sel; });
     return iter != markers.end() && iter->priority() >= priority;
 }
-
 
 Selection
 Universe::pickPlanet(const SolarSystem& solarSystem,
@@ -828,7 +794,6 @@ Universe::pickPlanet(const SolarSystem& solarSystem,
         return Selection();
 }
 
-
 Selection
 Universe::pickStar(const UniversalCoord& origin,
                    const Eigen::Vector3f& direction,
@@ -867,7 +832,6 @@ Universe::pickStar(const UniversalCoord& origin,
         return Selection();
 }
 
-
 Selection
 Universe::pickDeepSkyObject(const UniversalCoord& origin,
                             const Eigen::Vector3f& direction,
@@ -901,7 +865,6 @@ Universe::pickDeepSkyObject(const UniversalCoord& origin,
     else
         return Selection();
 }
-
 
 Selection
 Universe::pick(const UniversalCoord& origin,
@@ -946,7 +909,6 @@ Universe::pick(const UniversalCoord& origin,
     return sel;
 }
 
-
 // Search by name for an immediate child of the specified object.
 Selection
 Universe::findChildObject(const Selection& sel,
@@ -988,7 +950,6 @@ Universe::findChildObject(const Selection& sel,
 
     return Selection();
 }
-
 
 // Search for a name within an object's context.  For stars, planets (bodies),
 // and locations, the context includes all bodies in the associated solar
@@ -1036,7 +997,6 @@ Universe::findObjectInContext(const Selection& sel,
     return Selection();
 }
 
-
 // Select an object by name, with the following priority:
 //   1. Try to look up the name in the star catalog
 //   2. Search the deep sky catalog for a matching name.
@@ -1078,7 +1038,6 @@ Universe::find(std::string_view s,
     return Selection();
 }
 
-
 // Find an object from a path, for example Sol/Earth/Moon or Upsilon And/b
 // Currently, 'absolute' paths starting with a / are not supported nor are
 // paths that contain galaxies.  The caller may pass in a list of solar systems
@@ -1117,7 +1076,6 @@ Universe::findPath(std::string_view s,
     return sel;
 }
 
-
 void
 Universe::getCompletion(std::vector<std::string>& completion,
                         std::string_view s,
@@ -1149,7 +1107,6 @@ Universe::getCompletion(std::vector<std::string>& completion,
     if (starCatalog != nullptr)
         starCatalog->getCompletion(completion, s);
 }
-
 
 void
 Universe::getCompletionPath(std::vector<std::string>& completion,
@@ -1202,7 +1159,6 @@ Universe::getCompletionPath(std::vector<std::string>& completion,
     }
 }
 
-
 // Return the closest solar system to position, or nullptr if there are no planets
 // with in one light year.
 SolarSystem*
@@ -1214,7 +1170,6 @@ Universe::getNearestSolarSystem(const UniversalCoord& position) const
     starCatalog->findCloseStars(closestFinder, pos, 1.0f);
     return getSolarSystem(closestFinder.closestStar);
 }
-
 
 void
 Universe::getNearStars(const UniversalCoord& position,

--- a/src/celutil/blockarray.h
+++ b/src/celutil/blockarray.h
@@ -39,6 +39,8 @@ public:
     using difference_type = std::ptrdiff_t;
     using size_type = std::size_t;
 
+    static_assert(BLOCKSIZE > 0, "BLOCKSIZE must be greater than zero");
+
     class const_iterator;
 
     class iterator


### PR DESCRIPTION
- Separate octree types and octree node types
- Store nodes in vectors (BlockArray for the DynamicOctree)
- For static octree, order the nodes in depth-first order, together with the node to jump to when skipping the subtree
- Avoids need to perform recursive calls when processing the octree (including the destructor)