### PR TITLE
Remove UTF8 multiplication and degree symbol macros

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 20:42+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -819,26 +819,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "كيلومتر"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr "كيلومتر"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " الأيام"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " الساعات"
@@ -920,232 +920,232 @@ msgstr "القطر الظاهر: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "المقدار الظاهر: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "القيمة المطلقة: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "المسافة: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "نقطة منتصف نظام النجوم\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Abs (app) mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "اللمعان: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "نجم نيوترون"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "فجوة سوداء"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "الفصل: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "حرارة السطح: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "تواجد كواكب مرافقه\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "المسافة من المركز: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/hud.cpp:611
-#, c++-format
-msgid "Phase angle: {:.1f}{}\n"
-msgstr ""
+#: ../src/celestia/hud.cpp:610
+#, fuzzy, c++-format
+msgid "Phase angle: {:.1f}°\n"
+msgstr "المقدار الظاهر: "
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "درجة الحرارة: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "وضع التنسيق"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "الوقت الحقيقي"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-الوقت الحقيقي"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "تم ايقاف الوقت"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " أسرع"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " أبطأ"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (ايقاف موقت)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "الانتقال "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "الانتقال "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "تتبع "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "يتبع "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "مدار مصاحب"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "ملاحقة "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr " ايقاف مؤقت"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "  تسجيل"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 بدأ/ايقاف مؤقت    F12 ايقاف"
 
@@ -2989,172 +2989,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&معلومات"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&معلومات"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 غير ممتد</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "نص المعلومات"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "وحدة قياس فضائية"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "المسافة: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "نصف القطر: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "فترة الدوران: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "الحجم:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "الحجم:"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "الحجم:"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "الحجم:"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/be.po
+++ b/po/be.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>, 2024\n"
 "Language-Team: Belarusian (https://app.transifex.com/celestia/teams/93131/"
@@ -805,24 +805,24 @@ msgstr "футаў"
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr "дзён"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "гадзін"
 
@@ -894,232 +894,232 @@ msgid "Apparent diameter: %s\n"
 msgstr "Бачны дыямэтар: %s\n"
 
 #: ../src/celestia/hud.cpp:298
-#, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+#, fuzzy, c++-format
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr "Сх: {:+d}{} {:02d}' {:.1f}\"\n"
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr "ПУ: {}гадз {:02}м {:.1f}с\n"
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Бачная велічыня: {:.1f}\n"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Абсалютная велічыня: {:.1f}\n"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr "{:.6f}{} {:.6f}{} {}"
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Адлегласьць: %s\n"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Барыцэнтар сонечнай сыстэмы\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Абс (бач) вел: {:.2f} ({:.2f})\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Сьвятлівасьць: {} сонечных\n"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Нэўтронная зорка"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Чорная дзірка"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr "Кляса: %s\n"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, c-format
 msgid "Surface temp: %s\n"
 msgstr "Тэмпэратура паверхні: %s\n"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Радыюс: {} сонечных  ({})\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, c++-format
 msgid "Radius: {}\n"
 msgstr "Радыюс {}\n"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Наяўныя плянэтныя спадарожнікі\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Адлегласьць ад цэнтру: %s\n"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr "Радыюс %s\n"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "<b>Экватарыяльны радыюс:</b> %L1 %2"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Радыюс {}\n"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Радыюс: {} сонечных  ({})\n"
 
-#: ../src/celestia/hud.cpp:611
-#, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+#: ../src/celestia/hud.cpp:610
+#, fuzzy, c++-format
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Фазавы вугал: {:.1f}{}\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr "Шчыльнасьць: {} фунтаў/фут³\n"
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr "Шчыльнасьць: {} кг/м³\n"
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, c-format
 msgid "Temperature: %s\n"
 msgstr "Тэмпэратура: %s K\n"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr "Невядомая сыстэма мераньня  {}, выкарыстоўваем мэтрычную"
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 "Не атрымалася атрымаць прадвызначанаю сыстэму мераньня  {}, выкарыстоўваем "
 "мэтрычную"
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "К/С: {:.1f}\n"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Рэжым праўкі"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  ПЧРС"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Сапраўдны час"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Сапраўдны час"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Хада часу спыненая"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, c++-format
 msgid "{:.6g} x faster"
 msgstr "{:.6g} × хутчэй"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, c++-format
 msgid "{:.6g} x slower"
 msgstr "{:.6g} × павольней"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Прыпыненая)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, c++-format
 msgid "Travelling ({})\n"
 msgstr "Падарожнічаем ({})\n"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr "Падарожнічаем\n"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr "Сачыць за %s\n"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr "Усьлед за %s\n"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Сынхранізаваць арбіту з %s\n"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Замацаваны %s -> %s\n"
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr "Даганяць %s\n"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr "ПЗ: {} ({:.2f}×)\n"
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr "{}x{} пры {:.2f} к/с  {}"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "Прыпынена"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr "Запіс"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Пачаць/Паўза   F12 Спыніць"
 
@@ -2810,169 +2810,169 @@ msgstr "Celestia ня здолела ініцыялізаваць OpenGLGLES 2.0
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia ня здолела ініцыялізаваць OpenGL 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr "Памылка: ніякі аб'ект ня вылучаны!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Зьвесткі"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr "Сеціўныя зьвесткі: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Экватарыяльны радыюс:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Памер:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr "<b>Сплюшчанасьць: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Сыдэрычны пэрыяд авароту:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr "Праградны"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr "Рэтраградны"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Напрамак аварачэньня:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Даўжыня дня:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Мае кольцы</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Мае атмасфэру</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Пачатак:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Канец:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Зьвесткі пра арбіту"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Аскуляваныя элемэнты для %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "гады"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Пэрыяд:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "АА"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Дадатковыя восі:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Эксцэнтрысытэт:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
 msgstr "<b>Схіленьне:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Адлегласьць да пэрыцэнтру:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Адлегласьць да апацэнтру:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "<b>Узыходны вузел:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "<b>Парамэтар пэрыяпсыды:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "<b>Сярэдняя анамалія:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Пэрыяд (разьлічаны):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
-#, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+#: ../src/celestia/qt/qtinfopanel.cpp:334
+#, fuzzy, qt-format
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "<b>Сярэдні рух (разьлічаны):</b> %L1%2/дзень"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>ПУ:</b> %L1г %L2м %L3с"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "<b>Сх:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "<b>Д:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "<b>Ш:</b> %L1%2 %L3' %L4\""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/bg.po
+++ b/po/bg.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Georgi Georgiev (RacerBG) <g.georgiev.shumen@gmail.com>, "
 "2024\n"
@@ -804,24 +804,24 @@ msgstr "фт"
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr "дни"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "часа"
 
@@ -893,232 +893,232 @@ msgid "Apparent diameter: %s\n"
 msgstr "Видим диаметър: %s\n"
 
 #: ../src/celestia/hud.cpp:298
-#, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+#, fuzzy, c++-format
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr "δ: {:+d}{} {:02d} ' {:.1f} \"\n"
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr "α: {} ч. {:02} м. {:.1f} с.\n"
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Видима звездна величина: {:.1f}\n"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Абсолютна звездна величина: {:.1f}\n"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr "{:.6f}{} {:.6f}{} {}"
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Разстояние: %s\n"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Център на масата на звездната система\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Абс. (видима) величина: {:.2f} ({:.2f})\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Яркост: {} слънца\n"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Неутронна звезда"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Черна дупка"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr "Спектрален клас: %s\n"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, c-format
 msgid "Surface temp: %s\n"
 msgstr "Температура на повърхността: %s\n"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Радиус: {} сл. рад.  ({})\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, c++-format
 msgid "Radius: {}\n"
 msgstr "Радиус: {}\n"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Присъстват планетарни спътници\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Разстояние от центъра: %s\n"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr "Радиус: %s\n"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "<b>Екваториален радиус</b> %L1 %2"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Радиус: {}\n"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Радиус: {} сл. рад.  ({})\n"
 
-#: ../src/celestia/hud.cpp:611
-#, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+#: ../src/celestia/hud.cpp:610
+#, fuzzy, c++-format
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Фазов ъгъл: {:.1f}{}\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr "Плътност: {} фунта/фт³\n"
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr "Плътност: {} кг/м³\n"
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, c-format
 msgid "Temperature: %s\n"
 msgstr "Температура: %s\n"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr "{} мерни единици са неизвестни, връщане към метрична система"
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 "Неуспешно получаване на {} мерни единици по подразбиране, връщане към "
 "метричната система"
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "ЧКС: {:.1f}\n"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Режим на редактиране"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Реално време"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Реално време"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Времето е спряно"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, c++-format
 msgid "{:.6g} x faster"
 msgstr "{:.6g} пъти по-бързо"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, c++-format
 msgid "{:.6g} x slower"
 msgstr "{:.6g} пъти по-бавно"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (На пауза)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, c++-format
 msgid "Travelling ({})\n"
 msgstr "Придвижване ({})\n"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr "Придвижване\n"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr "Следвай %s\n"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr "Следвай %s\n"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Синхронизирай с орбитата %s\n"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Заключи %s -> %s\n"
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr "Преследвай %s\n"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr "ЧКС: {} ({:.2f}x)\n"
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr "{}x{} при {:.2f} ЧКС  {}"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "На пауза"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr "Записване"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 за Старт и Пауза    F12 за Спиране"
 
@@ -2809,169 +2809,169 @@ msgstr "„Celestia“ не успя да стартира OpenGLES 2.0."
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "„Celestia“ не успя да стартира OpenGL 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr "Грешка: не е избран обект!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Информация"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr "Интернет информация: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Екваториален радиус</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Размер:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr "<b>Сплеснатост: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Звезден ден:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr "Проградна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr "Ретроградна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Посока на въртене:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Продължителност на деня:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Има пръстени</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Има атмосфера</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Начало:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Край:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Орбитална информация"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Оскулационни елементи за %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "години"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Период:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "АЕ"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Полуголяма ос:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Ексцентрицитет:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
 msgstr "<b>Наклон:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Разстояние до перицентъра:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Разстояние до апоцентъра:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "<b>Възходящ възел:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "<b>Параметър на перихелия:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "<b>Средна аномалия:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Период (изчислен):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
-#, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+#: ../src/celestia/qt/qtinfopanel.cpp:334
+#, fuzzy, qt-format
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "<b>Средно движение (изчислено):</b> %L1%2/на ден"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>α:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "<b>δ:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/celestia.pot
+++ b/po/celestia.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -790,24 +790,24 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr ""
 
@@ -880,229 +880,229 @@ msgstr ""
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, c-format
 msgid "Surface temp: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, c++-format
 msgid "Radius: {}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, c++-format
 msgid "Polar radius: {}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, c-format
 msgid "Temperature: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, c++-format
 msgid "{:.6g} x faster"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, c++-format
 msgid "{:.6g} x slower"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, c++-format
 msgid "Travelling ({})\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr ""
 
@@ -2776,169 +2776,169 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
+msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr ""
 
 #: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:336
-#, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr ""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr ""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr ""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-08-10 19:42+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -811,26 +811,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " Tage"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " Stunden"
@@ -912,232 +912,232 @@ msgstr "Scheinbarer Durchmesser: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Scheinbare Magnitude: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Absolute Magnitude: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Entfernung: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Schwerezentrum des Sternsystems\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Absolute (scheinb.) Mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Leuchtkraft: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Neutronenstern"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Schwarzes Loch"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasse: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Oberflächentemp.: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Radius: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Radius: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Planetare Begleiter vorhanden\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Entfernung vom Zentrum: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radius: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Äquatorial"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Radius: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Radius: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Phasenwinkel: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatur: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Editier-Modus"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Echtzeit"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Echtzeit"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Zeit angehalten"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr "2x schneller"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr "2x langsamer"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Angehalten)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Objekt wird angeflogen "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Objekt wird angeflogen "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Zentriert halten: "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Folge "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synchr. Orbit: "
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Nacheilen: "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr "  Angehalten"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "  Aufnahme"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pause    F12 Beenden"
 
