### PR TITLE
Fix constellation line fade distance

### DIFF
--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -363,6 +363,33 @@ StarTextures
 # OrbitPeriodsShown      1.0
   LinearFadeFraction     0.8
 
+#------------------------------------------------------------------------
+# Constellation rendering parameters
+#------------------------------------------------------------------------
+# A constellation has three components:
+# 1. "Asterism": The lines connecting the stars in the constellation.
+# 2. "Boundary": The boundary of the constellation.
+# 3. "Label": The name of the constellation.
+# 
+# "FadeStartDist" ->
+# The maximum distance of the observer to the origin of coordinates
+# before the specified component starts to linearly fade out.
+# Unit is in light years. The default values are:
+# 6.0 for boundaries, 600.0 for asterisms and labels.
+#
+# "FadeEndDist" ->
+# The maximum distance of the observer to the origin of coordinates
+# before the specified component fades out completely.
+# Unit is in light years. The default values are:
+# 20.0 for boundaries, 65200.0 for asterisms and labels.
+#------------------------------------------------------------------------
+  RenderAsterismsFadeStartDist        600.0
+  RenderAsterismsFadeEndDist          65200.0
+  RenderBoundariesFadeStartDist       6.0
+  RenderBoundariesFadeEndDist         20.0
+  LabelConstellationsFadeStartDist    600.0
+  LabelConstellationsFadeEndDist      65200.0
+
 
 #-----------------------------------------------------------------------
 # Set the level of multisample antialiasing.  Not all 3D graphics

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -3132,8 +3132,8 @@ void Renderer::renderBoundaries(const Universe& universe, float dist, const Matr
     //*** Boundaries fading parameters
 
     //   The two values are for distances from centre where the boundaries begins fading and finish fading, respectively.
-    const float RenderBoundariesFadeStartDist     = detailOptions.renderBoundariesFadeStartDist;
-    const float RenderBoundariesFadeEndDist     = detailOptions.renderBoundariesFadeEndDist;
+    const float RenderBoundariesFadeStartDist = detailOptions.renderBoundariesFadeStartDist;
+    const float RenderBoundariesFadeEndDist   = detailOptions.renderBoundariesFadeEndDist;
     
     if (!util::is_set(renderFlags, RenderFlags::ShowBoundaries) || boundaries == nullptr)
         return;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4026,8 +4026,8 @@ void Renderer::labelConstellations(const AsterismList& asterisms,
     //*** Constellation label fading parameters
 
     //   The two values are for distances from centre where the labels begins fading and finish fading, respectively.
-    const float LabelConstellationsFadeStartDist     = detailOptions.labelConstellationsFadeStartDist;
-    const float LabelConstellationsFadeEndDist     = detailOptions.labelConstellationsFadeEndDist;
+    const float LabelConstellationsFadeStartDist = detailOptions.labelConstellationsFadeStartDist;
+    const float LabelConstellationsFadeEndDist   = detailOptions.labelConstellationsFadeEndDist;
 
     for (const auto& ast : asterisms)
     {

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -130,16 +130,6 @@ static const float MinOrbitSizeForLabel = 20.0f;
 // a label for it.
 static const float MinFeatureSizeForLabel = 20.0f;
 
-/* The maximum distance of the observer to the origin of coordinates before
-   asterism lines and labels start to linearly fade out (in light years) */
-static const float MaxAsterismLabelsConstDist  = 6.0f;
-static const float MaxAsterismLinesConstDist   = 600.0f;
-
-/* The maximum distance of the observer to the origin of coordinates before
-   asterisms labels and lines fade out completely (in light years) */
-static const float MaxAsterismLabelsDist = 20.0f;
-static const float MaxAsterismLinesDist  = 6.52e4f;
-
 // Static meshes and textures used by all instances of Simulation
 
 static bool commonDataInitialized = false;
@@ -293,7 +283,14 @@ Renderer::DetailOptions::DetailOptions() :
     eclipseTextureSize(128),
     orbitWindowEnd(0.5),
     orbitPeriodsShown(1.0),
-    linearFadeFraction(0.0)
+    linearFadeFraction(0.0),
+    
+    renderAsterismsFadeStartDist(600.0f),
+    renderAsterismsFadeEndDist(6.52e4f),
+    renderBoundariesFadeStartDist(6.0f),
+    renderBoundariesFadeEndDist(20.0f),
+    labelConstellationsFadeStartDist(6.0f),
+    labelConstellationsFadeEndDist(20.0f)
 {
 }
 
@@ -3095,6 +3092,12 @@ void Renderer::renderAsterisms(const Universe& universe, float dist, const Matri
 {
     auto *asterisms = universe.getAsterisms();
 
+    //*** Asterism fading parameters
+
+    //   The two values are for distances from centre where the asterism begins fading and finish fading, respectively.
+    const float RenderAsterismsFadeStartDist     = detailOptions.renderAsterismsFadeStartDist;
+    const float RenderAsterismsFadeEndDist     = detailOptions.renderAsterismsFadeEndDist;
+
     if (!util::is_set(renderFlags, RenderFlags::ShowDiagrams) || asterisms == nullptr)
         return;
 
@@ -3104,10 +3107,10 @@ void Renderer::renderAsterisms(const Universe& universe, float dist, const Matri
     }
 
     float opacity = 1.0f;
-    if (dist > MaxAsterismLinesConstDist)
+    if (dist > RenderAsterismsFadeStartDist)
     {
-        opacity = std::clamp((MaxAsterismLinesConstDist - dist)
-                             / (MaxAsterismLinesDist - MaxAsterismLinesConstDist) + 1.0f,
+        opacity = std::clamp((RenderAsterismsFadeStartDist - dist)
+                             / (RenderAsterismsFadeEndDist - RenderAsterismsFadeStartDist) + 1.0f,
                              0.0f,
                              1.0f);
     }
@@ -3125,6 +3128,13 @@ void Renderer::renderAsterisms(const Universe& universe, float dist, const Matri
 void Renderer::renderBoundaries(const Universe& universe, float dist, const Matrices& mvp)
 {
     auto boundaries = universe.getBoundaries();
+
+    //*** Boundaries fading parameters
+
+    //   The two values are for distances from centre where the boundaries begins fading and finish fading, respectively.
+    const float RenderBoundariesFadeStartDist     = detailOptions.renderBoundariesFadeStartDist;
+    const float RenderBoundariesFadeEndDist     = detailOptions.renderBoundariesFadeEndDist;
+    
     if (!util::is_set(renderFlags, RenderFlags::ShowBoundaries) || boundaries == nullptr)
         return;
 
@@ -3136,10 +3146,10 @@ void Renderer::renderBoundaries(const Universe& universe, float dist, const Matr
     /* We'll linearly fade the boundaries as a function of the
        observer's distance to the origin of coordinates: */
     float opacity = 1.0f;
-    if (dist > MaxAsterismLabelsConstDist)
+    if (dist > RenderBoundariesFadeStartDist)
     {
-        opacity = std::clamp((MaxAsterismLabelsConstDist - dist)
-                             / (MaxAsterismLabelsDist - MaxAsterismLabelsConstDist) + 1.0f,
+        opacity = std::clamp((RenderBoundariesFadeStartDist - dist)
+                             / (RenderBoundariesFadeEndDist - RenderBoundariesFadeStartDist) + 1.0f,
                              0.0f,
                              1.0f);
     }
@@ -4013,6 +4023,12 @@ void Renderer::labelConstellations(const AsterismList& asterisms,
 {
     Vector3f observerPos = observer.getPosition().toLy().cast<float>();
 
+    //*** Constellation label fading parameters
+
+    //   The two values are for distances from centre where the labels begins fading and finish fading, respectively.
+    const float LabelConstellationsFadeStartDist     = detailOptions.labelConstellationsFadeStartDist;
+    const float LabelConstellationsFadeEndDist     = detailOptions.labelConstellationsFadeEndDist;
+
     for (const auto& ast : asterisms)
     {
         if (!ast.getActive())
@@ -4031,10 +4047,10 @@ void Renderer::labelConstellations(const AsterismList& asterisms,
             // We'll linearly fade the labels as a function of the
             // observer's distance to the origin of coordinates:
             float opacity = 1.0f;
-            if (float dist = observerPos.norm(); dist > MaxAsterismLabelsConstDist)
+            if (float dist = observerPos.norm(); dist > LabelConstellationsFadeStartDist)
             {
-                opacity = std::clamp((MaxAsterismLabelsConstDist - dist)
-                                     / (MaxAsterismLabelsDist - MaxAsterismLabelsConstDist) + 1.0f,
+                opacity = std::clamp((LabelConstellationsFadeStartDist - dist)
+                                     / (LabelConstellationsFadeEndDist - LabelConstellationsFadeStartDist) + 1.0f,
                                      0.0f,
                                      1.0f);
             }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -3095,8 +3095,8 @@ void Renderer::renderAsterisms(const Universe& universe, float dist, const Matri
     //*** Asterism fading parameters
 
     //   The two values are for distances from centre where the asterism begins fading and finish fading, respectively.
-    const float RenderAsterismsFadeStartDist     = detailOptions.renderAsterismsFadeStartDist;
-    const float RenderAsterismsFadeEndDist     = detailOptions.renderAsterismsFadeEndDist;
+    const float RenderAsterismsFadeStartDist = detailOptions.renderAsterismsFadeStartDist;
+    const float RenderAsterismsFadeEndDist   = detailOptions.renderAsterismsFadeEndDist;
 
     if (!util::is_set(renderFlags, RenderFlags::ShowDiagrams) || asterisms == nullptr)
         return;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -122,6 +122,13 @@ class Renderer
         double orbitWindowEnd{ 0.5 };
         double orbitPeriodsShown{ 1.0 };
         double linearFadeFraction{ 0.0 };
+        
+        float renderAsterismsFadeStartDist{ 600.0f };
+        float renderAsterismsFadeEndDist{ 6.52e4f };
+        float renderBoundariesFadeStartDist{ 6.0f };
+        float renderBoundariesFadeEndDist{ 20.0f };
+        float labelConstellationsFadeStartDist{ 6.0f };
+        float labelConstellationsFadeEndDist{ 20.0f };
 #ifndef GL_ES
         bool useMesaPackInvert{ true };
 #endif

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2595,6 +2595,13 @@ bool CelestiaCore::initRenderer([[maybe_unused]] bool useMesaPackInvert)
     detailOptions.orbitWindowEnd = config->renderDetails.orbitWindowEnd;
     detailOptions.orbitPeriodsShown = config->renderDetails.orbitPeriodsShown;
     detailOptions.linearFadeFraction = config->renderDetails.linearFadeFraction;
+
+    detailOptions.renderAsterismsFadeStartDist = config->renderDetails.renderAsterismsFadeStartDist;
+    detailOptions.renderAsterismsFadeEndDist = config->renderDetails.renderAsterismsFadeEndDist;
+    detailOptions.renderBoundariesFadeStartDist = config->renderDetails.renderBoundariesFadeStartDist;
+    detailOptions.renderBoundariesFadeEndDist = config->renderDetails.renderBoundariesFadeEndDist;
+    detailOptions.labelConstellationsFadeStartDist = config->renderDetails.labelConstellationsFadeStartDist;
+    detailOptions.labelConstellationsFadeEndDist = config->renderDetails.labelConstellationsFadeEndDist;
 #ifndef GL_ES
     detailOptions.useMesaPackInvert = useMesaPackInvert;
 #endif

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -185,6 +185,14 @@ applyRenderDetails(CelestiaConfig::RenderDetails& renderDetails, const Associati
     applyNumber(renderDetails.orbitPeriodsShown, hash, "OrbitPeriodsShown"sv);
     applyNumber(renderDetails.linearFadeFraction, hash, "LinearFadeFraction"sv);
     applyNumber(renderDetails.faintestVisible, hash, "FaintestVisibleMagnitude"sv);
+
+    applyNumber(renderDetails.renderAsterismsFadeStartDist, hash, "RenderAsterismsFadeStartDist"sv);
+    applyNumber(renderDetails.renderAsterismsFadeEndDist, hash, "RenderAsterismsFadeEndDist"sv);
+    applyNumber(renderDetails.renderBoundariesFadeStartDist, hash, "RenderBoundariesFadeStartDist"sv);
+    applyNumber(renderDetails.renderBoundariesFadeEndDist, hash, "RenderBoundariesFadeEndDist"sv);
+    applyNumber(renderDetails.labelConstellationsFadeStartDist, hash, "LabelConstellationsFadeStartDist"sv);
+    applyNumber(renderDetails.labelConstellationsFadeEndDist, hash, "LabelConstellationsFadeEndDist"sv);
+
     applyNumber(renderDetails.shadowTextureSize, hash, "ShadowTextureSize"sv);
     applyNumber(renderDetails.eclipseTextureSize, hash, "EclipseTextureSize"sv);
     applyNumber(renderDetails.orbitPathSamplePoints, hash, "OrbitPathSamplePoints"sv);

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -69,6 +69,14 @@ struct CelestiaConfig
         double orbitPeriodsShown{ 1.0 };
         double linearFadeFraction{ 0.0 };
         float faintestVisible{ 6.0f };
+
+        float renderAsterismsFadeStartDist{ 600.0f };
+        float renderAsterismsFadeEndDist{ 6.52e4f };
+        float renderBoundariesFadeStartDist{ 6.0f };
+        float renderBoundariesFadeEndDist{ 20.0f };
+        float labelConstellationsFadeStartDist{ 6.0f };
+        float labelConstellationsFadeEndDist{ 20.0f };
+
         unsigned int shadowTextureSize{ 256 };
         unsigned int eclipseTextureSize{ 128 };
         unsigned int orbitPathSamplePoints{ 100 };


### PR DESCRIPTION
As per Issue #2176. Removed the random scaling factor applied to “dist” value, which is confusing and unintuitive. Now constellation lines should show up at interstellar distances, as preferred by many users. If fading at smaller distance is preferred then it would make sense to change the constants themselves rather than this.