### PR TITLE
Add support for a second thumbstick

### DIFF
--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -707,7 +707,7 @@ Observer::update(double dt, double timeScale)
 
         // At some threshold, we just set the velocity to zero; otherwise,
         // we'll end up with ridiculous velocities like 10^-40 m/s.
-        if (v.norm() < 1.0e-12)
+        if (v.norm() < celestia::engine::MIN_SIG_LINEAR_SPEED)
             v = Eigen::Vector3d::Zero();
         setVelocity(v);
     }
@@ -724,7 +724,7 @@ Observer::update(double dt, double timeScale)
         originalOrientation = undoTransform(expectedOrientation);
 
         // Update the input angular orientation transform
-        if (inputAngularVelocity.norm() > 1.0e-12)
+        if (inputAngularVelocity.norm() > celestia::engine::MIN_SIG_ANGULAR_SPEED)
         {
             inputEulerAngles += inputAngularVelocity * dt;
             // Clamp pitch between -90 and +90 to avoid gimbal lock

--- a/src/celengine/observer.h
+++ b/src/celengine/observer.h
@@ -31,6 +31,14 @@
 #include "shared.h"
 #include "univcoord.h"
 
+namespace celestia::engine
+{
+
+constexpr inline double MIN_SIG_ANGULAR_SPEED     = 1.0e-10;
+constexpr inline double MIN_SIG_LINEAR_SPEED      = 1.0e-12;
+
+}
+
 class ReferenceFrame;
 
 /*! ObserverFrame is a wrapper class for ReferenceFrame which adds some

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -716,7 +716,7 @@ void CelestiaCore::mouseMove(float dx, float dy, int modifiers)
 }
 
 
-void CelestiaCore::joystickAxis(int axis, float amount)
+void CelestiaCore::joystickAxis(JoyAxis axis, float amount)
 {
     float deadZone = 0.25f;
 
@@ -727,14 +727,23 @@ void CelestiaCore::joystickAxis(int axis, float amount)
 
     amount = math::sign(amount) * math::square(amount);
 
-    if (axis == Joy_XAxis)
+    switch (axis)
+    {
+    case CelestiaCore::JoyAxis::X:
         joystickRotation.y() = amount;
-    else if (axis == Joy_YAxis)
+        break;
+    case JoyAxis::Y:
         joystickRotation.x() = -amount;
-    else if (axis == Joy_RXAxis)
+        break;
+    case JoyAxis::RX:
         joystickRightRotation.y() = amount;
-    else if (axis == Joy_RYAxis)
+        break;
+    case JoyAxis::RY:
         joystickRightRotation.x() = -amount;
+        break;
+    default:
+        break;
+    }
 }
 
 
@@ -1896,7 +1905,7 @@ void CelestiaCore::tick(double dt)
                 sim->setTargetSpeed(currentSpeed / std::exp(static_cast<float>(dt) * 3.0f * decelerationCoefficient));
         }
     }
-    if (!bSetTargetSpeed && av.norm() > 1.0e-10)
+    if (!bSetTargetSpeed && av.norm() > MIN_SIG_ANGULAR_SPEED)
     {
         // Force observer velocity vector to align with observer direction if an observer
         // angular velocity still exists.

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -100,14 +100,14 @@ public:
         WhatsThisCursor     = 16,
     };
 
-    enum
+    enum class JoyAxis
     {
-        Joy_XAxis           = 0,
-        Joy_YAxis           = 1,
-        Joy_ZAxis           = 2,
-        Joy_RXAxis          = 3,
-        Joy_RYAxis          = 4,
-        Joy_RZAxis          = 5,
+        X           = 0,
+        Y           = 1,
+        Z           = 2,
+        RX          = 3,
+        RY          = 4,
+        RZ          = 5,
     };
 
     enum
@@ -226,7 +226,7 @@ public:
     void mouseButtonUp(float, float, int);
     void mouseMove(float, float, int);
     void mouseMove(float, float);
-    void joystickAxis(int axis, float amount);
+    void joystickAxis(JoyAxis axis, float amount);
     void joystickButton(int button, bool down);
     void pinchUpdate(float focusX, float focusY, float scale, bool zoomFOV);
     void resize(GLsizei w, GLsizei h);

--- a/src/celestia/win32/winmainwindow.cpp
+++ b/src/celestia/win32/winmainwindow.cpp
@@ -569,9 +569,9 @@ MainWindow::handleKey(WPARAM wParam, bool down)
     case VK_F8:
         if (joystickAvailable && down)
         {
-            appCore->joystickAxis(CelestiaCore::Joy_XAxis, 0);
-            appCore->joystickAxis(CelestiaCore::Joy_YAxis, 0);
-            appCore->joystickAxis(CelestiaCore::Joy_ZAxis, 0);
+            appCore->joystickAxis(CelestiaCore::JoyAxis::X, 0);
+            appCore->joystickAxis(CelestiaCore::JoyAxis::Y, 0);
+            appCore->joystickAxis(CelestiaCore::JoyAxis::Z, 0);
             useJoystick = !useJoystick;
         }
         break;
@@ -1211,8 +1211,8 @@ MainWindow::handleJoystick()
     float x = static_cast<float>(info.dwXpos) / 32768.0f - 1.0f;
     float y = static_cast<float>(info.dwYpos) / 32768.0f - 1.0f;
 
-    appCore->joystickAxis(CelestiaCore::Joy_XAxis, x);
-    appCore->joystickAxis(CelestiaCore::Joy_YAxis, y);
+    appCore->joystickAxis(CelestiaCore::JoyAxis::X, x);
+    appCore->joystickAxis(CelestiaCore::JoyAxis::Y, y);
     appCore->joystickButton(CelestiaCore::JoyButton1,
                             (info.dwButtons & 0x1) != 0);
     appCore->joystickButton(CelestiaCore::JoyButton2,


### PR DESCRIPTION
can be potentially used for right joystick on the game controller. unlike the yaw/pitch with existing joystick which might cause roll, this one store Euler angles and has pitch clamped between ±90 so won't cause rolls, works more like a planetarium.