### PR TITLE
Use the starting orientation transform value throughout journey

### DIFF
--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -663,7 +663,7 @@ Observer::update(double dt, double timeScale)
 
         // Spherically interpolate the orientation over the first half
         // of the journey.
-        originalOrientation = undoTransform(interpolateOrientation(journey, t));
+        originalOrientation = journey.orientationTransformInverse * interpolateOrientation(journey, t);
 
         // If the journey's complete, reset to manual control
         if (t == 1.0f)
@@ -672,7 +672,7 @@ Observer::update(double dt, double timeScale)
             {
                 //situation = RigidTransform(journey.to, journey.finalOrientation);
                 position = journey.to;
-                originalOrientation = undoTransform(journey.finalOrientation);
+                originalOrientation = journey.orientationTransformInverse * journey.finalOrientation;
             }
 
             observerMode = ObserverMode::Free;
@@ -950,7 +950,7 @@ Observer::centerSelectionCO(const Selection& selection, double centerTime)
     if (!selection.empty() && !frame->getRefObject().empty())
     {
         computeCenterCOParameters(selection, journey, centerTime);
-        observerMode = ObserverMode::Travelling;
+        startTraveling();
     }
 }
 
@@ -1240,6 +1240,13 @@ Observer::gotoJourney(const JourneyParams& params)
                                               0.0001, 100.0,
                                               1e-10).first;
     journey.startTime = realTime;
+    startTraveling();
+}
+
+void
+Observer::startTraveling()
+{
+    journey.orientationTransformInverse = Eigen::Quaterniond(orientationTransform).inverse();
     observerMode = ObserverMode::Travelling;
 }
 
@@ -1276,7 +1283,7 @@ Observer::gotoSelection(const Selection& selection,
                           ObserverFrame::CoordinateSystem::Universal,
                           up, upFrame);
 
