### PR TITLE
Update ReferenceMark renderer and tags

### DIFF
--- a/src/celengine/axisarrow.cpp
+++ b/src/celengine/axisarrow.cpp
@@ -88,7 +88,7 @@ ArrowReferenceMark::render(render::ReferenceMarkRenderer* refMarkRenderer,
     Eigen::Affine3f transform = Eigen::Translation3f(position) * q.cast<float>() * Eigen::Scaling(size);
     Eigen::Matrix4f mv = (*m.modelview) * transform.matrix();
 
-    render::ArrowRenderer& arrowRenderer = refMarkRenderer->arrowRenderer();
+    const render::ArrowRenderer& arrowRenderer = refMarkRenderer->arrowRenderer();
     CelestiaGLProgram* prog = arrowRenderer.program();
     if (prog == nullptr)
         return;

--- a/src/celengine/axisarrow.h
+++ b/src/celengine/axisarrow.h
@@ -23,6 +23,11 @@
 
 class Body;
 
+namespace celestia::render
+{
+class ReferenceMarkRenderer;
+}
+
 class ArrowReferenceMark : public ReferenceMark
 {
 public:
@@ -31,7 +36,7 @@ public:
     void setSize(float _size);
     void setColor(const Color& _color);
 
-    void render(Renderer* renderer,
+    void render(celestia::render::ReferenceMarkRenderer* refMarkRenderer,
                 const Eigen::Vector3f& position,
                 float discSize,
                 double tdb,
@@ -60,7 +65,7 @@ public:
     void setSize(float _size);
     void setOpacity(float _opacity);
 
-    void render(Renderer* renderer,
+    void render(celestia::render::ReferenceMarkRenderer* refMarkRenderer,
                 const Eigen::Vector3f& position,
                 float discSize,
                 double tdb,

--- a/src/celengine/axisarrow.h
+++ b/src/celengine/axisarrow.h
@@ -10,6 +10,10 @@
 
 #pragma once
 
+#include <string_view>
+
+#include <Eigen/Core>
+
 #include <celutil/color.h>
 #include <celengine/referencemark.h>
 #include <celengine/selection.h>
@@ -37,20 +41,14 @@ public:
         return size;
     }
 
-    bool isOpaque() const override
-    {
-        return opacity == 1.0f;
-    }
-
     virtual Eigen::Vector3d getDirection(double tdb) const = 0;
 
 protected:
     const Body& body;
 
 private:
-    float size;
-    Color color;
-    float opacity;
+    float size{ 1.0f };
+    Color color{ 1.0f, 1.0f, 1.0f };
     ShaderProperties shadprop;
 };
 
@@ -83,8 +81,8 @@ protected:
     const Body& body;
 
 private:
-    float size;
-    float opacity;
+    float size{ 0.0f };
+    float opacity{ 1.0f };
     ShaderProperties shadprop;
 };
 
@@ -94,6 +92,9 @@ class BodyAxisArrows : public AxesReferenceMark
 public:
     explicit BodyAxisArrows(const Body& _body);
     Eigen::Quaterniond getOrientation(double tdb) const override;
+
+protected:
+    std::string_view defaultTag() const override;
 };
 
 
@@ -102,6 +103,9 @@ class FrameAxisArrows : public AxesReferenceMark
 public:
     explicit FrameAxisArrows(const Body& _body);
     Eigen::Quaterniond getOrientation(double tdb) const override;
+
+protected:
+    std::string_view defaultTag() const override;
 };
 
 
@@ -110,6 +114,9 @@ class SunDirectionArrow : public ArrowReferenceMark
 public:
     explicit SunDirectionArrow(const Body& _body);
     Eigen::Vector3d getDirection(double tdb) const override;
+
+protected:
+    std::string_view defaultTag() const override;
 };
 
 
@@ -118,6 +125,9 @@ class VelocityVectorArrow : public ArrowReferenceMark
 public:
     explicit VelocityVectorArrow(const Body& _body);
     Eigen::Vector3d getDirection(double tdb) const override;
+
+protected:
+    std::string_view defaultTag() const override;
 };
 
 
@@ -126,6 +136,9 @@ class SpinVectorArrow : public ArrowReferenceMark
 public:
     explicit SpinVectorArrow(const Body& _body);
     Eigen::Vector3d getDirection(double tdb) const override;
+
+protected:
+    std::string_view defaultTag() const override;
 };
 
 
@@ -137,6 +150,9 @@ class BodyToBodyDirectionArrow : public ArrowReferenceMark
 public:
     BodyToBodyDirectionArrow(const Body& _body, const Selection& _target);
     Eigen::Vector3d getDirection(double tdb) const override;
