### PR TITLE
Handle out-of-range catalog numbers in .stc, fix line number counting

### DIFF
--- a/src/celengine/stardbbuilder.cpp
+++ b/src/celengine/stardbbuilder.cpp
@@ -222,6 +222,8 @@ parseStcHeader(util::Tokenizer& tokenizer, StarDatabaseBuilder::StcHeader& heade
 {
     header.lineNumber = tokenizer.getLineNumber();
 
+    header.catalogNumber = AstroCatalog::InvalidIndex;
+    header.names.clear();
     header.isStar = true;
 
     // Parse the disposition--either Add, Replace, or Modify. The disposition
@@ -267,14 +269,17 @@ parseStcHeader(util::Tokenizer& tokenizer, StarDatabaseBuilder::StcHeader& heade
     }
 
     // Parse the catalog number; it may be omitted if a name is supplied.
-    header.catalogNumber = AstroCatalog::InvalidIndex;
     if (auto tokenValue = tokenizer.getNumberValue<AstroCatalog::IndexNumber>(); tokenValue.has_value())
     {
         header.catalogNumber = *tokenValue;
         tokenizer.nextToken();
     }
+    else if (tokenizer.getTokenType() == util::TokenType::Number)
+    {
+        stcError(header, _("invalid catalog number"));
+        tokenizer.nextToken();
+    }
 
-    header.names.clear();
     if (auto tokenValue = tokenizer.getStringValue(); tokenValue.has_value())
     {
         for (std::string_view remaining = *tokenValue; !remaining.empty();)

--- a/src/celutil/buffile.h
+++ b/src/celutil/buffile.h
@@ -8,6 +8,8 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#pragma once
+
 #include <cstddef>
 #include <cstdint>
 #include <iosfwd>


### PR DESCRIPTION
As reported on Discord, if the .stc file contains a catalog number which cannot be parsed as an unsigned 32-bit integer, the rest of the file will be parsed incorrectly.

While investigating this, I found that the line numbers reported in the log are invalid if a line ends with a number, fix that as well.