### PR TITLE
Various BMP loader fixes

### DIFF
--- a/src/celimage/bmp.cpp
+++ b/src/celimage/bmp.cpp
@@ -8,33 +8,49 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <istream>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
+#include <celutil/array_view.h>
 #include <celutil/binaryread.h>
+#include <celutil/gettext.h>
 #include <celutil/logger.h>
 #include "image.h"
+
+using celestia::util::GetLogger;
 
 namespace celestia::engine
 {
 namespace
 {
 
+#pragma pack(push, 1)
+
 // BMP file definitions--can't use windows.h because we might not be
 // built on Windows!
-typedef struct
+struct BMPFileHeader
 {
+    BMPFileHeader() = delete;
+
     unsigned char magic[2];
     std::uint32_t size;
-    std::uint32_t reserved;
+    std::uint16_t reserved1;
+    std::uint16_t reserved2;
     std::uint32_t offset;
-} BMPFileHeader;
+};
 
-typedef struct
+struct BMPInfoHeader
 {
+    BMPInfoHeader() = delete;
+
     std::uint32_t size;
     std::int32_t width;
     std::int32_t height;
@@ -46,128 +62,372 @@ typedef struct
     std::int32_t heightPPM;
     std::uint32_t colorsUsed;
     std::uint32_t colorsImportant;
-} BMPImageHeader;
+};
 
+#pragma pack(pop)
 
-Image* LoadBMPImage(std::istream& in)
+static_assert(std::is_standard_layout_v<BMPFileHeader>);
+static_assert(std::is_standard_layout_v<BMPInfoHeader>);
+
+static_assert(sizeof(BMPInfoHeader) == 40);
+
+// We do not support 16bpp images
+constexpr std::array<std::uint32_t, 6> validBpps
 {
-    BMPFileHeader fileHeader;
-    BMPImageHeader imageHeader;
+    1, 2, 4, 8, 24, 32,
+};
 