+
+protected:
+    std::string_view defaultTag() const override;
 
 private:
     Selection target;

--- a/src/celengine/axisarrow.h
+++ b/src/celengine/axisarrow.h
@@ -13,20 +13,16 @@
 #include <string_view>
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include <celutil/color.h>
 #include <celengine/referencemark.h>
 #include <celengine/selection.h>
 #include <celengine/shadermanager.h>
-#include <Eigen/Core>
-#include <Eigen/Geometry>
+#include <celrender/rendererfwd.h>
 
 class Body;
-
-namespace celestia::render
-{
-class ReferenceMarkRenderer;
-}
+struct Matrices;
 
 class ArrowReferenceMark : public ReferenceMark
 {

--- a/src/celengine/planetgrid.h
+++ b/src/celengine/planetgrid.h
@@ -12,11 +12,20 @@
 
 #pragma once
 
+#include <string_view>
+
+#include <Eigen/Core>
+
 #include <celengine/referencemark.h>
-#include <celrender/linerenderer.h>
 
 class Body;
+struct Matrices;
 class Renderer;
+
+namespace celestia::render
+{
+class LineRenderer;
+}
 
 class PlanetographicGrid : public ReferenceMark
 {
@@ -29,7 +38,7 @@ public:
      *      EastWest measures longitude both east and west, and is used only
      *         for the Earth and Moon (strictly because of convention.)
      */
-    enum LongitudeConvention
+    enum class LongitudeConvention
     {
         EastWest,
         Westward,
@@ -40,7 +49,7 @@ public:
      *  the rotation north. It should be set for retrograde rotators in
      *  order to conform with IAU conventions.
      */
-    enum NorthDirection
+    enum class NorthDirection
     {
         NorthNormal,
         NorthReversed
@@ -60,6 +69,9 @@ public:
 
     static void deinit();
 
+protected:
+    std::string_view defaultTag() const override;
+
 private:
     static celestia::render::LineRenderer *latitudeRenderer;
     static celestia::render::LineRenderer *equatorRenderer;
@@ -72,6 +84,6 @@ private:
     float minLongitudeStep{ 10.0f };
     float minLatitudeStep{ 10.0f };
 
-    LongitudeConvention longitudeConvention{ Westward };
-    NorthDirection northDirection{ NorthNormal };
+    LongitudeConvention longitudeConvention{ LongitudeConvention::Westward };
+    NorthDirection northDirection{ NorthDirection::NorthNormal };
 };

--- a/src/celengine/planetgrid.h
+++ b/src/celengine/planetgrid.h
@@ -24,7 +24,7 @@ class Renderer;
 
 namespace celestia::render
 {
-class LineRenderer;
+class ReferenceMarkRenderer;
 }
 
 class PlanetographicGrid : public ReferenceMark
@@ -58,7 +58,7 @@ public:
     PlanetographicGrid(const Body& _body);
     ~PlanetographicGrid() = default;
 
-    void render(Renderer* renderer,
+    void render(celestia::render::ReferenceMarkRenderer* renderer,
                 const Eigen::Vector3f& pos,
                 float discSizeInPixels,
                 double tdb,
@@ -67,18 +67,10 @@ public:
 
     void setIAULongLatConvention();
 
-    static void deinit();
-
 protected:
     std::string_view defaultTag() const override;
 
 private:
-    static celestia::render::LineRenderer *latitudeRenderer;
-    static celestia::render::LineRenderer *equatorRenderer;
-    static celestia::render::LineRenderer *longitudeRenderer;
-    static bool initialized;
-    static void InitializeGeometry(const Renderer&);
-
     const Body& body;
 
     float minLongitudeStep{ 10.0f };

--- a/src/celengine/planetgrid.h
+++ b/src/celengine/planetgrid.h
@@ -17,15 +17,11 @@
 #include <Eigen/Core>
 
 #include <celengine/referencemark.h>
+#include <celrender/rendererfwd.h>
 
 class Body;
 struct Matrices;
 class Renderer;
-
-namespace celestia::render
-{
-class ReferenceMarkRenderer;
-}
 
 class PlanetographicGrid : public ReferenceMark
 {
@@ -72,9 +68,6 @@ protected:
 
 private:
     const Body& body;
-
-    float minLongitudeStep{ 10.0f };
-    float minLatitudeStep{ 10.0f };
 
     LongitudeConvention longitudeConvention{ LongitudeConvention::Westward };
     NorthDirection northDirection{ NorthDirection::NorthNormal };

--- a/src/celengine/referencemark.h
+++ b/src/celengine/referencemark.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <Eigen/Core>
 
 class Renderer;
@@ -54,16 +55,24 @@ class ReferenceMark
      */
     virtual bool isOpaque() const { return true; }
 
-    void setTag(const std::string& _tag)
+    void setTag(std::string_view tag)
     {
-        tag = _tag;
+        if (tag.empty() || tag == defaultTag())
+            m_tag = std::string{};
+        else
+            m_tag = tag;
     }
 
-    const std::string& getTag() const
+    std::string_view getTag() const
     {
-        return tag;
+        if (m_tag.empty())
+            return defaultTag();
+        return m_tag;
     }
+
+protected:
+    virtual std::string_view defaultTag() const = 0;
 
 private:
-    std::string tag;
+    std::string m_tag;
 };

--- a/src/celengine/referencemark.h
+++ b/src/celengine/referencemark.h
@@ -16,8 +16,12 @@
 #include <string_view>
 #include <Eigen/Core>
 
-class Renderer;
 struct Matrices;
+
+namespace celestia::render
+{
+class ReferenceMarkRenderer;
+}
 
 /*! Reference marks give additional visual information about the
  *  position and orientation of a solar system body. Items such as
@@ -38,7 +42,7 @@ class ReferenceMark
 
     /*! Draw the reference mark geometry at the specified time.
      */
-    virtual void render(Renderer* renderer,
+    virtual void render(celestia::render::ReferenceMarkRenderer* refMarkRenderer,
                         const Eigen::Vector3f& position,
                         float discSizeInPixels,
                         double tdb,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -68,6 +68,7 @@
 #include <celrender/globularrenderer.h>
 #include <celrender/nebularenderer.h>
 #include <celrender/openclusterrenderer.h>
+#include <celrender/referencemarkrenderer.h>
 #include <celrender/ringrenderer.h>
 #include <celrender/skygridrenderer.h>
 #include <celrender/gl/buffer.h>
@@ -215,6 +216,7 @@ Renderer::Renderer() :
     m_hollowMarkerRenderer(std::make_unique<LineRenderer>(*this, 1.0f, LineRenderer::PrimType::Lines, LineRenderer::StorageType::Static)),
     m_nebulaRenderer(std::make_unique<NebulaRenderer>(*this)),
     m_openClusterRenderer(std::make_unique<OpenClusterRenderer>(*this)),
+    m_referenceMarkRenderer(std::make_unique<ReferenceMarkRenderer>(*this)),
     m_ringRenderer(std::make_unique<RingRenderer>(*this)),
     m_skyGridRenderer(std::make_unique<SkyGridRenderer>(*this))
 {
@@ -224,7 +226,6 @@ Renderer::Renderer() :
 Renderer::~Renderer()
 {
     CurvePlot::deinit();
-    PlanetographicGrid::deinit();
 }
 
 
@@ -3004,7 +3005,7 @@ void Renderer::renderReferenceMark(const ReferenceMark& refMark,
     if (discSizeInPixels <= 1)
         return;
 
-    refMark.render(this, pos, discSizeInPixels, now, m);
+    refMark.render(m_referenceMarkRenderer.get(), pos, discSizeInPixels, now, m);
 }
 
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2996,7 +2996,7 @@ void Renderer::renderReferenceMark(const ReferenceMark& refMark,
                                    float distance,
                                    double now,
                                    float nearPlaneDistance,
-                                   const Matrices &m)
+                                   const Matrices &m) const
 {
     float altitude = distance - refMark.boundingSphereRadius();
     float discSizeInPixels = refMark.boundingSphereRadius() /

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -479,7 +479,7 @@ class Renderer
                              float distance,
                              double now,
                              float nearPlaneDistance,
-                             const Matrices&);
+                             const Matrices&) const;
 
     void renderCometTail(const Body& body,
                          const Eigen::Vector3f& pos,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -714,6 +714,7 @@ class Renderer
     std::unique_ptr<celestia::render::LineRenderer> m_hollowMarkerRenderer;
     std::unique_ptr<celestia::render::NebulaRenderer> m_nebulaRenderer;
     std::unique_ptr<celestia::render::OpenClusterRenderer> m_openClusterRenderer;
+    std::unique_ptr<celestia::render::ReferenceMarkRenderer> m_referenceMarkRenderer;
     std::unique_ptr<celestia::render::RingRenderer> m_ringRenderer;
     std::unique_ptr<celestia::render::SkyGridRenderer> m_skyGridRenderer;
 

--- a/src/celengine/visibleregion.cpp
+++ b/src/celengine/visibleregion.cpp
@@ -10,21 +10,23 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <cmath>
-#include <Eigen/Geometry>
-#include <celcompat/numbers.h>
-#include <celmath/intersect.h>
-#include <celrender/linerenderer.h>
-#include "body.h"
-#include "render.h"
-#include "selection.h"
 #include "visibleregion.h"
 
-using namespace std;
-using namespace Eigen;
-using celestia::render::LineRenderer;
-namespace math = celestia::math;
+#include <algorithm>
 
+#include <Eigen/Geometry>
+
+#include <celcompat/numbers.h>
+#include <celmath/mathlib.h>
+#include <celrender/linerenderer.h>
+#include "body.h"
+#include "glsupport.h"
+#include "render.h"
+
+using namespace std::string_view_literals;
+
+namespace math = celestia::math;
+namespace render = celestia::render;
 
 /*! Construct a new reference mark that shows the outline of the
  *  region on the surface of a body in which the target object is
@@ -39,13 +41,9 @@ namespace math = celestia::math;
  */
 VisibleRegion::VisibleRegion(const Body& body, const Selection& target) :
     m_body(body),
-    m_target(target),
-    m_color(1.0f, 1.0f, 0.0f),
-    m_opacity(1.0f)
+    m_target(target)
 {
-    setTag("visible region");
 }
-
 
 Color
 VisibleRegion::color() const
@@ -53,13 +51,11 @@ VisibleRegion::color() const
     return m_color;
 }
 
-
 void
 VisibleRegion::setColor(Color color)
 {
     m_color = color;
 }
-
 
 float
 VisibleRegion::opacity() const
@@ -67,19 +63,17 @@ VisibleRegion::opacity() const
     return m_opacity;
 }
 
-
 void
 VisibleRegion::setOpacity(float opacity)
 {
     m_opacity = opacity;
 }
 
-
 constexpr const unsigned maxSections = 360;
 
 void
 VisibleRegion::render(Renderer* renderer,
-                      const Vector3f& position,
+                      const Eigen::Vector3f& position,
                       float discSizeInPixels,
                       double tdb,
                       const Matrices& m) const
@@ -104,27 +98,27 @@ VisibleRegion::render(Renderer* renderer,
     // Don't render the terminator if the it's smaller than the minimum size
     if (opacity <= 0.0f)
         return;
-    opacity = min(opacity, 1.0f) * m_opacity;
+    opacity = std::min(opacity, 1.0f) * m_opacity;
 
     // Base the amount of subdivision on the apparent size
-    auto nSections = (unsigned int) (30.0f + discSizeInPixels * 0.5f);
-    nSections = min(nSections, maxSections);
+    auto nSections = static_cast<unsigned int>(30.0f + discSizeInPixels * 0.5f);
+    nSections = std::min(nSections, maxSections);
 
-    Quaterniond q = m_body.getEclipticToBodyFixed(tdb);
-    Quaternionf qf = q.cast<float>();
+    Eigen::Quaterniond q = m_body.getEclipticToBodyFixed(tdb);
+    Eigen::Quaternionf qf = q.cast<float>();
 
     // The outline can't be rendered exactly on the planet sphere, or
     // there will be z-fighting problems. Render it at a height above the
     // planet that will place it about one pixel away from the planet.
     float scale = (discSizeInPixels + 1) / discSizeInPixels;
-    scale = max(scale, 1.0001f);
+    scale = std::max(scale, 1.0001f);
 
-    Vector3f semiAxes = m_body.getSemiAxes();
+    Eigen::Vector3f semiAxes = m_body.getSemiAxes();
     double maxSemiAxis = m_body.getRadius();
 
     // In order to avoid precision problems and extremely large values, scale
     // the target position and semiaxes such that the largest semiaxis is 1.0.
-    Vector3d lightDir = m_body.getPosition(tdb).offsetFromKm(m_target.getPosition(tdb));
+    Eigen::Vector3d lightDir = m_body.getPosition(tdb).offsetFromKm(m_target.getPosition(tdb));
     lightDir = lightDir / maxSemiAxis;
     lightDir = q * lightDir;
 
@@ -135,31 +129,33 @@ VisibleRegion::render(Renderer* renderer,
         lightDir *= (10000.0 / lightDir.norm());
 
     // Pick two orthogonal axes both normal to the light direction
-    Vector3d lightDirNorm = lightDir.normalized();
+    Eigen::Vector3d lightDirNorm = lightDir.normalized();
 
-    Vector3d uAxis = lightDirNorm.unitOrthogonal();
-    Vector3d vAxis = uAxis.cross(lightDirNorm);
+    Eigen::Vector3d uAxis = lightDirNorm.unitOrthogonal();
+    Eigen::Vector3d vAxis = uAxis.cross(lightDirNorm);
 
-    Vector3d recipSemiAxes = maxSemiAxis * semiAxes.cast<double>().cwiseInverse();
-    Vector3d e = -lightDir;
-    Vector3d e_ = e.cwiseProduct(recipSemiAxes);
+    Eigen::Vector3d recipSemiAxes = maxSemiAxis * semiAxes.cast<double>().cwiseInverse();
+    Eigen::Vector3d e = -lightDir;
+    Eigen::Vector3d e_ = e.cwiseProduct(recipSemiAxes);
     double ee = e_.squaredNorm();
 
-    LineRenderer lr(*renderer, 1.0f, LineRenderer::PrimType::LineStrip);
+    render::LineRenderer lr(*renderer, 1.0f, render::LineRenderer::PrimType::LineStrip);
     lr.startUpdate();
 
     for (unsigned i = 0; i <= nSections + 1; i++)
     {
-        double theta = (double) i / (double) (nSections) * 2.0 * celestia::numbers::pi;
-        Vector3d w = cos(theta) * uAxis + sin(theta) * vAxis;
+        double stheta;
+        double ctheta;
+        math::sincos(static_cast<double>(i) / static_cast<double>(nSections) * 2.0 * celestia::numbers::pi, stheta, ctheta);
+        Eigen::Vector3d w = ctheta * uAxis + stheta * vAxis;
 
-        Vector3d toCenter = math::ellipsoidTangent(recipSemiAxes, w, e, e_, ee);
+        Eigen::Vector3d toCenter = math::ellipsoidTangent(recipSemiAxes, w, e, e_, ee);
         toCenter *= maxSemiAxis * scale;
-        lr.addVertex(Vector3f(toCenter.cast<float>()));
+        lr.addVertex(Eigen::Vector3f(toCenter.cast<float>()));
     }
 
-    Affine3f transform = Translation3f(position) * qf.conjugate();
-    Matrix4f modelView = (*m.modelview) * transform.matrix();
+    Eigen::Affine3f transform = Eigen::Translation3f(position) * qf.conjugate();
+    Eigen::Matrix4f modelView = (*m.modelview) * transform.matrix();
 
     Renderer::PipelineState ps;
     ps.blending = true;
@@ -173,9 +169,14 @@ VisibleRegion::render(Renderer* renderer,
     lr.finish();
 }
 
-
 float
 VisibleRegion::boundingSphereRadius() const
 {
     return m_body.getRadius();
+}
+
+std::string_view
+VisibleRegion::defaultTag() const
+{
+    return "visible region"sv;
 }

--- a/src/celengine/visibleregion.cpp
+++ b/src/celengine/visibleregion.cpp
@@ -19,6 +19,7 @@
 #include <celcompat/numbers.h>
 #include <celmath/mathlib.h>
 #include <celrender/linerenderer.h>
+#include <celrender/referencemarkrenderer.h>
 #include "body.h"
 #include "glsupport.h"
 #include "render.h"
@@ -72,7 +73,7 @@ VisibleRegion::setOpacity(float opacity)
 constexpr const unsigned maxSections = 360;
 
 void
-VisibleRegion::render(Renderer* renderer,
+VisibleRegion::render(render::ReferenceMarkRenderer* refMarkRenderer,
                       const Eigen::Vector3f& position,
                       float discSizeInPixels,
                       double tdb,
@@ -139,7 +140,8 @@ VisibleRegion::render(Renderer* renderer,
     Eigen::Vector3d e_ = e.cwiseProduct(recipSemiAxes);
     double ee = e_.squaredNorm();
 
-    render::LineRenderer lr(*renderer, 1.0f, render::LineRenderer::PrimType::LineStrip);
+    render::LineRenderer& lr = refMarkRenderer->visibleRegionRenderer();
+    lr.clear();
     lr.startUpdate();
 
     for (unsigned i = 0; i <= nSections + 1; i++)
@@ -163,7 +165,7 @@ VisibleRegion::render(Renderer* renderer,
     ps.depthMask = true;
     ps.depthTest = true;
     ps.smoothLines = true;
-    renderer->setPipelineState(ps);
+    refMarkRenderer->renderer().setPipelineState(ps);
 
     lr.render({ m.projection, &modelView }, Color(m_color, opacity), nSections+1, 0);
     lr.finish();

--- a/src/celengine/visibleregion.h
+++ b/src/celengine/visibleregion.h
@@ -12,12 +12,16 @@
 
 #pragma once
 
+#include <string_view>
+
+#include <Eigen/Core>
+
 #include <celengine/referencemark.h>
 #include <celengine/selection.h>
 #include <celutil/color.h>
 
 class Body;
-
+struct Matrices;
 
 /*! VisibleRegion is a reference mark that shows the outline of
  *  region on the surface of a body in which a specified target
@@ -41,9 +45,12 @@ public:
     float opacity() const;
     void setOpacity(float opacity);
 
+protected:
+    std::string_view defaultTag() const override;
+
 private:
     const Body& m_body;
     const Selection m_target;
-    Color m_color;
-    float m_opacity;
+    Color m_color{ 1.0f, 1.0f, 1.0f };
+    float m_opacity{ 1.0f };
 };

--- a/src/celengine/visibleregion.h
+++ b/src/celengine/visibleregion.h
@@ -23,6 +23,11 @@
 class Body;
 struct Matrices;
 
+namespace celestia::render
+{
+class ReferenceMarkRenderer;
+}
+
 /*! VisibleRegion is a reference mark that shows the outline of
  *  region on the surface of a body in which a specified target
  *  is visible.
@@ -33,7 +38,7 @@ public:
     VisibleRegion(const Body& body, const Selection& target);
     ~VisibleRegion() = default;
 
-    void render(Renderer* renderer,
+    void render(celestia::render::ReferenceMarkRenderer* refMarkRenderer,
                 const Eigen::Vector3f& pos,
                 float discSizeInPixels,
                 double tdb,

--- a/src/celengine/visibleregion.h
+++ b/src/celengine/visibleregion.h
@@ -18,15 +18,11 @@
 
 #include <celengine/referencemark.h>
 #include <celengine/selection.h>
+#include <celrender/rendererfwd.h>
 #include <celutil/color.h>
 
 class Body;
 struct Matrices;
-
-namespace celestia::render
-{
-class ReferenceMarkRenderer;
-}
 
 /*! VisibleRegion is a reference mark that shows the outline of
  *  region on the surface of a body in which a specified target

--- a/src/celrender/CMakeLists.txt
+++ b/src/celrender/CMakeLists.txt
@@ -21,6 +21,8 @@ set(CELRENDER_SOURCES
   nebularenderer.h
   openclusterrenderer.cpp
   openclusterrenderer.h
+  referencemarkrenderer.cpp
+  referencemarkrenderer.h
   ringrenderer.cpp
   ringrenderer.h
   skygridrenderer.cpp

--- a/src/celrender/referencemarkrenderer.cpp
+++ b/src/celrender/referencemarkrenderer.cpp
@@ -138,8 +138,8 @@ constexpr unsigned int circleSubdivisions = 100U;
 ArrowRenderer::~ArrowRenderer() = default;
 
 ArrowRenderer::ArrowRenderer(const Renderer& renderer) :
-    m_lineRenderer(renderer),
-    m_vo(std::make_unique<gl::VertexObject>())
+    m_vo(std::make_unique<gl::VertexObject>()), //NOSONAR
+    m_lineRenderer(renderer)
 {
     auto vertices = getArrowVertices();
     auto indices = getArrowIndices();

--- a/src/celrender/referencemarkrenderer.cpp
+++ b/src/celrender/referencemarkrenderer.cpp
@@ -1,0 +1,210 @@
+// referencemarkrenderer.cpp
+//
+// Copyright (C) 2007-2025, Celestia Development Team
+//
+// Based on axisarrow.cpp, planetgrid.cpp
+// Original version by Chris Laurel <claurel@gmail.com>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "referencemarkrenderer.h"
+
+#include <Eigen/Core>
+
+#include <celcompat/numbers.h>
+#include <celengine/glsupport.h>
+#include <celengine/render.h>
+#include <celengine/shadermanager.h>
+#include <celmath/mathlib.h>
+#include "gl/buffer.h"
+#include "gl/vertexobject.h"
+
+namespace celestia::render
+{
+
+namespace
+{
+
+constexpr unsigned int arrowSections = 30U;
+
+std::vector<Eigen::Vector3f>
+getArrowVertices()
+{
+    constexpr float shaftLength  = 0.85f;
+    constexpr float headLength   = 0.10f;
+    constexpr float shaftRadius  = 0.010f;
+    constexpr float headRadius   = 0.025f;
+
+    constexpr unsigned int totalVertices = arrowSections * 3U + 3U;
+
+    std::vector<Eigen::Vector3f> vertices;
+    vertices.reserve(totalVertices);
+    vertices.emplace_back(Eigen::Vector3f::Zero());
+    vertices.emplace_back(0.0f, 0.0f, shaftLength);
+    vertices.emplace_back(0.0f, 0.0f, shaftLength + headLength);
+
+    for (unsigned int i = 0U; i < arrowSections; ++i)
+    {
+        float s;
+        float c;
+        math::sincos((static_cast<float>(i) * 2.0f * celestia::numbers::pi_v<float>) / arrowSections, s, c);
+
+        vertices.emplace_back(shaftRadius * s, shaftRadius * c, 0.0f);
+        vertices.emplace_back(shaftRadius * s, shaftRadius * c, shaftLength);
+        vertices.emplace_back(headRadius * s, headRadius * c, shaftLength);
+    }
+
+    return vertices;
+}
+
+std::vector<GLushort>
+getArrowIndices()
+{
+    constexpr unsigned int circleSize = (arrowSections + 1U) * 3U;
+    constexpr unsigned int shaftSize = 3U + arrowSections * 6U;
+    constexpr unsigned int annulusSize = (arrowSections + 1U) * 3U;
+    constexpr unsigned int headSize = (arrowSections + 1U) * 3U;
+
+    constexpr unsigned int totalSize = circleSize + shaftSize + annulusSize + headSize;
+
+    std::vector<GLushort> indices(totalSize, GLushort(0));
+
+    GLushort* const circle = indices.data();
+    GLushort* const shaft = circle + circleSize;
+    GLushort* const annulus = shaft + shaftSize;
+    GLushort* const head = annulus + annulusSize;
+
+    GLushort* circlePtr = circle;
+    GLushort* shaftPtr = shaft;
+    GLushort* annulusPtr = annulus;
+    GLushort* headPtr = head;
+
+    constexpr GLushort vZero = 0;
+    constexpr GLushort v3 = 1;
+    constexpr GLushort v4 = 2;
+    for (unsigned int i = 0U; i <= arrowSections; ++i)
+    {
+        unsigned int idx = i < arrowSections ? i : 0;
+        auto v0 = static_cast<GLushort>(3U + idx * 3U);
+        auto v1 = static_cast<GLushort>(v0 + 1U);
+        auto v2 = static_cast<GLushort>(v0 + 2U);
+
+        // Circle at bottom
+        if (i > 0)
+            *(circlePtr++) = v0;
+        *(circlePtr++) = vZero;
+        *(circlePtr++) = v1;
+
+        // Shaft
+        if (i > 0)
+        {
+            *(shaftPtr++) = v0; // left triangle
+
+            *(shaftPtr++) = v0; // right
+            *(shaftPtr++) = static_cast<GLushort>(idx * 3U + 1U) ; // v1Prev
+            *(shaftPtr++) = v1;
+        }
+        *(shaftPtr++) = v0; // left
+        *(shaftPtr++) = v1;
+
+        // Annulus
+        if (i > 0)
+            *(annulusPtr++) = v2;
+        *(annulusPtr++) = v2;
+        *(annulusPtr++) = v3;
+
+        // Head
+        if (i > 0)
+            *(headPtr++) = v2;
+        *(headPtr++) = v4;
+        *(headPtr++) = v2;
+    }
+
+    *circlePtr = circle[1];
+    *shaftPtr = shaft[0];
+    *annulusPtr = annulus[1];
+    *headPtr = head[1];
+
+    return indices;
+}
+
+constexpr unsigned int circleSubdivisions = 100U;
+
+} // end unnamed namespace
+
+ArrowRenderer::~ArrowRenderer() = default;
+
+ArrowRenderer::ArrowRenderer(const Renderer& renderer) :
+    m_lineRenderer(renderer),
+    m_vo(std::make_unique<gl::VertexObject>())
+{
+    auto vertices = getArrowVertices();
+    auto indices = getArrowIndices();
+
+    m_buffer = std::make_unique<gl::Buffer>(gl::Buffer::TargetHint::Array);
+    m_buffer->setData(vertices, gl::Buffer::BufferUsage::StaticDraw);
+
+    m_vo->addVertexBuffer(*m_buffer,
+                          CelestiaGLProgram::VertexCoordAttributeIndex,
+                          3,
+                          gl::VertexObject::DataType::Float);
+    gl::Buffer indexBuffer(gl::Buffer::TargetHint::ElementArray, indices);
+    m_vo->setCount(static_cast<int>(indices.size()));
+    m_vo->setIndexBuffer(std::move(indexBuffer), 0, gl::VertexObject::IndexType::UnsignedShort);
+
+    ShaderProperties shaderProperties;
+    shaderProperties.texUsage = TexUsage::VertexColors;
+    shaderProperties.lightModel = LightingModel::UnlitModel;
+    m_prog = renderer.getShaderManager().getShader(shaderProperties);
+}
+
+PlanetGridRenderer::PlanetGridRenderer(const Renderer& renderer) :
+    m_latitudeRenderer(renderer, 1.0f, LineRenderer::PrimType::LineStrip, LineRenderer::StorageType::Static),
+    m_equatorRenderer(renderer, 2.0f, LineRenderer::PrimType::LineStrip, LineRenderer::StorageType::Static),
+    m_longitudeRenderer(renderer, 1.0f, LineRenderer::PrimType::LineStrip, LineRenderer::StorageType::Static)
+{
+    for (unsigned int i = 0; i <= circleSubdivisions + 1; i++)
+    {
+        float s, c;
+        math::sincos((2.0f * celestia::numbers::pi_v<float>) * static_cast<float>(i) / circleSubdivisions, s, c);
+        Eigen::Vector3f latitudePoint(c, 0.0f, s);
+        Eigen::Vector3f longitudePoint(c, s, 0.0f);
+        m_latitudeRenderer.addVertex(latitudePoint);
+        m_equatorRenderer.addVertex(latitudePoint);
+        m_longitudeRenderer.addVertex(longitudePoint);
+    }
+}
+
+ReferenceMarkRenderer::ReferenceMarkRenderer(Renderer& renderer) :
+    m_renderer(renderer)
+{
+}
+
+ArrowRenderer&
+ReferenceMarkRenderer::arrowRenderer()
+{
+    if (!m_arrowRenderer)
+        m_arrowRenderer = std::make_unique<ArrowRenderer>(m_renderer);
+    return *m_arrowRenderer;
+}
+
+PlanetGridRenderer&
+ReferenceMarkRenderer::planetGridRenderer()
+{
+    if (!m_planetGridRenderer)
+        m_planetGridRenderer = std::make_unique<PlanetGridRenderer>(m_renderer);
+    return *m_planetGridRenderer;
+}
+
+LineRenderer&
+ReferenceMarkRenderer::visibleRegionRenderer()
+{
+    if (!m_visibleRegionRenderer)
+        m_visibleRegionRenderer = std::make_unique<LineRenderer>(m_renderer, 1.0f, render::LineRenderer::PrimType::LineStrip);
+    return *m_visibleRegionRenderer;
+}
+
+} // end namespace celestia::render

--- a/src/celrender/referencemarkrenderer.h
+++ b/src/celrender/referencemarkrenderer.h
@@ -1,0 +1,82 @@
+// referencemarkrenderer.h
+//
+// Copyright (C) 2025, Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "linerenderer.h"
+
+class CelestiaGLProgram;
+
+namespace celestia
+{
+
+namespace gl
+{
+class Buffer;
+class VertexObject;
+}
+
+namespace render
+{
+
+class ArrowRenderer
+{
+public:
+    explicit ArrowRenderer(const Renderer& renderer);
+    ~ArrowRenderer();
+
+    CelestiaGLProgram* program() const { return m_prog; }
+    gl::VertexObject* vertexObject() const { return m_vo.get(); }
+    LineRenderer& lineRenderer() { return m_lineRenderer; }
+
+private:
+    CelestiaGLProgram* m_prog;
+    std::unique_ptr<gl::Buffer> m_buffer;
+    std::unique_ptr<gl::VertexObject> m_vo;
+    LineRenderer m_lineRenderer;
+};
+
+class PlanetGridRenderer
+{
+public:
+    explicit PlanetGridRenderer(const Renderer& renderer);
+
+    LineRenderer& latitudeRenderer() { return m_latitudeRenderer; }
+    LineRenderer& equatorRenderer() { return m_equatorRenderer; }
+    LineRenderer& longitudeRenderer() { return m_longitudeRenderer; }
+
+private:
+    LineRenderer m_latitudeRenderer;
+    LineRenderer m_equatorRenderer;
+    LineRenderer m_longitudeRenderer;
+};
+
+class ReferenceMarkRenderer
+{
+public:
+    explicit ReferenceMarkRenderer(Renderer&);
+
+    Renderer& renderer() { return m_renderer; }
+    ArrowRenderer& arrowRenderer();
+    PlanetGridRenderer& planetGridRenderer();
+    LineRenderer& visibleRegionRenderer();
+
+private:
+    Renderer& m_renderer;
+    std::unique_ptr<ArrowRenderer> m_arrowRenderer;
+    std::unique_ptr<PlanetGridRenderer> m_planetGridRenderer;
+    std::unique_ptr<LineRenderer> m_visibleRegionRenderer;
+};
+
+} // end namespace celestia::render
+
+} // end namespace celestia

--- a/src/celrender/rendererfwd.h
+++ b/src/celrender/rendererfwd.h
@@ -13,6 +13,7 @@ class LargeStarRenderer;
 class LineRenderer;
 class NebulaRenderer;
 class OpenClusterRenderer;
+class ReferenceMarkRenderer;
 class RingRenderer;
 class SkyGridRenderer;
 }


### PR DESCRIPTION
- Move OpenGL objects into new renderer classes owned by the `Renderer`, instead of using static lifetimes.
- Do not create strings when using the default tags
- Remove some unnecessary fields
- Use integers rather than floats in planet grid loops
- Reuse string instance for planet grid labels