### PR TITLE
Update InfoURL handling, use fmt >=10.1 for path formatting

### DIFF
--- a/src/celengine/deepskyobj.h
+++ b/src/celengine/deepskyobj.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <Eigen/Core>
@@ -86,7 +87,7 @@ public:
     virtual bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
                       double& distanceToPicker,
                       double& cosAngleToBoundCenter) const;
-    virtual bool load(const AssociativeArray*, const fs::path& resPath);
+    virtual bool load(const AssociativeArray*, const fs::path& resPath, std::string_view name);
 
     virtual std::uint64_t getRenderMask() const { return 0; }
     virtual unsigned int getLabelMask() const { return 0; }

--- a/src/celengine/dsodbbuilder.cpp
+++ b/src/celengine/dsodbbuilder.cpp
@@ -247,7 +247,7 @@ DSODatabaseBuilder::load(std::istream& in, const fs::path& resourcePath)
 
         std::unique_ptr<DeepSkyObject> obj = createDSO(objType);
 
-        if (obj == nullptr || !obj->load(objParams, resourcePath))
+        if (obj == nullptr || !obj->load(objParams, resourcePath, objName))
         {
             GetLogger()->warn("Bad Deep Sky Object definition--will continue parsing file.\n");
             continue;

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -133,7 +133,7 @@ bool Galaxy::pick(const Eigen::ParametrizedLine<double, 3>& ray,
         cosAngleToBoundCenter);
 }
 
-bool Galaxy::load(const AssociativeArray* params, const fs::path& resPath)
+bool Galaxy::load(const AssociativeArray* params, const fs::path& resPath, std::string_view name)
 {
     setDetail(params->getNumber<float>("Detail").value_or(1.0f));
 
@@ -148,7 +148,7 @@ bool Galaxy::load(const AssociativeArray* params, const fs::path& resPath)
     else
         setForm({});
 
-    return DeepSkyObject::load(params, resPath);
+    return DeepSkyObject::load(params, resPath, name);
 }
 
 GalaxyType Galaxy::getGalaxyType() const

--- a/src/celengine/galaxy.h
+++ b/src/celengine/galaxy.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <string>
+#include <string_view>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -60,7 +61,7 @@ public:
     bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
               double& distanceToPicker,
               double& cosAngleToBoundCenter) const override;
-    bool load(const AssociativeArray*, const fs::path&) override;
+    bool load(const AssociativeArray*, const fs::path&, std::string_view) override;
 
     static void  increaseLightGain();
     static void  decreaseLightGain();

--- a/src/celengine/globular.cpp
+++ b/src/celengine/globular.cpp
@@ -94,10 +94,10 @@ bool Globular::pick(const Eigen::ParametrizedLine<double, 3>& ray,
                                   cosAngleToBoundCenter);
 }
 
-bool Globular::load(const AssociativeArray* params, const fs::path& resPath)
+bool Globular::load(const AssociativeArray* params, const fs::path& resPath, std::string_view name)
 {
     // Load the basic DSO parameters first
-    if (!DeepSkyObject::load(params, resPath))
+    if (!DeepSkyObject::load(params, resPath, name))
         return false;
 
     if (auto detailVal = params->getNumber<float>("Detail"); detailVal.has_value())

--- a/src/celengine/globular.h
+++ b/src/celengine/globular.h
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -30,7 +31,6 @@ class Renderer;
 class Globular : public DeepSkyObject
 {
 public:
-
    // min/max c-values of globular cluster data
    static constexpr float MinC = 0.50f;
    static constexpr float MaxC = 2.58f;
@@ -52,7 +52,7 @@ public:
     bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
               double& distanceToPicker,
               double& cosAngleToBoundCenter) const override;
-    bool load(const AssociativeArray*, const fs::path&) override;
+    bool load(const AssociativeArray*, const fs::path&, std::string_view) override;
 
     std::uint64_t getRenderMask() const override;
     unsigned int getLabelMask() const override;

--- a/src/celengine/nebula.cpp
+++ b/src/celengine/nebula.cpp
@@ -59,7 +59,7 @@ Nebula::getObjType() const
 }
 
 bool