@@ -2926,174 +2926,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL-Informationen"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Infotext"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "AE"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Entfernung (Lichtjahre)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Äquatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Rotationsperiode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Größe: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Größe: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Größe: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Größe: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 20:45+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -812,26 +812,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "χμ"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " μ/δ"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " μέρες"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " ώρες"
@@ -913,232 +913,232 @@ msgstr "Φαινόμενη διάμετρος: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Φαινόμενο μέγεθος: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Απόλυτο μέγεθος:"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Απόσταση: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Βαρύκεντρο συστήματος αστέρων\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Απόλυτο(φαινόμενο)μέγεθος: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Φωτεινότητα: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Αστέρας νετρονίων"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Μαύρη τρύπα"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Τάξη: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Θερμοκρασία επιφάνειας:"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Planetary companions present\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Απόσταση από το κέντρο: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Ακτίνα: "
 
-#: ../src/celestia/hud.cpp:611
-#, c++-format
-msgid "Phase angle: {:.1f}{}\n"
-msgstr ""
+#: ../src/celestia/hud.cpp:610
+#, fuzzy, c++-format
+msgid "Phase angle: {:.1f}°\n"
+msgstr "Φαινόμενο μέγεθος: "
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Θερμοκρασία: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Κατάσταση Επεξεργασίας"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Πραγματικός χρόνος"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Πραγματικός χρόνος "
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Ο χρόνος έχει σταματήσει"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " πιο γρήγορα"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " πιο αργά"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr "(Σταματημένο)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Ταξιδεύοντας"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Ταξιδεύοντας"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Τροχιά"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "&Παρακολούθηση"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Συγχρονισμός Τροχιάς"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Καταδίωξη"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr "  Σταματημένο"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "  Εγγραφή"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Εκκίνηση/Παύση    F12 Σταμάτημα "
 
@@ -2972,174 +2972,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Πληροφορίες"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Πληροφορίες OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Βελιγράδι"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Βελιγράδι"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Πληροφοριακό Κείμενο"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "αμ"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Απόσταση (εφ)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Ισημερινή"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Περίοδος περιστροφής: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Μέγεθος: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Μέγεθος: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Μέγεθος: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Μέγεθος: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 20:45+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -813,26 +813,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " días"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " horas"
@@ -914,232 +914,232 @@ msgstr "Diámetro aparente: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Magnitud aparente: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Magnitud absoluta: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distancia: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Baricentro del sistema estelar\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Mag. abs. (aparente): %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosidad: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Estrella de neutrones"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Agujero negro"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Clase: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Temp. superficial: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Radio: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Radio: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Existen compañeros planetarios\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distancia desde el centro: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radio: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Radio: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Radio: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Ángulo de fase: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "CPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Modo de edición"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Tiempo real"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Tiempo real"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Tiempo detenido"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " más rápido"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " más lento"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Pausa)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Viajando "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Viajando "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Rastrear "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Orbita sincrónica "
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Perseguir "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr " Pausa"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr " Grabando"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Empezar/Pausar    F12 Detener"
 
@@ -2974,174 +2974,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Información"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Información OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 sin extensiones</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Información"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "UA"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Distancia (años luz) "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Ecuatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Período de rotación: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamaño: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Tamaño: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Tamaño: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Tamaño: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2019-02-14 21:33+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: French (https://www.transifex.com/celestia/teams/93131/fr/)\n"
@@ -807,24 +807,24 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr ""
 
@@ -897,229 +897,229 @@ msgstr ""
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Barycentre du système stellaire\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Mag. abs (app) : %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Étoile à neutrons"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Trou noir"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Temp. de surface : "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Rayon : "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Rayon : "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Compagnons planétaires présents\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Grille équatoriale"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Rayon : "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Angle de phase : %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Moteur de rendu : "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Mode d’édition"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Temps réel"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "- Temps réel"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Temps arrêté"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, c++-format
 msgid "{:.6g} x faster"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, c++-format
 msgid "{:.6g} x slower"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr "  (en pause)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, c++-format
 msgid "Travelling ({})\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Démarrer/Pause     F12 Arrêter"
 
@@ -2805,171 +2805,171 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrade"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrade"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "Moteur de rendu : "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
+msgstr "Moteur de rendu : "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
+msgstr "Fournisseur : "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
+msgstr "Fournisseur : "
 
 #: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:336
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr ""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr ""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr ""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2022-08-06 14:24+0200\n"
 "Last-Translator: Parodper <parodper@gmail.com>\n"
 "Language-Team: \n"
@@ -805,24 +805,24 @@ msgstr "pés"
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr "días"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "horas"
 
@@ -895,229 +895,229 @@ msgstr "Diámetro aparente: %s\n"
 
 #: ../src/celestia/hud.cpp:298
 #, fuzzy, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr "Declinación: %+d%s %02d' %.1f\"\n"
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, fuzzy, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr "Ascensión recta: %dh %02dm %.1fs\n"
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Magnitude aparente: %.1f\n"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Magnitude absoluta: %.1f\n"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Distancia: %s\n"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Centro de masas do sistema estelar\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Mag. abs. (aparente): %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosidade: %s veces ó Sol\n"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Estrela de neutróns"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Burato negro"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr "Clase: %s\n"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, c-format
 msgid "Surface temp: %s\n"
 msgstr "Temp. superficial: %s\n"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Radio: %s Rsol  (%s)\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Radio:"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Compañeiros planetarios presentes\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distancia dende o centro: %s\n"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr "Radio: %s\n"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "<b>Radio ecuatorial:</b> %L1 %2"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Radio:"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Radio: %s Rsol  (%s)\n"
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Ángulo de fase: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, fuzzy, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr "Densidade: %.2f x 1000 libras/pés³\n"
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, fuzzy, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr "Densidade: %.2f x 1000 kg/m³\n"
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatura: %s\n"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: %.1f\n"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Modo de edición"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Tempo real"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Tempo real"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Tempo parado"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr "%.6g veces máis rápido"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr "%.6g veces máis amodo"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Pausado)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Viaxando (%s)\n"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr "Viaxando\n"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr "Rastrexar %s\n"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr "Seguir %s\n"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Órbita Estacionaria %s\n"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Bloquear %s -> %s\n"
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr "Perseguir %s\n"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, fuzzy, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr "Campo de visión: %s (%.2fx)\n"
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, fuzzy, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr "%dx%d a %.2f fps  %s"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "Parado"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr "Grabando"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Iniciar/Parar    F12 Deter"
 
@@ -2824,169 +2824,169 @@ msgstr "Celestia non puido inicializar OpenGL 2.1."
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia non puido inicializar OpenGL 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr "Error: non hai obxectos seleccionados!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Información"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr "Información Web: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Radio ecuatorial:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Tamaño:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr "<b>Oblatidade: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Período de rotación sideral:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr "Progrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr "Retrógrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Dirección da rotación:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Duración do día:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Ten aneis</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Ten atmosfera</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Inicio:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Fin:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Información orbital"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Elementos oscilantes de %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "anos"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Período:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "UA"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Semieixe maior:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Excentricidade:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
 msgstr "<b>Inclinación:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Distancia do pericentro:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Distancia do apocentro:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "<b>Nodo ascendente:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "<b>Argumento da periapse:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "<b>Anomalía media:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Período (calculado):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "<b>Período (calculado):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>Asc. recta:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "<b>Dec:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 20:47+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -811,26 +811,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr "nap"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr "óra"
@@ -912,232 +912,232 @@ msgstr "Látszólagos átmérő: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Látszólagos fényesség"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Abszolút fényesség: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Távolság: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Csillagrendszer tömegközéppontja\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Absz. (látszó) fényesség: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Fényesség: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Neutroncsillag"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Fekete lyuk"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Osztály:"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Felszíni hőm.: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Kapcsolódó égitestek\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Távolság a középponttól:  "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Sugár: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Fázisszög: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Hőmérséklet: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Edit Mode"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Helyi idő"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Helyi idő"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Idő leállítva"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr "gyorsabb"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr "lassabb"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr "Idő megállítása"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Utazás"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Utazás"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Vontat"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Követ "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Pálya szinkr."
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Üldöz"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr " Szünet"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "Felvétel"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Szünet    F12 Stop"
 
@@ -2972,174 +2972,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Adatok"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Adatok"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrád"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrád"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Kiterjesztések nélküli OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Adatok"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "CSE"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Távolság: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Egyenlítői"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Tengely forgási idő: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Méret: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Méret: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Méret: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Méret: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2023-08-06 17:40+0200\n"
 "Last-Translator: Mattia Verga <mattia.verga@tiscali.it>\n"
 "Language-Team: \n"
@@ -809,24 +809,24 @@ msgstr "ft"
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr "giorni"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "ore"
 
@@ -905,229 +905,229 @@ msgstr "Diametro apparente: %s\n"
 
 #: ../src/celestia/hud.cpp:298
 #, fuzzy, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr "Dec: %+d%s %02d' %.1f\"\n"
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, fuzzy, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr "AR: %dh %02dm %.1fs\n"
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Magnitudine apparente: %.1f\n"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Magnitudine assoluta: %.1f\n"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Distanza: %s\n"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Baricentro del sistema stellare\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Magnitudine assoluta (app.): %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosità: {}x Soli\n"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Stella di neutroni"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Buco nero"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr "Classe: %s\n"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, c-format
 msgid "Surface temp: %s\n"
 msgstr "Temp. superficiale: %s\n"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Raggio: {} Rsole  ({})\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, c++-format
 msgid "Radius: {}\n"
 msgstr "Raggio: {}\n"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Sistema planetario presente\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distanza dal centro: %s\n"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr "Raggio: %s\n"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "<b>Raggio equatoriale:</b> %L1 %2"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Raggio: {}\n"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Raggio: {} Rsole  ({})\n"
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Angolo di fase: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, fuzzy, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr "Densità: %.2f x 1000 lb/m^3\n"
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, fuzzy, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr "Densità: %.2f x 1000 kg/m^3\n"
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatura: %s\n"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: %.1f\n"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Modalità modifica"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  Tempo Locale"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Tempo reale"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Tempo reale"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Tempo arrestato"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr "%.6g x più veloce"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr "%.6g x più lento"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (In Pausa)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, c++-format
 msgid "Travelling ({})\n"
 msgstr "In viaggio ({})\n"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr "In viaggio\n"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr "Aggancia %s\n"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr "Segui %s\n"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Sincronizza Orbita %s\n"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Blocca %s -> %s\n"
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr "Insegui %s\n"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, fuzzy, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr "Campo Visivo: %s (%.2fx)\n"
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, fuzzy, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr "%dx%d a %.2f fps  %s"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "In pausa"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr "In registrazione"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 avvia/pausa    F12 Ferma"
 
@@ -2836,169 +2836,169 @@ msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 "Celestia non è stato in grado di inizializzare le estensioni OpenGL 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr "Errore: nessun oggetto selezionato!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Informazioni"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr "Informazioni web: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Raggio equatoriale:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Dimensione:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr "<b>Schiacciamento: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Periodo di rotazione siderale:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr "Progrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr "Retrogrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Direzione di rotazione:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Durata del giorno:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Ha anelli</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Ha un'atmosfera</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Inizio:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Fine:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Informazioni sull'orbita"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Elementi osculanti per %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "anni"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Periodo:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "UA"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Semiasse maggiore:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Eccentricità:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
 msgstr "<b>Inclinazione:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Distanza pericentro:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Distanza apocentro:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "<b>Nodo ascendente:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "<b>Argomento del pericentro:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "<b>Anomalia media:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Periodo (calcolato):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "<b>Periodo (calcolato):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>AR:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "<b>Dec:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2020-07-05 21:01+0900\n"
 "Last-Translator: Sui Ota <aqua@aqsp.net>\n"
 "Language-Team: \n"
@@ -805,24 +805,24 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr "日"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "時間"
 
