### PR TITLE
[celimage] DDS Texture Display

### DIFF
--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -330,7 +330,8 @@ Image* LoadDDSImage(const fs::path& filename)
                                        static_cast<std::int32_t>(ddsd.width),
                                        static_cast<std::int32_t>(ddsd.height),
                                        std::max(static_cast<std::int32_t>(ddsd.mipMapLevels), INT32_C(1)));
-    if (!in.read(reinterpret_cast<char*>(img->getPixels()), img->getSize())) /* Flawfinder: ignore */
+    in.read(reinterpret_cast<char*>(img->getPixels()), img->getSize()); /* Flawfinder: ignore */
+    if (!in.eof() && !in.good())
     {
         util::GetLogger()->error("Failed reading data from DDS texture file {}.\n", filename);
         return nullptr;


### PR DESCRIPTION
This code reverts an if statement format in dds.cpp found in git 62716d8 to the format of a prior version.

It fixes issue #2292.