### PR TITLE
Make open clusters non-pickable

### DIFF
--- a/src/celengine/opencluster.cpp
+++ b/src/celengine/opencluster.cpp
@@ -7,58 +7,50 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <config.h>
-#include "render.h"
 #include "opencluster.h"
-#include "meshmanager.h"
-#include <celmath/mathlib.h>
+
 #include <celutil/gettext.h>
-#include <algorithm>
 
-using namespace Eigen;
-using namespace std;
-
-
-const char* OpenCluster::getType() const
+const char*
+OpenCluster::getType() const
 {
     return "Open cluster";
 }
 
-
-void OpenCluster::setType(const std::string& /*typeStr*/)
+void
+OpenCluster::setType(const std::string& /*typeStr*/)
 {
 }
 
-
-string OpenCluster::getDescription() const
+std::string
+OpenCluster::getDescription() const
 {
     return _("Open cluster");
 }
 
-
-
-DeepSkyObjectType OpenCluster::getObjType() const
+DeepSkyObjectType
+OpenCluster::getObjType() const
 {
     return DeepSkyObjectType::OpenCluster;
 }
 
-
-bool OpenCluster::pick(const Eigen::ParametrizedLine<double, 3>& ray,
-                       double& distanceToPicker,
-                       double& cosAngleToBoundCenter) const
+bool
+OpenCluster::pick(const Eigen::ParametrizedLine<double, 3>& ray,
+                  double& distanceToPicker,
+                  double& cosAngleToBoundCenter) const
 {
-    // The preconditional sphere-ray intersection test is enough for now:
-    return DeepSkyObject::pick(ray, distanceToPicker, cosAngleToBoundCenter);
+    // Open clusters are not rendered, do not pick them
+    return false;
 }
 
-
-RenderFlags OpenCluster::getRenderMask() const
+RenderFlags
+OpenCluster::getRenderMask() const
 {
     return RenderFlags::ShowOpenClusters;
 }
 
-
-RenderLabels OpenCluster::getLabelMask() const
+RenderLabels
+OpenCluster::getLabelMask() const
 {
     return RenderLabels::OpenClusterLabels;
 }

--- a/src/celengine/opencluster.h
+++ b/src/celengine/opencluster.h
@@ -9,9 +9,7 @@
 
 #pragma once
 
-#include <cstdint>
 #include <string>
-#include <string_view>
 
 #include <Eigen/Geometry>
 


### PR DESCRIPTION
There is no rendering for open clusters, so making them pickable just leads to a confusing experience when trying to select visible objects.