### PR TITLE
For fmt 11, use report_error

### DIFF
--- a/src/celutil/formatnum.cpp
+++ b/src/celutil/formatnum.cpp
@@ -57,7 +57,9 @@ struct fmt::formatter<ExtendedSubstring>
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}')
         {
-#if FMT_VERSION >= 100100
+#if FMT_VERSION >= 110000
+            report_error("invalid format");
+#elif FMT_VERSION >= 100100
             throw_format_error("invalid format");
 #else
             assert(0);

--- a/src/celutil/formatnum.h
+++ b/src/celutil/formatnum.h
@@ -121,7 +121,9 @@ struct fmt::formatter<celestia::util::FormattedFloat<T>>
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}')
         {
-#if FMT_VERSION >= 100100
+#if FMT_VERSION >= 110000
+            report_error("invalid format");
+#elif FMT_VERSION >= 100100
             throw_format_error("invalid format");
 #else
             assert(0);


### PR DESCRIPTION
throw_format_error was deprecated and removed in fmt 11.1: https://github.com/fmtlib/fmt/commit/9a2aae37d4537b3de391ce29b905438cc84b4633

It was just a redirect to report_error, so use this one for fmt 11