### PR TITLE
Set Boost minimum version to 1.67 (for container_hash library)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,8 @@ endif()
 
 find_package(gperf REQUIRED)
 
-find_package(Boost REQUIRED)
+# We need Boost 1.67 for the boost/container_hash/hash.hpp header
+find_package(Boost 1.67 REQUIRED)
 link_libraries(Boost::boost)
 add_definitions(-DBOOST_NO_EXCEPTIONS)
 


### PR DESCRIPTION
Pre-Boost 1.67 (released April 2018), the hash functions were located in Boost functional. To avoid introducing complexity by trying to support this, set a minimum version in the CMakeLists.txt

For reference, Debian 11 supplies Boost 1.74, so this should hopefully not be too onerous a restriction.

See also discussion in #2424