@@ -895,229 +895,229 @@ msgstr "視直径: %s\n"
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "視等級: %.1f\n"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "絶対等級: %.1f\n"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr "距離: %s\n"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "重心\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "絶対等級: %.2f 視等級: %.2f\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "光度: 太陽の%s 倍\n"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "中性子星"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "ブラックホール"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr "スペクトル型: %s\n"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "表面温度: %s K\n"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "半径: 太陽の%s 倍 (%s km)\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "半径: %s\n"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "惑星が存在\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "中心からの距離: %s\n"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr "半径: %s\n"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "<b>赤道半径:</b> %L1 %2"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "半径: %s\n"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "半径: 太陽の%s 倍 (%s km)\n"
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "位相角: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, fuzzy, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr "密度: %.2f×1000 kg/m³\n"
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, fuzzy, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr "密度: %.2f×1000 kg/m³\n"
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "温度: %.0f K\n"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: %.1f\n"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "編集モード"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr " 光速"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "等倍速"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-等倍速"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "停止中"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr "%.6g 倍速"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr "1/%.6g 倍速"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (停止中)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "移動中 (%s)\n"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr "移動中\n"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr "%s を中央保持\n"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr "%s に天球同期\n"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "%s に自転同期\n"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "%s から%s に同期\n"
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr "%s に公転同期\n"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, fuzzy, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr "視野: %s (%.2fx)\n"
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, fuzzy, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr "%d×%d at %f fps  %s"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "停止中"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr "録画中"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 録画開始/一時停止    F12 停止"
 
@@ -2832,171 +2832,171 @@ msgstr ""
 "CelestiaはOpenGL拡張の初期化に失敗しました(エラー %i)。グラフィック品質が低下"
 "します。"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr "エラー: 天体が選択されていません。\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "情報"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr "Web情報: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>赤道半径:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>大きさ:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr "<b>偏平率: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>自転周期(恒星時):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "ベオグラード"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "ベオグラード"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>レンダラー: </b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>1日の長さ:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>軌道長半径:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>周期:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "軌道情報"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "%1 の接触要素"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "年"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>周期:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "天文単位"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>軌道長半径:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>軌道長半径:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
 msgstr "<b>軌道傾斜角:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>近点距離:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>遠点距離:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "<b>昇交点:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "<b>近点引数:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "<b>平均近点角:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>自転周期 (計算):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "<b>自転周期 (計算):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>赤経:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "<b>赤緯:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/ka.po
+++ b/po/ka.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2023-11-03 13:48+0200\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023\n"
 "Language-Team: Georgian (https://app.transifex.com/celestia/teams/93131/"
@@ -800,24 +800,24 @@ msgstr "ფტ"
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "კმ"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr "წთ"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr "დღე"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "საათი"
 
@@ -890,229 +890,229 @@ msgstr ""
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr "დაშორება: %s\n"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "ვარსკვლავური სისტემის ბარიცენტრი\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "სიკაშკაშე: {}x მზე\n"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "ნეიტრონული ვარსკვლავი"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "შავი ხვრელი"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr "კლასი: %s\n"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, c-format
 msgid "Surface temp: %s\n"
 msgstr "ზედაპირის ტემპერატურა: %s\n"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "რადიუსი: {} Rმზის  ({})\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, c++-format
 msgid "Radius: {}\n"
 msgstr "რადიუსი: {}\n"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr "რადიუსი: %s\n"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "<b>ეკვატორული რადიუსი:</b> %L1 %2"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "რადიუსი: {}\n"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "რადიუსი: {} Rმზის  ({})\n"
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "ფაზის კუთხე: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, fuzzy, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr "სიმკვრივე: %.2f x 1000 გირვ/ფტ^3\n"
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, fuzzy, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr "სიმკვრივე: %.2f x 1000 კგ/მ^3\n"
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, c-format
 msgid "Temperature: %s\n"
 msgstr "ტემპერატურა: %s\n"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "კადრი/წმ: %.1f\n"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "ჩასწორების რეჟიმი"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "რეალურ დროში"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-რეალური დრო"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "დრო გაჩერებულია"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr "%.6g x სწრაფად"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr "%.6g x ნელა"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (შეჩერებულია)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, c++-format
 msgid "Travelling ({})\n"
 msgstr "მოგზაურობა ({})\n"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr "მოგზაურობა\n"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr "ტრეკი %s\n"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr "%s-ის მიყოლა\n"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "სინქ. ორბიტა %s\n"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "დაბლოკე %s -> %s\n"
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr "%s-ის დევნა\n"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, fuzzy, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr "%dx%d %.2f კ/წმ  %s"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "შეჩერება"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr "ჩანაწერი"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr ""
 
@@ -2793,170 +2793,170 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "ინფორმაცია"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>ეკვატორული რადიუსი:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>ზომა:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>ბრუნვის მიმართულება:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>დღის სიგრძე:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>აქვს რგოლები</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>აქვს ატმოსფერო</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>დასაწყისი:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>დასასრული:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "ორბიტის ინფორმაცია"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "წელი"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>პერიოდი:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "აე"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>ნახევრად-მნიშვნელოვანი ღერძი:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>ექსცენტრულობა:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
 msgstr "<b>დახრა:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>პერიცენტრს დაშორება:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>აპოცენტრის დაშორება:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
+msgstr "<b>მომწოდებელი:</b> %1"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
+msgstr "<b>დღის სიგრძე:</b> %L1 %2"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
+msgstr "<b>დღის სიგრძე:</b> %L1 %2"
 
 #: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:336
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
+msgstr "<b>ზომა:</b> %L1 %2"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
+msgstr "<b>ზომა:</b> %L1 %2"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
+msgstr "<b>ზომა:</b> %L1 %2"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208
 msgid "OpenGL 2.1"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 20:48+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -811,26 +811,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " 일"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " 시간"
@@ -912,232 +912,232 @@ msgstr "시직경: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "겉보기 등급: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "절대등급: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "거리: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "중심\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "절대등급: %.2f 겉보기 등급: %.2f\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "밝기: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "중성자 별"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "블랙홀"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "분광형: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "표면온도: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "반지름: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "반지름: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "행성 존재\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "중심에서의 거리: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "반지름: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "적도"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "반지름: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "반지름: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "위상각: : %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "온도: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "편집 모드"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  광속"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "실시간"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-실시간"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "시간멈춤"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " 배속"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " 분의 1배속"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr "(멈춤)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "이동중 "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "이동중 "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "화면중앙에 유지: "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "추적: "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "자전 동기: "
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "공전 동기: "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr " 멈춤"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr " 동영상 저장중"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 녹화시작/일시정지    F12 정지"
 
@@ -2972,174 +2972,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "천체정보(&I)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL정보"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "자전주기: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "베오그라드"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "베오그라드"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>미확장 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "천체 정보 표시"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "AU"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "거리(광년)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "적도"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "자전주기: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "자전주기: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "크기: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "크기: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "크기: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "크기: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/lt.po
+++ b/po/lt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia lt\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2020-07-14 06:47+0300\n"
 "Last-Translator: Mantas Kriaučiūnas <baltix@gmail.com>\n"
 "Language-Team: \n"
@@ -801,25 +801,25 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr "dienos"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr "valandos"
@@ -901,232 +901,232 @@ msgstr "Regimasis skersmuo:"
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Regimasis ryškis:"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Absoliutus ryškis:"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Atstumas: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Žvaigždžių sistemos baricentras\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Abs (app) ryšk: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Šviesumas:"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Neutroninė žvaigždė"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Juodoji bedugnė"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasė: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Paviršiaus temp.: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Skersmuo: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Skersmuo: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Dabartiniai planetų palydovai\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Atstumas nuo centro: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Skersmuo: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Pusiaujo tinklelis"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Skersmuo: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Skersmuo: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Fazės kampas: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatūra: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Redagavimo režimas"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Realus laikas"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Realus laikas"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Laikas sustabdytas"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " greičiau"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " lėčiau"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Sustabdyta)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Keliaujama "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Keliaujama "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Takas"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Sekti "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Sinchronizuoti orbitą"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Persekioti"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr " Sustabdyta"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr " Įrašymas"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Pradėti/Pauzė    F12 Sustabdyti"
 
@@ -2924,174 +2924,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Didis:  %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgradas"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgradas"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "Plokštė:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informacinis tekstas"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
+msgstr "Plokštė:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
+msgstr "Tiekėjas: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
+msgstr "Plokštė:"
+
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
+msgstr "Tiekėjas: "
 
 #: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:336
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
+msgstr "Didis:  %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
+msgstr "Didis:  %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
+msgstr "Didis:  %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208
 #, fuzzy

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 20:49+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -812,26 +812,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " dienas"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " stundas"
@@ -913,232 +913,232 @@ msgstr "Redzamais diametrs: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Redzamais spožums: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Absolūtais spožums: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distance: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Zvaigžņu sistēmas baricentrs\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Absolūtais (redz.) spožums: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Starjauda: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Neitronu zvaigzne"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Melnais caurums"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klase: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Virsmas temperatūra: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Šai sistēmā ir planētas\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Attālums no centra:"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Radiuss: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Fāzes lenķis: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatūra: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Rediģēšanas režīms"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Reālais laiks"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Reālais laiks"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Laiks apturēts"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr "ātrāk"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr "lēnāk"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Pauze)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Ceļā"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Ceļā"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Tur skatu uz objektu "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seko objektam"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Sinhronajā orbītītā ap objektu "
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Novēro objektu "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr "Pauze"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "Ieraksta"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Sākt/Pauze    F12 Stop"
 
@@ -2973,174 +2973,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Informācija"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL informācija"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrada"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrada"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Nepaplašināts OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informatīvais teksts"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Attālums(ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Ekvatoriālais"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Rotācijas periods: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Izmērs: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Izmērs: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Izmērs: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Izmērs: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/nb.po
+++ b/po/nb.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2010-02-25 17:50+0100\n"
 "Last-Translator: Bjørn Steensrud <bjornst@skogkatt.homelinux.org>\n"
 "Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
@@ -810,26 +810,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " dager"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " timer"
@@ -910,231 +910,231 @@ msgstr "Tilsynelatende diameter: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Tilsynelatende størrelse: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Absolutt størrelse: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Avstand: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Stjernesystemets tyngdesenter\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Abs (tils.) størr.: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Lysstyrke: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Nøytronstjerne"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Svart hull"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasse: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Overflatetemperatur: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Radius: %.2f Rsol\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Radius: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Planetære satellitter tilstede\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Avstand fra sentrum: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radius: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Himmelrutenett"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Radius: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Radius: %.2f Rsol\n"
 
-#: ../src/celestia/hud.cpp:611
-#, c++-format
-msgid "Phase angle: {:.1f}{}\n"
-msgstr ""
+#: ../src/celestia/hud.cpp:610
+#, fuzzy, c++-format
+msgid "Phase angle: {:.1f}°\n"
+msgstr "Tilsynelatende størrelse: "
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatur: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Redigeringsmodus"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Sanntid"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Sanntid"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Tid stoppet"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " raskere"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " langsommere"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr "  (Pause)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Reiser "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Reiser "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Spor "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Følg "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synkronbane"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Jag "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "Pause"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "  Opptak"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pause    F12 Stopp"
 
@@ -2937,172 +2937,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Størrelse: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "Omløpstid: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informasjonstekst"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
+msgstr "Omløpstid: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
+msgstr "Leverandør: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
+msgstr "Leverandør: "
 
 #: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:336
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
+msgstr "Størrelse: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
+msgstr "Størrelse: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
+msgstr "Størrelse: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208
 #, fuzzy

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 20:50+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -811,26 +811,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr "dagen"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr "uren"
@@ -912,232 +912,232 @@ msgstr "Observeerbare diameter: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Schijnbare helderheid: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Absolute helderheid: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Afstand: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Massamiddelpunt van zonnestelsel\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Abs. (schijnb.) helderheid:  %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Helderheid: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Neutronenster"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Zwart gat"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klasse: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Oppervlaktetemperatuur: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Straal: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Straal: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Planitaire metgezellen aanwezig\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Afstand van centrum: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Straal: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Straal: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Straal: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Fasehoek: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatuur: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS:"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Bewerk modus"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Lokale Tijd"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Lokale Tijd"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Tijd gestopt"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr "sneller"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr "langzamer"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr "Gepauzeerd"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Reizen "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Reizen "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "volgen"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Achtervolg "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synchronizeer omloopbaan"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Opjagen "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "Opnemen"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pause F12 Stop"
 
