### PR TITLE
chore: update r128 from `1.6.0` to `1.6.1`

### DIFF
--- a/src/celutil/r128.h
+++ b/src/celutil/r128.h
@@ -1,5 +1,5 @@
 /*
-r128.h: 128-bit (64.64) signed fixed-point arithmetic. Version 1.6.0
+r128.h: 128-bit (64.64) signed fixed-point arithmetic. Version 1.6.1
 
 COMPILATION
 -----------
@@ -302,8 +302,10 @@ struct numeric_limits<R128>
    static const bool has_infinity = false;
    static const bool has_quiet_NaN = false;
    static const bool has_signaling_NaN = false;
+#if !(__cplusplus > 202002L || (defined(_MSVC_LANG) && _MSVC_LANG > 202002L))
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
+#endif
 
    static R128 infinity() throw() { return R128_zero; }
    static R128 quiet_NaN() throw() { return R128_zero; }
@@ -670,7 +672,7 @@ static R128_U64 r128__umul64(R128_U32 a, R128_U32 b)
 {
 #  if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    return __emulu(a, b);
-#  elif defined(_M_ARM) && !defined(R128_STDC_ONLY)
+#  elif defined(_M_ARM) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    return _arm_umull(a, b);
 #  else
    return a * (R128_U64)b;
@@ -813,7 +815,7 @@ static const r128__udiv128Proc r128__udiv128 = (r128__udiv128Proc)(void*)r128__u
 #else
 static R128_U64 r128__udiv128(R128_U64 nlo, R128_U64 nhi, R128_U64 d, R128_U64 *rem)
 {
-#if defined(_M_X64) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
+#if defined(_M_X64) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__) && !defined(__clang__)
    return _udiv128(nhi, nlo, d, rem);
 #elif defined(__x86_64__) && !defined(R128_STDC_ONLY)
    R128_U64 q, r;
@@ -1678,7 +1680,7 @@ void r128Shl(R128 *dst, const R128 *src, int amount)
       r[1] = r[0] << (amount - 64);
       r[0] = 0;
    } else if (amount) {
-#  ifdef _M_X64
+#  if defined(_M_X64) && !defined(R128_STDC_ONLY)
       r[1] = __shiftleft128(r[0], r[1], (char) amount);
 #  else
       r[1] = (r[1] << amount) | (r[0] >> (64 - amount));
@@ -1740,7 +1742,7 @@ void r128Shr(R128 *dst, const R128 *src, int amount)
       r[2] = r[3] >> (amount - 64);
       r[3] = 0;
    } else if (amount) {
-#ifdef _M_X64
+#if defined(_M_X64) && !defined(R128_STDC_ONLY)
       r[2] = __shiftright128(r[2], r[3], (char) amount);
 #else
       r[2] = (r[2] >> amount) | (r[3] << (64 - amount));


### PR DESCRIPTION
This fixes compilation on Windows using `clang`.

Related commit: https://github.com/fahickman/r128/commit/907665a7041a00903749a4cc9288bef1c955cdc6 (added in https://github.com/fahickman/r128/pull/19).

Diff between the two versions: https://github.com/fahickman/r128/compare/v1.6.0...v1.6.1

There are also some deprecation warnings that appear when compiling with `clang` but not with `MSVC`. I haven't yet investigated these and it's not high on my priority list.
```console
$ cmake --build build --target install
[182/208] Building CXX object src/celestia/qt6/CMakeFiles/celestia-qt6.dir/__/qt/qtdateutil.cpp.obj
E:/code/cloned/cpp/Celestia/src/celestia/qt/qtdateutil.cpp:35:12: warning: 'QDateTime' is deprecated: Pass QTimeZone instead [-Wdeprecated-declarations]
   35 |     return QDateTime(QDate(date.year, date.month, date.day),
      |            ^
E:/code/vcpkg/installed/x64-windows/include/Qt6/QtCore\qdatetime.h:358:5: note: 'QDateTime' has been explicitly marked deprecated here
  358 |     QT_DEPRECATED_VERSION_X_6_9("Pass QTimeZone instead")
      |     ^
E:/code/vcpkg/installed/x64-windows/include/Qt6\QtCore/qtdeprecationmarkers.h:179:44: note: expanded from macro 'QT_DEPRECATED_VERSION_X_6_9'
  179 | # define QT_DEPRECATED_VERSION_X_6_9(text) QT_DEPRECATED_X(text)
      |                                            ^
E:/code/vcpkg/installed/x64-windows/include/Qt6\QtCore/qtdeprecationmarkers.h:29:33: note: expanded from macro 'QT_DEPRECATED_X'
   29 | #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
      |                                 ^
E:/code/vcpkg/installed/x64-windows/include/Qt6\QtCore/qcompilerdetection.h:994:36: note: expanded from macro 'Q_DECL_DEPRECATED_X'
  994 | #  define Q_DECL_DEPRECATED_X(x) [[deprecated(x)]]
      |                                    ^
E:/code/cloned/cpp/Celestia/src/celestia/qt/qtdateutil.cpp:35:12: warning: 'QDateTime' is deprecated: Pass QTimeZone instead [-Wdeprecated-declarations]
   35 |     return QDateTime(QDate(date.year, date.month, date.day),
      |            ^
E:/code/vcpkg/installed/x64-windows/include/Qt6/QtCore\qdatetime.h:358:5: note: 'QDateTime' has been explicitly marked deprecated here
  358 |     QT_DEPRECATED_VERSION_X_6_9("Pass QTimeZone instead")
      |     ^
E:/code/vcpkg/installed/x64-windows/include/Qt6\QtCore/qtdeprecationmarkers.h:179:44: note: expanded from macro 'QT_DEPRECATED_VERSION_X_6_9'
  179 | # define QT_DEPRECATED_VERSION_X_6_9(text) QT_DEPRECATED_X(text)
      |                                            ^
E:/code/vcpkg/installed/x64-windows/include/Qt6\QtCore/qtdeprecationmarkers.h:29:33: note: expanded from macro 'QT_DEPRECATED_X'
   29 | #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
      |                                 ^
E:/code/vcpkg/installed/x64-windows/include/Qt6\QtCore/qcompilerdetection.h:994:36: note: expanded from macro 'Q_DECL_DEPRECATED_X'
  994 | #  define Q_DECL_DEPRECATED_X(x) [[deprecated(x)]]
      |                                    ^
2 warnings generated.
```

<details>
  <summary>My Windows 10 build environment for future readers</summary>

  - **Operating system**: `Microsoft Windows 10 Pro` (version `10.0.19045 Build 19045`)
  - **Visual Studio Installer version**: `3.14.2082.42463`
  - **Visual Studio Community 2022 version**: `17.14.8`
  - **Visual Studio Community 2022 components**:
    - C++ core desktop features
    - MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)
    - C++ ATL for latest v143 build tools (x86 & x64)
    - C++ Build Insights
    - Just-In-Time debugger
    - C++ profiling tools
    - C++ CMake tools for Windows
    - C++ AddressSanitizer
    - Windows 11 SDK (10.0.26100.4188)
    - C++ Clang tools for Windows (19.1.5 - x64/x86)

  ```console
  $ cmake --version
  cmake version 3.31.6-msvc6

  CMake suite maintained and supported by Kitware (kitware.com/cmake).
  $ ninja --version
  1.12.1
  $ clang --version
  clang version 19.1.5
  Target: x86_64-pc-windows-msvc
  Thread model: posix
  InstalledDir: C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin
  $ vcpkg --version
  vcpkg package management program version 2025-06-20-ef7c0d541124bbdd334a03467e7edb6c3364d199

  See LICENSE.txt for license information.
  $ vcpkg list
  boost-assert:x64-windows                          1.88.0              Boost assert module
  boost-cmake:x64-windows                           1.88.0              Boost cmake module
  boost-config:x64-windows                          1.88.0              Boost config module
  boost-container:x64-windows                       1.88.0              Boost container module
  boost-core:x64-windows                            1.88.0              Boost core module
  boost-headers:x64-windows                         1.88.0              Boost headers module
  boost-intrusive:x64-windows                       1.88.0              Boost intrusive module
  boost-move:x64-windows                            1.88.0              Boost move module
  boost-smart-ptr:x64-windows                       1.88.0              Boost smart_ptr module
  boost-static-assert:x64-windows                   1.88.0              Boost static_assert module
  boost-throw-exception:x64-windows                 1.88.0              Boost throw_exception module
  boost-uninstall:x64-windows                       1.88.0              Internal vcpkg port used to uninstall Boost
  brotli:x64-windows                                1.1.0#1             a generic-purpose lossless compression algorithm...
  bzip2:x64-windows                                 1.0.8#6             bzip2 is a freely available, patent free, high-q...
  bzip2[tool]:x64-windows                                               Builds bzip2 executable
  cspice:x64-windows                                67#3                NASA C SPICE toolkit
  double-conversion:x64-windows                     3.3.0#1             Efficient binary-decimal and decimal-binary conv...
  egl-registry:x64-windows                          2024-01-25          EGL API and Extension Registry
  eigen3:x64-windows                                3.4.0#5             C++ template library for linear algebra: matrice...
  ffmpeg:x64-windows                                7.1.1#3             A library to decode, encode, transcode, mux, dem...
  ffmpeg[avcodec]:x64-windows                                           Build the avcodec library
  ffmpeg[avformat]:x64-windows                                          Build the avformat library
  ffmpeg[gpl]:x64-windows                                               Allow use of GPL code, the resulting libs and bi...
  ffmpeg[swscale]:x64-windows                                           Build the swscale library
  ffmpeg[x264]:x64-windows                                              H.264 encoding via x264
  fmt:x64-windows                                   11.0.2#1            {fmt} is an open-source formatting library provi...
  freetype:x64-windows                              2.13.3              A library to render fonts.
  freetype[brotli]:x64-windows                                          Support decompression of WOFF2 streams
  freetype[bzip2]:x64-windows                                           Support bzip2 compressed fonts.
  freetype[png]:x64-windows                                             Support PNG compressed OpenType embedded bitmaps.
  freetype[zlib]:x64-windows                                            Use zlib instead of internal library for DEFLATE
  gettext-libintl:x64-windows                       0.22.5#3            The libintl C library from GNU gettext-runtime.
  gettext:x64-windows                               0.22.5#2            A GNU framework to help produce multi-lingual me...
  gettext[tools]:x64-windows                                            Build gettext tools
  gperf:x64-windows                                 3.1#7               GNU perfect hash function generator
  harfbuzz:x64-windows                              11.2.0              HarfBuzz OpenType text shaping engine
  harfbuzz[freetype]:x64-windows                                        Enable FreeType support
  libepoxy:x64-windows                              1.5.10#2            Epoxy is a library for handling OpenGL function ...
  libiconv:x64-windows                              1.18#1              iconv() text conversion.
  libjpeg-turbo:x64-windows                         3.1.0#1             libjpeg-turbo is a JPEG image codec that uses SI...
  libpng:x64-windows                                1.6.48              libpng is a library implementing an interface fo...
  luajit:x64-windows                                2023-01-04#7        LuaJIT is a Just-In-Time (JIT) compiler for the ...
  opengl-registry:x64-windows                       2024-02-10#1        OpenGL, OpenGL ES, and OpenGL ES-SC API and Exte...
  opengl:x64-windows                                2022-12-04#3        Open Graphics Library (OpenGL)[3][4][5] is a cro...
  pcre2:x64-windows                                 10.45               Regular Expression pattern matching using the sa...
  pcre2[jit]:x64-windows                                                Enable support for Just-In-Time compiling regex ...
  pcre2[platform-default-features]:x64-windows                          Enable default features
  pkgconf:x64-windows                               2.4.3#1             pkgconf is a program which helps to configure co...
  qtbase:x64-windows                                6.8.3#3             Qt Base (Core, Gui, Widgets, Network, ...)
  qtbase[doubleconversion]:x64-windows                                  Enable double conversion support
  qtbase[freetype]:x64-windows                                          Supports the FreeType 2 font engine (and its sup...
  qtbase[gui]:x64-windows                                               Qt Gui
  qtbase[harfbuzz]:x64-windows                                          Use harfbuzz
  qtbase[jpeg]:x64-windows                                              Enable JPEG
  qtbase[opengl]:x64-windows                                            OpenGL
  qtbase[png]:x64-windows                                               Enable PNG
  qtbase[thread]:x64-windows                                            Thread support; provides QThread and related cla...
  qtbase[widgets]:x64-windows                                           Qt Widgets
  vcpkg-boost:x64-windows                           2025-03-29
  vcpkg-cmake-config:x64-windows                    2024-05-23
  vcpkg-cmake-get-vars:x64-windows                  2025-05-29
  vcpkg-cmake:x64-windows                           2024-04-23
  vcpkg-make:x64-windows                            2025-06-10
  vcpkg-pkgconfig-get-modules:x64-windows           2024-04-03
  vcpkg-tool-meson:x64-windows                      1.8.2               Meson build system
  x264:x64-windows                                  0.164.3108#2        x264 is a free software library and application ...
  x264[asm]:x64-windows                                                 Enable platform-specific assembly optimizations
  x264[gpl]:x64-windows                                                 Allow use of GPL code, the resulting libs and bi...
  zlib:x64-windows                                  1.3.1               A compression library
  ```

  Configure command:
  ```powershell
  cmake -S . -B build -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DCMAKE_INSTALL_PREFIX="E:\code\installed\Celestia" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_QT6=ON -DENABLE_SPICE=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=1
  ```
  Build command:
  ```powershell
  cmake --build build --target install
  ```
</details>