-    if (!util::readLE<unsigned char>(in, fileHeader.magic[0])
-        || fileHeader.magic[0] != 'B'
-        || !util::readLE<unsigned char>(in, fileHeader.magic[1])
-        || fileHeader.magic[1] != 'M'
-        || !util::readLE<std::uint32_t>(in, fileHeader.size)
-        || !util::readLE<std::uint32_t>(in, fileHeader.reserved)
-        || !util::readLE<std::uint32_t>(in, fileHeader.offset)
-        || !util::readLE<std::uint32_t>(in, imageHeader.size)
-        || !util::readLE<std::int32_t>(in, imageHeader.width)
-        || imageHeader.width <= 0
-        || !util::readLE<std::int32_t>(in, imageHeader.height)
-        || imageHeader.height <= 0
-        || !util::readLE<std::uint16_t>(in, imageHeader.planes)
-        || !util::readLE<std::uint16_t>(in, imageHeader.bpp)
-        // We don't handle 1-, 2-, or 4-bpp images
-        || (imageHeader.bpp != 8 && imageHeader.bpp != 24 && imageHeader.bpp != 32)
-        || !util::readLE<std::uint32_t>(in, imageHeader.compression)
-        // We currently don't support compressed BMPs
-        || imageHeader.compression != 0
-        || !util::readLE<std::uint32_t>(in, imageHeader.imageSize)
-        || !util::readLE<std::int32_t>(in, imageHeader.widthPPM)
-        || !util::readLE<std::int32_t>(in, imageHeader.heightPPM)
-        || !util::readLE<std::uint32_t>(in, imageHeader.colorsUsed)
-        || !util::readLE<std::uint32_t>(in, imageHeader.colorsImportant))
+constexpr std::array<std::size_t, 5> validHeaderSizes
+{
+    40,  // BITMAPINFOHEADER
+    52,  // BITMAPV2INFOHEADER (Adobe Photoshop)
+    56,  // BITMAPV3INFOHEADER (Adobe Photoshop)
+    108, // BITMAPV4HEADER (Windows NT 4.0, 95 or later)
+    124, // BITMAPV5HEADER (GIMP)
+};
+
+struct PaletteEntry
+{
+    std::uint8_t blue;
+    std::uint8_t green;
+    std::uint8_t red;
+    std::uint8_t reserved;
+};
+
+static_assert(std::is_trivially_copyable_v<PaletteEntry> && alignof(PaletteEntry) == 1);
+
+struct BMPInfo
+{
+    std::uint32_t fileSize{ 0 };
+    std::uint32_t offset{ 0 };
+    std::uint32_t infoSize{ 0 };
+    std::int32_t width{ 0 };
+    std::int32_t height{ 0 };
+    std::uint32_t bpp{ 0 };
+    std::uint32_t rowStride{ 0 };
+    std::uint32_t imageSize{ 0 };
+    std::uint32_t paletteCount{ 0 };
+    std::vector<PaletteEntry> palette;
+};
+
+bool
+parseBMPFileHeader(const char* fileHeader, BMPInfo& info, const fs::path& filename)
+{
+    if (fileHeader[0] != 'B' || fileHeader[1] != 'M')
     {
-        return nullptr;
+        GetLogger()->error(_("BMP read failure '{}' - incorrect header bytes\n"), filename);
+        return false;
     }
 
-    std::vector<uint8_t> palette;
-    if (imageHeader.bpp == 8)
+    info.fileSize = util::fromMemoryLE<std::uint32_t>(fileHeader + offsetof(BMPFileHeader, size));
+    info.offset = util::fromMemoryLE<std::uint32_t>(fileHeader + offsetof(BMPFileHeader, offset));
+    return true;
+}
+
+bool
+parseBMPInfoHeader(const char* infoHeader,
+                   BMPInfo& info,
+                   const fs::path& filename)
+{
+    info.infoSize = util::fromMemoryLE<std::uint32_t>(infoHeader + offsetof(BMPInfoHeader, size));
+    if (std::find(validHeaderSizes.begin(), validHeaderSizes.end(), info.infoSize) == validHeaderSizes.end())
     {
-        util::GetLogger()->debug("Reading {} color palette\n", imageHeader.colorsUsed);
-        palette.resize(imageHeader.colorsUsed * 4);
-        if (!in.read(reinterpret_cast<char*>(palette.data()), imageHeader.colorsUsed * 4).good())
+        GetLogger()->error(_("BMP read failure '{}' - unsupported header format\n"), filename);
+        return false;
+    }
+
+    info.width = util::fromMemoryLE<std::int32_t>(infoHeader + offsetof(BMPInfoHeader, width));
+    if (info.width <= 0)
+    {
+        GetLogger()->error(_("BMP read failure '{}' - width must be greater than 0\n"), filename);
+        return false;
+    }
+
+    info.height = util::fromMemoryLE<std::int32_t>(infoHeader + offsetof(BMPInfoHeader, height));
+    if (info.height <= 0)
+    {
+        GetLogger()->error(_("BMP read failure '{}' - height must be greater than 0\n"), filename);
+        return false;
+    }
+
+    if (auto planes = util::fromMemoryLE<std::uint16_t>(infoHeader + offsetof(BMPInfoHeader, planes));
+        planes != 1)
+    {
+        GetLogger()->error(_("BMP read failure '{}' - number of planes must be 1\n"), filename);
+        return false;
+    }
+
+    info.bpp = util::fromMemoryLE<std::uint16_t>(infoHeader + offsetof(BMPInfoHeader, bpp));
+    // We don't handle 1-, 2-, or 4-bpp images
+    if (std::find(validBpps.begin(), validBpps.end(), info.bpp) == validBpps.end())
+    {
+        GetLogger()->error(_("BMP read failure '{}' - invalid bits per pixel {}\n"), filename, info.bpp);
+        return false;
+    }
+
+    // We currently don't support compressed BMPs
+    if (auto compression = util::fromMemoryLE<std::uint32_t>(infoHeader + offsetof(BMPInfoHeader, compression));
+        compression != 0)
+    {
+        GetLogger()->error(_("BMP read failure '{}' - compressed images are not supported\n"), filename);
+        return false;
+    }
+
+    if (info.bpp > 8)
+    {
+        std::uint32_t factor = info.bpp >> 3;
+        if (UINT32_MAX / factor < static_cast<std::uint32_t>(info.width))
         {
-            return nullptr;
+            GetLogger()->error(_("BMP read failure '{}' - image too wide\n"), filename);
+            return false;
+        }
+
+        info.rowStride = static_cast<std::uint32_t>(info.width) * factor;
+    }
+    else if (info.bpp == 8)
+    {
+        info.rowStride = static_cast<std::uint32_t>(info.width);
+    }
+    else
+    {
+        std::uint32_t factor = UINT32_C(8) / info.bpp;
+        if (info.width > UINT32_MAX - factor)
+        {
+            GetLogger()->error(_("BMP read failure '{}' - image too wide\n"), filename);
+        }
+        info.rowStride = (static_cast<std::uint32_t>(info.width) + factor - UINT32_C(1)) / factor;
+    }
+
+    if (info.rowStride > UINT32_MAX - 3)
+    {
+        GetLogger()->error(_("BMP read failure '{}' - image too wide\n"), filename);
+        return false;
+    }
+
+    // round up to nearest DWORD (4 bytes)
+    info.rowStride = (info.rowStride + UINT32_C(3)) & ~UINT32_C(3);
+
+    if ((UINT32_MAX / info.rowStride) < static_cast<std::uint32_t>(info.height))
+    {
+        GetLogger()->error(_("BMP read failure '{}' - image too tall\n"), filename);
+        return false;
+    }
+
+    info.imageSize = info.rowStride * static_cast<std::uint32_t>(info.height);
+    // Uncompressed bitmaps can have a size of 0
+    if (auto size = util::fromMemoryLE<std::uint32_t>(infoHeader + offsetof(BMPInfoHeader, imageSize));
+        size != 0 && size != info.imageSize || (info.offset + info.imageSize) < info.fileSize)
+    {
+        GetLogger()->error(_("BMP read failure '{}' - size mismatch\n"), filename);
+        return false;
+    }
+
+    if (info.bpp <= 8)
+    {
+        info.paletteCount = util::fromMemoryLE<std::uint32_t>(infoHeader + offsetof(BMPInfoHeader, colorsUsed));
+        std::uint32_t maxCount = UINT32_C(1) << info.bpp;
+        if (info.paletteCount == 0)
+        {
+            info.paletteCount = maxCount;
+        }
+        else if (info.paletteCount > maxCount)
+        {
+            GetLogger()->error(_("BMP read failure '{}' - palette too large\n"), filename);
+            return false;
         }
     }
 
-    if (!in.seekg(fileHeader.offset, std::ios::beg)) { return nullptr; }
+    return true;
+}
 
