### PR TITLE
Minor fixes to meshmanager

### DIFF
--- a/src/celengine/meshmanager.cpp
+++ b/src/celengine/meshmanager.cpp
@@ -404,7 +404,7 @@ ModelLoader::getHandle(const std::filesystem::path& filename)
 std::unique_ptr<cmod::Model>
 LoadCMODModel(const GeometryInfo& info, engine::TexturePaths& paths)
 {
-    std::ifstream in(info.path, std::ios::binary);
+    std::ifstream in(info.path, std::ios_base::binary | std::ios_base::in);
     if (!in.good())
         return nullptr;
 
@@ -568,7 +568,7 @@ GeometryPaths::getInfo(GeometryHandle handle, GeometryInfo& info) const
     return true;
 }
 
-GeometryManager::GeometryManager(std::shared_ptr<GeometryPaths> geometryPaths,
+GeometryManager::GeometryManager(std::shared_ptr<const GeometryPaths> geometryPaths,
                                  std::shared_ptr<TexturePaths> texturePaths) :
     m_geometryPaths(geometryPaths),
     m_texturePaths(texturePaths)

--- a/src/celengine/meshmanager.h
+++ b/src/celengine/meshmanager.h
@@ -102,12 +102,12 @@ private:
 class GeometryManager
 {
 public:
-    GeometryManager(std::shared_ptr<GeometryPaths>, std::shared_ptr<TexturePaths>);
+    GeometryManager(std::shared_ptr<const GeometryPaths>, std::shared_ptr<TexturePaths>);
 
     const Geometry* find(GeometryHandle);
 
 private:
-    std::shared_ptr<GeometryPaths> m_geometryPaths;
+    std::shared_ptr<const GeometryPaths> m_geometryPaths;
     std::shared_ptr<TexturePaths> m_texturePaths;
     std::unordered_map<GeometryHandle, std::unique_ptr<const Geometry>> m_geometry;
 };


### PR DESCRIPTION
- Pass std::ios_base::in when opening the CMOD file stream
- Use const pointer to GeometryPaths in GeometryManager