### PR TITLE
[ci] Update vcpkg for libpng 1.6.53

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Update vcpkg
       shell: pwsh
       run: |
-        $vcpkgCommit = 'c50ed424775a4227d3e8a784d0ce5cccfe19caa4'
+        $vcpkgCommit = '5dfa11cf88a8da8877b54fcbc5f6db78bc13f75a'
         pushd "$env:VCPKG_INSTALLATION_ROOT"
         git fetch origin $vcpkgCommit
         git reset --hard $vcpkgCommit


### PR DESCRIPTION
Pick up fix for [CVE-2025-66293](https://www.cve.org/CVERecord?id=CVE-2025-66293) in libpng.