### PR TITLE
More use of smart pointers in Renderer

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -442,14 +442,6 @@ translateLabelModeToClassMask(RenderLabels labelMode)
 }
 
 
-// Depth comparison function for render list entries
-bool operator<(const RenderListEntry& a, const RenderListEntry& b)
-{
-    // Operation is reversed because -z axis points into the screen
-    return a.centerZ - a.radius > b.centerZ - b.radius;
-}
-
-
 // Depth comparison for labels
 // Note that it's essential to declare this operator as a member
 // function of Renderer::Label; if it's not a class member, C++'s
@@ -462,7 +454,7 @@ bool Renderer::Annotation::operator<(const Annotation& a) const
 }
 
 // Depth comparison for orbit paths
-bool Renderer::OrbitPathListEntry::operator<(const Renderer::OrbitPathListEntry& o) const
+bool Renderer::OrbitPathListEntry::operator<(const OrbitPathListEntry& o) const
 {
     // Operation is reversed because -z axis points into the screen
     return centerZ - radius > o.centerZ - o.radius;
@@ -4871,7 +4863,12 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
     // ideal for performance; should render opaque objects front to
     // back, then translucent objects back to front. However, the
     // amount of overdraw in Celestia is typically low.)
-    sort(renderList.begin(), renderList.end());
+    std::sort(renderList.begin(), renderList.end(),
+              [](const RenderListEntry& a, const RenderListEntry& b)
+              {
+                  // Operation is reversed because -z axis points into the screen
+                  return a.centerZ - a.radius > b.centerZ - b.radius;
+              });
 }
 
 bool

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -99,36 +99,28 @@ using celestia::util::GetLogger;
 
 namespace util = celestia::util;
 
-static const int REF_DISTANCE_TO_SCREEN  = 400; //[mm]
+static constexpr int REF_DISTANCE_TO_SCREEN  = 400; //[mm]
 
 // Contribution from planetshine beyond this distance (in units of object radius)
 // is considered insignificant.
-static const float PLANETSHINE_DISTANCE_LIMIT_FACTOR = 100.0f;
+static constexpr float PLANETSHINE_DISTANCE_LIMIT_FACTOR = 100.0f;
 
 // Planetshine from objects less than this pixel size is treated as insignificant
 // and will be ignored.
-static const float PLANETSHINE_PIXEL_SIZE_LIMIT      =   0.1f;
+static constexpr float PLANETSHINE_PIXEL_SIZE_LIMIT      =   0.1f;
 
 // Fractional pixel offset used when rendering text as texture mapped
 // quads to ensure consistent mapping of texels to pixels.
-static const float PixelOffset = 0.125f;
+static constexpr float PixelOffset = 0.125f;
 
 // These two values constrain the near and far planes of the view frustum
 // when rendering planet and object meshes.  The near plane will never be
 // closer than MinNearPlaneDistance, and the far plane is set so that far/near
 // will not exceed MaxFarNearRatio.
-static const float MinNearPlaneDistance = 0.0001f; // km
-static const float MaxFarNearRatio      = 2000000.0f;
+static constexpr float MinNearPlaneDistance = 0.0001f; // km
+static constexpr float MaxFarNearRatio      = 2000000.0f;
 
-static const float MinRelativeOccluderRadius = 0.005f;
-
-// The minimum apparent size of an objects orbit in pixels before we display
-// a label for it.  This minimizes label clutter.
-static const float MinOrbitSizeForLabel = 20.0f;
-
-// The minimum apparent size of a surface feature in pixels before we display
-// a label for it.
-static const float MinFeatureSizeForLabel = 20.0f;
+static constexpr float MinRelativeOccluderRadius = 0.005f;
 
 // Static meshes and textures used by all instances of Simulation
 
@@ -140,12 +132,12 @@ LODSphereMesh* g_lodSphere = nullptr;
 static Texture* gaussianDiscTex = nullptr;
 static Texture* gaussianGlareTex = nullptr;
 
-static const float CoronaHeight = 0.2f;
+static constexpr float CoronaHeight = 0.2f;
 
 // Size at which the orbit cache will be flushed of old orbit paths
