### PR TITLE
Load asterism name translations from asterism context

### DIFF
--- a/src/celengine/asterism.cpp
+++ b/src/celengine/asterism.cpp
@@ -101,7 +101,7 @@ Asterism::Asterism(std::string&& name, std::vector<Chain>&& chains) :
     m_chains(std::move(chains))
 {
 #ifdef ENABLE_NLS
-    if (std::string_view localizedName(D_(m_name.c_str())); localizedName != m_name)
+    if (std::string_view localizedName(DCX_("asterism", m_name.c_str())); localizedName != m_name)
         m_i18nName = localizedName;
 #endif
 


### PR DESCRIPTION
- Use separate context to enable distinguishing Hydra (constellation) and Hydra (moon of Pluto)
- Reduce allocations during context-based translation lookup by using fmt basic_memory_buffer

Related content PR: CelestiaProject/CelestiaContent#212