### PR TITLE
Use octree traversal to implement star browser functions

### DIFF
--- a/src/celengine/starbrowser.h
+++ b/src/celengine/starbrowser.h
@@ -105,7 +105,6 @@ private:
     // The star browser data is valid for a particular point
     // in space/time, and for performance issues is not continuously
     // updated.
-    Eigen::Vector3f m_pos;
     UniversalCoord m_ucPos;
     double m_jd{ celestia::astro::J2000 };
 

--- a/src/celengine/stardb.h
+++ b/src/celengine/stardb.h
@@ -46,6 +46,8 @@ public:
     StarDatabase() = default;
     ~StarDatabase();
 
+    const celestia::engine::StarOctree* getOctree() const;
+
     inline Star* getStar(const std::uint32_t) const;
     inline std::uint32_t size() const;
 
@@ -79,6 +81,12 @@ private:
 
     friend class StarDatabaseBuilder;
 };
+
+inline const celestia::engine::StarOctree*
+StarDatabase::getOctree() const
+{
+    return octreeRoot.get();
+}
 
 inline Star*
 StarDatabase::getStar(const std::uint32_t n) const


### PR DESCRIPTION
- Store node depth instead of size in static octree
- Implement "breadth-first" octree traversal with iterative depth-first processing
- Rewrite the star browser comparison functions to use breadth-first traversal