### PR TITLE
Fixes/improvements to array_view

### DIFF
--- a/src/celengine/modelgeometry.cpp
+++ b/src/celengine/modelgeometry.cpp
@@ -153,7 +153,7 @@ ModelGeometry::render(RenderContext& rc, double /* t */)
 
             m_glData->vbos.emplace_back(
                 gl::Buffer::TargetHint::Array,
-                util::array_view<const void>(
+                util::array_view<void>(
                     mesh->getVertexData(),
                     mesh->getVertexCount() * vertexDesc.strideBytes));
 

--- a/src/celengine/universe.cpp
+++ b/src/celengine/universe.cpp
@@ -1006,7 +1006,7 @@ Universe::findObjectInContext(const Selection& sel,
 //      to us to search.
 Selection
 Universe::find(std::string_view s,
-               util::array_view<const Selection> contexts,
+               util::array_view<Selection> contexts,
                bool i18n) const
 {
     if (starCatalog != nullptr)
@@ -1047,7 +1047,7 @@ Universe::find(std::string_view s,
 // in which the user is currently located.
 Selection
 Universe::findPath(std::string_view s,
-                   util::array_view<const Selection> contexts,
+                   util::array_view<Selection> contexts,
                    bool i18n) const
 {
     std::string_view::size_type pos = s.find('/', 0);
@@ -1080,7 +1080,7 @@ Universe::findPath(std::string_view s,
 void
 Universe::getCompletion(std::vector<celestia::engine::Completion>& completion,
                         std::string_view s,
-                        util::array_view<const Selection> contexts,
+                        util::array_view<Selection> contexts,
                         bool withLocations) const
 {
     // Solar bodies first:
@@ -1112,7 +1112,7 @@ Universe::getCompletion(std::vector<celestia::engine::Completion>& completion,
 void
 Universe::getCompletionPath(std::vector<celestia::engine::Completion>& completion,
                             std::string_view s,
-                            util::array_view<const Selection> contexts,
+                            util::array_view<Selection> contexts,
                             bool withLocations) const
 {
     std::string_view::size_type pos = s.rfind('/', s.length());

--- a/src/celengine/universe.h
+++ b/src/celengine/universe.h
@@ -58,12 +58,12 @@ public:
 
 
     Selection findPath(std::string_view s,
-                       celestia::util::array_view<const Selection> contexts,
+                       celestia::util::array_view<Selection> contexts,
                        bool i18n = false) const;
 
     void getCompletionPath(std::vector<celestia::engine::Completion>& completion,
                            std::string_view s,
-                           celestia::util::array_view<const Selection> contexts,
+                           celestia::util::array_view<Selection> contexts,
                            bool withLocations = false) const;
 
 
@@ -89,11 +89,11 @@ public:
 private:
     void getCompletion(std::vector<celestia::engine::Completion>& completion,
                        std::string_view s,
-                       celestia::util::array_view<const Selection> contexts,
+                       celestia::util::array_view<Selection> contexts,
                        bool withLocations = false) const;
 
     Selection find(std::string_view s,
-                   celestia::util::array_view<const Selection> contexts,
+                   celestia::util::array_view<Selection> contexts,
                    bool i18n = false) const;
     Selection findChildObject(const Selection& sel,
                               std::string_view name,

--- a/src/celrender/gl/buffer.cpp
+++ b/src/celrender/gl/buffer.cpp
@@ -25,7 +25,7 @@ Buffer::Buffer(Buffer::TargetHint targetHint) :
     glGenBuffers(1, &m_id);
 }
 
-Buffer::Buffer(Buffer::TargetHint targetHint, util::array_view<const void> data, Buffer::BufferUsage usage) :
+Buffer::Buffer(Buffer::TargetHint targetHint, util::array_view<void> data, Buffer::BufferUsage usage) :
     Buffer(targetHint)
 {
     Binder::get().bind(*this);
@@ -100,7 +100,7 @@ Buffer::unbind(Buffer::TargetHint target)
 }
 
 Buffer&
-Buffer::setData(util::array_view<const void> data, Buffer::BufferUsage usage)
+Buffer::setData(util::array_view<void> data, Buffer::BufferUsage usage)
 {
     m_bufferSize = data.size();
     m_usage = usage;
@@ -110,7 +110,7 @@ Buffer::setData(util::array_view<const void> data, Buffer::BufferUsage usage)
 }
 
 Buffer&
-Buffer::setSubData(GLintptr offset, util::array_view<const void> data)
+Buffer::setSubData(GLintptr offset, util::array_view<void> data)
 {
     glBufferSubData(GLenum(m_targetHint), offset, data.size(), data.data());
     return *this;
@@ -120,7 +120,7 @@ Buffer::setSubData(GLintptr offset, util::array_view<const void> data)
 Buffer&
 Buffer::invalidateData()
 {
-    return setData(util::array_view<const void>(nullptr, m_bufferSize), m_usage);
+    return setData(util::array_view<void>(nullptr, m_bufferSize), m_usage);
 }
 
 Buffer&

--- a/src/celrender/gl/buffer.h
+++ b/src/celrender/gl/buffer.h
@@ -86,9 +86,9 @@ public:
      *
      * @see @ref TargetHint @ref BufferUsage
      */
-    Buffer(TargetHint                   targetHint,
-           util::array_view<const void> data,
-           BufferUsage                  usage = BufferUsage::StaticDraw);
+    Buffer(TargetHint             targetHint,
+           util::array_view<void> data,
+           BufferUsage            usage = BufferUsage::StaticDraw);
 
     //! Copying is prohibited.
     Buffer(const Buffer &) = delete;
@@ -121,7 +121,7 @@ public:
      * @param usage Buffer usage policy. @see @ref BufferUsage
      * @return Reference to self.
      */
-    Buffer& setData(util::array_view<const void> data, BufferUsage usage = BufferUsage::StaticDraw);
+    Buffer& setData(util::array_view<void> data, BufferUsage usage = BufferUsage::StaticDraw);
 
     /**
      * @brief Partially update the Buffer.
@@ -130,7 +130,7 @@ public:
      * @param data Data.
      * @return Reference to self.
      */
-    Buffer& setSubData(GLintptr offset, util::array_view<const void> data);
+    Buffer& setSubData(GLintptr offset, util::array_view<void> data);
 
     //! Invalidate buffer data.
     Buffer& invalidateData();
@@ -158,13 +158,13 @@ private:
 
     //! Buffer Id (OpenGL name)
     GLuint m_id{ 0 };
-    
+
     //! Buffer target hint, @see @ref TargetHint
     TargetHint m_targetHint{ TargetHint::Array };
     //! Buffer usage hint, @see @ref BufferUsage
-    
+
     BufferUsage m_usage{ BufferUsage::StaticDraw };
-    
+
     //! Wrapped objects are managed externally
     bool m_wrapped{ false };
 

--- a/src/celutil/array_view.h
+++ b/src/celutil/array_view.h
@@ -14,7 +14,7 @@
 #include <array>
 #include <cstddef> // std::size_t
 #include <vector>
-#include <type_traits> // std::remove_cv
+#include <type_traits>
 
 namespace celestia::util
 {
@@ -32,15 +32,14 @@ public:
     /**
      * Create an empty array view.
      */
-    constexpr array_view() noexcept :
-        m_ptr(nullptr),
-        m_size(0)
-    {}
+    constexpr array_view() noexcept = default;
 
     /**
      * Wrap a pointer and length
      */
-    constexpr array_view(const T* ptr, size_type size) noexcept :
+    template<typename U,
+             std::enable_if_t<std::is_convertible_v<U(*)[], const element_type(*)[]>, int> = 0>
+    constexpr array_view(const U* ptr, size_type size) noexcept :
         m_ptr(ptr),
         m_size(size)
     {}
@@ -48,7 +47,9 @@ public:
     /**
      * Wrap a C-style array.
      */
-    template<std::size_t N> constexpr array_view(const T (&ary)[N]) noexcept :
+    template<typename U, std::size_t N,
+             std::enable_if_t<std::is_convertible_v<U(*)[], const element_type(*)[]>, int> = 0>
+    constexpr array_view(const U (&ary)[N]) noexcept : //NOSONAR
         m_ptr(ary),
         m_size(N)
     {}
@@ -57,28 +58,38 @@ public:
      * Wrap a std::array or std::vector or other classes which have the same
      * memory layout and interface.
      */
-    template<std::size_t N> constexpr array_view(const std::array<element_type, N> &ary) noexcept :
+    template<typename U, std::size_t N,
+             std::enable_if_t<std::is_convertible_v<U(*)[], const element_type(*)[]>, int> = 0>
+    constexpr array_view(const std::array<U, N> &ary) noexcept : //NOSONAR
         m_ptr(ary.data()),
         m_size(N)
     {}
 
     /** @copydoc array_view::array_view((const std::array<T, N> &ary) */
-    template<std::size_t N> constexpr array_view(std::array<element_type, N> &&ary) noexcept :
-        m_ptr(ary.data()),
-        m_size(N)
-    {}
-
-    /** @copydoc array_view::array_view((const std::array<T, N> &ary) */
-    constexpr array_view(const std::vector<element_type> &vec) noexcept :
+    template<typename U,
+             std::enable_if_t<std::is_convertible_v<U(*)[], const element_type(*)[]>, int> = 0>
+    constexpr array_view(const std::vector<U> &vec) noexcept : //NOSONAR
         m_ptr(vec.data()),
         m_size(vec.size())
     {}
 
-    /** @copydoc array_view::array_view((const std::array<T, N> &ary) */
-    constexpr array_view(std::vector<element_type> &&vec) noexcept :
-        m_ptr(vec.data()),
-        m_size(vec.size())
-    {}
+    /**
+     * Copy another view.
+     */
+    constexpr array_view(const array_view&) = default;
+
+    /**
+     * Copy another view of compatible type
+     */
+    template<typename U,
+             std::enable_if_t<!std::is_same_v<std::remove_cv_t<U>, void> &&
+                              !std::is_same_v<std::remove_cv_t<U>, element_type> &&
+                              std::is_convertible_v<std::remove_cv_t<U>(*)[], const element_type(*)[]>, int> = 0>
+    constexpr array_view(const array_view<U>& other) noexcept : //NOSONAR
+        m_ptr(other.m_ptr),
+        m_size(other.m_size)
+    {
+    }
 
     /**
      * Direct access to the underlying array.
@@ -172,8 +183,8 @@ public:
     }
 
 private:
-    const element_type* m_ptr;
-    size_type m_size;
+    const element_type* m_ptr{ nullptr };
+    size_type m_size{ 0 };
 };
 
 /**
@@ -189,10 +200,7 @@ public:
     /**
      * Create an empty array view.
      */
-    constexpr array_view() noexcept :
-        m_ptr(nullptr),
-        m_size(0)
-    {}
+    constexpr array_view() noexcept = default;
 
     /**
      * Wrap a pointer and length
@@ -205,7 +213,8 @@ public:
     /**
      * Wrap a C-style array.
      */
-    template<typename T, std::size_t N> constexpr array_view(const T (&ary)[N]) noexcept :
+    template<typename T, std::size_t N>
+    constexpr array_view(const T (&ary)[N]) noexcept : //NOSONAR
         m_ptr(ary),
         m_size(N * sizeof(T))
     {}
@@ -214,25 +223,15 @@ public:
      * Wrap a std::array or std::vector or other classes which have the same
      * memory layout and interface.
      */
-    template<typename T, std::size_t N> constexpr array_view(const std::array<T, N> &ary) noexcept :
+    template<typename T, std::size_t N>
+    constexpr array_view(const std::array<T, N> &ary) noexcept : //NOSONAR
         m_ptr(ary.data()),
         m_size(N * sizeof(T))
     {}
 
     /** @copydoc array_view::array_view((const std::array<T, N> &ary) */
-    template<typename T, std::size_t N> constexpr array_view(std::array<T, N> &&ary) noexcept :
-        m_ptr(ary.data()),
-        m_size(N * sizeof(T))
-    {}
-
-    /** @copydoc array_view::array_view((const std::array<T, N> &ary) */
-    template<typename T> constexpr array_view(const std::vector<T> &vec) noexcept :
-        m_ptr(vec.data()),
-        m_size(vec.size() * sizeof(T))
-    {}
-
-    /** @copydoc array_view::array_view((const std::array<T, N> &ary) */
-    template<typename T> constexpr array_view(std::vector<T> &&vec) noexcept :
+    template<typename T>
+    constexpr array_view(const std::vector<T> &vec) noexcept : //NOSONAR
         m_ptr(vec.data()),
         m_size(vec.size() * sizeof(T))
     {}
@@ -240,13 +239,14 @@ public:
     /**
      * Copy another view.
      */
-    template<typename T> constexpr array_view(const array_view<T> &ary) :
-        m_ptr(ary.data()),
-        m_size(ary.size())
-    {}
+    constexpr array_view(const array_view&) = default;
 
-    /** @copydoc array_view::array_view(const array_view<T> &ary) */
-    template<typename T> constexpr array_view(array_view<T> &&ary) :
+    /**
+     * Copy another view of concrete type.
+     */
+    template<typename T,
+             std::enable_if_t<!std::is_same_v<std::remove_cv_t<T>, void>, int> = 0>
+    constexpr array_view(const array_view<T> &ary) : //NOSONAR
         m_ptr(ary.data()),
         m_size(ary.size() * sizeof(T))
     {}
@@ -254,15 +254,14 @@ public:
     /**
      * Assign another view.
      */
-    template<typename T> constexpr array_view& operator=(const array_view<T> &ary)
-    {
-        m_ptr = ary.data();
-        m_size = ary.size() * sizeof(T);
-        return *this;
-    }
+    constexpr array_view& operator=(const array_view&) = default;
 
-    /** @copydoc array_view::operator=(const array_view<T> &ary) */
-    template<typename T> constexpr array_view& operator=(array_view<T> &&ary) noexcept
+    /**
+     * Assign from another view of concrete type.
+     */
+    template<typename T,
+             std::enable_if_t<!std::is_same_v<std::remove_cv_t<T>, void>, int> = 0>
+    constexpr array_view& operator=(const array_view<T> &ary)
     {
         m_ptr = ary.data();
         m_size = ary.size() * sizeof(T);
@@ -294,130 +293,20 @@ public:
     }
 
 private:
-    const element_type* m_ptr;
-    size_type m_size;
+    const element_type* m_ptr{ nullptr };
+    size_type m_size{ 0 };
 };
 
-/**
- * Specialization for API accepting opaque blobs of data.
- */
-template <>
-class array_view<const void>
-{
-public:
-    using element_type = const void;
-    using size_type = std::size_t;
+template<typename T>
+array_view(const T*, std::size_t) -> array_view<std::remove_cv_t<T>>;
 
-    /**
-     * Create an empty array view.
-     */
-    constexpr array_view() noexcept :
-        m_ptr(nullptr),
-        m_size(0)
-    {}
+template<typename T, std::size_t N>
+array_view(const T (&)[N]) -> array_view<std::remove_cv_t<T>>;
 
-    /**
-     * Wrap a pointer and length
-     */
-    constexpr array_view(const void* ptr, size_type size) noexcept :
-        m_ptr(ptr),
-        m_size(size)
-    {}
+template<typename T, std::size_t N>
+array_view(const std::array<T, N> &) -> array_view<std::remove_cv_t<T>>;
 
-    /**
-     * Wrap a C-style array.
-     */
-    template<typename T, std::size_t N> constexpr array_view(const T (&ary)[N]) noexcept :
-        m_ptr(ary),
-        m_size(N * sizeof(T))
-    {}
-
-    /**
-     * Wrap a std::array or std::vector or other classes which have the same
-     * memory layout and interface.
-     */
-    template<typename T, std::size_t N> constexpr array_view(const std::array<T, N> &ary) noexcept :
-        m_ptr(ary.data()),
-        m_size(N * sizeof(T))
-    {}
-
-    /** @copydoc array_view::array_view((const std::array<T, N> &ary) */
-    template<typename T, std::size_t N> constexpr array_view(std::array<T, N> &&ary) noexcept :
-        m_ptr(ary.data()),
-        m_size(N * sizeof(T))
-    {}
-
-    /** @copydoc array_view::array_view((const std::array<T, N> &ary) */
-    template<typename T> constexpr array_view(const std::vector<T> &vec) noexcept :
-        m_ptr(vec.data()),
-        m_size(vec.size() * sizeof(T))
-    {}
-
-    /** @copydoc array_view::array_view((const std::array<T, N> &ary) */
-    template<typename T> constexpr array_view(std::vector<T> &&vec) noexcept :
-        m_ptr(vec.data()),
-        m_size(vec.size() * sizeof(T))
-    {}
-
-    /**
-     * Copy another view.
-     */
-    template<typename T> constexpr array_view(const array_view<T> &ary) :
-        m_ptr(ary.data()),
-        m_size(ary.size())
-    {}
-
-    /** @copydoc array_view::array_view(const array_view<T> &ary) */
-    template<typename T> constexpr array_view(array_view<T> &&ary) :
-        m_ptr(ary.data()),
-        m_size(ary.size() * sizeof(T))
-    {}
-
-    /**
-     * Assign another view.
-     */
-    template<typename T> constexpr array_view& operator=(const array_view<T> &ary)
-    {
-        m_ptr = ary.data();
-        m_size = ary.size() * sizeof(T);
-        return *this;
-    }
-
-    /** @copydoc array_view::operator=(const array_view<T> &ary) */
-    template<typename T> constexpr array_view& operator=(array_view<T> &&ary) noexcept
-    {
-        m_ptr = ary.data();
-        m_size = ary.size() * sizeof(T);
-        return *this;
-    }
-
-    /**
-     * Direct access to the underlying array.
-     */
-    constexpr const element_type* data() const noexcept
-    {
-        return m_ptr;
-    }
-
-    /**
-     * Return the number of elements.
-     */
-    constexpr size_type size() const noexcept
-    {
-        return m_size;
-    }
-
-    /**
-     * Check whether the view is empty.
-     */
-    constexpr bool empty() const noexcept
-    {
-        return m_size == 0;
-    }
-
-private:
-    const element_type* m_ptr;
-    size_type m_size;
-};
+template<typename T>
+array_view(const std::vector<T> &) -> array_view<std::remove_cv_t<T>>;
 
 } // end namespace celestia::util

--- a/test/unit/array_view_test.cpp
+++ b/test/unit/array_view_test.cpp
@@ -8,7 +8,7 @@ TEST_SUITE_BEGIN("array_view");
 TEST_CASE("array_view")
 {
     std::array<int,4> a = {1,2,3,4};
-    util::array_view<const void> v(a);
+    util::array_view<void> v(a);
 
     REQUIRE(a.size() * sizeof(a[0]) == v.size());
     REQUIRE(a.data() == v.data());


### PR DESCRIPTION
- Allow creating array_views from compatible types, e.g. const T* from T*
- Remove constructors from rvalue collections - if collection goes out of scope, view is invalid
- Remove const void specialization - array_view is always to const
- Remove usages of array_view<const T> in codebase

Compatibility check is based on the check for C++20 `std::span` described on the [constructors page at cppreference](https://en.cppreference.com/w/cpp/container/span/span.html#Conversion_requirements).