### PR TITLE
Rebuild fonts when DPI changes

### DIFF
--- a/src/celestia/sdl/appwindow.h
+++ b/src/celestia/sdl/appwindow.h
@@ -60,6 +60,8 @@ private:
 
     void toggleFullscreen();
 
+    void updateScreenDpi();
+
     // Important! Members destroyed in reverse order of declaration
     std::shared_ptr<Environment> m_environment;
     UniqueWindow m_window;
@@ -70,6 +72,7 @@ private:
 
     int m_width{ 0 };
     int m_height{ 0 };
+    float m_scale{ 0.0f };
 
     // mouse drag data
     Sint32 m_lastX{ 0 };

--- a/src/celestia/sdl/gui.cpp
+++ b/src/celestia/sdl/gui.cpp
@@ -148,7 +148,7 @@ Gui::menuBar()
 {
     ImGui::BeginMainMenuBar();
 
-    if (float menuBarHeight = ImGui::GetFrameHeight(); menuBarHeight != m_menuBarHeight)
+    if (float menuBarHeight = ImGui::GetFrameHeight() * m_scale; menuBarHeight != m_menuBarHeight)
     {
         m_appCore->setSafeAreaInsets(0, static_cast<int>(menuBarHeight), 0, 0);
         m_menuBarHeight = menuBarHeight;
@@ -214,6 +214,28 @@ Gui::scriptMenu()
         if (ImGui::MenuItem(item.title.c_str()))
             m_appCore->runScript(item.filename);
     }
+}
+
+void
+Gui::updateScreenDpi(float scale)
+{
+    if (scale == m_scale)
+        return;
+
+    ImGuiIO& io = ImGui::GetIO();
+
+    ImFontConfig fontConfig;
+    fontConfig.SizePixels = 13.0f * scale;
+    io.Fonts->Clear();
+    io.Fonts->AddFontDefault(&fontConfig);
+    io.Fonts->Build();
+    io.FontGlobalScale = 1.0f / scale;
+    io.DisplayFramebufferScale = ImVec2(scale, scale);
+
+    ImGui_ImplOpenGL3_DestroyFontsTexture();
+    ImGui_ImplOpenGL3_CreateFontsTexture();
+
+    m_scale = scale;
 }
 
 } // end namespace celestia::sdl

--- a/src/celestia/sdl/gui.h
+++ b/src/celestia/sdl/gui.h
@@ -48,6 +48,8 @@ public:
     inline bool wantCaptureMouse() const { return m_io->WantCaptureMouse; }
     inline bool isQuitRequested() const { return m_isQuitRequested; }
 
+    void updateScreenDpi(float scale);
+
 private:
     void menuBar();
     void scriptMenu();
@@ -68,6 +70,7 @@ private:
     bool m_isTimeDialogOpen{ false };
 
     float m_menuBarHeight{ 0.0f };
+    float m_scale{ 1.0f };
 
     bool m_isQuitRequested{ false };
 };


### PR DESCRIPTION
1. Use scaling factor from drawable height / window height, instead of `SDL_GetDisplayDPI`
2. Multiply by scaling factor in safe area
3. Reset font on DPI change