@@ -2971,174 +2971,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Unextended OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informatietekst"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Afstand (ly)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Equatoriaal"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Rotatie periode: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Grootte: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Grootte: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Grootte: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Grootte: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/pl.po
+++ b/po/pl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2019-02-14 21:31+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: Polish (https://www.transifex.com/celestia/teams/93131/pl/)\n"
@@ -810,24 +810,24 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr ""
 
@@ -900,229 +900,229 @@ msgstr ""
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Barycentrum systemu gwiezdnego\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Mag. abs (poz): %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Gwiazda neuronowa"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Czarna dziura"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Temp. powierzchni:"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Promień: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Promień: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Obecne towarzysze planetarne\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Siatka równikowa"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Promień: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Kąt fazowy: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Renderer: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Tryb edycji"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Czas rzeczywisty"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Czas rzeczywisty"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Czas zatrzymany"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, c++-format
 msgid "{:.6g} x faster"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, c++-format
 msgid "{:.6g} x slower"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Wstrzymano)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, c++-format
 msgid "Travelling ({})\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pauza    F12 Stop"
 
@@ -2828,171 +2828,171 @@ msgstr ""
 "Celestia nie mogła zainicjować rozszerzeń OpenGL (błąd %1). Jakość grafiki "
 "będzie zmniejszona."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "Renderer: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
-msgstr ""
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
+msgstr "Renderer: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
+msgstr "Dostawca: "
+
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr ""
+
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
+msgstr "Dostawca: "
 
 #: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
-msgstr ""
-
-#: ../src/celestia/qt/qtinfopanel.cpp:336
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr ""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr ""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr ""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 20:52+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -811,26 +811,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " dias"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " horas"
@@ -912,232 +912,232 @@ msgstr "Diâmetro aparente: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Magnitude aparente: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Magnitude absoluta: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distância: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Baricentro do sistema estelar\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Mag abs (apa): %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosidade: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Estrela de neutrões"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Buraco negro"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Classe: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Temp à superfície:"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Companheiros planetários presentes\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distância do centro: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Equatorial"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Ângulo de fase: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Modo de edição"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Tempo real"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Tempo real"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Tempo parado"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " mais depressa"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " mais devagar"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Pausado)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "A viajar"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "A viajar"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Seguir a rota "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Órbita Geoest. "
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr " Pausa"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr " A gravar"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Iniciar/Pausar    F12 Parar"
 
@@ -2971,174 +2971,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Informação"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Informação"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Distância: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Tamanho: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Tamanho: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Tamanho: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 20:52+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -811,26 +811,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " dias"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " horas"
@@ -912,232 +912,232 @@ msgstr "Diâmetro aparente: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Magnitude aparente: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Magnitude absoluta: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distância: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Baricentro do sistema estelar\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Mag abs (apa): %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Luminosidade: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Estrela de neutrões"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Buraco negro"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Classe: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Temp à superfície:"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Companheiros planetários presentes\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distância do centro: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Equatorial"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Raio: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Ângulo de fase: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Modo de edição"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Tempo real"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Tempo real"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Tempo parado"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " mais depressa"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " mais devagar"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Pausado)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "A viajar"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "A viajar"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Seguir a rota "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Órbita Geoest. "
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Seguir "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr " Pausa"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr " A gravar"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Iniciar/Pausar    F12 Parar"
 
@@ -2971,174 +2971,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Informação"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Informação do OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrado"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1. sem extensão</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Texto Informativo"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Distância (anos-luz)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Equatorial"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Período de rotação: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Tamanho: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Tamanho: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Tamanho: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Tamanho: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 21:00+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -814,26 +814,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " zile"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " ore"
@@ -915,232 +915,232 @@ msgstr "Diametru aparent: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Magnitudine aparentă: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Magnitudine absolută: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Distanţă: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Baricentrul sistemului stelar\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Mag abs. (aparentă): %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Luminozitate: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Stea de neutroni"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Gaura neagra"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Clasa: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Temperatura la suprafaţă: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Raza: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Raza: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Însoţitor planetar prezent\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Distanţa de la centru: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Raza: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Raza: "
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Raza: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Raza: "
 
-#: ../src/celestia/hud.cpp:611
-#, c++-format
-msgid "Phase angle: {:.1f}{}\n"
-msgstr ""
+#: ../src/celestia/hud.cpp:610
+#, fuzzy, c++-format
+msgid "Phase angle: {:.1f}°\n"
+msgstr "Magnitudine aparentă: "
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatura: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "IPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Mod de editare"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  TL"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Timp real"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Timp real"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Timp oprit"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " mai repede"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " mai încet"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Pauză)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Pe drum"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Pe drum"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Rută"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Urmează "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Orbită sincronă"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Urmăreşte"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr "  Pauză"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "  Înregistrează"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Pauză    F12 Stop"
 
@@ -2975,172 +2975,172 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "Informaţii OpenGL"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 neextins</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Text informativ"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "ua"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Distanţa (al)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Raza: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Perioada de rotaţie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Dimensiune: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Dimensiune: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Dimensiune: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Dimensiune: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/ru.po
+++ b/po/ru.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Askaniy Anpilogov, 2024\n"
 "Language-Team: Russian (https://app.transifex.com/celestia/teams/93131/ru/)\n"
@@ -806,24 +806,24 @@ msgstr "(в футах)"
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr "м"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr "дн."
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "ч."
 
@@ -895,232 +895,232 @@ msgid "Apparent diameter: %s\n"
 msgstr "Угловой размер: %s\n"
 
 #: ../src/celestia/hud.cpp:298
-#, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+#, fuzzy, c++-format
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr "Склонение: {:+d}{} {:02d}' {:.1f}\"\n"
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr "Прямое восхождение: {}ч {:02}м {:.1f}с\n"
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Видимая звёздная величина: {:.1f}\n"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Абсолютная звёздная величина: {:.1f}\n"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr "{:.6f}{} {:.6f}{} {}"
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Расстояние: %s\n"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Центр масс звёздной системы\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Абс. (вид.) зв. величина: {:.2f} ({:.2f})\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Светимость: {}x солн.\n"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Нейтронная звезда"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Чёрная дыра"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr "Класс: %s\n"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, c-format
 msgid "Surface temp: %s\n"
 msgstr "Температура поверхности: %s\n"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Радиус: {} солн.  ({})\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, c++-format
 msgid "Radius: {}\n"
 msgstr "Радиус: {}\n"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Присутствует планетарная система\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Расстояние от центра: %s\n"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr "Радиус: %s\n"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "<b>Экв. радиус:</b> %L1 %2"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Радиус: {}\n"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Радиус: {} солн.  ({})\n"
 
-#: ../src/celestia/hud.cpp:611
-#, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+#: ../src/celestia/hud.cpp:610
+#, fuzzy, c++-format
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Фазовый угол: {:.1f}{}\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr "Плотность: {} (в фунтах/фут³)\n"
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr "Плотность: {} кг/м³\n"
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, c-format
 msgid "Temperature: %s\n"
 msgstr "Температура: %s\n"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr "Неизвестная система измерения {}, переход на метрическую систему"
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 "Не удалось получить систему измерения по умолчанию {}, переход на "
 "метрическую систему"
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: {:.1f}\n"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Режим правки"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Прямой ход времени"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "Обратный ход времени"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Ход времени остановлен"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, c++-format
 msgid "{:.6g} x faster"
 msgstr "{:.6g}-кратное ускорение"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, c++-format
 msgid "{:.6g} x slower"
 msgstr "{:.6g}-кратное замедление"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Пауза)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, c++-format
 msgid "Travelling ({})\n"
 msgstr "Перемещение ({})\n"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr "Перемещение\n"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr "Следование %s\n"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr "Наблюдение %s\n"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Синх. вращение %s\n"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Блокировка фазы %s -> %s\n"
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr "Сопровождение %s\n"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr "Поле зрения: {} ({:.2f}x)\n"
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr "{}x{} при {:.2f} fps  {}"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "Пауза"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr "Запись"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Пуск/Пауза    F12 Стоп"
 
@@ -2812,169 +2812,169 @@ msgstr "Celestia не удалось инициализировать OpenGLES 2
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia не удалось инициализировать OpenGL 2.1."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr "Ошибка: нет выделенного!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Информация"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr "В интернете: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Экв. радиус:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Размер:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr "<b>Полярное сжатие: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Звёздные сутки:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr "Прямое"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr "Ретроградное"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Направление вращения:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Солнечные сутки:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Есть кольца</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Есть атмосфера</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>От:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>До:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Параметры орбиты"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "Оскулирующие элементы на %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "л."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Период обращения:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "а.е."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Большая полуось:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Эксцентриситет:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
 msgstr "<b>Наклонение:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Перицентрическое расстояние:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Апоцентрическое расстояние:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "<b>Долгота восходящего узла:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "<b>Аргумент перицентра:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "<b>Средняя аномалия:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Период обращения (рассчитанный):</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
-#, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+#: ../src/celestia/qt/qtinfopanel.cpp:334
+#, fuzzy, qt-format
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "<b>Среднее движение (рассчитанное):</b> %L1%2 за сутки"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>Прямое восх.:</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "<b>Склонение:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 21:00+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -812,26 +812,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " dní"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " hodín"
@@ -913,232 +913,232 @@ msgstr "Zdanlivý priemer: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Zdanlivá hviezdna jasnosť: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Absolútna hviezdna jasnosť: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Barycentrum (ťažisko) hviezdneho systému\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Abs. (zdan.) jasnosť: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Svietivosť: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Neutrónová hviezda"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Čierna diera"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Trieda: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Povrchová teplota: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Existujú planetárni súputníci\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Vzdialenosť od stredu: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Rovníková"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Polomer: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Fázový uhol: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Teplota: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Režim zmien"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  Miestny čas"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Skutočný čas"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Skutočný čas"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Čas zastavený"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " rýchlejšie"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " pomalšie"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Pozastavený)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Cestovanie "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Cestovanie "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Sleduje sa "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Nasleduje sa "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synchr. obeh nad "
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Prenasleduje sa "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr " Pozastavené"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "  Nahrávanie"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Spustiť/Pozastaviť    F12 Ukončiť"
 
@@ -2975,174 +2975,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Informácie"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Informácie"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belehrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belehrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 bez rozšírení</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informačný text"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "AU"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Vzdialenosť: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Rovníková"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Doba rotácie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Veľkosť: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Veľkosť: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Veľkosť: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Veľkosť: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 21:01+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -811,26 +811,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " dagar"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " timmar"
@@ -912,232 +912,232 @@ msgstr "Apparent diameter: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Apparent magnitud: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Absolut magnitud: "
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Avstånd: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Stjärnsystemets masscentrum\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Abs (ungefärlig) mag: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Ljusstyrka: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Neutronstjärna"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Svart hål"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Klass: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Yttemperatur: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Radie: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Radie: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Följeslagare till stjärnan finns\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Avstånd från centrum: "
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Radie: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Radie: "
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Radie: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Radie: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Fasvinkel: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Temperatur: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Redigeringsläge"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Realtid"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Realtid"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Tid stoppad"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " snabbare"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " långsammare"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Pausad)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Reser "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Reser "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Spåra "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Följ "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Synkronisera omloppsbana "
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Jaga"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr "  Pausad"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "  Spelar in"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Start/Paus     F12 Stopp"
 
