### PR TITLE
Renamed and rearranged stars files

### DIFF
--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -29,17 +29,17 @@ Configuration
 #------------------------------------------------------------------------
   StarDatabase                 "data/stars.dat"
   StarNameDatabase             "data/starnames.dat"
-  StarCatalogs               [ "data/revised.stc"
-                               "data/extrasolar.stc"
-                               "data/nearstars.stc"
-                               "data/visualbins.stc"
-                               "data/spectbins.stc"
-                               "data/charm2.stc"
+  StarCatalogs               [ "data/stars-charm2.stc"
+                               "data/stars-visualbins.stc"
+                               "data/stars-spectbins.stc"
                                "data/whitedwarfs.stc"
-                               "data/pulsars.stc" ]
+                               "data/pulsars.stc"
+                               "data/extrasolar.stc"
+                               "data/stars-revised.stc"
+                               "data/stars-near.stc" ]
 
-  HDCrossIndex                 "data/hdxindex.dat"
-  SAOCrossIndex                "data/saoxindex.dat"
+  HDCrossIndex                 "data/starxindex-hd.dat"
+  SAOCrossIndex                "data/starxindex-sao.dat"
 
   SolarSystemCatalogs        [ "data/solarsys.ssc"
                                "data/dwarfplanets.ssc"


### PR DESCRIPTION
The ambiguously-named star files are given a prefix "stars-" to 1) inform viewers that they are star files, and 2) group them alphabetically, making them easier to find.

The loading order of the files are also rearranged so that the bulk-generated files such as charm2 or whitedwarfs are loaded first, and then manually-created files (like stars-near) are loaded afterwards so that manually curated values supersede rather than being overridden.

This PR is accompanied by this PR https://github.com/CelestiaProject/CelestiaContent/pull/310 in CelestiaContent, and MUST be approved alongside it, else the program would break.