### PR TITLE
CMake: Set CMake to 3.10...3.19 range for !WIN32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ if(WIN32)
   # Require more recent CMake on Windows because DLLs are a pain
   cmake_minimum_required(VERSION 3.19)
 else()
-  cmake_minimum_required(VERSION 3.9)
+  cmake_minimum_required(VERSION 3.10...3.19)
 endif()
 
 # Plain and keyword target_link_libraries() signatures cannot be mixed


### PR DESCRIPTION
Raise !WIN32 minimum mildly from 3.9 to 3.10, which was released in 2017. If Windows build can deal with 3.19, so should others. This enables policy level up to 3.19 when using modern versions of CMake.

Fixes CMake 3.31 warning:

> CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
>   Compatibility with CMake < 3.10 will be removed from a future version of
>   CMake.
>
>   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
>   to tell CMake that the project requires at least <min> but has been updated
>   to work with policies introduced by <max> or earlier.