### PR TITLE
Remove redundant Renderer::DetailOptions constructor

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -228,25 +228,6 @@ Renderer::~Renderer()
     CurvePlot::deinit();
 }
 
-
-Renderer::DetailOptions::DetailOptions() :
-    orbitPathSamplePoints(100),
-    shadowTextureSize(256),
-    eclipseTextureSize(128),
-    orbitWindowEnd(0.5),
-    orbitPeriodsShown(1.0),
-    linearFadeFraction(0.0),
-
-    renderAsterismsFadeStartDist(600.0f),
-    renderAsterismsFadeEndDist(6.52e4f),
-    renderBoundariesFadeStartDist(6.0f),
-    renderBoundariesFadeEndDist(20.0f),
-    labelConstellationsFadeStartDist(6.0f),
-    labelConstellationsFadeEndDist(20.0f)
-{
-}
-
-
 #if 0
 // Not used yet.
 

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -116,7 +116,6 @@ class Renderer
 
     struct DetailOptions
     {
-        DetailOptions();
         unsigned int orbitPathSamplePoints{ 100 };
         unsigned int shadowTextureSize{ 256 };
         unsigned int eclipseTextureSize{ 128 };


### PR DESCRIPTION
Field initializers handle all this already, so just use compiler-generated default constructor