### PR TITLE
Support fmt 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Update vcpkg
       shell: pwsh
       run: |
-        $vcpkgCommit = 'cacf5994341f27e9a14a7b8724b0634b138ecb30'
+        $vcpkgCommit = 'a2367ceec5f092d8777606ca110426cadd7ed7db'
         pushd "$env:VCPKG_INSTALLATION_ROOT"
         git cat-file -e "${vcpkgCommit}^{commit}" 2> $null
         if (!$?) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ find_package(Eigen3 3.3 REQUIRED NO_MODULE) # -DEigen3_DIR=...
 message(STATUS "Found Eigen3 ${EIGEN3_VERSION_STRING}")
 link_libraries(Eigen3::Eigen)
 
-find_package(fmt 6.1.0 CONFIG QUIET)
+find_package(fmt 8.0.0 CONFIG QUIET)
 if(NOT fmt_FOUND)
   message(STATUS "Using fmt submodule")
   add_subdirectory("${CMAKE_SOURCE_DIR}/thirdparty/fmt")

--- a/src/cel3ds/3dsread.cpp
+++ b/src/cel3ds/3dsread.cpp
@@ -87,13 +87,14 @@ constexpr auto chunkHeaderSize = static_cast<std::int32_t>(sizeof(M3DChunkType) 
 template<>
 struct fmt::formatter<M3DChunkType>
 {
-    constexpr auto parse(const format_parse_context& ctx) const -> decltype(ctx.begin()) {
+    constexpr auto parse(const format_parse_context& ctx) const
+    {
         // we should validate the format here but exceptions are disabled
         return ctx.begin();
     }
 
-    template<typename FormatContext>
-    auto format(const M3DChunkType& chunkType, FormatContext& ctx) -> decltype(ctx.out()) {
+    auto format(const M3DChunkType& chunkType, format_context& ctx) const
+    {
         return format_to(ctx.out(), "{:04x}", static_cast<std::uint16_t>(chunkType));
     }
 };

--- a/src/celengine/stardbbuilder.cpp
+++ b/src/celengine/stardbbuilder.cpp
@@ -75,7 +75,7 @@ StarDatabaseBuilder::StcHeader::StcHeader(const fs::path& _path) :
 template<>
 struct fmt::formatter<StarDatabaseBuilder::StcHeader> : formatter<std::string_view>
 {
-    format_context::iterator format(const StarDatabaseBuilder::StcHeader& header, format_context& ctx)
+    auto format(const StarDatabaseBuilder::StcHeader& header, format_context& ctx) const
     {
         fmt::basic_memory_buffer<char> data;
         fmt::format_to(std::back_inserter(data), "line {}", header.lineNumber);

--- a/src/celutil/formatnum.cpp
+++ b/src/celutil/formatnum.cpp
@@ -52,7 +52,7 @@ ExtendedSubstring::ExtendedSubstring(std::string_view _source,
 template<>
 struct fmt::formatter<ExtendedSubstring>
 {
-    constexpr format_parse_context::iterator parse(const format_parse_context& ctx) const
+    constexpr auto parse(const format_parse_context& ctx) const
     {
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}')
@@ -68,7 +68,7 @@ struct fmt::formatter<ExtendedSubstring>
         return it;
     }
 
-    format_context::iterator format(const ExtendedSubstring& value, format_context& ctx) const
+    auto format(const ExtendedSubstring& value, format_context& ctx) const
     {
         if (value.start >= value.source.size())
             return format_to(ctx.out(), "{:0<{}}", ""sv, value.length);

--- a/src/celutil/formatnum.h
+++ b/src/celutil/formatnum.h
@@ -116,7 +116,7 @@ FormattedFloat<T>::format(fmt::format_context& ctx) const
 template<typename T>
 struct fmt::formatter<celestia::util::FormattedFloat<T>>
 {
-    constexpr format_parse_context::iterator parse(const format_parse_context& ctx) const
+    constexpr auto parse(const format_parse_context& ctx) const
     {
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}')
@@ -132,8 +132,7 @@ struct fmt::formatter<celestia::util::FormattedFloat<T>>
         return it;
     }
 
-    format_context::iterator format(const celestia::util::FormattedFloat<T>& f,
-                                    format_context& ctx) const
+    auto format(const celestia::util::FormattedFloat<T>& f, format_context& ctx) const
     {
         return f.format(ctx);
     }


### PR DESCRIPTION
Resolves #2223

- Bump minimum supported fmt version to 8.0.0 (supply 8.1.1 in thirdparty/fmt)
- Use const format functions
- Rewrite path formatter to avoid copying on non-Windows systems
- Update vcpkg version to latest