### PR TITLE
Detect invalid UTF-8 in binary CMOD filenames

### DIFF
--- a/src/celutil/utf8.cpp
+++ b/src/celutil/utf8.cpp
@@ -555,3 +555,16 @@ UTF8Validator::check(unsigned char c)
         return InvalidStarter;
     }
 }
+
+bool
+UTF8Validator::validate(std::string_view str)
+{
+    UTF8Validator validator;
+    for (char c : str)
+    {
+        if (validator.check(c) < 0)
+            return false;
+    }
+
+    return true;
+}

--- a/src/celutil/utf8.h
+++ b/src/celutil/utf8.h
@@ -46,6 +46,8 @@ public:
     inline std::int32_t check(char c) { return check(static_cast<unsigned char>(c)); }
     inline bool isInitial() const { return state == State::Initial; }
 
+    static bool validate(std::string_view str);
+
     static constexpr std::int32_t PartialSequence = -1;
     static constexpr std::int32_t InvalidStarter = -2;
     static constexpr std::int32_t InvalidTrailing = -3;


### PR DESCRIPTION
- Fix a crash when invalid UTF-8 is present in a binary CMOD file
- Slightly more lenient handling of invalid filenames in CMOD files
- Downgrade some loader log messages to debug status

I believe this addresses the Windows crash reported in #2450 - I am not sure if it also has any impact on the iOS/Android crashes though. Presumably somewhere in the add-on universe there is a binary cmod file containing a filename encoded in a local encoding that does not work as UTF-8.