### PR TITLE
Make imgui work on macOS

### DIFF
--- a/src/celestia/sdl/gui.cpp
+++ b/src/celestia/sdl/gui.cpp
@@ -91,7 +91,13 @@ Gui::create(SDL_Window* window, SDL_GLContext context, CelestiaCore* appCore, co
         return nullptr;
     }
 
-    if (!ImGui_ImplOpenGL3_Init())
+    #if defined(__APPLE__) && !defined(GL_ES)
+    // Celestia uses legacy profile, on macOS we cannot use core profile shaders with a legacy profile context
+    const char *glslVersion = "#version 120";
+    #else
+    const char *glslVersion = nullptr;
+    #endif
+    if (!ImGui_ImplOpenGL3_Init(glslVersion))
     {
         ImGui_ImplSDL2_Shutdown();
         ImGui::DestroyContext(ctx);


### PR DESCRIPTION
Before this patch it would error

```
ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to compile vertex shader! With GLSL: #version 150

ERROR: 0:1: '' :  version '150' is not supported

ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to compile fragment shader! With GLSL: #version 150

ERROR: 0:1: '' :  version '150' is not supported

ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to link shader program! With GLSL #version 150

ERROR: One or more attached shaders not successfully compiled
```