### PR TITLE
Fix OrbitCache leaking CurvePlot instances

### DIFF
--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -122,7 +122,7 @@ class Renderer
         double orbitWindowEnd{ 0.5 };
         double orbitPeriodsShown{ 1.0 };
         double linearFadeFraction{ 0.0 };
-        
+
         float renderAsterismsFadeStartDist{ 600.0f };
         float renderAsterismsFadeEndDist{ 6.52e4f };
         float renderBoundariesFadeStartDist{ 6.0f };
@@ -659,7 +659,7 @@ class Renderer
 
     std::array<int, 4> m_viewport { 0, 0, 0, 0 };
 
-    typedef std::map<const celestia::ephem::Orbit*, CurvePlot*> OrbitCache;
+    using OrbitCache = std::map<const celestia::ephem::Orbit*, std::unique_ptr<CurvePlot>>;
     OrbitCache orbitCache;
     uint32_t lastOrbitCacheFlush;
 


### PR DESCRIPTION
- Use unique_ptr to track ownership of CurvePlot
- Use iterator hint to insert new CurvePlot instances
- Use return value of erase(iter) in cache invalidation loop