### PR TITLE
Set underlying type of BufferUsage and TargetHint to GLenum

### DIFF
--- a/src/celrender/gl/buffer.h
+++ b/src/celrender/gl/buffer.h
@@ -32,7 +32,7 @@ public:
      * Provides information how frequently buffer object is used.
      * @see @ref setData().
      */
-    enum class BufferUsage
+    enum class BufferUsage : GLenum
     {
         //! Set data once and use frequently.
         StaticDraw  = GL_STATIC_DRAW,
@@ -49,7 +49,7 @@ public:
      *
      * @see @ref Buffer(TargetHint)
      */
-    enum class TargetHint
+    enum class TargetHint : GLenum
     {
         //! Store vertex attributes.
         Array        = GL_ARRAY_BUFFER,


### PR DESCRIPTION
Since these end up being cast to `GLenum` to pass to the OpenGL functions, might as well match the underlying type.