### PR TITLE
Use untransformed orientation for velocity

### DIFF
--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -1209,10 +1209,10 @@ Observer::setTargetSpeed(float s)
         s = -s;
     if (trackObject.empty())
     {
-        trackingOrientation = getOrientation();
+        trackingOrientation = originalOrientationUniv;
         // Generate vector for velocity using current orientation
         // and specified speed.
-        v = getOrientation().conjugate() * Eigen::Vector3d(0, 0, -s);
+        v = trackingOrientation.conjugate() * Eigen::Vector3d(0, 0, -s);
     }
     else
     {

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -1884,7 +1884,7 @@ void CelestiaCore::tick(double dt)
                 sim->setTargetSpeed(currentSpeed / std::exp(static_cast<float>(dt) * 3.0f * decelerationCoefficient));
         }
     }
-    if (!bSetTargetSpeed && av.norm() > 0.0f)
+    if (!bSetTargetSpeed && av.norm() > 1.0e-10)
     {
         // Force observer velocity vector to align with observer direction if an observer
         // angular velocity still exists.


### PR DESCRIPTION
Does not affect frontends here. The direction of traveling should depend on the untransformed orientation so that change of posture does not affect it.