### PR TITLE
Fix undefined behavior in star color lookup at huge temperatures

### DIFF
--- a/src/celengine/starcolors.h
+++ b/src/celengine/starcolors.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <vector>
@@ -35,11 +36,13 @@ class ColorTemperatureTable
 
     Color lookupColor(float temp) const
     {
-        auto colorTableIndex = static_cast<std::size_t>(std::nearbyint(temp * tempScale));
-        if (colorTableIndex >= colors.size())
+        assert(temp >= 0.0f);
+        
+        float colorTableIndex = std::nearbyint(temp * tempScale);
+        if (colorTableIndex >= static_cast<float>(colors.size()))
             return colors.back();
-        else
-            return colors[colorTableIndex];
+
+        return colors[static_cast<std::size_t>(colorTableIndex)];
     }
 
     Color lookupTintColor(float temp, float saturation, float fadeFactor) const


### PR DESCRIPTION
Some people like putting absurdly huge star temperatures in their add-ons, which can result in an out-of-range value when casting to `std::size_t`