### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,11 @@ if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
 
+# Normalize install(DESTINATION) paths
+if(POLICY CMP0177)
+  cmake_policy(SET CMP0177 NEW)
+endif()
+
 project(celestia VERSION 1.7.0 LANGUAGES C CXX)
 set(DISPLAY_NAME "Celestia")
 #

--- a/src/celestia/qt6/CMakeLists.txt
+++ b/src/celestia/qt6/CMakeLists.txt
@@ -40,7 +40,7 @@ if(WIN32)
   install(
     TARGETS celestia-qt6
     RUNTIME_DEPENDENCIES
-      PRE_EXCLUDE_REGEXES "^api-ms" "^ext-ms-"
+      PRE_EXCLUDE_REGEXES "^api-ms" "^ext-ms-" "^qt6"
       POST_EXCLUDE_REGEXES ".*system32/.*\\.dll$"
       DIRECTORIES $<TARGET_FILE_DIR:celestia>
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
- Set CMP0177 to avoid warnings on recent CMake versions
- Don't copy Qt6 DLLs on Windows as these are handled by the deploy script (this fixes building with the pre-built binaries from Qt as opposed to the vcpkg version)