### PR TITLE
Make GalaxyRenderer/GlobularRenderer own textures and OpenGL objects

### DIFF
--- a/src/celrender/galaxyrenderer.cpp
+++ b/src/celrender/galaxyrenderer.cpp
@@ -8,6 +8,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include "galaxyrenderer.h"
+
 #include <cassert>
 #include <cstdint>
 #include <cmath>
@@ -21,7 +23,6 @@
 #include <celmath/geomutil.h>
 #include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
-#include "galaxyrenderer.h"
 
 using celestia::engine::GalacticFormManager;
 
@@ -52,35 +53,6 @@ colorTextureEval(float u, float /*v*/, float /*w*/, std::uint8_t *pixel)
     Color::fromHSV(hue, 0.20f, 1.0f).get(pixel);
 }
 
-void
-BindTextures()
-{
-    static Texture* galaxyTex = nullptr;
-    static Texture* colorTex  = nullptr;
-
-    if (galaxyTex == nullptr)
-    {
-        galaxyTex = CreateProceduralTexture(kGalaxyTextureSize,
-                                            kGalaxyTextureSize,
-                                            engine::PixelFormat::Luminance,
-                                            galaxyTextureEval).release();
-    }
-    assert(galaxyTex != nullptr);
-    glActiveTexture(GL_TEXTURE0);
-    galaxyTex->bind();
-
-    if (colorTex == nullptr)
-    {
-        colorTex = CreateProceduralTexture(256, 1, engine::PixelFormat::RGBA,
-                                           colorTextureEval,
-                                           Texture::EdgeClamp,
-                                           Texture::NoMipMaps).release();
-    }
-    assert(colorTex != nullptr);
-    glActiveTexture(GL_TEXTURE1);
-    colorTex->bind();
-}
-
 } // anonymous namespace
 
 struct GalaxyRenderer::RenderData
@@ -90,8 +62,9 @@ struct GalaxyRenderer::RenderData
         vo(std::move(vo))
     {
     }
-    gl::Buffer       bo{ util::NoCreateT{} };
-    gl::VertexObject vo{ util::NoCreateT{} };
+
+    gl::Buffer       bo;
+    gl::VertexObject vo;
 };
 
 struct GalaxyRenderer::Object
@@ -194,6 +167,34 @@ GalaxyRenderer::getRenderInfo(const GalaxyRenderer::Object &obj, float &brightne
 }
 
 void
+GalaxyRenderer::bindTextures()
+{
+    if (m_galaxyTex == nullptr)
+    {
+        m_galaxyTex = CreateProceduralTexture(kGalaxyTextureSize,
+                                              kGalaxyTextureSize,
+                                              engine::PixelFormat::Luminance,
+                                              &galaxyTextureEval);
+    }
+
+    assert(m_galaxyTex != nullptr);
+    glActiveTexture(GL_TEXTURE0);
+    m_galaxyTex->bind();
+
+    if (m_colorTex == nullptr)
+    {
+        m_colorTex = CreateProceduralTexture(256, 1, engine::PixelFormat::RGBA,
+                                             &colorTextureEval,
+                                             Texture::EdgeClamp,
+                                             Texture::NoMipMaps);
+    }
+
+    assert(m_colorTex != nullptr);
+    glActiveTexture(GL_TEXTURE1);
+    m_colorTex->bind();
+}
+
+void
 GalaxyRenderer::renderGL2()
 {
     CelestiaGLProgram *prog =  m_renderer.getShaderManager().getShader("galaxy");
@@ -202,7 +203,7 @@ GalaxyRenderer::renderGL2()
 
     initializeGL2(prog);
 
-    BindTextures();
+    bindTextures();
 
     prog->use();
     prog->samplerParam("galaxyTex") = 0;
@@ -357,7 +358,7 @@ GalaxyRenderer::renderGL3()
 
     initializeGL3(prog);
 
-    BindTextures();
+    bindTextures();
 
     prog->use();
     prog->samplerParam("galaxyTex") = 0;

--- a/src/celrender/galaxyrenderer.h
+++ b/src/celrender/galaxyrenderer.h
@@ -20,6 +20,7 @@
 class CelestiaGLProgram;
 class Galaxy;
 class Renderer;
+class Texture;
 
 namespace celestia::render
 {
@@ -38,13 +39,17 @@ public:
 
 private:
     struct Object;
-
-    using BlobVector = engine::GalacticForm::BlobVector;
-
-    bool getRenderInfo(const GalaxyRenderer::Object &obj, float &brightness, float &size, float minimumFeatureSize, Eigen::Matrix4f &m, Eigen::Matrix4f &pr, int &nPoints) const;
-
     struct RenderData;
-    std::vector<RenderData>  m_renderData;
+
+    bool getRenderInfo(const GalaxyRenderer::Object &obj,
+                       float &brightness,
+                       float &size,
+                       float minimumFeatureSize,
+                       Eigen::Matrix4f &m,
+                       Eigen::Matrix4f &pr,
+                       int &nPoints) const;
+
+    void bindTextures();
 
     void renderGL2();
     void initializeGL2(const CelestiaGLProgram *prog);
@@ -52,9 +57,13 @@ private:
     void renderGL3();
     void initializeGL3(const CelestiaGLProgram *prog);
 
+    std::vector<RenderData>  m_renderData;
+
     // global state
-    std::vector<Object>     m_objects;
-    Renderer               &m_renderer;
+    std::unique_ptr<Texture> m_galaxyTex;
+    std::unique_ptr<Texture> m_colorTex;
+    std::vector<Object>      m_objects;
+    Renderer                &m_renderer;
 
     // per-frame state
     Eigen::Quaternionf  m_viewerOrientation{ Eigen::Quaternionf::Identity() };

--- a/src/celrender/globularrenderer.h
+++ b/src/celrender/globularrenderer.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include <Eigen/Core>
@@ -36,13 +37,15 @@ public:
     void render();
 
 private:
+    struct FormManager;
     struct Object;
 
     void renderForm(CelestiaGLProgram *tidalProg, CelestiaGLProgram *globProg, const Object &obj) const;
 
     // global state
-    std::vector<Object> m_objects;
-    Renderer           &m_renderer;
+    std::unique_ptr<FormManager> m_formManager;
+    std::vector<Object>          m_objects;
+    Renderer                    &m_renderer;
 
     // per-frame state
     Eigen::Quaternionf m_viewerOrientation{ Eigen::Quaternionf::Identity() };


### PR DESCRIPTION
Ensures proper cleanup when Renderer is destroyed.