### PR TITLE
Add a method in Observer to applyTransform

### DIFF
--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -591,6 +591,17 @@ Observer::setOrientationTransform(const Eigen::Matrix3d& transform)
     updateOrientation();
 }
 
+/*! Apply the transform to the original orientation and reset transform.
+ */
+void
+Observer::applyCurrentTransform()
+{
+    originalOrientationUniv = transformedOrientationUniv;
+    originalOrientation = transformedOrientation;
+    orientationTransform = Eigen::Matrix3d::Identity();
+    updateOrientation();
+}
+
 /*! Get the velocity of the observer within the observer's reference frame.
  */
 Eigen::Vector3d

--- a/src/celengine/observer.h
+++ b/src/celengine/observer.h
@@ -136,6 +136,8 @@ public:
     Eigen::Matrix3d getOrientationTransform() const;
     void            setOrientationTransform(const Eigen::Matrix3d&);
 
+    void            applyCurrentTransform();
+
     Eigen::Vector3d getVelocity() const;
     void            setVelocity(const Eigen::Vector3d&);
     Eigen::Vector3d getAngularVelocity() const;


### PR DESCRIPTION
When moving the camera using gyroscope/rotation vector, I hope to use `setOrientationTransform` instead of `rotate` on observer to achieve the effect that the camera follows the device's orientation. This is 

When user enables gyroscope, we call `setOrientationTransform` to update the transform with device input, and when user disables gyroscope, we apply the transform onto the `originalOrientation` and resets the transform to identity, so that there is no change in the rendered content and when users enables gyroscope again we can start clean.