### PR TITLE
Update default comet tail colour

### DIFF
--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -43,7 +43,7 @@ namespace util = celestia::util;
 namespace
 {
 
-const Color defaultCometTailColor(0.65f, 0.65f, 0.65f);
+const Color defaultCometTailColor(0.625f, 0.625f, 0.625f);
 
 constexpr auto CLASSES_VISIBLE_AS_POINT = ~(BodyClassification::Invisible      |
                                             BodyClassification::SurfaceFeature |


### PR DESCRIPTION
The current colour of comet tails (pale blue, with R = 0.5, G = 0.5, B = 0.75) has been noted by arbodox (n3), our resident small bodies guru, to be unrealistic. Therefore, I decided to change its colour to white, which is created by Mie scattering off the dust particles in the dust tail (gas tail is not always visible; it is only visible if it is ionized).