### PR TITLE
Increment samplerId even if it is optimized out

### DIFF
--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -2973,65 +2973,64 @@ CelestiaGLProgram::initSamplers()
 
     if (util::is_set(props.texUsage, TexUsage::DiffuseTexture))
     {
-        int slot = glGetUniformLocation(program.getID(), "diffTex");
-        if (slot != -1)
-            glUniform1i(slot, nSamplers++);
+        if (GLint slot = glGetUniformLocation(program.getID(), "diffTex"); slot != -1)
+            glUniform1i(slot, nSamplers);
+        nSamplers++;
     }
 
     if (util::is_set(props.texUsage, TexUsage::NormalTexture))
     {
-        int slot = glGetUniformLocation(program.getID(), "normTex");
-        if (slot != -1)
-            glUniform1i(slot, nSamplers++);
+        if (GLint slot = glGetUniformLocation(program.getID(), "normTex"); slot != -1)
+            glUniform1i(slot, nSamplers);
+        nSamplers++;
     }
 
     if (util::is_set(props.texUsage, TexUsage::SpecularTexture))
     {
-        int slot = glGetUniformLocation(program.getID(), "specTex");
-        if (slot != -1)
-            glUniform1i(slot, nSamplers++);
+        if (GLint slot = glGetUniformLocation(program.getID(), "specTex"); slot != -1)
+            glUniform1i(slot, nSamplers);
+        nSamplers++;
     }
 
     if (util::is_set(props.texUsage, TexUsage::NightTexture))
     {
-        int slot = glGetUniformLocation(program.getID(), "nightTex");
-        if (slot != -1)
-            glUniform1i(slot, nSamplers++);
+        if (GLint slot = glGetUniformLocation(program.getID(), "nightTex"); slot != -1)
+            glUniform1i(slot, nSamplers);
+        nSamplers++;
     }
 
     if (util::is_set(props.texUsage, TexUsage::EmissiveTexture))
     {
-        int slot = glGetUniformLocation(program.getID(), "emissiveTex");
-        if (slot != -1)
-            glUniform1i(slot, nSamplers++);
+        if (GLint slot = glGetUniformLocation(program.getID(), "emissiveTex"); slot != -1)
+            glUniform1i(slot, nSamplers);
+        nSamplers++;
     }
 
     if (util::is_set(props.texUsage, TexUsage::OverlayTexture))
     {
-        int slot = glGetUniformLocation(program.getID(), "overlayTex");
-        if (slot != -1)
-            glUniform1i(slot, nSamplers++);
+        if (GLint slot = glGetUniformLocation(program.getID(), "overlayTex"); slot != -1)
+            glUniform1i(slot, nSamplers);
+        nSamplers++;
     }
 
     if (util::is_set(props.texUsage, TexUsage::RingShadowTexture))
     {
-        int slot = glGetUniformLocation(program.getID(), "ringTex");
-        if (slot != -1)
-            glUniform1i(slot, nSamplers++);
+        if (GLint slot = glGetUniformLocation(program.getID(), "ringTex"); slot != -1)
+            glUniform1i(slot, nSamplers);
+        nSamplers++;
     }
 
     if (util::is_set(props.texUsage, TexUsage::CloudShadowTexture))
     {
-        int slot = glGetUniformLocation(program.getID(), "cloudShadowTex");
-        if (slot != -1)
-            glUniform1i(slot, nSamplers++);
+        if (GLint slot = glGetUniformLocation(program.getID(), "cloudShadowTex"); slot != -1)
+            glUniform1i(slot, nSamplers);
+        nSamplers++;
     }
 
     if (util::is_set(props.texUsage, TexUsage::ShadowMapTexture))
     {
-        int slot = glGetUniformLocation(program.getID(), "shadowMapTex0");
-        if (slot != -1)
-            glUniform1i(slot, nSamplers++);
+        if (GLint slot = glGetUniformLocation(program.getID(), "shadowMapTex0"); slot != -1)
+            glUniform1i(slot, nSamplers);
     }
 }
 


### PR DESCRIPTION
when rendering model with no light source, the shader source might look like below. `normTex` is defined in shader source but it is optimized out because it does not affect gl_FragColor, glGetUniformLocation return -1.

as a result the normTex we bind will be used as specTex, and specTex will be used as emissiveTex.

```
#version 100
precision highp float;
uniform sampler2D diffTex;
uniform sampler2D normTex;
uniform sampler2D specTex;
uniform sampler2D emissiveTex;
varying vec2 diffTexCoord;
uniform vec3 eyePosition;
varying vec3 normal;
varying vec3 position;
uniform vec3 ambientColor;
uniform float opacity;
varying vec3 tangent;
uniform float shininess;

void main(void)
{
vec4 color;
vec3 N = normalize(normal);
vec3 nposition = normalize(position);
vec4 diff = vec4(ambientColor, opacity);
vec3 T = normalize(tangent);
vec3 eyeDir_tan;
vec4 spec = vec4(0.0);
vec3 eyeDir = normalize(eyePosition - nposition);
vec3 bitangent = cross(N, T);
eyeDir_tan.x = dot(T, eyeDir);
eyeDir_tan.y = dot(-bitangent, eyeDir);
eyeDir_tan.z = dot(N, eyeDir);
float NL;
vec3 n = texture2D(normTex, diffTexCoord.st).xyz * 2.0 - vec3(1.0);
float l;
vec3 V = normalize(eyeDir_tan);
vec3 H;
float NH;
color = texture2D(diffTex, diffTexCoord.st);
gl_FragColor = color * diff + texture2D(specTex, diffTexCoord.st) * spec;
gl_FragColor += texture2D(emissiveTex, diffTexCoord.st);
}
```