### PR TITLE
curveplot: remove static vertex buffer

### DIFF
--- a/src/celengine/curveplot.h
+++ b/src/celengine/curveplot.h
@@ -30,6 +30,8 @@
 #pragma once
 
 #include <deque>
+#include <memory>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -38,6 +40,25 @@
 
 class Color;
 class Renderer;
+
+class CurvePlotVertexBuffer
+{
+public:
+    explicit CurvePlotVertexBuffer(const Renderer& _renderer);
+
+    void setup(const Color& _color);
+    void finish();
+    void vertex(const Eigen::Vector4d& v, float opacity = 1.0f);
+    void end();
+    void flush();
+
+private:
+    unsigned int currentStripLength { 0 };
+    std::vector<unsigned int> stripLengths;
+    std::unique_ptr<celestia::render::LineRenderer> lr;
+    const Renderer *renderer { nullptr };
+    Color color;
+};
 
 class CurvePlotSample
 {
@@ -48,11 +69,10 @@ public:
     double boundingRadius { 0.0 };
 };
 
-
 class CurvePlot
 {
- public:
-    explicit CurvePlot(const Renderer &renderer);
+public:
+    explicit CurvePlot(CurvePlotVertexBuffer& vbuf);
 
     double duration() const { return m_duration; }
     void setDuration(double duration);
@@ -103,12 +123,9 @@ class CurvePlot
 
     unsigned int sampleCount() const { return static_cast<unsigned int>(m_samples.size()); }
 
-    static void deinit();
-
- private:
+private:
     std::deque<CurvePlotSample>     m_samples;
-    const Renderer                 &m_renderer;
+    CurvePlotVertexBuffer          &m_vbuf;
     double                          m_duration      { 0.0 };
     unsigned int                    m_lastUsed      { 0   };
 };
-

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -207,6 +207,7 @@ Renderer::Renderer() :
 #endif
     pointStarVertexBuffer(std::make_unique<PointStarVertexBuffer>(*this, 2048)),
     glareVertexBuffer(std::make_unique<PointStarVertexBuffer>(*this, 2048)),
+    curvePlotVertexBuffer(std::make_unique<CurvePlotVertexBuffer>(*this)),
     m_atmosphereRenderer(std::make_unique<AtmosphereRenderer>(*this)),
     m_cometRenderer(std::make_unique<CometRenderer>(*this)),
     m_eclipticLineRenderer(std::make_unique<EclipticLineRenderer>(*this)),
@@ -222,11 +223,7 @@ Renderer::Renderer() :
 {
 }
 
-
-Renderer::~Renderer()
-{
-    CurvePlot::deinit();
-}
+Renderer::~Renderer() = default;
 
 #if 0
 // Not used yet.
@@ -1006,7 +1003,7 @@ void Renderer::renderOrbit(const OrbitPathListEntry& orbitPath,
                 startTime = begin;
         }
 
-        cachedOrbit = orbitCache.emplace_hint(cached, orbit, std::make_unique<CurvePlot>(*this))->second.get();
+        cachedOrbit = orbitCache.emplace_hint(cached, orbit, std::make_unique<CurvePlot>(*curvePlotVertexBuffer))->second.get();
         cachedOrbit->setLastUsed(frameCount);
 
         OrbitSampler sampler;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -39,6 +39,7 @@ class FrameTree;
 class LODSphereMesh;
 class ReferenceMark;
 class CurvePlot;
+class CurvePlotVertexBuffer;
 class PointStarVertexBuffer;
 class Observer;
 class Surface;
@@ -659,6 +660,7 @@ class Renderer
     std::array<int, 4> m_viewport { 0, 0, 0, 0 };
 
     using OrbitCache = std::map<const celestia::ephem::Orbit*, std::unique_ptr<CurvePlot>>;
+    std::unique_ptr<CurvePlotVertexBuffer> curvePlotVertexBuffer;
     OrbitCache orbitCache;
     std::uint32_t lastOrbitCacheFlush{ 0 };
 


### PR DESCRIPTION
Store the vertex buffer in the Renderer to constrain lifetime