@@ -2972,174 +2972,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL-info"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Ej utökad OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Informationstext"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "au"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Avstånd (lj)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Radie: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Rotationsperiod: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Storlek: %1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Storlek: %1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Storlek: %1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Storlek: %1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/tr.po
+++ b/po/tr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2021-12-20 00:20+0200\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: Turkish (https://www.transifex.com/celestia/teams/93131/tr/)\n"
@@ -806,24 +806,24 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr "gün"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "saat"
 
@@ -896,229 +896,229 @@ msgstr "Görünür çap: %s\n"
 
 #: ../src/celestia/hud.cpp:298
 #, fuzzy, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr "Sap: %+d%s %02d' %.1f\"\n"
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, fuzzy, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr "RA: %dh %02dm %.1fs\n"
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Görünür kadir: %.1f\n"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Mutlak kadir %.1f\n"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr "Mesafe: %s\n"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Yıldız sistemi kütle merkezi\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Mtlk (grnr) kad: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Parlaklık: %s x Güneş\n"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Nötron yıldızı"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Kara delik"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr "Sınıf: %s\n"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Yüzey sıcaklığı: %s K\n"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Yarıçap: %s Rgüneş  (%s)\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Yarıçap: %s\n"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Gezegensel refakatçiler mevcut\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "Merkezden uzaklık %s\n"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr "Yarıçap: %s\n"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "<b>Ekvatoral yarıçap:</b> %L1 %2"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Yarıçap: %s\n"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Yarıçap: %s Rgüneş  (%s)\n"
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Faz açısı: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, fuzzy, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr "Yoğunluk: %.2f x 1000 kg/m^3\n"
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, fuzzy, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr "Yoğunluk: %.2f x 1000 kg/m^3\n"
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Sıcaklık: %.0f K\n"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS: %.1f\n"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Düzenleme Modu"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr " LT"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Gerçek zaman"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Gerçek zaman"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Zaman durdu"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr "%.6g x daha hızlı"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr "%.6g x daha yavaş"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr "(duraklatıldı)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Seyahat ediliyor (%s)\n"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr "Seyahat ediliyor\n"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr "%s İzle\n"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr "%s Takip Et\n"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "%s Yörüngesiyle Senkronize Et\n"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "Kilitle %s -> %s\n"
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr "%s Peşinden Git\n"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, fuzzy, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr "FOV: %s (%.2fx)\n"
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "Durduruldu"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr "Kaydediyor"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Başlat/Duraklat    F12 Durdur"
 
@@ -2826,171 +2826,171 @@ msgstr "Celestia, OpenGL 2.1'i başlatamadı."
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia, OpenGL 2.1'i başlatamadı."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr "Hata: hiçbir cisim seçilmedi!\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "Bilgi"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr "Web bilgisi: %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>Ekvatoral yarıçap:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>Boyut:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr "<b>Yassılık:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>Yıldızsal dönüş periyodu:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Belgrad"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>Renderer:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>Gün uzunluğu:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>Halkalı</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>Atmosfere sahip</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>Başlangıç:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>Bitiş:</b> %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "Yörünge bilgisi"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "%1 için elemanlar teğet"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "yıl"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>Periyot:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "AB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>Yarı-büyük eksen:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>Dış merkezlilik:</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
 msgstr "<b>Eğiklik:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>Enberi uzaklığı:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>Enöte uzaklığı:</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "<b>Yükselen düğüm:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "<b>Periapsis argümanı:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "<b>Ortalama anomali:</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>Periyot (hesaplanan):</b>  %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "<b>Periyot (hesaplanan):</b>  %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>SY:</b> %L1sa %L2d %L3sn"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "<b>Sap:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "<b>L:</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "<b>B:</b> %L1%2 %L3' %L4\""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 21:02+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -812,26 +812,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "км"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr " м/с"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " днів"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " годин"
@@ -913,232 +913,232 @@ msgstr "Видимий діаметр: "
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "Видима зоряна величина: "
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "Абсолютна величина:"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "Відстань: "
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "Центр тяжіння зоряної системи \n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "Абс. (вид.) величина: %.2f (%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "Світність: "
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "Нейтронна зірка"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "Чорна дірка"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "Клас: "
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "Темп. поверхні: "
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "Має планетарну систему\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "Відстань від центру:"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "Радіус: "
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "Фазовий кут: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "Температура: "
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "Кд/с: "
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "Режим редагування"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  НТ"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "Реальний час"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-Реальний час"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "Час зупинений"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " раз швидше"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " раз повільніше"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (Призупинено)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "Подорож "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "Подорож "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "Траєкторія "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "Стеження "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "Синхронна орбіта "
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "Гонитва "
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr "  Призупинено"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "  Запис"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 Пуск/Пауза    F12 Зупинка"
 
@@ -2973,174 +2973,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "&Інформація"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "&Інформація"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "Період обертання: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "Белград"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "Белград"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>OpenGL 1.1 без додатків</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "Інформаційний текст"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "а. о."
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "Відстань: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "Екваторіальна"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "Період обертання: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "Період обертання: "
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "Розмір: %1 Мб"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "Розмір: %1 Мб"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "Розмір: %1 Мб"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "Розмір: %1 Мб"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,25 +2,26 @@
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Hleb Valoshka <375gnu@gmail.com>, 2023
 # LBV 2012-26 <lbv2012-26@outlook.com>, 2024
 # Levin Li <lilinfeng.app@outlook.com>, 2024
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-11-02 18:33+0000\n"
 "Last-Translator: Levin Li <lilinfeng.app@outlook.com>, 2024\n"
-"Language-Team: Chinese (China) (https://app.transifex.com/celestia/teams/93131/zh_CN/)\n"
+"Language-Team: Chinese (China) (https://app.transifex.com/celestia/"
+"teams/93131/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: ../src/celastro/date.cpp:487
@@ -796,24 +797,24 @@ msgstr "ft"
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "km"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 msgid "m"
 msgstr "m"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 msgid "days"
 msgstr "天"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 msgid "hours"
 msgstr "小时"
 
@@ -885,242 +886,240 @@ msgid "Apparent diameter: %s\n"
 msgstr "视直径：%s\n"
 
 #: ../src/celestia/hud.cpp:298
-#, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+#, fuzzy, c++-format
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr "赤纬：{:+d}{} {:02d}' {:.1f}\"\n"
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr "赤经：{}h {:02}m {:.1f}s\n"
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "视星等：{:.1f}\n"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "绝对星等：{:.1f}\n"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr "{:.6f}{} {:.6f}{} {}"
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, c-format
 msgid "Distance: %s\n"
 msgstr "距离：%s\n"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "星系质心\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "绝对（视觉）星等：{:.2f}（{:.2f}）\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "光度: {} Lsun\n"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "中子星"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "黑洞"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, c-format
 msgid "Class: %s\n"
 msgstr "类别：%s\n"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, c-format
 msgid "Surface temp: %s\n"
 msgstr "表面温度：%s\n"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "半径：{} 倍太阳半径（{}）\n"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, c++-format
 msgid "Radius: {}\n"
 msgstr "半径：{}\n"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "拥有行星\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, c-format
 msgid "Distance from center: %s\n"
 msgstr "到中心的距离：%s\n"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, c-format
 msgid "Radius: %s\n"
 msgstr "半径：%s\n"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "赤道半径：{}\n"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, c++-format
 msgid "Polar radius: {}\n"
 msgstr "极半径：{}\n"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "半径：{} × {} × {}\n"
 
-#: ../src/celestia/hud.cpp:611
-#, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+#: ../src/celestia/hud.cpp:610
+#, fuzzy, c++-format
+msgid "Phase angle: {:.1f}°\n"
 msgstr "相位角：{:.1f}{}\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr "密度：{} lb/ft³\n"
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr "密度：{} kg/m³\n"
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, c-format
 msgid "Temperature: %s\n"
 msgstr "温度：%s\n"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr "未知测量系统 {}，回退到公制系统"
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr "获取默认测量系统 {} 失败，回退到公制系统"
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "FPS：{:.1f}\n"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "编辑模式"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr " 本地时间"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "实时"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-实时"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "时间已停止"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, c++-format
 msgid "{:.6g} x faster"
 msgstr "加快 {:.6g} 倍"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, c++-format
 msgid "{:.6g} x slower"
 msgstr "减慢至 1/{:.6g}"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr "（已暂停）"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, c++-format
 msgid "Travelling ({})\n"
 msgstr "正在飞行（{}）\n"
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 msgid "Travelling\n"
 msgstr "正在飞行\n"
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, c-format
 msgid "Track %s\n"
 msgstr "跟踪 %s\n"
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, c-format
 msgid "Follow %s\n"
 msgstr "跟随 %s\n"
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, c-format
 msgid "Sync Orbit %s\n"
 msgstr "同步轨道 %s\n"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr "锁定 %s -> %s\n"
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, c-format
 msgid "Chase %s\n"
 msgstr "追逐 %s\n"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr "FOV：{} ({:.2f}x)\n"
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr "{}x{} at {:.2f} fps  {}"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Paused"
 msgstr "已暂停"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 msgid "Recording"
 msgstr "正在录像"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 开始/暂停    F12 停止"
 
-#. TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {}
-#. catalog"
+#. TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
 #: ../src/celestia/loaddso.cpp:32
 msgctxt "catalog"
 msgid "deep sky"
 msgstr "深空"
 
-#. TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {}
-#. catalog"
+#. TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
 #: ../src/celestia/loadsso.cpp:39
 msgctxt "catalog"
 msgid "solar system"
@@ -1150,8 +1149,7 @@ msgstr "打开 {} 时出错\n"
 msgid "Error reading star names file {}\n"
 msgstr "读取恒星名字文件 {} 出错\n"
 
-#. TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {}
-#. catalog"
+#. TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
 #: ../src/celestia/loadstars.cpp:97
 msgctxt "catalog"
 msgid "star"
@@ -1759,8 +1757,8 @@ msgstr "获取 log 文件的路径时出错。"
 
 #: ../src/celestia/qt/qtappwin.cpp:267
 msgid ""
-"Celestia is unable to run because the data directory was not found, probably"
-" due to improper installation."
+"Celestia is unable to run because the data directory was not found, probably "
+"due to improper installation."
 msgstr "找不到数据目录，Celestia 无法运行，可能是安装时出现了错误。"
 
 #: ../src/celestia/qt/qtappwin.cpp:349
@@ -1781,8 +1779,7 @@ msgstr "太阳系"
 msgid "Deep Sky Objects"
 msgstr "深空天体"
 
-#: ../src/celestia/qt/qtappwin.cpp:391
-#: ../src/celestia/qt/qteventfinder.cpp:379
+#: ../src/celestia/qt/qtappwin.cpp:391 ../src/celestia/qt/qteventfinder.cpp:379
 #: ../src/celestia/qt/qteventfinder.cpp:389
 msgid "Event Finder"
 msgstr "事件查找器"
@@ -1878,30 +1875,29 @@ msgstr "新建书签"
 #: ../src/celestia/qt/qtappwin.cpp:1170
 #, qt-format
 msgid ""
-"<html><h1>Celestia 1.7.0 </h1><p>Development snapshot, commit "
-"<b>%1</b>.</p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt "
-"library: %5<br>NAIF kernels are %7<br>AVIF images are %8<br>Runtime Qt "
-"version: %6</p><p>Copyright (C) 2001-2023 by the Celestia Development "
-"Team.<br>Celestia is free software. You can redistribute it and/or modify it"
-" under the terms of the GNU General Public License as published by the Free "
-"Software Foundation; either version 2 of the License, or (at your option) "
-"any later version.</p><p>Main site: <a "
-"href=\"https://celestiaproject.space/\">https://celestiaproject.space/</a><br>Forum:"
-" <a "
-"href=\"https://celestiaproject.space/forum/\">https://celestiaproject.space/forum/</a><br>GitHub"
-" project: <a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></p></html>"
+"<html><h1>Celestia 1.7.0 </h1><p>Development snapshot, commit <b>%1</b>.</"
+"p><p>Built for %2 bit CPU<br>Using %3 %4<br>Built against Qt library: "
+"%5<br>NAIF kernels are %7<br>AVIF images are %8<br>Runtime Qt version: %6</"
+"p><p>Copyright (C) 2001-2023 by the Celestia Development Team.<br>Celestia "
+"is free software. You can redistribute it and/or modify it under the terms "
+"of the GNU General Public License as published by the Free Software "
+"Foundation; either version 2 of the License, or (at your option) any later "
+"version.</p><p>Main site: <a href=\"https://celestiaproject.space/\">https://"
+"celestiaproject.space/</a><br>Forum: <a href=\"https://celestiaproject.space/"
+"forum/\">https://celestiaproject.space/forum/</a><br>GitHub project: <a "
+"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/"
+"CelestiaProject/Celestia</a></p></html>"
 msgstr ""
-"<html><h1>Celestia 1.7.0 开发快照与提交<b>%1</b>。</p><p>为 %2 bit CPU 构建<br>使用 %3 "
-"%4<br>使用 Qt 库 %5<br>NAIF kernels %7<br>AVIF images %8<br>Qt "
-"运行时版本：%6</p><p>Copyright (C) 2001-2023 by the Celestia Development "
-"Team.<br>Celestia 是一款自由软件。您可以根据自由软件基金会发布的 GNU "
-"通用公共许可证的条款对其进行再发布和/或修改；无论是许可证的第 2 版，还是（由您选择的）任何后续版本。</p><p>官网主页：<a "
-"href=\"https://celestiaproject.space/\">https://celestiaproject.space/</a><br>官方论坛：<a"
-" "
-"href=\"https://celestiaproject.space/forum/\">https://celestiaproject.space/forum/</a><br>GitHub"
-" 代码仓库：<a "
-"href=\"https://github.com/CelestiaProject/Celestia\">https://github.com/CelestiaProject/Celestia</a></html>"
+"<html><h1>Celestia 1.7.0 开发快照与提交<b>%1</b>。</p><p>为 %2 bit CPU 构建"
+"<br>使用 %3 %4<br>使用 Qt 库 %5<br>NAIF kernels %7<br>AVIF images %8<br>Qt 运"
+"行时版本：%6</p><p>Copyright (C) 2001-2023 by the Celestia Development Team."
+"<br>Celestia 是一款自由软件。您可以根据自由软件基金会发布的 GNU 通用公共许可"
+"证的条款对其进行再发布和/或修改；无论是许可证的第 2 版，还是（由您选择的）任"
+"何后续版本。</p><p>官网主页：<a href=\"https://celestiaproject.space/"
+"\">https://celestiaproject.space/</a><br>官方论坛：<a href=\"https://"
+"celestiaproject.space/forum/\">https://celestiaproject.space/forum/</"
+"a><br>GitHub 代码仓库：<a href=\"https://github.com/CelestiaProject/"
+"Celestia\">https://github.com/CelestiaProject/Celestia</a></html>"
 
 #: ../src/celestia/qt/qtappwin.cpp:1206
 msgid "Unknown compiler"
@@ -2799,169 +2795,169 @@ msgstr "Celesita 无法初始化 OpenGL ES 2.0。"
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr "Celestia 无法初始化 OpenGL 2.1。"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr "错误：未选择天体。\n"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 msgid "Info"
 msgstr "信息"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, qt-format
 msgid "Web info: %1"
 msgstr "Web 信息：%1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "<b>赤道半径：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "<b>大小：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr "<b>扁率："
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "<b>自转周期：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Prograde"
 msgstr "Prograde"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 msgid "Retrograde"
 msgstr "Retrograde"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>旋转方向：</b>%1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "<b>太阳日：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr "<b>拥有光环</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr "<b>拥有大气层</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "<b>开始：</b>%1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, qt-format
 msgid "<b>End:</b> %1"
 msgstr "<b>结束：</b>%1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 msgid "Orbit information"
 msgstr "轨道信息"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr "密切元素 %1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr "yr"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "<b>周期：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 msgid "AU"
 msgstr "AU"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "<b>半长轴：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "<b>离心率：</b> %L1"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
-#, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:320
+#, fuzzy, qt-format
+msgid "<b>Inclination:</b> %L1°"
 msgstr "<b>倾角：</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "<b>近心点距离：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "<b>远心点距离：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
-#, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:325
+#, fuzzy, qt-format
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "<b>升交点经度：</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
-#, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:326
+#, fuzzy, qt-format
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "<b>近心点幅角：</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
-#, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+#: ../src/celestia/qt/qtinfopanel.cpp:327
+#, fuzzy, qt-format
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "<b>平近点角：</b> %L1%2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "<b>周期（已计算）：</b> %L1 %2"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
-#, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+#: ../src/celestia/qt/qtinfopanel.cpp:334
+#, fuzzy, qt-format
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "<b>网格动作（已计算）：</b>%L1%2/天"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "<b>赤经：</b> %L1h %L2m %L3s"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
-#, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
+#, fuzzy, qt-format
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "<b>赤纬：</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
-#, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:390
+#, fuzzy, qt-format
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "<b>L：</b> %L1%2 %L3' %L4\""
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
-#, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+#: ../src/celestia/qt/qtinfopanel.cpp:393
+#, fuzzy, qt-format
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "<b>B：</b> %L1%2 %L3' %L4\""
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208
@@ -3337,14 +3333,12 @@ msgid "No guide destinations were found."
 msgstr "未找到向导目的地。"
 
 #. ectx: property (text), widget (QLabel, label)
-#: ../src/celestia/qt/tourguide.ui:49
-#: ../src/celestia/win32/res/celestia.rc:605
+#: ../src/celestia/qt/tourguide.ui:49 ../src/celestia/win32/res/celestia.rc:605
 msgid "Select your destination:"
 msgstr "选择目标："
 
 #. ectx: property (text), widget (QPushButton, gotoButton)
-#: ../src/celestia/qt/tourguide.ui:76
-#: ../src/celestia/win32/res/celestia.rc:432
+#: ../src/celestia/qt/tourguide.ui:76 ../src/celestia/win32/res/celestia.rc:432
 #: ../src/celestia/win32/res/celestia.rc:603
 msgid "Go To"
 msgstr "转到"
@@ -4064,8 +4058,7 @@ msgstr "无法保存图片文件。"
 msgid "Celestia Script (*.celx, *.cel)"
 msgstr "Celestia Script (*.celx, *.cel)"
 
-#. Gettext complains about using \r in translated messages, so add it in
-#. afterwards
+#. Gettext complains about using \r in translated messages, so add it in afterwards
 #: ../src/celestia/win32/winhelpdlgs.cpp:158
 #, c++-format
 msgid ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2024-11-18 19:45+0100\n"
+"POT-Creation-Date: 2024-11-21 21:29+0100\n"
 "PO-Revision-Date: 2018-05-28 21:03+0300\n"
 "Last-Translator: Alexell <alexell@alexell.ru>\n"
 "Language-Team: \n"
@@ -811,26 +811,26 @@ msgstr ""
 
 #. ectx: property (text), widget (QRadioButton, kmButton)
 #: ../src/celestia/hud.cpp:133 ../src/celestia/qt/gotoobjectdialog.ui:180
-#: ../src/celestia/qt/qtinfopanel.cpp:195
-#: ../src/celestia/qt/qtinfopanel.cpp:317
+#: ../src/celestia/qt/qtinfopanel.cpp:193
+#: ../src/celestia/qt/qtinfopanel.cpp:315
 #: ../src/celestia/win32/res/celestia.rc:429
 msgid "km"
 msgstr "公里"
 
-#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:199
+#: ../src/celestia/hud.cpp:138 ../src/celestia/qt/qtinfopanel.cpp:197
 #, fuzzy
 msgid "m"
 msgstr "m/s"
 
-#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:251
-#: ../src/celestia/qt/qtinfopanel.cpp:298
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/hud.cpp:160 ../src/celestia/qt/qtinfopanel.cpp:249
+#: ../src/celestia/qt/qtinfopanel.cpp:296
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy
 msgid "days"
 msgstr " 日"
 
-#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:247
-#: ../src/celestia/qt/qtinfopanel.cpp:294
+#: ../src/celestia/hud.cpp:165 ../src/celestia/qt/qtinfopanel.cpp:245
+#: ../src/celestia/qt/qtinfopanel.cpp:292
 #, fuzzy
 msgid "hours"
 msgstr " 時"
@@ -912,232 +912,232 @@ msgstr "視直徑:"
 
 #: ../src/celestia/hud.cpp:298
 #, c++-format
-msgid "Dec: {:+d}{} {:02d}' {:.1f}\"\n"
+msgid "Dec: {:+d}° {:02d}′ {:.1f}″\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:311
+#: ../src/celestia/hud.cpp:310
 #, c++-format
 msgid "RA: {}h {:02}m {:.1f}s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:324
+#: ../src/celestia/hud.cpp:323
 #, fuzzy, c++-format
 msgid "Apparent magnitude: {:.1f}\n"
 msgstr "視星等:"
 
-#: ../src/celestia/hud.cpp:328
+#: ../src/celestia/hud.cpp:327
 #, fuzzy, c++-format
 msgid "Absolute magnitude: {:.1f}\n"
 msgstr "絕對星等:"
 
-#: ../src/celestia/hud.cpp:407
+#: ../src/celestia/hud.cpp:406
 #, c++-format
 msgid "{:.6f}{} {:.6f}{} {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:422 ../src/celestia/hud.cpp:500
-#: ../src/celestia/hud.cpp:533 ../src/celestia/hud.cpp:650
+#: ../src/celestia/hud.cpp:421 ../src/celestia/hud.cpp:499
+#: ../src/celestia/hud.cpp:532 ../src/celestia/hud.cpp:649
 #, fuzzy, c-format
 msgid "Distance: %s\n"
 msgstr "距離:"
 
-#: ../src/celestia/hud.cpp:427
+#: ../src/celestia/hud.cpp:426
 msgid "Star system barycenter\n"
 msgstr "恆星系統質心\n"
 
-#: ../src/celestia/hud.cpp:431
+#: ../src/celestia/hud.cpp:430
 #, fuzzy, c++-format
 msgid "Abs (app) mag: {:.2f} ({:.2f})\n"
 msgstr "絕對星等(視星等):%.2f(%.2f)\n"
 
-#: ../src/celestia/hud.cpp:436
+#: ../src/celestia/hud.cpp:435
 #, fuzzy, c++-format
 msgid "Luminosity: {}x Sun\n"
 msgstr "光度:"
 
-#: ../src/celestia/hud.cpp:442
+#: ../src/celestia/hud.cpp:441
 msgid "Neutron star"
 msgstr "中子星"
 
-#: ../src/celestia/hud.cpp:445
+#: ../src/celestia/hud.cpp:444
 msgid "Black hole"
 msgstr "黑洞"
 
-#: ../src/celestia/hud.cpp:450
+#: ../src/celestia/hud.cpp:449
 #, fuzzy, c-format
 msgid "Class: %s\n"
 msgstr "類別:"
 
-#: ../src/celestia/hud.cpp:457
+#: ../src/celestia/hud.cpp:456
 #, fuzzy, c-format
 msgid "Surface temp: %s\n"
 msgstr "表面溫度:"
 
-#: ../src/celestia/hud.cpp:462
+#: ../src/celestia/hud.cpp:461
 #, fuzzy, c++-format
 msgid "Radius: {} Rsun ({})\n"
 msgstr "半徑:"
 
-#: ../src/celestia/hud.cpp:468 ../src/celestia/hud.cpp:547
-#: ../src/celestia/hud.cpp:565
+#: ../src/celestia/hud.cpp:467 ../src/celestia/hud.cpp:546
+#: ../src/celestia/hud.cpp:564
 #, fuzzy, c++-format
 msgid "Radius: {}\n"
 msgstr "半徑:"
 
-#: ../src/celestia/hud.cpp:484
+#: ../src/celestia/hud.cpp:483
 msgid "Planetary companions present\n"
 msgstr "呈現行星的伴星\n"
 
-#: ../src/celestia/hud.cpp:505
+#: ../src/celestia/hud.cpp:504
 #, fuzzy, c-format
 msgid "Distance from center: %s\n"
 msgstr "與中心距離:"
 
-#: ../src/celestia/hud.cpp:508
+#: ../src/celestia/hud.cpp:507
 #, fuzzy, c-format
 msgid "Radius: %s\n"
 msgstr "半徑:"
 
-#: ../src/celestia/hud.cpp:551
+#: ../src/celestia/hud.cpp:550
 #, fuzzy, c++-format
 msgid "Equatorial radius: {}\n"
 msgstr "赤道"
 
-#: ../src/celestia/hud.cpp:552
+#: ../src/celestia/hud.cpp:551
 #, fuzzy, c++-format
 msgid "Polar radius: {}\n"
 msgstr "半徑:"
 
-#: ../src/celestia/hud.cpp:557
+#: ../src/celestia/hud.cpp:556
 #, fuzzy, c++-format
 msgid "Radii: {} × {} × {}\n"
 msgstr "半徑:"
 
-#: ../src/celestia/hud.cpp:611
+#: ../src/celestia/hud.cpp:610
 #, fuzzy, c++-format
-msgid "Phase angle: {:.1f}{}\n"
+msgid "Phase angle: {:.1f}°\n"
 msgstr "相位角: %.1f%s\n"
 
-#: ../src/celestia/hud.cpp:627
+#: ../src/celestia/hud.cpp:626
 #, c++-format
 msgid "Density: {} lb/ft³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:632
+#: ../src/celestia/hud.cpp:631
 #, c++-format
 msgid "Density: {} kg/m³\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:638
+#: ../src/celestia/hud.cpp:637
 #, fuzzy, c-format
 msgid "Temperature: %s\n"
 msgstr "溫度:"
 
-#: ../src/celestia/hud.cpp:870
+#: ../src/celestia/hud.cpp:869
 #, c++-format
 msgid "Unknown measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:876
+#: ../src/celestia/hud.cpp:875
 #, c++-format
 msgid "Failed to get default measurement system {}, fallback to Metric system"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:919
+#: ../src/celestia/hud.cpp:918
 #, fuzzy, c++-format
 msgid "FPS: {:.1f}\n"
 msgstr "每秒影格速率:"
 
-#: ../src/celestia/hud.cpp:952 ../src/celestia/hud.cpp:955
+#: ../src/celestia/hud.cpp:951 ../src/celestia/hud.cpp:954
 msgid "Edit Mode"
 msgstr "編輯模式"
 
-#: ../src/celestia/hud.cpp:979 ../src/celestia/hud.cpp:994
+#: ../src/celestia/hud.cpp:978 ../src/celestia/hud.cpp:993
 msgid "  LT"
 msgstr "  本地時間"
 
-#: ../src/celestia/hud.cpp:1002 ../src/celestia/qt/qttimetoolbar.cpp:48
+#: ../src/celestia/hud.cpp:1001 ../src/celestia/qt/qttimetoolbar.cpp:48
 msgid "Real time"
 msgstr "即時"
 
-#: ../src/celestia/hud.cpp:1004
+#: ../src/celestia/hud.cpp:1003
 msgid "-Real time"
 msgstr "-即時"
 
-#: ../src/celestia/hud.cpp:1008
+#: ../src/celestia/hud.cpp:1007
 msgid "Time stopped"
 msgstr "時間已停止"
 
-#: ../src/celestia/hud.cpp:1012
+#: ../src/celestia/hud.cpp:1011
 #, fuzzy, c++-format
 msgid "{:.6g} x faster"
 msgstr " 增快"
 
-#: ../src/celestia/hud.cpp:1016
+#: ../src/celestia/hud.cpp:1015
 #, fuzzy, c++-format
 msgid "{:.6g} x slower"
 msgstr " 減慢"
 
-#: ../src/celestia/hud.cpp:1022
+#: ../src/celestia/hud.cpp:1021
 msgid " (Paused)"
 msgstr " (已暫停)"
 
-#: ../src/celestia/hud.cpp:1044
+#: ../src/celestia/hud.cpp:1043
 #, fuzzy, c++-format
 msgid "Travelling ({})\n"
 msgstr "旅行中 "
 
-#: ../src/celestia/hud.cpp:1046
+#: ../src/celestia/hud.cpp:1045
 #, fuzzy
 msgid "Travelling\n"
 msgstr "旅行中 "
 
-#: ../src/celestia/hud.cpp:1056
+#: ../src/celestia/hud.cpp:1055
 #, fuzzy, c-format
 msgid "Track %s\n"
 msgstr "追蹤 "
 
-#: ../src/celestia/hud.cpp:1064
+#: ../src/celestia/hud.cpp:1063
 #, fuzzy, c-format
 msgid "Follow %s\n"
 msgstr "跟隨 "
 
-#: ../src/celestia/hud.cpp:1068
+#: ../src/celestia/hud.cpp:1067
 #, fuzzy, c-format
 msgid "Sync Orbit %s\n"
 msgstr "同步軌道"
 
-#: ../src/celestia/hud.cpp:1072
+#: ../src/celestia/hud.cpp:1071
 #, c-format
 msgid "Lock %s -> %s\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1078
+#: ../src/celestia/hud.cpp:1077
 #, fuzzy, c-format
 msgid "Chase %s\n"
 msgstr "追逐"
 
-#: ../src/celestia/hud.cpp:1092
+#: ../src/celestia/hud.cpp:1091
 #, c++-format
 msgid "FOV: {} ({:.2f}x)\n"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1265
+#: ../src/celestia/hud.cpp:1264
 #, c++-format
 msgid "{}x{} at {:.2f} fps  {}"
 msgstr ""
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Paused"
 msgstr " 已暫停"
 
-#: ../src/celestia/hud.cpp:1268
+#: ../src/celestia/hud.cpp:1267
 #, fuzzy
 msgid "Recording"
 msgstr "  錄影中"
 
-#: ../src/celestia/hud.cpp:1288
+#: ../src/celestia/hud.cpp:1287
 msgid "F11 Start/Pause    F12 Stop"
 msgstr "F11 開始/暫停   F12 停止"
 
@@ -2971,174 +2971,174 @@ msgstr ""
 msgid "Celestia was unable to initialize OpenGL 2.1."
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:156
+#: ../src/celestia/qt/qtinfopanel.cpp:154
 msgid "Error: no object selected!\n"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:168
+#: ../src/celestia/qt/qtinfopanel.cpp:166
 #: ../src/celestia/qt/qtselectionpopup.cpp:178
 #, fuzzy
 msgid "Info"
 msgstr "資訊(&I)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:188
+#: ../src/celestia/qt/qtinfopanel.cpp:186
 #, fuzzy, qt-format
 msgid "Web info: %1"
 msgstr "OpenGL 資訊"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:204
+#: ../src/celestia/qt/qtinfopanel.cpp:202
 #, fuzzy, qt-format
 msgid "<b>Equatorial radius:</b> %L1 %2"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:206
+#: ../src/celestia/qt/qtinfopanel.cpp:204
 #, fuzzy, qt-format
 msgid "<b>Size:</b> %L1 %2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:211
+#: ../src/celestia/qt/qtinfopanel.cpp:209
 msgid "<b>Oblateness: "
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:254
+#: ../src/celestia/qt/qtinfopanel.cpp:252
 #, fuzzy, qt-format
 msgid "<b>Sidereal rotation period:</b> %L1 %2"
 msgstr "自轉週期:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Prograde"
 msgstr "貝爾格萊德"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:257
+#: ../src/celestia/qt/qtinfopanel.cpp:255
 #, fuzzy
 msgid "Retrograde"
 msgstr "貝爾格萊德"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:258
+#: ../src/celestia/qt/qtinfopanel.cpp:256
 #, fuzzy, qt-format
 msgid "<b>Rotation direction:</b> %1"
 msgstr "<b>未延伸 OpenGL 1.1</b>"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:262
+#: ../src/celestia/qt/qtinfopanel.cpp:260
 #, fuzzy, qt-format
 msgid "<b>Length of day:</b> %L1 %2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:270
+#: ../src/celestia/qt/qtinfopanel.cpp:268
 msgid "<b>Has rings</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:272
+#: ../src/celestia/qt/qtinfopanel.cpp:270
 msgid "<b>Has atmosphere</b>"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:280
+#: ../src/celestia/qt/qtinfopanel.cpp:278
 #, fuzzy, qt-format
 msgid "<b>Start:</b> %1"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:283
+#: ../src/celestia/qt/qtinfopanel.cpp:281
 #, fuzzy, qt-format
 msgid "<b>End:</b> %1"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:285
+#: ../src/celestia/qt/qtinfopanel.cpp:283
 #, fuzzy
 msgid "Orbit information"
 msgstr "資訊文字"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:286
+#: ../src/celestia/qt/qtinfopanel.cpp:284
 #, qt-format
 msgid "Osculating elements for %1"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:302
+#: ../src/celestia/qt/qtinfopanel.cpp:300
 msgid "years"
 msgstr ""
 
-#: ../src/celestia/qt/qtinfopanel.cpp:306
+#: ../src/celestia/qt/qtinfopanel.cpp:304
 #, fuzzy, qt-format
 msgid "<b>Period:</b> %L1 %2"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:312
+#: ../src/celestia/qt/qtinfopanel.cpp:310
 #, fuzzy
 msgid "AU"
 msgstr "天文單位"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:320
+#: ../src/celestia/qt/qtinfopanel.cpp:318
 #, fuzzy, qt-format
 msgid "<b>Semi-major axis:</b> %L1 %2"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:321
+#: ../src/celestia/qt/qtinfopanel.cpp:319
 #, fuzzy, qt-format
 msgid "<b>Eccentricity:</b> %L1"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:322
+#: ../src/celestia/qt/qtinfopanel.cpp:320
 #, fuzzy, qt-format
-msgid "<b>Inclination:</b> %L1%2"
+msgid "<b>Inclination:</b> %L1°"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:324
+#: ../src/celestia/qt/qtinfopanel.cpp:321
 #, fuzzy, qt-format
 msgid "<b>Pericenter distance:</b> %L1 %2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:326
+#: ../src/celestia/qt/qtinfopanel.cpp:323
 #, fuzzy, qt-format
 msgid "<b>Apocenter distance:</b> %L1 %2"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:328
+#: ../src/celestia/qt/qtinfopanel.cpp:325
 #, fuzzy, qt-format
-msgid "<b>Ascending node:</b> %L1%2"
+msgid "<b>Ascending node:</b> %L1°"
 msgstr "距離(光年)"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:330
+#: ../src/celestia/qt/qtinfopanel.cpp:326
 #, fuzzy, qt-format
-msgid "<b>Argument of periapsis:</b> %L1%2"
+msgid "<b>Argument of periapsis:</b> %L1°"
 msgstr "赤道"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:332
+#: ../src/celestia/qt/qtinfopanel.cpp:327
 #, fuzzy, qt-format
-msgid "<b>Mean anomaly:</b> %L1%2"
+msgid "<b>Mean anomaly:</b> %L1°"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:336
+#: ../src/celestia/qt/qtinfopanel.cpp:330
 #, fuzzy, qt-format
 msgid "<b>Period (calculated):</b> %L1 %2"
 msgstr "自轉週期:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:340
+#: ../src/celestia/qt/qtinfopanel.cpp:334
 #, fuzzy, qt-format
-msgid "<b>Mean motion (calculated):</b> %L1%2/day"
+msgid "<b>Mean motion (calculated):</b> %L1°/day"
 msgstr "自轉週期:"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:364
-#: ../src/celestia/qt/qtinfopanel.cpp:387
+#: ../src/celestia/qt/qtinfopanel.cpp:357
+#: ../src/celestia/qt/qtinfopanel.cpp:379
 #, fuzzy, qt-format
 msgid "<b>RA:</b> %L1h %L2m %L3s"
 msgstr "大小:%1 MB"
 
-#: ../src/celestia/qt/qtinfopanel.cpp:368
-#: ../src/celestia/qt/qtinfopanel.cpp:391
+#: ../src/celestia/qt/qtinfopanel.cpp:361
+#: ../src/celestia/qt/qtinfopanel.cpp:383
 #, fuzzy, qt-format
-msgid "<b>Dec:</b> %L1%2 %L3' %L4\""
+msgid "<b>Dec:</b> %L1° %L2′ %L3″"
 msgstr "大小:%1 MB"
 
 #. TRANSLATORS: Galactic longitude
-#: ../src/celestia/qt/qtinfopanel.cpp:399
+#: ../src/celestia/qt/qtinfopanel.cpp:390
 #, fuzzy, qt-format
-msgid "<b>L:</b> %L1%2 %L3' %L4\""
+msgid "<b>L:</b> %L1° %L2′ %L3″"
 msgstr "大小:%1 MB"
 
 #. TRANSLATORS: Galactic latitude
-#: ../src/celestia/qt/qtinfopanel.cpp:403
+#: ../src/celestia/qt/qtinfopanel.cpp:393
 #, fuzzy, qt-format
-msgid "<b>B:</b> %L1%2 %L3' %L4\""
+msgid "<b>B:</b> %L1° %L2′ %L3″"
 msgstr "大小:%1 MB"
 
 #: ../src/celestia/qt/qtpreferencesdialog.cpp:208

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -261,16 +261,16 @@ angleToStr(double angle, const std::locale& loc)
 
     if (degrees > 0)
     {
-        return fmt::format(loc, "{}" UTF8_DEGREE_SIGN "{:02d}' {:.1f}\"",
+        return fmt::format(loc, "{}° {:02d}′ {:.1f}″",
                            degrees, std::abs(minutes), std::abs(seconds));
     }
 
     if (minutes > 0)
     {
-        return fmt::format(loc, "{:02d}' {:.1f}\"", std::abs(minutes), std::abs(seconds));
+        return fmt::format(loc, "{:02d}′ {:.1f}″", std::abs(minutes), std::abs(seconds));
     }
 
-    return fmt::format(loc, "{:.2f}\"", std::abs(seconds));
+    return fmt::format(loc, "{:.2f}″", std::abs(seconds));
 }
 
 void
@@ -295,9 +295,8 @@ displayDeclination(Overlay& overlay, double angle, const std::locale& loc)
     double seconds;
     astro::decimalToDegMinSec(angle, degrees, minutes, seconds);
 
-    overlay.print(loc, _("Dec: {:+d}{} {:02d}' {:.1f}\"\n"),
-                  std::abs(degrees), UTF8_DEGREE_SIGN,
-                  std::abs(minutes), std::abs(seconds));
+    overlay.print(loc, _("Dec: {:+d}° {:02d}′ {:.1f}″\n"),
+                  std::abs(degrees), std::abs(minutes), std::abs(seconds));
 }
 
 void
@@ -608,7 +607,7 @@ displayPlanetInfo(const util::NumberFormatter& formatter,
             sunVec.normalize();
             double cosPhaseAngle = std::clamp(sunVec.dot(viewVec.normalized()), -1.0, 1.0);
             double phaseAngle = acos(cosPhaseAngle);
-            overlay.print(loc, _("Phase angle: {:.1f}{}\n"), math::radToDeg(phaseAngle), UTF8_DEGREE_SIGN);
+            overlay.print(loc, _("Phase angle: {:.1f}°\n"), math::radToDeg(phaseAngle));
         }
     }
 

