### PR TITLE
Default emissivity should be 1

### DIFF
--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -88,7 +88,7 @@ Body::setDefaultProperties()
     geomAlbedo = 0.5f;
     reflectivity = 0.5f;
     temperature = 0.0f;
-    emissivity = 0.0f;
+    emissivity = 1.0f;
     internalHeatFlux = 0.0f;
     geometryOrientation = Eigen::Quaternionf::Identity();
     geometry = InvalidResource;

--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -375,7 +375,7 @@ private:
     float bondAlbedo{ 0.5f };
     float reflectivity{ 0.5f };
     float temperature{ 0.0f };
-    float emissivity{ 0.0f };
+    float emissivity{ 1.0f };
     float internalHeatFlux{ 0.0f };
 
     Eigen::Quaternionf geometryOrientation{ Eigen::Quaternionf::Identity() };


### PR DESCRIPTION
Fixes infinite temperatures where emissivity is not specified