-    observerMode = ObserverMode::Travelling;
+    startTraveling();
 }
 
 /*! Like normal goto, except we'll follow a great circle trajectory.  Useful
@@ -1318,7 +1325,7 @@ Observer::gotoSelectionGC(const Selection& selection,
                             up, upFrame,
                             centerObj);
 
-    observerMode = ObserverMode::Travelling;
+    startTraveling();
 }
 
 void
@@ -1341,7 +1348,7 @@ Observer::gotoSelection(const Selection& selection,
     computeGotoParameters(selection, journey,
                           v * -distance, ObserverFrame::CoordinateSystem::Universal,
                           up, upFrame);
-    observerMode = ObserverMode::Travelling;
+    startTraveling();
 }
 
 void
@@ -1368,7 +1375,7 @@ Observer::gotoSelectionGC(const Selection& selection,
                             up, upFrame,
                             centerObj);
 
-    observerMode = ObserverMode::Travelling;
+    startTraveling();
 }
 
 /** Make the observer travel to the specified planetocentric coordinates.
@@ -1404,7 +1411,7 @@ Observer::gotoSelectionLongLat(const Selection& selection,
                           ObserverFrame::CoordinateSystem::BodyFixed,
                           up, ObserverFrame::CoordinateSystem::BodyFixed);
 
-    observerMode = ObserverMode::Travelling;
+    startTraveling();
 }
 
 void
@@ -1429,7 +1436,7 @@ Observer::gotoLocation(const UniversalCoord& toPosition,
                                               0.0001, 100.0,
                                               1e-10).first;
 
-    observerMode = ObserverMode::Travelling;
+    startTraveling();
 }
 
 void
@@ -1494,7 +1501,7 @@ Observer::centerSelection(const Selection& selection, double centerTime)
         return;
 
     computeCenterParameters(selection, journey, centerTime);
-    observerMode = ObserverMode::Travelling;
+    startTraveling();
 }
 
 void

--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -578,14 +578,14 @@ Observer::setOriginalOrientation(const Eigen::Quaterniond& q)
     updateOrientation();
 }
 
-Eigen::Matrix3d
+const Eigen::Quaterniond&
 Observer::getOrientationTransform() const
 {
     return orientationTransform;
 }
 
 void
-Observer::setOrientationTransform(const Eigen::Matrix3d& transform)
+Observer::setOrientationTransform(const Eigen::Quaterniond& transform)
 {
     orientationTransform = transform;
     updateOrientation();
@@ -598,7 +598,7 @@ Observer::applyCurrentTransform()
 {
     originalOrientationUniv = transformedOrientationUniv;
     originalOrientation = transformedOrientation;
-    orientationTransform = Eigen::Matrix3d::Identity();
+    orientationTransform = Eigen::Quaterniond::Identity();
     updateOrientation();
 }
 
@@ -720,14 +720,14 @@ Observer::update(double dt, double timeScale)
 void
 Observer::updateOrientation()
 {
-    transformedOrientationUniv = Eigen::Quaterniond(orientationTransform) * originalOrientationUniv;
+    transformedOrientationUniv = orientationTransform * originalOrientationUniv;
     transformedOrientation = frame->convertFromUniversal(transformedOrientationUniv, getTime());
 }
 
 Eigen::Quaterniond
 Observer::undoTransform(const Eigen::Quaterniond& transformed) const
 {
-    return Eigen::Quaterniond(orientationTransform).inverse() * transformed;
+    return orientationTransform.inverse() * transformed;
 }
 
 Selection
@@ -1246,7 +1246,7 @@ Observer::gotoJourney(const JourneyParams& params)
 void
 Observer::startTraveling()
 {
-    journey.orientationTransformInverse = Eigen::Quaterniond(orientationTransform).inverse();
+    journey.orientationTransformInverse = orientationTransform.inverse();
     observerMode = ObserverMode::Travelling;
 }
 

--- a/src/celengine/observer.h
+++ b/src/celengine/observer.h
@@ -259,6 +259,7 @@ public:
         double expFactor{ 0.5 };
         double accelTime{ AccelerationTime };
         Eigen::Quaterniond rotation1; // rotation on the CircularOrbit around centerObject
+        Eigen::Quaterniond orientationTransformInverse; // the inverse of orientation transform when the journey starts
 
         Selection centerObject;
 
@@ -266,7 +267,7 @@ public:
     };
 
     void gotoJourney(const JourneyParams&);
-    // void setSimulation(Simulation* _sim) { sim = _sim; };
+    void startTraveling();
 
 private:
     void computeGotoParameters(const Selection &sel,

--- a/src/celengine/observer.h
+++ b/src/celengine/observer.h
@@ -133,10 +133,9 @@ public:
     void               setOrientation(const Eigen::Quaternionf&);
     void               setOrientation(const Eigen::Quaterniond&);
 
-    Eigen::Matrix3d getOrientationTransform() const;
-    void            setOrientationTransform(const Eigen::Matrix3d&);
-
-    void            applyCurrentTransform();
+    const Eigen::Quaterniond& getOrientationTransform() const;
+    void                      setOrientationTransform(const Eigen::Quaterniond&);
+    void                      applyCurrentTransform();
 
     Eigen::Vector3d getVelocity() const;
     void            setVelocity(const Eigen::Vector3d&);
@@ -267,7 +266,6 @@ public:
     };
 
     void gotoJourney(const JourneyParams&);
-    void startTraveling();
 
 private:
     void computeGotoParameters(const Selection &sel,
@@ -290,6 +288,8 @@ private:
                                    JourneyParams &jparams,
                                    double centerTime) const;
 
+    void startTraveling();
+
     void setOriginalOrientation(const Eigen::Quaternionf&);
     void setOriginalOrientation(const Eigen::Quaterniond&);
     void updateUniversal();
@@ -303,7 +303,7 @@ private:
     UniversalCoord      position{ 0.0, 0.0, 0.0 };
     Eigen::Quaterniond  originalOrientation{ Eigen::Quaterniond::Identity() };
     Eigen::Quaterniond  transformedOrientation{ Eigen::Quaterniond::Identity() };
-    Eigen::Matrix3d     orientationTransform{ Eigen::Matrix3d::Identity() };
+    Eigen::Quaterniond  orientationTransform{ Eigen::Quaterniond::Identity() };
     Eigen::Vector3d     velocity{ Eigen::Vector3d::Zero() };
     Eigen::Vector3d     angularVelocity{ Eigen::Vector3d::Zero() };
 


### PR DESCRIPTION
This does not affect Celestia frontends here since the transform is always .identity.

The initial/final orientation of journeys should be the same, because in VR, user might look away and the orientation transform changes.