-    std::size_t bytesPerRow =
-        (imageHeader.width * imageHeader.bpp / 8 + 1) & ~1;
-    std::size_t imageBytes = bytesPerRow * imageHeader.height;
+bool
+loadBMPHeaders(std::istream& in, BMPInfo& info, const fs::path& filename)
+{
+    std::array<char, sizeof(BMPFileHeader) + sizeof(BMPInfoHeader)> buffer;
+    if (!in.read(buffer.data(), buffer.size())) /* Flawfinder: ignore */
+    {
+        GetLogger()->error(_("BMP read failure '{}' - could not read file headers\n"), filename);
+        return false;
+    }
+
+    if (!parseBMPFileHeader(buffer.data(), info, filename))
+        return false;
+
+    if (!parseBMPInfoHeader(buffer.data() + sizeof(BMPFileHeader), info, filename))
+        return false;
+
+    if (info.bpp <= 8)
+    {
+        if (!in.seekg(sizeof(BMPFileHeader) + info.infoSize, std::ios_base::beg))
+        {
+            GetLogger()->error(_("BMP read failure '{}' - could not seek to palette\n"), filename);
+            return false;
+        }
+
+        info.palette.resize(info.paletteCount);
+        if (!in.read(reinterpret_cast<char*>(info.palette.data()), info.paletteCount * sizeof(PaletteEntry))) /* Flawfinder: ignore */
+        {
+            GetLogger()->error(_("BMP read failure '{}' - could not read palette\n"), filename);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void
+processRow(const std::uint8_t* src,
+           std::uint8_t* dst,
+           std::int32_t width,
+           std::size_t srcOffset)
+{
+    for (std::int32_t x = 0; x < width; ++x)
+    {
+        dst[0] = src[2];
+        dst[1] = src[1];
+        dst[2] = src[0];
+        src += srcOffset;
+        dst += 3;
+    }
+}
+
+inline void
+writePaletteColor(std::uint8_t* dst,
+                  std::uint32_t index,
+                  util::array_view<PaletteEntry> palette)
+{
+    if (index < palette.size())
+    {
+        const PaletteEntry& color = palette[index];
+        dst[0] = color.red;
+        dst[1] = color.green;
+        dst[2] = color.blue;
+    }
+    else
+    {
+        // Out of range of palette - use horrible magenta color
+        dst[0] = UINT8_C(255);
+        dst[1] = UINT8_C(0);
+        dst[2] = UINT8_C(255);
+    }
+}
+
+void
+process8BppRow(const std::uint8_t* src,
+               std::uint8_t* dst,
+               std::int32_t width,
+               util::array_view<PaletteEntry> palette)
+{
+    for (std::int32_t x = 0; x < width; ++x)
+    {
+        writePaletteColor(dst, *src, palette);
+        ++src;
+        dst += 3;
+    }
+}
+
+void
+processLowBppRow(const std::uint8_t* src,
+                 std::uint8_t* dst,
+                 std::int32_t width,
+                 std::uint32_t bpp,
+                 util::array_view<PaletteEntry> palette)
+{
+    assert(bpp == 1 || bpp == 2 || bpp == 4);
+    const unsigned int mask = (1U << bpp) - 1U;
+    const unsigned int initalShift = 8U - bpp;
+    unsigned int shift = initalShift;
+    for (std::int32_t x = 0; x < width; ++x)
+    {
+        unsigned int idx = (*src >> shift) & mask;
+        writePaletteColor(dst, idx, palette);
+        if (shift > 0)
+        {
+            shift -= bpp;
+        }
+        else
+        {
+            shift = initalShift;
+            ++src;
+        }
+
+        dst += 3;
+    }
+}
+
+std::unique_ptr<Image>
+LoadBMPImage(std::istream& in, const fs::path& filename)
+{
+    BMPInfo info;
+    if (!loadBMPHeaders(in, info, filename))
+        return nullptr;
+
+    if (!in.seekg(info.offset, std::ios_base::beg))
+    {
+        GetLogger()->error(_("BMP read failure '{}' - could not seek to image data\n"), filename);
+        return nullptr;
+    }
 
     // slurp the image data
-    std::vector<std::uint8_t> pixels(imageBytes);
-    if (!in.read(reinterpret_cast<char*>(pixels.data()), imageBytes).good())
+    std::vector<std::uint8_t> pixels(info.imageSize);
+    if (!in.read(reinterpret_cast<char*>(pixels.data()), info.imageSize)) /* Flawfinder: ignore */
     {
+        GetLogger()->error(_("BMP read failure '{}' - could not read image data\n"), filename);
         return nullptr;
     }
 
-    // check for truncated file
-
-    auto img = std::make_unique<Image>(PixelFormat::RGB, imageHeader.width, imageHeader.height);
+    auto img = std::make_unique<Image>(PixelFormat::RGB, info.width, info.height);
 
     // Copy the image and perform any necessary conversions
-    for (std::int32_t y = 0; y < imageHeader.height; y++)
+    const std::uint8_t* src = pixels.data();
+    for (std::int32_t y = info.height; y-- > 0;)
     {
-        const std::uint8_t* src = pixels.data() + y * bytesPerRow;
-        uint8_t* dst = img->getPixelRow(y);
+        std::uint8_t* dst = img->getPixelRow(y);
 
-        switch (imageHeader.bpp)
+        switch (info.bpp)
         {
+        case 1:
+        case 2:
+        case 4:
+            processLowBppRow(src, dst, info.width, info.bpp, info.palette);
+            break;
+
         case 8:
-            for (std::int32_t x = 0; x < imageHeader.width; x++)
-            {
-                const uint8_t* color = palette.data() + (*src << 2);
-                dst[0] = color[2];
-                dst[1] = color[1];
-                dst[2] = color[0];
-                src++;
-                dst += 3;
-            }
+            process8BppRow(src, dst, info.width, info.palette);
             break;
+
         case 24:
-            for (std::int32_t x = 0; x < imageHeader.width; x++)
-            {
-                dst[0] = src[2];
-                dst[1] = src[1];
-                dst[2] = src[0];
-                src += 3;
-                dst += 3;
-            }
+            processRow(src, dst, info.width, 3);
             break;
+
         case 32:
-            for (std::int32_t x = 0; x < imageHeader.width; x++)
-            {
-                dst[0] = src[2];
-                dst[1] = src[1];
-                dst[2] = src[0];
-                src += 4;
-                dst += 3;
-            }
+            processRow(src, dst, info.width, 4);
+            break;
+
+        default:
+            assert(0);
             break;
         }
+
+        src += info.rowStride;
     }
 
-    return img.release();
+    return img;
 }
+
 } // anonymous namespace
 
-Image* LoadBMPImage(const fs::path& filename)
+Image*
+LoadBMPImage(const fs::path& filename)
 {
-    std::ifstream bmpFile(filename.string(), std::ios::in | std::ios::binary);
-
-    if (bmpFile.good())
+    std::ifstream bmpFile(filename, std::ios_base::in | std::ios_base::binary);
+    if (!bmpFile)
     {
-        Image* img = LoadBMPImage(bmpFile);
-        bmpFile.close();
-        return img;
+        GetLogger()->error(_("BMP read failure '{}' - could not open file\n"), filename);
+        return nullptr;
     }
 
-    return nullptr;
+    return LoadBMPImage(bmpFile, filename).release();
 }
 
 } // namespace celestia::engine


### PR DESCRIPTION
- Fix mirrored vertical orientation
- Detect more error conditions/malformed files
- Execute fewer read operations on the stream
- Fix issue calculating the row stride (should round up to multiple of 4, not 2)
- Fix palette offset in the presence of extended info structures
- Use magenta for out-of-range palette references
- Support 1, 2, 4 bits per pixel

The vertical orientation issue seems to be a long-standing bug, I guess no-one's noticed because no-one uses .bmp images.