-static const unsigned int OrbitCacheCullThreshold = 200;
+static constexpr unsigned int OrbitCacheCullThreshold = 200;
 // Age in frames at which unused orbit paths may be eliminated from the cache
-static const uint32_t OrbitCacheRetireAge = 16;
+static constexpr std::uint32_t OrbitCacheRetireAge = 16;
 
 Color Renderer::StarLabelColor          (0.471f, 0.356f, 0.682f);
 Color Renderer::PlanetLabelColor        (0.407f, 0.333f, 0.964f);
@@ -219,28 +211,11 @@ inline void glVertexAttrib(GLuint index, const Color &color)
 }
 
 Renderer::Renderer() :
-    windowWidth(0),
-    windowHeight(0),
-    fov(standardFOV),
-    screenDpi(96),
-    corrFac(1.12f),
-    faintestAutoMag45deg(8.0f), //def. 7.0f
 #ifndef GL_ES
     renderMode(GL_FILL),
 #endif
-    brightnessBias(0.0f),
-    saturationMagNight(1.0f),
-    saturationMag(1.0f),
     pointStarVertexBuffer(nullptr),
     glareVertexBuffer(nullptr),
-    frameCount(0),
-    lastOrbitCacheFlush(0),
-    minOrbitSize(MinOrbitSizeForLabel),
-    distanceLimit(1.0e6f),
-    minFeatureSize(MinFeatureSizeForLabel),
-    locationFilter(~0ull),
-    settingsChanged(true),
-    objectAnnotationSetOpen(false),
     m_atmosphereRenderer(std::make_unique<AtmosphereRenderer>(*this)),
     m_cometRenderer(std::make_unique<CometRenderer>(*this)),
     m_eclipticLineRenderer(std::make_unique<EclipticLineRenderer>(*this)),