-Nebula::load(const AssociativeArray* params, const fs::path& resPath)
+Nebula::load(const AssociativeArray* params, const fs::path& resPath, std::string_view name)
 {
     if (const std::string* t = params->getString("Mesh"); t != nullptr)
     {
@@ -75,7 +75,7 @@ Nebula::load(const AssociativeArray* params, const fs::path& resPath)
         setGeometry(geometryHandle);
     }
 
-    return DeepSkyObject::load(params, resPath);
+    return DeepSkyObject::load(params, resPath, name);
 }
 
 std::uint64_t

--- a/src/celengine/nebula.h
+++ b/src/celengine/nebula.h
@@ -10,6 +10,11 @@
 
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include <celcompat/filesystem.h>
 #include <celutil/reshandle.h>
 #include <celengine/deepskyobj.h>
 
@@ -23,9 +28,9 @@ public:
     std::string getDescription() const override;
 
     // pick: the preconditional sphere-ray intersection test is enough for now
-    bool load(const AssociativeArray*, const fs::path&) override;
+    bool load(const AssociativeArray*, const fs::path&, std::string_view) override;
 
-    uint64_t getRenderMask() const override;
+    std::uint64_t getRenderMask() const override;
     unsigned int getLabelMask() const override;
 
     void setGeometry(ResourceHandle);

--- a/src/celengine/opencluster.cpp
+++ b/src/celengine/opencluster.cpp
@@ -52,14 +52,6 @@ bool OpenCluster::pick(const Eigen::ParametrizedLine<double, 3>& ray,
 }
 
 
