### PR TITLE
Implement orbital precession

### DIFF
--- a/src/celastro/astro.h
+++ b/src/celastro/astro.h
@@ -244,6 +244,8 @@ struct KeplerElements
     double argPericenter{ 0.0 };
     double meanAnomaly{ 0.0 };
     double period{ 0.0 };
+    double nodalPeriod{ 0.0 };
+    double apsidalPeriod{ 0.0 };
 };
 
 

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -133,6 +133,11 @@ GetDefaultUnits(bool usePlanetUnits, double& distanceScale)
  *     # One or none of the following:
  *     MeanAnomaly <degrees>     (default: 0.0)
  *     MeanLongitude <degrees>   (default: 0.0)
+ * 
+ *     # For precessing orbits (default unit is Julian years):
+ *     # Default values result in no precession
+ *     NodalPrecessionPeriod <number>   (default: 0.0)
+ *     ApsidalPrecessionPeriod <number> (default: 0.0)
  * } \endcode
  *
  * If usePlanetUnits is true:
@@ -198,6 +203,10 @@ CreateKeplerianOrbit(const AssociativeArray* orbitData,
         return nullptr;
     }
 
+    elements.nodalPeriod = orbitData->getTime<double>("NodalPrecessionPeriod", 1.0, astro::DAYS_PER_YEAR).value_or(0.0);
+
+    elements.apsidalPeriod = orbitData->getTime<double>("ApsidalPrecessionPeriod", 1.0, astro::DAYS_PER_YEAR).value_or(0.0);
+
     elements.inclination = orbitData->getAngle<double>("Inclination").value_or(0.0);
 
     elements.longAscendingNode = orbitData->getAngle<double>("AscendingNode").value_or(0.0);
