### PR TITLE
Texture class updates

### DIFF
--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -292,11 +292,6 @@ VirtualTexture::loadTileTexture(unsigned int lod, unsigned int u, unsigned int v
     if (isPow2(img->getWidth()) && isPow2(img->getHeight()))
         tex = std::make_unique<ImageTexture>(*img, EdgeClamp, mipMapMode);
 
-    // TODO: Virtual textures can have tiles in different formats, some
-    // compressed and some not. The compression flag doesn't make much
-    // sense for them.
-    compressed = img->isCompressed();
-
     return tex;
 }
 

--- a/src/celimage/image.h
+++ b/src/celimage/image.h
@@ -33,11 +33,6 @@ public:
     static constexpr std::int32_t MAX_DIMENSION = INT32_C(16384);
 
     Image(PixelFormat format, std::int32_t w, std::int32_t h, std::int32_t mip = 1);
-    ~Image() = default;
-    Image(Image&&) = default;
-    Image(const Image&) = delete;
-    Image& operator=(Image&&) = default;
-    Image& operator=(const Image&) = delete;
 
     bool isValid() const noexcept;
     std::int32_t getWidth() const;

--- a/src/celrender/galaxyrenderer.cpp
+++ b/src/celrender/galaxyrenderer.cpp
@@ -34,14 +34,14 @@ constexpr int kGalaxyTextureSize = 128;
 constexpr float kSpriteScaleFactor = 1.0f / 1.55f;
 
 void
-galaxyTextureEval(float u, float v, float /*w*/, std::uint8_t *pixel)
+galaxyTextureEval(float u, float v, std::uint8_t *pixel)
 {
     float r = std::max(0.0f, 0.9f - std::hypot(u, v));
     *pixel = static_cast<std::uint8_t>(r * 255.99f);
 }
 
 void
-colorTextureEval(float u, float /*v*/, float /*w*/, std::uint8_t *pixel)
+colorTextureEval(float u, float /*v*/, std::uint8_t *pixel)
 {
     auto i = static_cast<int>((u * 0.5f + 0.5f) * 255.99f); // [-1, 1] -> [0, 255]
 
@@ -171,10 +171,10 @@ GalaxyRenderer::bindTextures()
 {
     if (m_galaxyTex == nullptr)
     {
-        m_galaxyTex = CreateProceduralTexture(kGalaxyTextureSize,
-                                              kGalaxyTextureSize,
-                                              engine::PixelFormat::Luminance,
-                                              &galaxyTextureEval);
+        m_galaxyTex = ImageTexture::createProcedural(kGalaxyTextureSize,
+                                                     kGalaxyTextureSize,
+                                                     engine::PixelFormat::Luminance,
+                                                     &galaxyTextureEval);
     }
 
     assert(m_galaxyTex != nullptr);
@@ -183,10 +183,10 @@ GalaxyRenderer::bindTextures()
 
     if (m_colorTex == nullptr)
     {
-        m_colorTex = CreateProceduralTexture(256, 1, engine::PixelFormat::RGBA,
-                                             &colorTextureEval,
-                                             Texture::EdgeClamp,
-                                             Texture::NoMipMaps);
+        m_colorTex = ImageTexture::createProcedural(256, 1, engine::PixelFormat::RGBA,
+                                                    &colorTextureEval,
+                                                    Texture::EdgeClamp,
+                                                    Texture::NoMipMaps);
     }
 
     assert(m_colorTex != nullptr);

--- a/src/celrender/globularrenderer.cpp
+++ b/src/celrender/globularrenderer.cpp
@@ -101,7 +101,7 @@ relStarDensity(float eta)
 }
 
 void
-centerCloudTexEval(float u, float v, float /*w*/, std::uint8_t *pixel)
+centerCloudTexEval(float u, float v, std::uint8_t *pixel)
 {
     /*! For reasons of speed, calculate central "cloud" texture only for
      *  8 bins of King_1962 concentration, c = CBin, XI(CBin), RRatio(CBin).
@@ -129,7 +129,7 @@ centerCloudTexEval(float u, float v, float /*w*/, std::uint8_t *pixel)
 }
 
 void
-colorTextureEval(float u, float /*v*/, float /*w*/, std::uint8_t *pixel)
+colorTextureEval(float u, float /*v*/, std::uint8_t *pixel)
 {
     auto i = static_cast<int>((u * 0.5f + 0.5f) * 255.99f); // [-1, 1] -> [0, 255]
 
@@ -348,7 +348,7 @@ buildGlobularForm(GlobularForm& globularForm, float c)
 }
 
 void
-globularTextureEval(float u, float v, float /*w*/, std::uint8_t *pixel)
+globularTextureEval(float u, float v, std::uint8_t *pixel)
 {
     // use an exponential luminosity shape for the individual stars
     // giving sort of a halo for the brighter (i.e.bigger) stars.
@@ -435,9 +435,9 @@ GlobularRenderer::FormManager::getCenterTex(int form)
 {
     if (centerTex[form] == nullptr)
     {
-        centerTex[form] = CreateProceduralTexture(cntrTexWidth, cntrTexHeight,
-                                                  engine::PixelFormat::Luminance,
-                                                  centerCloudTexEval);
+        centerTex[form] = ImageTexture::createProcedural(cntrTexWidth, cntrTexHeight,
+                                                         engine::PixelFormat::Luminance,
+                                                         &centerCloudTexEval);
     }
 
     assert(centerTex[form] != nullptr);
@@ -449,9 +449,9 @@ GlobularRenderer::FormManager::getGlobularTex()
 {
     if (globularTex == nullptr)
     {
-        globularTex = CreateProceduralTexture(starTexWidth, starTexHeight,
-                                              engine::PixelFormat::Luminance,
-                                              globularTextureEval);
+        globularTex = ImageTexture::createProcedural(starTexWidth, starTexHeight,
+                                                     engine::PixelFormat::Luminance,
+                                                     &globularTextureEval);
     }
     assert(globularTex != nullptr);
     return globularTex.get();
@@ -462,10 +462,10 @@ GlobularRenderer::FormManager::getColorTex()
 {
     if (colorTex == nullptr)
     {
-        colorTex = CreateProceduralTexture(256, 1, engine::PixelFormat::RGBA,
-                                           colorTextureEval,
-                                           Texture::EdgeClamp,
-                                           Texture::NoMipMaps);
+        colorTex = ImageTexture::createProcedural(256, 1, engine::PixelFormat::RGBA,
+                                                  &colorTextureEval,
+                                                  Texture::EdgeClamp,
+                                                  Texture::NoMipMaps);
     }
     assert(colorTex != nullptr);
     return colorTex.get();


### PR DESCRIPTION
- Enforce no-copy on Texture base class
- Templatize procedural creation functions, remove functor class
- Remove unused w parameter from 2D procedural texture functions
- Use smart pointer for TiledTexture handles array
- Use single call to initialize/destroy multiple GL handles
- Additional checks for cubemap faces