@@ -255,11 +230,6 @@ Renderer::Renderer() :
 {
     pointStarVertexBuffer = new PointStarVertexBuffer(*this, 2048);
     glareVertexBuffer = new PointStarVertexBuffer(*this, 2048);
-
-    for (int i = 0; i < (int) FontCount; i++)
-    {
-        fonts[i] = nullptr;
-    }
     shaderManager = new ShaderManager();
 }
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -223,10 +223,6 @@ Renderer::Renderer() :
 
 Renderer::~Renderer()
 {
-    pointStarVertexBuffer.reset();
-    glareVertexBuffer.reset();
-    shaderManager.reset();
-
     m_atmosphereRenderer->deinitGL();
     m_cometRenderer->deinitGL();
     CurvePlot::deinit();

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -589,17 +589,17 @@ class Renderer
  private:
     ShaderManager* shaderManager{ nullptr };
 
-    int windowWidth;
-    int windowHeight;
-    float fov;
+    int windowWidth{ 0 };
+    int windowHeight{ 0 };
+    float fov{ celestia::engine::standardFOV };
     double cosViewConeAngle{ 0.0 };
-    int screenDpi;
-    float corrFac;
+    int screenDpi{ 96 };
+    float corrFac{ 1.12f };
     float pixelSize{ 1.0f };
-    float faintestAutoMag45deg;
+    float faintestAutoMag45deg{ 8.0f };
     std::vector<std::shared_ptr<TextureFont>> fonts{FontCount, nullptr};
 
-    std::shared_ptr<celestia::engine::ProjectionMode> projectionMode{ nullptr };
+    std::shared_ptr<celestia::engine::ProjectionMode> projectionMode;
     int renderMode;
     RenderLabels labelMode{ RenderLabels::NoLabels };
     bool rtl{ false };
@@ -609,13 +609,13 @@ class Renderer
     BodyClassification orbitMask{ BodyClassification::Planet | BodyClassification::Moon | BodyClassification::Stellar };
     float ambientLightLevel{ 0.1f };
     float tintSaturation{ 0.5f };
-    float brightnessBias;
+    float brightnessBias{ 0.0f };
 
     float brightnessScale{ 1.0f };
     float faintestMag{ 0.0f };
     float faintestPlanetMag{ 0.0f };
-    float saturationMagNight;
-    float saturationMag;
+    float saturationMagNight{ 1.0f };
+    float saturationMag{ 1.0f };
     StarStyle starStyle{ StarStyle::FuzzyPointStars };
 
     Color ambientColor;
@@ -649,7 +649,7 @@ class Renderer
     TextureResolution textureResolution{ TextureResolution::medres };
     DetailOptions detailOptions;
 
-    uint32_t frameCount;
+    std::uint32_t frameCount{ 0 };
 
     int currentIntervalIndex{ 0 };
 
@@ -659,22 +659,26 @@ class Renderer
 
     using OrbitCache = std::map<const celestia::ephem::Orbit*, std::unique_ptr<CurvePlot>>;
     OrbitCache orbitCache;
-    uint32_t lastOrbitCacheFlush;
+    std::uint32_t lastOrbitCacheFlush{ 0 };
 
-    float minOrbitSize;
-    float distanceLimit;
-    float minFeatureSize;
-    uint64_t locationFilter;
+    // The minimum apparent size of an objects orbit in pixels before we display
+    // a label for it.  This minimizes label clutter.
+    float minOrbitSize{ 20.0f };
+    float distanceLimit{ 1.0e6f };
+    // The minimum apparent size of a surface feature in pixels before we display
+    // a label for it.
+    float minFeatureSize{ 20.0f };
+    std::uint64_t locationFilter{ ~UINT64_C(0) };
 
     ColorTemperatureTable starColors{ ColorTableType::Blackbody_D65 };
     ColorTemperatureTable tintColors{ ColorTableType::SunWhite };
 
     Selection highlightObject;
 
-    bool settingsChanged;
+    bool settingsChanged{ true };
 
     // True if we're in between a begin/endObjectAnnotations
-    bool objectAnnotationSetOpen;
+    bool objectAnnotationSetOpen{ false };
 
     double realTime{ true };
 

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -587,7 +587,7 @@ class Renderer
     void createShadowFBO();
 
  private:
-    ShaderManager* shaderManager{ nullptr };
+    std::unique_ptr<ShaderManager> shaderManager{ std::make_unique<ShaderManager>() };
 
     int windowWidth{ 0 };
     int windowHeight{ 0 };
@@ -623,8 +623,8 @@ class Renderer
 
     Eigen::Quaterniond m_cameraOrientation;
     Eigen::Matrix3d m_cameraTransform{ Eigen::Matrix3d::Identity() };
-    PointStarVertexBuffer* pointStarVertexBuffer;
-    PointStarVertexBuffer* glareVertexBuffer;
+    std::unique_ptr<PointStarVertexBuffer> pointStarVertexBuffer;
+    std::unique_ptr<PointStarVertexBuffer> glareVertexBuffer;
     std::vector<RenderListEntry> renderList;
     std::vector<SecondaryIlluminator> secondaryIlluminators;
     std::vector<DepthBufferPartition> depthPartitions;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -35,6 +35,7 @@
 
 class RendererWatcher;
 class FrameTree;
+class LODSphereMesh;
 class ReferenceMark;
 class CurvePlot;
 class PointStarVertexBuffer;
@@ -698,6 +699,10 @@ class Renderer
     // Saturation magnitude used to calculate a point star size
     float satPoint;
 
+    std::unique_ptr<LODSphereMesh> m_lodSphere;
+    std::unique_ptr<Texture> m_gaussianDiscTex;
+    std::unique_ptr<Texture> m_gaussianGlareTex;
+
     std::unique_ptr<celestia::render::AsterismRenderer> m_asterismRenderer;
     std::unique_ptr<celestia::render::BoundariesRenderer> m_boundariesRenderer;
     std::unique_ptr<celestia::render::AtmosphereRenderer> m_atmosphereRenderer;
@@ -769,6 +774,7 @@ class Renderer
 
     static Color SelectionCursorColor;
 
+    friend class celestia::render::AtmosphereRenderer;
     friend class PointStarRenderer;
 };
 

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -131,7 +131,8 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
                           const Eigen::Quaternionf& planetOrientation,
                           const math::Frustum& frustum,
                           const Matrices &m,
