### PR TITLE
Change "Planetary companion" to "Planetary system"

### DIFF
--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -482,7 +482,7 @@ displayStarInfo(const util::NumberFormatter& formatter,
     {
         const SolarSystem* sys = universe.getSolarSystem(&star);
         if (sys != nullptr && sys->getPlanets()->getSystemSize() != 0)
-            overlay.print(_("Planetary companions present\n"));
+            overlay.print(_("Planetary system present\n"));
     }
 }
 


### PR DESCRIPTION
cubic pointed out in Discord that if there a star has any object in .ssc file orbiting it, the "Planetary companions present" text shows up. People pointed out that this is inaccurate since such an object can be an asteroid or a debris disc.

As such, I propose we reword this text to "Planetary system present", as a planetary system contains everything from the most massive giant planets to asteroids and dust particles in debris discs, and hence is more accurate.