### PR TITLE
[qt] Explicitly request OpenGL/OpenGLES in default QSurfaceFormat

### DIFF
--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -318,6 +318,11 @@ CelestiaAppWindow::init(const CelestiaCommandLineOptions& options)
     // Enable antialiasing if requested in the config file.
     // TODO: Make this settable via the GUI
     QSurfaceFormat glformat = QSurfaceFormat::defaultFormat();
+#ifdef GL_ES
+    glformat.setRenderableType(QSurfaceFormat::RenderableType::OpenGLES);
+#else
+    glformat.setRenderableType(QSurfaceFormat::RenderableType::OpenGL);
+#endif
     glformat.setAlphaBufferSize(0);
     if (m_appCore->getConfig()->renderDetails.aaSamples > 1)
     {


### PR DESCRIPTION
Fixes a bug in Qt6 where the surface fails to initialize if the default is OpenGLES but the build type is OpenGL.

(First issue I ran into after upgrading to Ubuntu 24.10)