### PR TITLE
Switch Mac build to use jpeg-turbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,14 +302,13 @@ jobs:
     steps:
     - name: 'Install dependencies'
       run: |
-        brew install pkg-config \
-                     ninja \
+        brew install ninja \
                      eigen \
                      ffmpeg \
                      boost \
                      cspice \
                      fmt \
-                     jpeg \
+                     jpeg-turbo \
                      gettext \
                      gperf \
                      libpng \


### PR DESCRIPTION
Matches the other platforms (we don't use jpeg9) and hopefully avoids some of the random failures due to jpeg/jpeg-turbo conflicts.

Don't install pkg-config as it is already installed on the runners and trying to install via brew seems to be responsible for a lot of the random failures.