### PR TITLE
Fix deprecated-literal-operator warnings in Clang 20

### DIFF
--- a/src/celastro/astro.h
+++ b/src/celastro/astro.h
@@ -215,15 +215,15 @@ double meanEclipticObliquity(double jd);
 namespace literals
 {
 
-constexpr long double operator "" _au (long double au)
+constexpr long double operator ""_au(long double au)
 {
     return AUtoKilometers(au);
 }
-constexpr long double operator "" _ly (long double ly)
+constexpr long double operator ""_ly(long double ly)
 {
     return lightYearsToKilometers(ly);
 }
-constexpr long double operator "" _c (long double n)
+constexpr long double operator ""_c(long double n)
 {
     return speedOfLight * n;
 }


### PR DESCRIPTION
Previously fixed in #2312 
Reintroduced in #2371

Syntax was deprecated in https://cplusplus.github.io/CWG/issues/2521.html