--- a/src/celestia/qt/qtinfopanel.cpp
+++ b/src/celestia/qt/qtinfopanel.cpp
@@ -48,8 +48,6 @@ namespace celestia::qt
 namespace
 {
 
-const QString DegreeSign = QString::fromUtf8(UTF8_DEGREE_SIGN);
-
 astro::KeplerElements
 CalculateOsculatingElements(const celestia::ephem::Orbit& orbit,
                             double t,
@@ -319,26 +317,21 @@ void InfoPanel::buildSolarSystemBodyPage(const Body* body,
 
     stream << QString(_("<b>Semi-major axis:</b> %L1 %2")).arg(sma).arg(units) << "<br>\n";
     stream << QString(_("<b>Eccentricity:</b> %L1")).arg(elements.eccentricity) << "<br>\n";
-    stream << QString(_("<b>Inclination:</b> %L1%2")).arg(math::radToDeg(elements.inclination))
-                                                     .arg(DegreeSign) << "<br>\n";
+    stream << QString(_("<b>Inclination:</b> %L1°")).arg(math::radToDeg(elements.inclination)) << "<br>\n";
     stream << QString(_("<b>Pericenter distance:</b> %L1 %2")).arg(sma * (1 - elements.eccentricity)).arg(units) << "<br>\n";
     if (elements.eccentricity < 1.0)
         stream << QString(_("<b>Apocenter distance:</b> %L1 %2")).arg(sma * (1 + elements.eccentricity)).arg(units) << "<br>\n";
 
-    stream << QString(_("<b>Ascending node:</b> %L1%2")).arg(math::radToDeg(elements.longAscendingNode))
-                                                        .arg(DegreeSign) << "<br>\n";
-    stream << QString(_("<b>Argument of periapsis:</b> %L1%2")).arg(math::radToDeg(elements.argPericenter))
-                                                               .arg(DegreeSign) << "<br>\n";
-    stream << QString(_("<b>Mean anomaly:</b> %L1%2")).arg(math::radToDeg(elements.meanAnomaly))
-                                                      .arg(DegreeSign) << "<br>\n";
+    stream << QString(_("<b>Ascending node:</b> %L1°")).arg(math::radToDeg(elements.longAscendingNode)) << "<br>\n";
+    stream << QString(_("<b>Argument of periapsis:</b> %L1°")).arg(math::radToDeg(elements.argPericenter)) << "<br>\n";
+    stream << QString(_("<b>Mean anomaly:</b> %L1°")).arg(math::radToDeg(elements.meanAnomaly)) << "<br>\n";
     if (elements.eccentricity < 1.0)
     {
         stream << QString(_("<b>Period (calculated):</b> %L1 %2")).arg(elements.period).arg(_("days")) << "<br>\n";
     }
     else
     {
-        stream << QString(_("<b>Mean motion (calculated):</b> %L1%2/day")).arg(360.0 / elements.period)
-                                                                          .arg(DegreeSign) << "<br>\n";
+        stream << QString(_("<b>Mean motion (calculated):</b> %L1°/day")).arg(360.0 / elements.period) << "<br>\n";
     }
 }
 
@@ -365,8 +358,7 @@ InfoPanel::buildStarPage(const Star* star, const Universe* universe, double tdb,
 
     int degrees = 0;
     astro::decimalToDegMinSec(math::radToDeg(sph.y()), degrees, minutes, seconds);
-    stream << QString(_("<b>Dec:</b> %L1%2 %L3' %L4\"")).arg(degrees).arg(DegreeSign)
-                                                        .arg(abs(minutes)).arg(abs(seconds)) << "<br>\n";
+    stream << QString(_("<b>Dec:</b> %L1° %L2′ %L3″")).arg(degrees).arg(abs(minutes)).arg(abs(seconds)) << "<br>\n";
 }
 
 
@@ -388,20 +380,17 @@ void InfoPanel::buildDSOPage(const DeepSkyObject* dso,
 
     int degrees = 0;
     astro::decimalToDegMinSec(math::radToDeg(sph.y()), degrees, minutes, seconds);
-    stream << QString(_("<b>Dec:</b> %L1%2 %L3' %L4\"")).arg(degrees).arg(DegreeSign)
-                                                        .arg(abs(minutes)).arg(abs(seconds)) << "<br>\n";
+    stream << QString(_("<b>Dec:</b> %L1° %L2′ %L3″")).arg(degrees).arg(abs(minutes)).arg(abs(seconds)) << "<br>\n";
 
     Eigen::Vector3d galPos = astro::equatorialToGalactic(eqPos);
     sph = rectToSpherical(galPos);
 
     astro::decimalToDegMinSec(math::radToDeg(sph.x()), degrees, minutes, seconds);
     // TRANSLATORS: Galactic longitude
-    stream << QString(_("<b>L:</b> %L1%2 %L3' %L4\"")).arg(degrees).arg(DegreeSign)
-                                                      .arg(abs(minutes)).arg(abs(seconds)) << "<br>\n";
+    stream << QString(_("<b>L:</b> %L1° %L2′ %L3″")).arg(degrees).arg(abs(minutes)).arg(abs(seconds)) << "<br>\n";
     astro::decimalToDegMinSec(math::radToDeg(sph.y()), degrees, minutes, seconds);
     // TRANSLATORS: Galactic latitude
-    stream << QString(_("<b>B:</b> %L1%2 %L3' %L4\"")).arg(degrees).arg(DegreeSign)
-                                                      .arg(abs(minutes)).arg(abs(seconds)) << "<br>\n";
+    stream << QString(_("<b>B:</b> %L1° %L2′ %L3″")).arg(degrees).arg(abs(minutes)).arg(abs(seconds)) << "<br>\n";
 }
 
 

--- a/src/celrender/skygridrenderer.cpp
+++ b/src/celrender/skygridrenderer.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <iterator>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <Eigen/Geometry>
@@ -31,6 +32,8 @@
 #include <celmath/vecgl.h>
 #include <celutil/color.h>
 #include "linerenderer.h"
+
+using namespace std::string_view_literals;
 
 namespace celestia::render
 {
@@ -233,7 +236,7 @@ latitudeLabel(int latitude, int latitudeStep)
     if (latitudeStep % DEG == 0)
         return result;
 
-    fmt::format_to(std::back_inserter(result), " {:02}'", (latitude / MIN) % 60);
+    fmt::format_to(std::back_inserter(result), " {:02}′", (latitude / MIN) % 60);
     if (latitudeStep % MIN == 0)
         return result;
 
@@ -241,7 +244,7 @@ latitudeLabel(int latitude, int latitudeStep)
     if (latitudeStep % SEC != 0)
         fmt::format_to(std::back_inserter(result), ".{:03}", latitude % SEC);
 
-    result.push_back('"');
+    result.append("″"sv);
     return result;
 }
 
@@ -254,17 +257,17 @@ longitudeLabel(int longitude, int longitudeStep,
 {
     int totalUnits = HOUR_MIN_SEC_TOTAL;
     int baseUnit = HR;
-    const char* baseUnitSymbol = "h";
-    char minuteSymbol = 'm';
-    char secondSymbol = 's';
+    std::string_view baseUnitSymbol = "°"sv;
+    std::string_view minuteSymbol = "m"sv;
+    std::string_view secondSymbol = "s"sv;
 
     if (longitudeUnits == engine::SkyGrid::LongitudeDegrees)
     {
         totalUnits = DEG_MIN_SEC_TOTAL * 2;
         baseUnit = DEG;
-        baseUnitSymbol = "°";
-        minuteSymbol = '\'';
-        secondSymbol = '"';
+        baseUnitSymbol = "°"sv;
+        minuteSymbol = "′"sv;
+        secondSymbol = "″"sv;
     }
 
     // Produce a sexigesimal string
@@ -289,7 +292,7 @@ longitudeLabel(int longitude, int longitudeStep,
     if (longitudeStep % SEC != 0)
         fmt::format_to(std::back_inserter(result), ".{:03}", longitude % SEC);
 
-    result.push_back(secondSymbol);
+    result.append(secondSymbol);
     return result;
 }
 

--- a/src/celutil/utf8.h
+++ b/src/celutil/utf8.h
@@ -15,9 +15,7 @@
 #include <string>
 #include <string_view>
 
-#define UTF8_DEGREE_SIGN         "\302\260"
-#define UTF8_MULTIPLICATION_SIGN "\303\227"
-#define UTF8_REPLACEMENT_CHAR    "\357\277\275"
+#define UTF8_REPLACEMENT_CHAR "\357\277\275"
 
 bool UTF8Decode(std::string_view str, std::int32_t &ch);
 bool UTF8Decode(std::string_view str, std::int32_t &pos, std::int32_t &ch);


### PR DESCRIPTION
- Switch to using prime and double prime for minutes/seconds
- Regenerate translations

we have utf-8 source code these days, no need to rely on macros and string concatenation here (plus xgettext doesn't like it)