### PR TITLE
[Qt]  Celestial browser sort indicator

### DIFF
--- a/src/celestia/qt/qtcelestialbrowser.cpp
+++ b/src/celestia/qt/qtcelestialbrowser.cpp
@@ -30,6 +30,7 @@
 #include <QComboBox>
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QHeaderView>
 #include <QItemSelectionModel>
 #include <QLabel>
 #include <QLineEdit>
@@ -577,6 +578,9 @@ CelestialBrowser::slotRefreshTable()
     treeView->resizeColumnToContents(StarTableModel::DistanceColumn);
     treeView->resizeColumnToContents(StarTableModel::AppMagColumn);
     treeView->resizeColumnToContents(StarTableModel::AbsMagColumn);
+
+    QHeaderView* header = treeView->header();
+    header->setSortIndicator(StarTableModel::DistanceColumn, Qt::AscendingOrder);
 
     searchResultLabel->setText(QString(_("%1 objects found")).arg(starModel->rowCount(QModelIndex())));
 }

--- a/src/celestia/qt/qtdeepskybrowser.cpp
+++ b/src/celestia/qt/qtdeepskybrowser.cpp
@@ -31,6 +31,7 @@
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
+#include <QHeaderView>
 #include <QItemSelectionModel>
 #include <QLabel>
 #include <QLineEdit>
@@ -598,6 +599,8 @@ DeepSkyBrowser::slotRefreshTable()
     UniversalCoord observerPos = appCore->getSimulation()->getActiveObserver()->getPosition();
 
     DSOPredicate::Criterion criterion = DSOPredicate::Distance;
+    QHeaderView* header = treeView->header();
+    header->setSortIndicator(DSOTableModel::DistanceColumn, Qt::AscendingOrder);
 
     treeView->clearSelection();
 


### PR DESCRIPTION
Several tables in the Celestial Browser panel are hard coded to sort ascending by distance (column 2) upon display/changes. The panel is using the default table display which places the sort indicator as descending in the first column. This code fixes this sync issue.