### PR TITLE
Make starnames parsing line-ending agnostic

### DIFF
--- a/src/celutil/CMakeLists.txt
+++ b/src/celutil/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CELUTIL_SOURCES
   binaryread.h
   binarywrite.h
   blockarray.h
+  buffile.cpp
+  buffile.h
   bytes.h
   color.cpp
   color.h

--- a/src/celutil/buffile.cpp
+++ b/src/celutil/buffile.cpp
@@ -1,0 +1,101 @@
+// buffile.h
+//
+// Copyright (C) 2025, the Celestia Development Team
+// Original version by Andrew Tribick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "buffile.h"
+
+#include <cstring>
+#include <istream>
+#include <string>
+
+#include "utf8.h"
+
+namespace celestia::util
+{
+
+BufferedFile::BufferedFile(std::istream& in, std::size_t bufferSize) :
+    m_stream(&in),
+    m_buffer(std::make_unique<char[]>(bufferSize)),
+    m_bufferSize(bufferSize)
+{
+    SkipUTF8BOM(*m_stream);
+}
+
+int
+BufferedFile::next()
+{
+    if (m_state == State::Error)
+        return std::char_traits<char>::eof();
+
+    if (m_position >= m_length)
+    {
+        std::size_t unconsumed = m_length - m_consumed;
+        if (unconsumed == m_bufferSize)
+        {
+            // We have an overlong token, set to error state
+            m_state = State::Error;
+            return std::char_traits<char>::eof();
+        }
+
+        if (unconsumed > 0)
+            std::memmove(m_buffer.get(), m_buffer.get() + m_consumed, unconsumed);
+
+        m_stream->read(m_buffer.get() + unconsumed, m_bufferSize - unconsumed); /* Flawfinder: ignore */
+        if (m_stream->bad())
+        {
+            m_state = State::Error;
+            return std::char_traits<char>::eof();
+        }
+
+        m_length = unconsumed + static_cast<std::size_t>(m_stream->gcount());
+        m_position = unconsumed;
+        m_consumed = 0;
+
+        if (m_position >= m_length)
+            return std::char_traits<char>::eof();
+    }
+
+    auto ch = m_buffer[m_position];
+    if (ch == '\n')
+    {
+        if (m_state != State::CR)
+            ++m_lineNumber;
+        m_state = State::LF;
+    }
+    else if (ch == '\r')
+    {
+        if (m_state != State::LF)
+            ++m_lineNumber;
+        m_state = State::CR;
+    }
+    else
+    {
+        m_state = State::Normal;
+    }
+
+    return std::char_traits<char>::to_int_type(ch);
+}
+
+void
+BufferedFile::advance(bool consume) noexcept
+{
+    ++m_position;
+    if (consume)
+        m_consumed = m_position;
+}
+
+std::string_view
+BufferedFile::value() const
+{
+    return m_position > m_consumed
+        ? std::string_view(m_buffer.get() + m_consumed, m_position - m_consumed)
+        : std::string_view{};
+}
+
+} // end namespace celestia::util

--- a/src/celutil/buffile.h
+++ b/src/celutil/buffile.h
@@ -1,0 +1,53 @@
+// buffile.h
+//
+// Copyright (C) 2025, the Celestia Development Team
+// Original version by Andrew Tribick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <cstddef>
+#include <cstdint>
+#include <iosfwd>
+#include <memory>
+#include <string_view>
+
+namespace celestia::util
+{
+
+class BufferedFile
+{
+public:
+    explicit BufferedFile(std::istream& in, std::size_t bufferSize = 4096);
+
+    int next();
+    void advance(bool consume) noexcept;
+
+    bool error() const noexcept { return m_state == State::Error; }
+    std::uint64_t lineNumber() const noexcept { return m_lineNumber; }
+    bool has_value() const noexcept { return m_position > m_consumed; }
+
+    std::string_view value() const;
+
+private:
+    enum class State
+    {
+        Normal,
+        LF,
+        CR,
+        Error,
+    };
+
+    std::istream* m_stream;
+    std::unique_ptr<char[]> m_buffer; //NOSONAR
+    std::size_t m_bufferSize;
+    std::size_t m_length{ 0 };
+    std::size_t m_position{ 0 };
+    std::size_t m_consumed{ 0 };
+    std::uint64_t m_lineNumber{ 1 };
+    State m_state{ State::Normal };
+};
+
+} // end namespace celestia::util

--- a/src/celutil/utf8.cpp
+++ b/src/celutil/utf8.cpp
@@ -12,7 +12,9 @@
 
 #include <cassert>
 #include <cwctype>
+#include <istream>
 
+using namespace std::string_view_literals;
 
 namespace
 {
@@ -462,6 +464,26 @@ bool UTF8StartsWith(std::string_view str, std::string_view prefix, bool ignoreCa
         if (ch0 != ch1)
             return false;
     }
+}
+
+std::istream&
+SkipUTF8BOM(std::istream& in)
+{
+    constexpr std::string_view bom = "\357\273\277"sv;
+
+    auto pos = in.tellg();
+    std::array<char, bom.size()> data;
+    in.read(data.data(), bom.size()); /* Flawfinder: ignore */
+    if (in.bad())
+        return in;
+
+    if (in.gcount() == bom.size() &&
+        std::string_view(data.data(), data.size()) == bom)
+    {
+        return in;
+    }
+
+    return in.seekg(pos);
 }
 
 std::int32_t

--- a/src/celutil/utf8.h
+++ b/src/celutil/utf8.h
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <cstdint>
+#include <iosfwd>
 #include <string>
 #include <string_view>
 
@@ -22,6 +23,8 @@ bool UTF8Decode(std::string_view str, std::int32_t &pos, std::int32_t &ch);
 void UTF8Encode(std::uint32_t ch, std::string &dest);
 int  UTF8StringCompare(std::string_view s0, std::string_view s1);
 bool UTF8StartsWith(std::string_view str, std::string_view prefix, bool ignoreCase = false);
+
+std::istream& SkipUTF8BOM(std::istream&);
 
 class UTF8StringOrderingPredicate
 {


### PR DESCRIPTION
- Add buffered file handler
- Handle both CR and LF in starnames loader
- Allow UTF-8 BOM in starnames.dat

The buffered file reader will be useful for simplifying the tokenizer implementation, but I don't have time to do that right now. Something for the next PR.