-bool OpenCluster::load(const AssociativeArray* params, const fs::path& resPath)
-{
-    // No parameters specific to open cluster, though a list of member stars
-    // could be useful.
-    return DeepSkyObject::load(params, resPath);
-}
-
-
 uint64_t OpenCluster::getRenderMask() const
 {
     return Renderer::ShowOpenClusters;

--- a/src/celengine/opencluster.h
+++ b/src/celengine/opencluster.h
@@ -9,6 +9,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <string_view>
+
 #include <Eigen/Geometry>
 
 #include <celutil/reshandle.h>
@@ -17,7 +21,7 @@
 
 class OpenCluster : public DeepSkyObject
 {
- public:
+public:
     OpenCluster() = default;
 
     const char* getType() const override;
@@ -27,22 +31,16 @@ class OpenCluster : public DeepSkyObject
     bool pick(const Eigen::ParametrizedLine<double, 3>& ray,
               double& distanceToPicker,
               double& cosAngleToBoundCenter) const override;
-    bool load(const AssociativeArray*, const fs::path&) override;
 
-    uint64_t getRenderMask() const override;
+    std::uint64_t getRenderMask() const override;
     unsigned int getLabelMask() const override;
 
     DeepSkyObjectType getObjType() const override;
 
- public:
     enum ClusterType
     {
         Open          = 0,
         Globular      = 1,
         NotDefined    = 2
     };
-
- private:
-    // TODO: It could be very useful to have a list of stars that are members
-    // of the cluster.
 };

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <Eigen/Geometry>
@@ -945,8 +946,13 @@ Body* CreateBody(const std::string& name,
         body->setClickable(false);
 
     // TODO: should be own class
-    if (const auto *infoURL = planetData->getString("InfoURL"); infoURL != nullptr)
-        body->setInfoURL(BuildInfoURL(*infoURL, path));
+    if (const auto *infoURLValue = planetData->getString("InfoURL"); infoURLValue != nullptr)
+    {
+        if (std::string infoURL = util::BuildInfoURL(*infoURLValue, path); !infoURL.empty())
+            body->setInfoURL(std::move(infoURL));
+        else
+            GetLogger()->error(_("Invalid InfoURL used in {} definition.\n"), name);
+    }
 
     if (auto albedo = planetData->getNumber<float>("Albedo"); albedo.has_value())
     {

--- a/src/celengine/star.cpp
+++ b/src/celengine/star.cpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstring>
+#include <utility>
 
 #include <fmt/format.h>
 
@@ -1043,10 +1044,10 @@ StarDetails::setRotationModel(boost::intrusive_ptr<StarDetails>& details,
 /*! Set the InfoURL for this star.
 */
 void
-StarDetails::setInfoURL(boost::intrusive_ptr<StarDetails>& details, std::string_view _infoURL)
+StarDetails::setInfoURL(boost::intrusive_ptr<StarDetails>& details, std::string&& _infoURL)
 {
     unshare(details);
-    details->infoURL = _infoURL;
+    details->infoURL = std::move(_infoURL);
 }
 
 void

--- a/src/celengine/star.h
+++ b/src/celengine/star.h
@@ -87,7 +87,7 @@ public:
     static void setVisibility(boost::intrusive_ptr<StarDetails>&, bool);
     static void setRotationModel(boost::intrusive_ptr<StarDetails>&, const std::shared_ptr<const celestia::ephem::RotationModel>&);
     static void setEllipsoidSemiAxes(boost::intrusive_ptr<StarDetails>&, const Eigen::Vector3f&);
-    static void setInfoURL(boost::intrusive_ptr<StarDetails>&, std::string_view _infoURL);
+    static void setInfoURL(boost::intrusive_ptr<StarDetails>&, std::string&& _infoURL);
     static void addOrbitingStar(boost::intrusive_ptr<StarDetails>&, Star*);
 
     bool shared() const;

--- a/src/celengine/stardbbuilder.h
+++ b/src/celengine/stardbbuilder.h
@@ -57,7 +57,10 @@ public:
     struct StcHeader;
 
 private:
-    bool createOrUpdateStar(const StcHeader&, const AssociativeArray*, Star*);
+    bool createOrUpdateStar(const StcHeader&,
+                            const AssociativeArray*,
+                            Star*,
+                            const fs::path&);
     bool checkStcPosition(const StcHeader&,
                           const AssociativeArray*,
                           const Star*,

--- a/src/celutil/CMakeLists.txt
+++ b/src/celutil/CMakeLists.txt
@@ -17,6 +17,8 @@ set(CELUTIL_SOURCES
   greek.cpp
   greek.h
   includeicu.h
+  infourl.cpp
+  infourl.h
   localeutil.h
   logger.cpp
   logger.h

--- a/src/celutil/infourl.cpp
+++ b/src/celutil/infourl.cpp
@@ -1,0 +1,60 @@
+#include "infourl.h"
+
+#include <system_error>
+
+#include <fmt/format.h>
+
+#ifdef _WIN32
+#include <algorithm>
+#include "winutil.h"
+#endif
+
+using namespace std::string_view_literals;
+
+namespace celestia::util
+{
+
+namespace
+{
+constexpr std::string_view httpPrefix = "http://"sv; //NOSONAR
+constexpr std::string_view httpsPrefix = "https://"sv;
+#ifdef _WIN32
+constexpr std::string_view filePrefix = "file:///"sv;
+constexpr std::wstring_view extPrefix = L"\\\\?\\"sv;
+#endif
+} // end unnamed namespace
+
+std::string
+BuildInfoURL(std::string_view infoUrl, const fs::path &resPath)
+{
+    if ((infoUrl.size() >= httpPrefix.size() && infoUrl.substr(0, httpPrefix.size()) == httpPrefix) ||
+        (infoUrl.size() >= httpsPrefix.size() && infoUrl.substr(0, httpsPrefix.size()) == httpsPrefix))
+    {
+        return std::string{ infoUrl };
+    }
+
+    std::error_code ec;
+    fs::path canonical = fs::canonical(resPath / fs::u8path(infoUrl), ec);
+    if (ec)
+        return {};
+
+#ifdef _WIN32
+    std::wstring_view canonicalView = canonical.native();
+    // Remove extended filepath prefix if any
+    if (canonicalView.size() >= extPrefix.size() && canonicalView.substr(0, extPrefix.size()) == extPrefix)
+        canonicalView = canonicalView.substr(extPrefix.size());
+
+    std::string fileUrl{ filePrefix };
+    WideToUTF8(canonicalView, fileUrl);
+    // Make sure the UTF-8 conversion worked
+    if (fileUrl.size() == filePrefix.size())
+        return {};
+
+    std::replace(fileUrl.begin(), fileUrl.end(), '\\', '/');
+    return fileUrl;
+#else
+    return fmt::format("file://{}", canonical.native());
+#endif
+}
+
+} // end namespace celestia::util

--- a/src/celutil/infourl.h
+++ b/src/celutil/infourl.h
@@ -1,22 +1,11 @@
 #pragma once
 
 #include <string>
+#include <string_view>
+
 #include <celcompat/filesystem.h>
 
-inline std::string
-BuildInfoURL(const std::string &infoUrl, const fs::path &resPath)
+namespace celestia::util
 {
-    std::string modifiedURL;
-    if (infoUrl.find(':') == std::string::npos && !resPath.empty())
-    {
-        // Relative URL, the base directory is the current one,
-        // not the main installation directory
-        std::string p = resPath.string();
-        const char *format = p.size() > 1 && p[1] == ':'
-            // Absolute Windows path, file:/// is required
-            ? "file:///{}/{}"
-            : "{}/{}";
-        modifiedURL = fmt::format(format, p, infoUrl);
-    }
-    return modifiedURL.empty() ? infoUrl : modifiedURL;
+std::string BuildInfoURL(std::string_view infoUrl, const fs::path &resPath);
 }

--- a/src/celutil/winutil.cpp
+++ b/src/celutil/winutil.cpp
@@ -14,28 +14,15 @@
 
 #include <windows.h>
 
-namespace celestia::util
+namespace celestia::util::detail
 {
 
-std::string
-WideToUTF8(std::wstring_view ws)
+int WideToUTF8(std::wstring_view ws, char* out, int outSize)
 {
-    if (ws.empty())
-        return {};
-
-    // get a converted string length
-    const auto srcLen = static_cast<int>(ws.size());
-    int len = WideCharToMultiByte(CP_UTF8, 0, ws.data(), srcLen, nullptr, 0, nullptr, nullptr);
-    if (len <= 0)
-        return {};
-
-    std::string out(static_cast<std::string::size_type>(len), '\0');
-    len = WideCharToMultiByte(CP_UTF8, 0, ws.data(), srcLen, out.data(), len, nullptr, nullptr);
-    if (len <= 0)
-        return {};
-
-    out.resize(static_cast<std::size_t>(len));
-    return out;
+    return WideCharToMultiByte(CP_UTF8, 0,
+                               ws.data(), static_cast<int>(ws.size()),
+                               out, outSize,
+                               nullptr, nullptr);
 }
 
-} // end namespace celestia::util
+} // end namespace celestia::util::detail

--- a/src/celutil/winutil.h
+++ b/src/celutil/winutil.h
@@ -18,6 +18,45 @@
 namespace celestia::util
 {
 
-std::string WideToUTF8(std::wstring_view ws);
+namespace detail
+{
+int WideToUTF8(std::wstring_view ws, char* out, int outSize);
+}
+
+template<typename T>
+void WideToUTF8(std::wstring_view ws, T& output)
+{
+    if (ws.empty())
+        return;
+
+    // get a converted string length
+    const auto srcLen = static_cast<int>(ws.size());
+    int len = detail::WideToUTF8(ws, nullptr, 0);
+    if (len <= 0)
+        return;
+
+    using size_type = decltype(output.size());
+    size_type initialSize = output.size();
+    auto newSize = static_cast<size_type>(initialSize + len);
+    output.resize(newSize);
+
+    len = detail::WideToUTF8(ws, output.data() + initialSize, len);
+    if (len <= 0)
+    {
+        output.resize(initialSize);
+        return;
+    }
+
+    newSize = static_cast<size_type>(initialSize + len);
+    output.resize(static_cast<std::size_t>(newSize));
+}
+
+inline std::string
+WideToUTF8(std::wstring_view ws)
+{
+    std::string result;
+    WideToUTF8(ws, result);
+    return result;
+}
 
 }


### PR DESCRIPTION
- Validate protocol of InfoURL is http or https, otherwise treat as file path
- Always convert file paths to absolute canonical file URLs
- Ensure backslashes are converted to forward slashes in Windows file URLs
- Warn if invalid URLs are detected
- fmt introduced non-quoted path formatting in fmt 10.1, use it if available