@@ -228,7 +237,12 @@ CreateKeplerianOrbit(const AssociativeArray* orbitData,
 
     if (elements.eccentricity < 1.0)
     {
-        return std::make_shared<ephem::EllipticalOrbit>(elements, epoch);
+        if (elements.nodalPeriod == 0.0 && elements.apsidalPeriod == 0.0)
+        {
+            return std::make_shared<ephem::EllipticalOrbit>(elements, epoch);
+        }
+
+        return std::make_shared<ephem::PrecessingOrbit>(elements, epoch);
     }
 
     return std::make_shared<ephem::HyperbolicOrbit>(elements, epoch);

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -206,7 +206,7 @@ CreateKeplerianOrbit(const AssociativeArray* orbitData,
     {
         double periodCorrection = 0.0;
         if (elements.nodalPeriod != 0.0)
-            periodCorrection += 1.0 / elements.nodalPeriod;
+            periodCorrection -= 1.0 / elements.nodalPeriod;
         if (elements.apsidalPeriod != 0.0)
             periodCorrection += 1.0 / elements.apsidalPeriod;
 

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -117,8 +117,9 @@ GetDefaultUnits(bool usePlanetUnits, double& distanceScale)
  *     SemiMajorAxis <number>
  *     PericenterDistance <number>
  *
- *     # Required
+ *     # One of the following is required:
  *     Period <number>
+ *     AnomalisticPeriod <number>
  *
  *     Eccentricity <number>   (default: 0.0)
  *     Inclination <degrees>   (default: 0.0)
@@ -134,18 +135,19 @@ GetDefaultUnits(bool usePlanetUnits, double& distanceScale)
  *     MeanAnomaly <degrees>     (default: 0.0)
  *     MeanLongitude <degrees>   (default: 0.0)
  * 
- *     # For precessing orbits (default unit is Julian years):
+ *     # One or both of the following for a precessing orbit:
  *     # Default values result in no precession
  *     NodalPrecessionPeriod <number>   (default: 0.0)
  *     ApsidalPrecessionPeriod <number> (default: 0.0)
  * } \endcode
  *
  * If usePlanetUnits is true:
- *     Period is in Julian years
+ *     Period or AnomalisticPeriod is in Julian years
  *     SemiMajorAxis or PericenterDistance is in AU
  * Otherwise:
- *     Period is in Julian days
+ *     Period or AnomalisticPeriod is in Julian days
  *     SemiMajorAxis or PericenterDistance is in kilometers.
+ * The default unit for precession periods is Julian years.
  */
 std::shared_ptr<const ephem::Orbit>
 CreateKeplerianOrbit(const AssociativeArray* orbitData,
@@ -188,6 +190,9 @@ CreateKeplerianOrbit(const AssociativeArray* orbitData,
         return nullptr;
     }
 
+    elements.nodalPeriod = orbitData->getTime<double>("NodalPrecessionPeriod", 1.0, astro::DAYS_PER_YEAR).value_or(0.0);
+    elements.apsidalPeriod = orbitData->getTime<double>("ApsidalPrecessionPeriod", 1.0, astro::DAYS_PER_YEAR).value_or(0.0);
+
     if (auto periodValue = orbitData->getTime<double>("Period", 1.0, timeScale); periodValue.has_value())
     {
         elements.period = *periodValue;
@@ -197,15 +202,26 @@ CreateKeplerianOrbit(const AssociativeArray* orbitData,
             return nullptr;
         }
     }
+    else if (auto anomPeriodValue = orbitData->getTime<double>("AnomalisticPeriod", 1.0, timeScale); anomPeriodValue.has_value())
+    {
+        double periodCorrection = 0.0;
+        if (elements.nodalPeriod != 0.0)
+            periodCorrection += 1.0 / elements.nodalPeriod;
+        if (elements.apsidalPeriod != 0.0)
+            periodCorrection += 1.0 / elements.apsidalPeriod;
+
+        elements.period = 1.0 / (1.0 / *anomPeriodValue + periodCorrection);
+        if (elements.period == 0.0)
+        {
+            GetLogger()->error("AnomalisticPeriod cannot be zero.\n");
+            return nullptr;
+        }
+    }
     else
     {
         GetLogger()->error("Period must be specified in EllipticalOrbit.\n");
         return nullptr;
     }
-
-    elements.nodalPeriod = orbitData->getTime<double>("NodalPrecessionPeriod", 1.0, astro::DAYS_PER_YEAR).value_or(0.0);
-
-    elements.apsidalPeriod = orbitData->getTime<double>("ApsidalPrecessionPeriod", 1.0, astro::DAYS_PER_YEAR).value_or(0.0);
 
     elements.inclination = orbitData->getAngle<double>("Inclination").value_or(0.0);
 
@@ -238,9 +254,7 @@ CreateKeplerianOrbit(const AssociativeArray* orbitData,
     if (elements.eccentricity < 1.0)
     {
         if (elements.nodalPeriod == 0.0 && elements.apsidalPeriod == 0.0)
-        {
             return std::make_shared<ephem::EllipticalOrbit>(elements, epoch);
-        }
 
         return std::make_shared<ephem::PrecessingOrbit>(elements, epoch);
     }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1002,8 +1002,11 @@ void Renderer::renderOrbit(const OrbitPathListEntry& orbitPath,
     const Body* body = orbitPath.body;
     double nearZ = -nearDist;  // negate, becase z is into the screen in camera space
     double farZ = -farDist;
+    bool isFadingEnabled = util::is_set(renderFlags, RenderFlags::ShowFadingOrbits);
 
-    const auto* orbit = body != nullptr ? body->getOrbit(t) : orbitPath.star->getOrbit();
+    const auto* orbit = body != nullptr ?
+                        body->getOrbit(t)->getOrbitForSampling(t, isFadingEnabled) :
+                        orbitPath.star->getOrbit()->getOrbitForSampling(t, isFadingEnabled);
 
     CurvePlot* cachedOrbit = nullptr;
     if (auto cached = orbitCache.lower_bound(orbit);
@@ -1174,7 +1177,7 @@ void Renderer::renderOrbit(const OrbitPathListEntry& orbitPath,
         double windowStart = windowEnd - period * OrbitPeriodsShown;
         double windowDuration = windowEnd - windowStart;
 
-        if (LinearFadeFraction == 0.0f || !util::is_set(renderFlags, RenderFlags::ShowFadingOrbits))
+        if (LinearFadeFraction == 0.0f || !isFadingEnabled)
         {
             cachedOrbit->render(modelview,
                                 nearZ, farZ, viewFrustumPlaneNormals,

--- a/src/celephem/orbit.cpp
+++ b/src/celephem/orbit.cpp
@@ -127,7 +127,12 @@ std::unique_ptr<Orbit>
 CreateKeplerOrbit(const astro::KeplerElements& elements, double epoch)
 {
     if (elements.eccentricity < 1.0)
-        return std::make_unique<EllipticalOrbit>(elements, epoch);
+    {
+        if (elements.nodalPeriod == 0.0 && elements.apsidalPeriod == 0.0)
+            return std::make_unique<EllipticalOrbit>(elements, epoch);
+
+        return std::make_unique<PrecessingOrbit>(elements, epoch);
+    }
 
     return std::make_unique<HyperbolicOrbit>(elements, epoch);
 }
@@ -269,15 +274,12 @@ Eigen::Vector3d Orbit::velocityAtTime(double tdb) const
 }
 
 
-EllipticalOrbit::EllipticalOrbit(const astro::KeplerElements& _elements, double _epoch) :
+EllipticalOrbitBase::EllipticalOrbitBase(const astro::KeplerElements& _elements, double _epoch) :
     semiMajorAxis(_elements.semimajorAxis),
     eccentricity(_elements.eccentricity),
     meanAnomalyAtEpoch(_elements.meanAnomaly),
     period(_elements.period),
-    epoch(_epoch),
-    orbitPlaneRotation((math::ZRotation(_elements.longAscendingNode) *
-                        math::XRotation(_elements.inclination) *
-                        math::ZRotation(_elements.argPericenter)).toRotationMatrix())
+    epoch(_epoch)
 {
     assert(eccentricity >= 0.0 && eccentricity < 1.0);
     assert(semiMajorAxis >= 0.0);
@@ -286,7 +288,7 @@ EllipticalOrbit::EllipticalOrbit(const astro::KeplerElements& _elements, double 
 }
 
 
-double EllipticalOrbit::eccentricAnomaly(double M) const
+double EllipticalOrbitBase::eccentricAnomaly(double M) const
 {
     if (eccentricity == 0.0)
     {
@@ -311,6 +313,26 @@ double EllipticalOrbit::eccentricAnomaly(double M) const
     double E = M + 0.85 * eccentricity * math::sign(std::sin(M));
     return math::solve_iteration_fixed(SolveKeplerLaguerreConway(eccentricity, M), E, 8).first;
 }
+
+
+double EllipticalOrbitBase::getPeriod() const
+{
+    return period;
+}
+
+
+double EllipticalOrbitBase::getBoundingRadius() const
+{
+    // TODO: watch out for unbounded parabolic and hyperbolic orbits
+    return semiMajorAxis * (1.0 + eccentricity);
+}
+
+
+EllipticalOrbit::EllipticalOrbit(const astro::KeplerElements& _elements, double _epoch) :
+    EllipticalOrbitBase(_elements, _epoch),
+    orbitPlaneRotation((math::ZRotation(_elements.longAscendingNode) *
+                        math::XRotation(_elements.inclination) *
+                        math::ZRotation(_elements.argPericenter)).toRotationMatrix()) {}
 
 
 // Compute the position at the specified eccentric
@@ -370,16 +392,89 @@ Eigen::Vector3d EllipticalOrbit::velocityAtTime(double t) const
 }
 
 
-double EllipticalOrbit::getPeriod() const
+PrecessingOrbit::PrecessingOrbit(const astro::KeplerElements& _elements, double _epoch) :
+    EllipticalOrbitBase(_elements, _epoch),
+    longAscendingNodeAtEpoch(_elements.longAscendingNode),
+    argPericenterAtEpoch(_elements.argPericenter),
+    nodalPeriod(_elements.nodalPeriod),
+    apsidalPeriod(_elements.apsidalPeriod),
+    inclinationRotation(math::XRotation(_elements.inclination)) {}
+
+
+// Compute the position at the specified eccentric
+// anomaly E.
+Eigen::Vector3d PrecessingOrbit::positionAtE(double E, double longAscendingNode, double argPericenter) const
 {
-    return period;
+    double x = semiMajorAxis * (std::cos(E) - eccentricity);
+    double y = semiMinorAxis * std::sin(E);
+
+    Eigen::Matrix3d orbitPlaneRotation = (math::ZRotation(longAscendingNode) *
+                                          inclinationRotation *
+                                          math::ZRotation(argPericenter)).toRotationMatrix();
+    Eigen::Vector3d p = orbitPlaneRotation * Eigen::Vector3d(x, y, 0);
+
+    // Convert to Celestia's internal coordinate system
+    return Eigen::Vector3d(p.x(), p.z(), -p.y());
 }
 
 
-double EllipticalOrbit::getBoundingRadius() const
+// Compute the velocity at the specified eccentric
+// anomaly E.
+Eigen::Vector3d PrecessingOrbit::velocityAtE(double E, double longAscendingNode, double argPericenter, double meanMotion) const
 {
-    // TODO: watch out for unbounded parabolic and hyperbolic orbits
-    return semiMajorAxis * (1.0 + eccentricity);
+    double sinE;
+    double cosE;
+    math::sincos(E, sinE, cosE);
+
+    double edot = meanMotion / (1.0 - eccentricity * cosE);
+
+    double x = -semiMajorAxis * sinE * edot;
+    double y =  semiMinorAxis * cosE * edot;
+
+    Eigen::Matrix3d orbitPlaneRotation = (math::ZRotation(longAscendingNode) *
+                                          inclinationRotation *
+                                          math::ZRotation(argPericenter)).toRotationMatrix();
+    Eigen::Vector3d v = orbitPlaneRotation* Eigen::Vector3d(x, y, 0);
+
+    // Convert to Celestia's coordinate system
+    return Eigen::Vector3d(v.x(), v.z(), -v.y());
+}
+
+
+// Return the offset from the center
+Eigen::Vector3d PrecessingOrbit::positionAtTime(double t) const
+{
+    t = t - epoch;
+
+    // Period is assumed to be sidereal
+    double meanMotion = 2.0 * celestia::numbers::pi / period;
+    double nodalPrecessionRate = nodalPeriod != 0.0 ? 2.0 * celestia::numbers::pi / -nodalPeriod : 0.0;
+    double apsidalPrecessionRate = apsidalPeriod != 0.0 ? 2.0 * celestia::numbers::pi / apsidalPeriod : 0.0;
+
+    double longAscendingNode = longAscendingNodeAtEpoch + t * nodalPrecessionRate;
+    double argPericenter = argPericenterAtEpoch + t * apsidalPrecessionRate;
+    double meanAnomaly = meanAnomalyAtEpoch + t * (meanMotion - apsidalPrecessionRate - nodalPrecessionRate);
+    double E = eccentricAnomaly(meanAnomaly);
+
+    return positionAtE(E, longAscendingNode, argPericenter);
+}
+
+
+Eigen::Vector3d PrecessingOrbit::velocityAtTime(double t) const
+{
+    t = t - epoch;
+
+    // Period is assumed to be sidereal
+    double meanMotion = 2.0 * celestia::numbers::pi / period;
+    double nodalPrecessionRate = nodalPeriod != 0.0 ? 2.0 * celestia::numbers::pi / -nodalPeriod : 0.0;
+    double apsidalPrecessionRate = apsidalPeriod != 0.0 ? 2.0 * celestia::numbers::pi / apsidalPeriod : 0.0;
+
+    double longAscendingNode = longAscendingNodeAtEpoch + t * nodalPrecessionRate;
+    double argPericenter = argPericenterAtEpoch + t * apsidalPrecessionRate;
+    double meanAnomaly = meanAnomalyAtEpoch + t * (meanMotion - apsidalPrecessionRate - nodalPrecessionRate);
+    double E = eccentricAnomaly(meanAnomaly);
+
+    return velocityAtE(E, longAscendingNode, argPericenter, meanMotion);
 }
 
 

--- a/src/celephem/orbit.cpp
+++ b/src/celephem/orbit.cpp
@@ -274,6 +274,12 @@ Eigen::Vector3d Orbit::velocityAtTime(double tdb) const
 }
 
 
+const Orbit* Orbit::getOrbitForSampling(double /*t*/, bool /*isFadingEnabled*/) const
+{
+    return this;
+}
+
+
 EllipticalOrbitBase::EllipticalOrbitBase(const astro::KeplerElements& _elements, double _epoch) :
     semiMajorAxis(_elements.semimajorAxis),
     eccentricity(_elements.eccentricity),
@@ -392,6 +398,12 @@ Eigen::Vector3d EllipticalOrbit::velocityAtTime(double t) const
 }
 
 
+void EllipticalOrbit::setOrientation(const Eigen::Matrix3d& _orbitPlaneRotation)
+{
+    orbitPlaneRotation = _orbitPlaneRotation;
+}
+
+
 PrecessingOrbit::PrecessingOrbit(const astro::KeplerElements& _elements, double _epoch) :
     EllipticalOrbitBase(_elements, _epoch),
     longAscendingNodeAtEpoch(_elements.longAscendingNode),
@@ -475,6 +487,40 @@ Eigen::Vector3d PrecessingOrbit::velocityAtTime(double t) const
     double E = eccentricAnomaly(meanAnomaly);
 
     return velocityAtE(E, longAscendingNode, argPericenter, meanMotion);
+}
+
+
+// For precessing orbits, get the osculating orbit when fading is disabled
+const Orbit* PrecessingOrbit::getOrbitForSampling(double t, bool isFadingEnabled) const
+{
+    if (!isFadingEnabled)
+    {
+        t = t - epoch;
+        double meanMotion = 2.0 * celestia::numbers::pi / period;
+        double nodalPrecessionRate = nodalPeriod != 0.0 ? 2.0 * celestia::numbers::pi / -nodalPeriod : 0.0;
+        double apsidalPrecessionRate = apsidalPeriod != 0.0 ? 2.0 * celestia::numbers::pi / apsidalPeriod : 0.0;
+
+        double longAscendingNode = longAscendingNodeAtEpoch + t * nodalPrecessionRate;
+        double argPericenter = argPericenterAtEpoch + t * apsidalPrecessionRate;
+        double meanAnomaly = meanAnomalyAtEpoch + t * (meanMotion - apsidalPrecessionRate - nodalPrecessionRate);
+
+        astro::KeplerElements elements;
+        elements.semimajorAxis = semiMajorAxis;
+        elements.eccentricity = eccentricity;
+        elements.meanAnomaly = meanAnomaly;
+        elements.period = period;
+
+        Eigen::Matrix3d orbitPlaneRotation = (math::ZRotation(longAscendingNode) *
+                                              inclinationRotation *
+                                              math::ZRotation(argPericenter)).toRotationMatrix();
+
+        auto* orbit = new EllipticalOrbit(elements, t);
+        orbit->setOrientation(orbitPlaneRotation);
+
+        return orbit;
+    }
+
+    return this;
 }
 
 

--- a/src/celephem/orbit.h
+++ b/src/celephem/orbit.h
@@ -67,7 +67,29 @@ protected:
 };
 
 
-class EllipticalOrbit final : public Orbit
+class EllipticalOrbitBase : public Orbit
+{
+public:
+    ~EllipticalOrbitBase() override = default;
+
+    double getPeriod() const override;
+    double getBoundingRadius() const override;
+
+protected:
+    EllipticalOrbitBase(const astro::KeplerElements&, double _epoch = 2451545.0);
+
+    double eccentricAnomaly(double) const;
+
+    double semiMajorAxis;
+    double semiMinorAxis;
+    double eccentricity;
+    double meanAnomalyAtEpoch;
+    double period;
+    double epoch;
+};
+
+
+class EllipticalOrbit final : public EllipticalOrbitBase
 {
 public:
     EllipticalOrbit(const astro::KeplerElements&, double _epoch = 2451545.0);
@@ -76,22 +98,35 @@ public:
     // Compute the orbit for a specified Julian date
     Eigen::Vector3d positionAtTime(double) const override;
     Eigen::Vector3d velocityAtTime(double) const override;
-    double getPeriod() const override;
-    double getBoundingRadius() const override;
 
 private:
-    double eccentricAnomaly(double) const;
     Eigen::Vector3d positionAtE(double) const;
     Eigen::Vector3d velocityAtE(double, double) const;
 
-    double semiMajorAxis;
-    double semiMinorAxis;
-    double eccentricity;
-    double meanAnomalyAtEpoch;
-    double period;
-    double epoch;
-
     Eigen::Matrix3d orbitPlaneRotation;
+};
+
+
+class PrecessingOrbit final : public EllipticalOrbitBase
+{
+public:
+    PrecessingOrbit(const astro::KeplerElements&, double _epoch = 2451545.0);
+    ~PrecessingOrbit() override = default;
+
+    // Compute the orbit for a specified Julian date
+    Eigen::Vector3d positionAtTime(double) const override;
+    Eigen::Vector3d velocityAtTime(double) const override;
+
+private:
+    Eigen::Vector3d positionAtE(double, double, double) const;
+    Eigen::Vector3d velocityAtE(double, double, double, double) const;
+
+    double longAscendingNodeAtEpoch;
+    double argPericenterAtEpoch;
+    double nodalPeriod;
+    double apsidalPeriod;
+
+    Eigen::Quaterniond inclinationRotation;
 };
 
 

--- a/src/celephem/orbit.h
+++ b/src/celephem/orbit.h
@@ -42,6 +42,8 @@ public:
     virtual double getPeriod() const = 0;
     virtual double getBoundingRadius() const = 0;
 
+    virtual const Orbit* getOrbitForSampling(double, bool) const;
+
     virtual void sample(double startTime, double endTime, OrbitSampleProc& proc) const;
 
     virtual bool isPeriodic() const { return true; };
@@ -99,6 +101,8 @@ public:
     Eigen::Vector3d positionAtTime(double) const override;
     Eigen::Vector3d velocityAtTime(double) const override;
 
+    void setOrientation(const Eigen::Matrix3d& _orbitPlaneRotation);
+
 private:
     Eigen::Vector3d positionAtE(double) const;
     Eigen::Vector3d velocityAtE(double, double) const;
@@ -116,6 +120,7 @@ public:
     // Compute the orbit for a specified Julian date
     Eigen::Vector3d positionAtTime(double) const override;
     Eigen::Vector3d velocityAtTime(double) const override;
+    const Orbit* getOrbitForSampling(double t, bool isFadingEnabled) const override;
 
 private:
     Eigen::Vector3d positionAtE(double, double, double) const;

--- a/src/celephem/rotation.cpp
+++ b/src/celephem/rotation.cpp
@@ -276,7 +276,9 @@ PrecessingRotationModel::getPeriod() const
 Eigen::Quaterniond
 PrecessingRotationModel::spin(double tjd) const
 {
-    double rotations = (tjd - epoch) / period;
+    // Correct the sidereal rotation period for precession of the node
+    double periodCorrection = precessionPeriod != 0.0 ? 1.0 / precessionPeriod : 0.0;
+    double rotations = (tjd - epoch) / (1.0 / (1.0 / period - periodCorrection));
     double wholeRotations = std::floor(rotations);
     double remainder = rotations - wholeRotations;
 


### PR DESCRIPTION
This adds two new parameters for modeling of [nodal](https://en.wikipedia.org/wiki/Nodal_precession) and [apsidal](https://en.wikipedia.org/wiki/Apsidal_precession) precession: `NodalPrecessionPeriod` and `ApsidalPrecessionPeriod`. The default unit for both is years.

Example syntax (orbit data from 16 Cyg Bb):
```
	EllipticalOrbit
	{
		Epoch 2456937
		Period 2.18863792
		SemiMajorAxis 1.6795
		Eccentricity 0.683
		Inclination 137.41309
		AscendingNode 316.95447
		ArgOfPericenter 232.8624
		MeanAnomaly 1.03341
		NodalPrecessionPeriod 100
		ApsidalPrecessionPeriod 100
	}
```

For the following images, I've set `OrbitPeriodsShown` to 3.0 in celestia.cfg.

**Nodal precession:**
<img width="500" src="https://github.com/user-attachments/assets/56b582bc-7110-452a-a0fd-1169a143ac1e" />

**Apsidal precession:**
<img width="500" src="https://github.com/user-attachments/assets/525778d6-104d-4229-b510-ffbd078baabc" />

One issue is that the orbit paths look incomplete (this is with fading disabled). I wonder if using some parameter other than period (such as eccentric anomaly) for sampling the orbit would address that.
<img width="500" src="https://github.com/user-attachments/assets/1a96ce6b-606e-44b4-994b-669e59e1464d" />

I'm not sure if the equations used are correct either.