-                          Renderer* renderer)
+                          Renderer* renderer,
+                          LODSphereMesh* lodSphere)
 {
     float radius = semiAxes.maxCoeff();
 
@@ -350,9 +351,9 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
 
     auto endTextures = std::remove(textures.begin(), textures.end(), nullptr);
     textures.erase(endTextures, textures.end());
-    g_lodSphere->render(attributes,
-                        frustum, ri.pixWidth,
-                        textures.data(), static_cast<int>(textures.size()), prog);
+    lodSphere->render(attributes,
+                      frustum, ri.pixWidth,
+                      textures.data(), static_cast<int>(textures.size()), prog);
 }
 
 
@@ -540,7 +541,8 @@ void renderClouds_GLSL(const RenderInfo& ri,
                        const Eigen::Quaternionf& planetOrientation,
                        const math::Frustum& frustum,
                        const Matrices &m,
-                       Renderer* renderer)
+                       Renderer* renderer,
+                       LODSphereMesh* lodSphere)
 {
     float radius = semiAxes.maxCoeff();
 
@@ -631,9 +633,9 @@ void renderClouds_GLSL(const RenderInfo& ri,
 
     auto endTextures = std::remove(textures.begin(), textures.end(), nullptr);
     textures.erase(endTextures, textures.end());
-    g_lodSphere->render(attributes,
-                        frustum, ri.pixWidth,
-                        textures.data(), static_cast<int>(textures.size()), prog);
+    lodSphere->render(attributes,
+                      frustum, ri.pixWidth,
+                      textures.data(), static_cast<int>(textures.size()), prog);
 
     prog->textureOffset = 0.0f;
 }

--- a/src/celengine/renderglsl.h
+++ b/src/celengine/renderglsl.h
@@ -24,6 +24,7 @@
 class Atmosphere;
 class Geometry;
 class LightingState;
+class LODSphereMesh;
 struct Matrices;
 class Renderer;
 struct RenderInfo;
@@ -44,7 +45,8 @@ void renderEllipsoid_GLSL(const RenderInfo& ri,
                           const Eigen::Quaternionf& planetOrientation,
                           const celestia::math::Frustum& frustum,
                           const Matrices &m,
-                          Renderer* renderer);
+                          Renderer* renderer,
+                          LODSphereMesh* lodSphere);
 
 void renderGeometry_GLSL(Geometry* geometry,
                          const RenderInfo& ri,
@@ -70,7 +72,8 @@ void renderClouds_GLSL(const RenderInfo& ri,
                        const Eigen::Quaternionf& planetOrientation,
                        const celestia::math::Frustum& frustum,
                        const Matrices &m,
-                       Renderer* renderer);
+                       Renderer* renderer,
+                       LODSphereMesh* lodSphere);
 
 void renderGeometry_GLSL_Unlit(Geometry* geometry,
                                const RenderInfo& ri,

--- a/src/celengine/renderinfo.h
+++ b/src/celengine/renderinfo.h
@@ -14,10 +14,7 @@
 
 #include <celutil/color.h>
 
-
-class LODSphereMesh;
 class Texture;
-
 
 struct RenderInfo
 {
@@ -40,6 +37,3 @@ struct RenderInfo
     float pixWidth{ 1.0f };
     float pointScale{ 1.0f };
 };
-
-extern LODSphereMesh* g_lodSphere;
-

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -402,10 +402,10 @@ AtmosphereRenderer::render(
     ps.depthTest = true;
     m_renderer.setPipelineState(ps);
 
-    g_lodSphere->render(LODSphereMesh::Normals,
-                        frustum,
-                        ri.pixWidth,
-                        nullptr);
+    m_renderer.m_lodSphere->render(LODSphereMesh::Normals,
+                                   frustum,
+                                   ri.pixWidth,
+                                   nullptr);
 
     glFrontFace(GL_CCW);
 }


### PR DESCRIPTION
- Move LODSphereMesh, Gaussian textures into Renderer
- Hold ShaderManager, PointStarVertexBuffers in unique_ptr
- Use more field initializers