### PR TITLE
Better temperature calculation

### DIFF
--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -395,7 +395,7 @@ Body::getTemperature(double time) const
     if (sun->getVisibility()) // the sun is a star
     {
         auto distFromSun = static_cast<float>(getAstrocentricPosition(time).norm());
-        float flux = math::square(s->getRadius() * math::square(s->getTemperature())) / math::square(distFromSun);
+        float flux = math::square(sun->getRadius() * math::square(sun->getTemperature())) / math::square(distFromSun);
         temp = std::pow(((1.0f - getBondAlbedo()) * flux / 4.0f +
                         internalHeatFlux / 5.670374e-8) / emissivity, 0.25f);
     }

--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -416,7 +416,7 @@ Body::getTemperature(double time) const
         temp = std::pow(((1.0f - getBondAlbedo()) * flux / 4.0f +
                         internalHeatFlux / 5.670374e-8) / emissivity, 0.25f);
     }
-    return getTempDiscrepancy() + temp;
+    return temp;
 }
 
 void

--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -252,8 +252,10 @@ public:
     void setReflectivity(float);
     float getTemperature(double t = 0) const;
     void setTemperature(float);
-    float getTempDiscrepancy() const;
-    void setTempDiscrepancy(float);
+    float getEmissivity() const;
+    void setEmissivity(float);
+    float getInternalHeatFlux() const;
+    void setInternalHeatFlux(float);
 
     BodyClassification getClassification() const;
     void setClassification(BodyClassification);
@@ -373,7 +375,8 @@ private:
     float bondAlbedo{ 0.5f };
     float reflectivity{ 0.5f };
     float temperature{ 0.0f };
-    float tempDiscrepancy{ 0.0f };
+    float emissivity{ 0.0f };
+    float internalHeatFlux{ 0.0f };
 
     Eigen::Quaternionf geometryOrientation{ Eigen::Quaternionf::Identity() };
 

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -1000,8 +1000,10 @@ Body* CreateBody(const std::string& name,
 
     if (auto temperature = planetData->getNumber<float>("Temperature"); temperature.has_value() && *temperature > 0.0f)
         body->setTemperature(*temperature);
-    if (auto tempDiscrepancy = planetData->getNumber<float>("TempDiscrepancy"); tempDiscrepancy.has_value())
-        body->setTempDiscrepancy(*tempDiscrepancy);
+    if (auto emissivity = planetData->getNumber<float>("Emissivity"); emissivity.has_value())
+        body->setEmissivity(*emissivity);
+    if (auto internalHeatFlux = planetData->getNumber<float>("InternalHeatFlux"); internalHeatFlux.has_value())
+        body->setInternalHeatFlux(*internalHeatFlux);
     if (auto mass = planetData->getMass<float>("Mass", 1.0, 1.0); mass.has_value())
         body->setMass(*mass);
     if (auto density = planetData->getNumber<float>("Density"); density.has_value())


### PR DESCRIPTION
Replace **TempDiscrepancy** with **Emissivity** and **InternalHeatFlux**
- **Emissivity** (unitless, 0-1) represents how efficient a surface emits thermal energy. This can be used to simulate greenhouse effect.
- **InternalHeatFlux** (W m^-2) is the amount of heat radiated from the interior per unit surface area, invariant of external factors.

Not sure how correct I did this thing, hopefully I didn't royally screw something up somewhere.
Also, currently the value of the Stefan-Boltzmann constant is simply written into the function as is.

This PR has to be approved at the same time as an update in CelestiaContent which replaces TempDiscrepancy with these values (PR to be made)!