### PR TITLE
Rework sRGB support

### DIFF
--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -477,4 +477,15 @@ StarTextures
 #------------------------------------------------------------------------
 # LayoutDirection "rtl"
 
+#------------------------------------------------------------------------
+# SRGBRendering enables a linear-light rendering pipeline with sRGB
+# output correction.  When enabled, colors and textures are linearized
+# before shading and a final linear-to-sRGB conversion is applied as a
+# post-process.  This produces physically correct blending and lighting.
+# On OpenGL ES, the GL_EXT_sRGB extension is required; if it is not
+# available the setting is silently ignored.
+# The default value is false.
+#------------------------------------------------------------------------
+# SRGBRendering true
+
 }

--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -484,7 +484,7 @@ StarTextures
 # before shading and a final linear-to-sRGB conversion is applied as a
 # post-process.  This produces physically correct blending and lighting.
 # On OpenGL ES, the GL_EXT_sRGB extension is required; if it is not
-# available the setting is silently ignored.
+# available the setting is ignored.
 # The default value is false.
 #------------------------------------------------------------------------
 # SRGBRendering true

--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -478,4 +478,15 @@ StarTextures
 #------------------------------------------------------------------------
 # LayoutDirection "rtl"
 
+#------------------------------------------------------------------------
+# SRGBRendering enables a linear-light rendering pipeline with sRGB
+# output correction.  When enabled, colors and textures are linearized
+# before shading and a final linear-to-sRGB conversion is applied as a
+# post-process.  This produces physically correct blending and lighting.
+# On OpenGL ES, the GL_EXT_sRGB extension is required; if it is not
+# available the setting is silently ignored.
+# The default value is false.
+#------------------------------------------------------------------------
+# SRGBRendering true
+
 }

--- a/shaders/srgb_frag.glsl
+++ b/shaders/srgb_frag.glsl
@@ -1,0 +1,24 @@
+varying vec2 texCoord;
+
+uniform sampler2D tex;
+
+// Apply the sRGB electro-optical transfer function (IEC 61966-2-1).
+// Input is assumed to be linear light; output is gamma-encoded for display.
+vec3 linearToSRGB(vec3 c)
+{
+    // Clamp negatives to avoid undefined pow() behaviour
+    c = max(c, vec3(0.0));
+    vec3 higher = vec3(1.055) * pow(c, vec3(1.0 / 2.4)) - vec3(0.055);
+    vec3 lower  = vec3(12.92) * c;
+    // step(edge, x): 0 when x < edge, 1 when x >= edge
+    return mix(lower, higher, step(vec3(0.0031308), c));
+}
+
+void main(void)
+{
+    vec4 color = texture2D(tex, texCoord);
+    // Clamp to [0,1] before conversion — the half-float FBO can accumulate
+    // values above 1.0 from additive blending (e.g. star glow), which must
+    // be saturated before the sRGB transfer function is applied.
+    gl_FragColor = vec4(linearToSRGB(min(color.rgb, vec3(1.0))), color.a);
+}

--- a/shaders/srgb_vert.glsl
+++ b/shaders/srgb_vert.glsl
@@ -1,0 +1,10 @@
+attribute vec2 in_Position;
+attribute vec2 in_TexCoord0;
+
+varying vec2 texCoord;
+
+void main(void)
+{
+    gl_Position = vec4(in_Position.xy, 0.0, 1.0);
+    texCoord = in_TexCoord0.st;
+}

--- a/src/celengine/galaxy.cpp
+++ b/src/celengine/galaxy.cpp
@@ -179,6 +179,8 @@ float Galaxy::getBrightnessCorrection(const Eigen::Vector3f &offset) const
     }
 
     float btot = (type == GalaxyType::Irr || type >= GalaxyType::E0) ? 2.5f : 5.0f;
+    if (celestia::gl::sRGBRendering)
+        btot /= 7.0f; // sRGB rendering causes galaxies to appear excessively bright; scale down to match original appearance
     return (4.0f * lightGain + 1.0f) * btot * brightness_corr;
 }
 

--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -27,6 +27,7 @@ CELAPI GLint maxPointSize                  = 0;
 CELAPI GLint maxTextureSize                = 0;
 CELAPI GLfloat maxLineWidth                = 0.0f;
 CELAPI GLint maxTextureAnisotropy          = 0;
+CELAPI bool sRGBRendering                  = false;
 
 namespace
 {

--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -28,6 +28,7 @@ CELAPI GLint maxPointSize                  = 0; //NOSONAR
 CELAPI GLint maxTextureSize                = 0; //NOSONAR
 CELAPI GLfloat maxLineWidth                = 0.0f; //NOSONAR
 CELAPI GLint maxTextureAnisotropy          = 0; //NOSONAR
+CELAPI bool sRGBRendering                  = false; //NOSONAR
 
 namespace
 {

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -58,6 +58,7 @@ extern CELAPI GLint maxPointSize; //NOSONAR
 extern CELAPI GLint maxTextureSize; //NOSONAR
 extern CELAPI GLfloat maxLineWidth; //NOSONAR
 extern CELAPI GLint maxTextureAnisotropy; //NOSONAR
+extern CELAPI bool sRGBRendering; //NOSONAR
 
 bool init(util::array_view<std::string> = {}) noexcept;
 bool checkVersion(int) noexcept;

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -59,6 +59,7 @@ extern CELAPI GLint maxPointSize; //NOSONAR
 extern CELAPI GLint maxTextureSize; //NOSONAR
 extern CELAPI GLfloat maxLineWidth; //NOSONAR
 extern CELAPI GLint maxTextureAnisotropy; //NOSONAR
+extern CELAPI bool sRGBRendering; //NOSONAR
 
 bool init(util::array_view<std::string> = {}) noexcept;
 bool checkVersion(int) noexcept;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -299,7 +299,7 @@ static std::unique_ptr<Texture>
 BuildGaussianDiscTexture(unsigned int log2size)
 {
     unsigned int size = 1U << log2size;
-    auto img = std::make_unique<Image>(PixelFormat::Luminance, size, size, log2size + 1);
+    auto img = std::make_unique<Image>(PixelFormat::sLuminance, size, size, log2size + 1);
 
     for (unsigned int mipLevel = 0; mipLevel <= log2size; mipLevel++)
     {
@@ -319,7 +319,7 @@ static std::unique_ptr<Texture>
 BuildGaussianGlareTexture(unsigned int log2size)
 {
     unsigned int size = 1U << log2size;
-    auto img = std::make_unique<Image>(PixelFormat::Luminance, size, size, log2size + 1);
+    auto img = std::make_unique<Image>(PixelFormat::sLuminance, size, size, log2size + 1);
 
     for (unsigned int mipLevel = 0; mipLevel <= log2size; mipLevel++)
     {
@@ -1255,7 +1255,7 @@ setupLightSources(const vector<const Star*>& nearStars,
                 continue;
 
             if (tintColors == nullptr)
-                ls.color = legacyTintColor(temp);
+                ls.color = legacyTintColor(temp).linearize();
             else
             {
                 float fadeFactor = temp < FADE_POINT
@@ -1458,7 +1458,7 @@ void Renderer::render(const Observer& observer,
     // Calculate saturation magnitude
     satPoint = faintestMag - (1.0f - brightnessBias) / brightnessScale;
 
-    ambientColor = Color(ambientLightLevel, ambientLightLevel, ambientLightLevel);
+    ambientColor = Color(ambientLightLevel, ambientLightLevel, ambientLightLevel).linearize();
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -1995,7 +1995,7 @@ setupObjectLighting(const vector<LightSource>& suns,
             ls.lights[i].direction_eye = toIllum.cast<float>();
             ls.lights[i].direction_eye.normalize();
             ls.lights[i].irradiance = maxIrr;
-            ls.lights[i].color = secondaryIlluminators[maxIrrSource].body->getSurface().color;
+            ls.lights[i].color = secondaryIlluminators[maxIrrSource].body->getSurface().color.linearize();
             ls.lights[i].apparentSize = 0.0f;
             ls.lights[i].castsShadows = false;
             i++;
@@ -2021,28 +2021,13 @@ setupObjectLighting(const vector<LightSource>& suns,
     for (i = 0; i < nLights; i++)
         totalIrradiance += ls.lights[i].irradiance;
 
-    // Compute a gamma factor to make dim light sources visible.  This is
-    // intended to approximate what we see with our eyes--for example,
-    // Earth-shine is visible on the night side of the Moon, even though
-    // the amount of reflected light from the Earth is 1/10000 of what
-    // the Moon receives directly from the Sun.
-    //
-    // TODO: Skip this step when high dynamic range rendering to floating point
-    //   buffers is enabled.
-    float minVisibleFraction = 1.0f / 10000.0f;
-    float minDisplayableValue = 1.0f / 255.0f;
-    float gamma = log(minDisplayableValue) / log(minVisibleFraction);
-    float minVisibleIrradiance = minVisibleFraction * totalIrradiance;
-
     Matrix3f m = objOrientation.toRotationMatrix();
 
-    // Gamma scale and normalize the light sources; cull light sources that
-    // aren't bright enough to contribute the final pixels rendered into the
-    // frame buffer.
+    // Normalize light source irradiance so the brightest light is ~1.0.
     ls.nLights = 0;
-    for (i = 0; i < nLights && ls.lights[i].irradiance > minVisibleIrradiance; i++)
+    for (i = 0; i < nLights; i++)
     {
-        ls.lights[i].irradiance = pow(ls.lights[i].irradiance / totalIrradiance, gamma);
+        ls.lights[i].irradiance /= totalIrradiance;
 
         // Compute the direction of the light in object space
         ls.lights[i].direction_obj = m * ls.lights[i].direction_eye;
@@ -2181,11 +2166,11 @@ void Renderer::renderObject(const Vector3f& pos,
     if (ri.baseTex == nullptr ||
         (obj.surface->appearanceFlags & Surface::BlendTexture) != 0)
     {
-        ri.color = obj.surface->color;
+        ri.color = obj.surface->color.linearize();
     }
 
     ri.ambientColor = ambientColor;
-    ri.specularColor = obj.surface->specularColor;
+    ri.specularColor = obj.surface->specularColor.linearize();
     ri.specularPower = obj.surface->specularPower;
     ri.lunarLambert = obj.surface->lunarLambert;
 
@@ -2846,7 +2831,7 @@ void Renderer::renderPlanet(Body& body,
 
     if (body.isVisibleAsPoint())
     {
-        const auto& surfaceColor = body.getSurface().color;
+        const auto& surfaceColor = body.getSurface().color.linearize();
         if (float maxCoeff = surfaceColor.toVector3().maxCoeff(); maxCoeff > 0.0f) // ignore [ 0 0 0 ]; used by old addons to make objects not get rendered as point
         {
             renderObjectAsPoint(pos,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1255,7 +1255,7 @@ setupLightSources(const vector<const Star*>& nearStars,
                 continue;
 
             if (tintColors == nullptr)
-                ls.color = legacyTintColor(temp).linearize();
+                ls.color = legacyTintColor(temp).linearize(gl::sRGBRendering);
             else
             {
                 float fadeFactor = temp < FADE_POINT
@@ -1458,7 +1458,7 @@ void Renderer::render(const Observer& observer,
     // Calculate saturation magnitude
     satPoint = faintestMag - (1.0f - brightnessBias) / brightnessScale;
 
-    ambientColor = Color(ambientLightLevel, ambientLightLevel, ambientLightLevel).linearize();
+    ambientColor = Color(ambientLightLevel, ambientLightLevel, ambientLightLevel).linearize(gl::sRGBRendering);
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -1995,7 +1995,7 @@ setupObjectLighting(const vector<LightSource>& suns,
             ls.lights[i].direction_eye = toIllum.cast<float>();
             ls.lights[i].direction_eye.normalize();
             ls.lights[i].irradiance = maxIrr;
-            ls.lights[i].color = secondaryIlluminators[maxIrrSource].body->getSurface().color.linearize();
+            ls.lights[i].color = secondaryIlluminators[maxIrrSource].body->getSurface().color.linearize(gl::sRGBRendering);
             ls.lights[i].apparentSize = 0.0f;
             ls.lights[i].castsShadows = false;
             i++;
@@ -2023,16 +2023,45 @@ setupObjectLighting(const vector<LightSource>& suns,
 
     Matrix3f m = objOrientation.toRotationMatrix();
 
-    // Normalize light source irradiance so the brightest light is ~1.0.
-    ls.nLights = 0;
-    for (i = 0; i < nLights; i++)
+    if (gl::sRGBRendering)
     {
-        ls.lights[i].irradiance /= totalIrradiance;
+        // Normalize light source irradiance so the brightest light is ~1.0.
+        ls.nLights = 0;
+        for (i = 0; i < nLights; i++)
+        {
+            ls.lights[i].irradiance /= totalIrradiance;
 
-        // Compute the direction of the light in object space
-        ls.lights[i].direction_obj = m * ls.lights[i].direction_eye;
+            // Compute the direction of the light in object space
+            ls.lights[i].direction_obj = m * ls.lights[i].direction_eye;
 
-        ls.nLights++;
+            ls.nLights++;
+        }
+    }
+    else
+    {
+        // Compute a gamma factor to make dim light sources visible.  This is
+        // intended to approximate what we see with our eyes--for example,
+        // Earth-shine is visible on the night side of the Moon, even though
+        // the amount of reflected light from the Earth is 1/10000 of what
+        // the Moon receives directly from the Sun.
+        float minVisibleFraction = 1.0f / 10000.0f;
+        float minDisplayableValue = 1.0f / 255.0f;
+        float gamma = log(minDisplayableValue) / log(minVisibleFraction);
+        float minVisibleIrradiance = minVisibleFraction * totalIrradiance;
+
+        // Gamma scale and normalize the light sources; cull light sources that
+        // aren't bright enough to contribute the final pixels rendered into the
+        // frame buffer.
+        ls.nLights = 0;
+        for (i = 0; i < nLights && ls.lights[i].irradiance > minVisibleIrradiance; i++)
+        {
+            ls.lights[i].irradiance = pow(ls.lights[i].irradiance / totalIrradiance, gamma);
+
+            // Compute the direction of the light in object space
+            ls.lights[i].direction_obj = m * ls.lights[i].direction_eye;
+
+            ls.nLights++;
+        }
     }
 
     Matrix3f invScale = objScale.cwiseInverse().asDiagonal();
@@ -2166,11 +2195,11 @@ void Renderer::renderObject(const Vector3f& pos,
     if (ri.baseTex == nullptr ||
         (obj.surface->appearanceFlags & Surface::BlendTexture) != 0)
     {
-        ri.color = obj.surface->color.linearize();
+        ri.color = obj.surface->color.linearize(gl::sRGBRendering);
     }
 
     ri.ambientColor = ambientColor;
-    ri.specularColor = obj.surface->specularColor.linearize();
+    ri.specularColor = obj.surface->specularColor.linearize(gl::sRGBRendering);
     ri.specularPower = obj.surface->specularPower;
     ri.lunarLambert = obj.surface->lunarLambert;
 
@@ -2831,7 +2860,7 @@ void Renderer::renderPlanet(Body& body,
 
     if (body.isVisibleAsPoint())
     {
-        const auto& surfaceColor = body.getSurface().color.linearize();
+        const auto surfaceColor = body.getSurface().color.linearize(gl::sRGBRendering);
         if (float maxCoeff = surfaceColor.toVector3().maxCoeff(); maxCoeff > 0.0f) // ignore [ 0 0 0 ]; used by old addons to make objects not get rendered as point
         {
             renderObjectAsPoint(pos,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1258,7 +1258,7 @@ setupLightSources(const vector<const Star*>& nearStars,
                 continue;
 
             if (tintColors == nullptr)
-                ls.color = legacyTintColor(temp).linearize();
+                ls.color = legacyTintColor(temp).linearize(gl::sRGBRendering);
             else
             {
                 float fadeFactor = temp < FADE_POINT
@@ -1461,7 +1461,7 @@ void Renderer::render(const Observer& observer,
     // Calculate saturation magnitude
     satPoint = faintestMag - (1.0f - brightnessBias) / brightnessScale;
 
-    ambientColor = Color(ambientLightLevel, ambientLightLevel, ambientLightLevel).linearize();
+    ambientColor = Color(ambientLightLevel, ambientLightLevel, ambientLightLevel).linearize(gl::sRGBRendering);
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -1998,7 +1998,7 @@ setupObjectLighting(const vector<LightSource>& suns,
             ls.lights[i].direction_eye = toIllum.cast<float>();
             ls.lights[i].direction_eye.normalize();
             ls.lights[i].irradiance = maxIrr;
-            ls.lights[i].color = secondaryIlluminators[maxIrrSource].body->getSurface().color.linearize();
+            ls.lights[i].color = secondaryIlluminators[maxIrrSource].body->getSurface().color.linearize(gl::sRGBRendering);
             ls.lights[i].apparentSize = 0.0f;
             ls.lights[i].castsShadows = false;
             i++;
@@ -2026,16 +2026,45 @@ setupObjectLighting(const vector<LightSource>& suns,
 
     Matrix3f m = objOrientation.toRotationMatrix();
 
-    // Normalize light source irradiance so the brightest light is ~1.0.
-    ls.nLights = 0;
-    for (i = 0; i < nLights; i++)
+    if (gl::sRGBRendering)
     {
-        ls.lights[i].irradiance /= totalIrradiance;
+        // Normalize light source irradiance so the brightest light is ~1.0.
+        ls.nLights = 0;
+        for (i = 0; i < nLights; i++)
+        {
+            ls.lights[i].irradiance /= totalIrradiance;
 
-        // Compute the direction of the light in object space
-        ls.lights[i].direction_obj = m * ls.lights[i].direction_eye;
+            // Compute the direction of the light in object space
+            ls.lights[i].direction_obj = m * ls.lights[i].direction_eye;
 
-        ls.nLights++;
+            ls.nLights++;
+        }
+    }
+    else
+    {
+        // Compute a gamma factor to make dim light sources visible.  This is
+        // intended to approximate what we see with our eyes--for example,
+        // Earth-shine is visible on the night side of the Moon, even though
+        // the amount of reflected light from the Earth is 1/10000 of what
+        // the Moon receives directly from the Sun.
+        float minVisibleFraction = 1.0f / 10000.0f;
+        float minDisplayableValue = 1.0f / 255.0f;
+        float gamma = log(minDisplayableValue) / log(minVisibleFraction);
+        float minVisibleIrradiance = minVisibleFraction * totalIrradiance;
+
+        // Gamma scale and normalize the light sources; cull light sources that
+        // aren't bright enough to contribute the final pixels rendered into the
+        // frame buffer.
+        ls.nLights = 0;
+        for (i = 0; i < nLights && ls.lights[i].irradiance > minVisibleIrradiance; i++)
+        {
+            ls.lights[i].irradiance = pow(ls.lights[i].irradiance / totalIrradiance, gamma);
+
+            // Compute the direction of the light in object space
+            ls.lights[i].direction_obj = m * ls.lights[i].direction_eye;
+
+            ls.nLights++;
+        }
     }
 
     Matrix3f invScale = objScale.cwiseInverse().asDiagonal();
@@ -2169,11 +2198,11 @@ void Renderer::renderObject(const Vector3f& pos,
     if (ri.baseTex == nullptr ||
         (obj.surface->appearanceFlags & Surface::BlendTexture) != 0)
     {
-        ri.color = obj.surface->color.linearize();
+        ri.color = obj.surface->color.linearize(gl::sRGBRendering);
     }
 
     ri.ambientColor = ambientColor;
-    ri.specularColor = obj.surface->specularColor.linearize();
+    ri.specularColor = obj.surface->specularColor.linearize(gl::sRGBRendering);
     ri.specularPower = obj.surface->specularPower;
     ri.lunarLambert = obj.surface->lunarLambert;
 
@@ -2834,7 +2863,7 @@ void Renderer::renderPlanet(Body& body,
 
     if (body.isVisibleAsPoint())
     {
-        const auto& surfaceColor = body.getSurface().color.linearize();
+        const auto surfaceColor = body.getSurface().color.linearize(gl::sRGBRendering);
         if (float maxCoeff = surfaceColor.toVector3().maxCoeff(); maxCoeff > 0.0f) // ignore [ 0 0 0 ]; used by old addons to make objects not get rendered as point
         {
             renderObjectAsPoint(pos,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -302,7 +302,7 @@ static std::unique_ptr<Texture>
 BuildGaussianDiscTexture(unsigned int log2size)
 {
     unsigned int size = 1U << log2size;
-    Image img(PixelFormat::Luminance, size, size, log2size + 1);
+    Image img(PixelFormat::sLuminance, size, size, log2size + 1);
 
     for (unsigned int mipLevel = 0; mipLevel <= log2size; ++mipLevel)
     {
@@ -322,7 +322,7 @@ static std::unique_ptr<Texture>
 BuildGaussianGlareTexture(unsigned int log2size)
 {
     unsigned int size = 1U << log2size;
-    Image img(PixelFormat::Luminance, size, size, log2size + 1);
+    Image img(PixelFormat::sLuminance, size, size, log2size + 1);
 
     for (unsigned int mipLevel = 0; mipLevel <= log2size; mipLevel++)
     {
@@ -1258,7 +1258,7 @@ setupLightSources(const vector<const Star*>& nearStars,
                 continue;
 
             if (tintColors == nullptr)
-                ls.color = legacyTintColor(temp);
+                ls.color = legacyTintColor(temp).linearize();
             else
             {
                 float fadeFactor = temp < FADE_POINT
@@ -1461,7 +1461,7 @@ void Renderer::render(const Observer& observer,
     // Calculate saturation magnitude
     satPoint = faintestMag - (1.0f - brightnessBias) / brightnessScale;
 
-    ambientColor = Color(ambientLightLevel, ambientLightLevel, ambientLightLevel);
+    ambientColor = Color(ambientLightLevel, ambientLightLevel, ambientLightLevel).linearize();
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -1998,7 +1998,7 @@ setupObjectLighting(const vector<LightSource>& suns,
             ls.lights[i].direction_eye = toIllum.cast<float>();
             ls.lights[i].direction_eye.normalize();
             ls.lights[i].irradiance = maxIrr;
-            ls.lights[i].color = secondaryIlluminators[maxIrrSource].body->getSurface().color;
+            ls.lights[i].color = secondaryIlluminators[maxIrrSource].body->getSurface().color.linearize();
             ls.lights[i].apparentSize = 0.0f;
             ls.lights[i].castsShadows = false;
             i++;
@@ -2024,28 +2024,13 @@ setupObjectLighting(const vector<LightSource>& suns,
     for (i = 0; i < nLights; i++)
         totalIrradiance += ls.lights[i].irradiance;
 
-    // Compute a gamma factor to make dim light sources visible.  This is
-    // intended to approximate what we see with our eyes--for example,
-    // Earth-shine is visible on the night side of the Moon, even though
-    // the amount of reflected light from the Earth is 1/10000 of what
-    // the Moon receives directly from the Sun.
-    //
-    // TODO: Skip this step when high dynamic range rendering to floating point
-    //   buffers is enabled.
-    float minVisibleFraction = 1.0f / 10000.0f;
-    float minDisplayableValue = 1.0f / 255.0f;
-    float gamma = log(minDisplayableValue) / log(minVisibleFraction);
-    float minVisibleIrradiance = minVisibleFraction * totalIrradiance;
-
     Matrix3f m = objOrientation.toRotationMatrix();
 
-    // Gamma scale and normalize the light sources; cull light sources that
-    // aren't bright enough to contribute the final pixels rendered into the
-    // frame buffer.
+    // Normalize light source irradiance so the brightest light is ~1.0.
     ls.nLights = 0;
-    for (i = 0; i < nLights && ls.lights[i].irradiance > minVisibleIrradiance; i++)
+    for (i = 0; i < nLights; i++)
     {
-        ls.lights[i].irradiance = pow(ls.lights[i].irradiance / totalIrradiance, gamma);
+        ls.lights[i].irradiance /= totalIrradiance;
 
         // Compute the direction of the light in object space
         ls.lights[i].direction_obj = m * ls.lights[i].direction_eye;
@@ -2184,11 +2169,11 @@ void Renderer::renderObject(const Vector3f& pos,
     if (ri.baseTex == nullptr ||
         (obj.surface->appearanceFlags & Surface::BlendTexture) != 0)
     {
-        ri.color = obj.surface->color;
+        ri.color = obj.surface->color.linearize();
     }
 
     ri.ambientColor = ambientColor;
-    ri.specularColor = obj.surface->specularColor;
+    ri.specularColor = obj.surface->specularColor.linearize();
     ri.specularPower = obj.surface->specularPower;
     ri.lunarLambert = obj.surface->lunarLambert;
 
@@ -2849,7 +2834,7 @@ void Renderer::renderPlanet(Body& body,
 
     if (body.isVisibleAsPoint())
     {
-        const auto& surfaceColor = body.getSurface().color;
+        const auto& surfaceColor = body.getSurface().color.linearize();
         if (float maxCoeff = surfaceColor.toVector3().maxCoeff(); maxCoeff > 0.0f) // ignore [ 0 0 0 ]; used by old addons to make objects not get rendered as point
         {
             renderObjectAsPoint(pos,

--- a/src/celengine/rendercolors.h
+++ b/src/celengine/rendercolors.h
@@ -72,6 +72,7 @@ struct RendererColors
     // Returns a copy of this RendererColors with every color converted from
     // sRGB to linear light, ready for use in a linear-light rendering pipeline.
     RendererColors linearize() const;
+    RendererColors linearize(bool enabled) const { return enabled ? linearize() : *this; }
 };
 
 } // namespace celestia::engine

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -3056,12 +3056,16 @@ CelestiaGLProgram::setLightParameters(const LightingState& ls,
 
         // Include a phase-based normalization factor to prevent planets from appearing
         // too dim when rendered with non-Lambertian photometric functions.
+        // Disabled: this was a gamma-space compensation that over-brightens planets
+        // in the linear-light rendering pipeline.
+#if 0
         float cosPhaseAngle = light.direction_obj.dot(ls.eyeDir_obj);
         if (util::is_set(props.lightModel, LightingModel::LunarLambertModel))
         {
             float photometricNormFactor = std::max(1.0f, 1.0f + cosPhaseAngle * 0.5f);
             lightColor *= photometricNormFactor;
         }
+#endif
 
         lights[i].diffuse = lightColor.cwiseProduct(diffuseColor);
         lights[i].brightness = lightColor.maxCoeff();

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -3056,16 +3056,12 @@ CelestiaGLProgram::setLightParameters(const LightingState& ls,
 
         // Include a phase-based normalization factor to prevent planets from appearing
         // too dim when rendered with non-Lambertian photometric functions.
-        // Disabled: this was a gamma-space compensation that over-brightens planets
-        // in the linear-light rendering pipeline.
-#if 0
         float cosPhaseAngle = light.direction_obj.dot(ls.eyeDir_obj);
         if (util::is_set(props.lightModel, LightingModel::LunarLambertModel))
         {
             float photometricNormFactor = std::max(1.0f, 1.0f + cosPhaseAngle * 0.5f);
             lightColor *= photometricNormFactor;
         }
-#endif
 
         lights[i].diffuse = lightColor.cwiseProduct(diffuseColor);
         lights[i].brightness = lightColor.maxCoeff();

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -62,6 +62,7 @@ constexpr std::array StaticShaderBaseNames
     "globular"sv,
     "largestar"sv,
     "passthrough"sv,
+    "srgb"sv,
     "selpointer"sv,
     "star"sv,
     "text"sv,

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -3065,12 +3065,16 @@ CelestiaGLProgram::setLightParameters(const LightingState& ls,
 
         // Include a phase-based normalization factor to prevent planets from appearing
         // too dim when rendered with non-Lambertian photometric functions.
+        // Disabled: this was a gamma-space compensation that over-brightens planets
+        // in the linear-light rendering pipeline.
+#if 0
         float cosPhaseAngle = light.direction_obj.dot(ls.eyeDir_obj);
         if (util::is_set(props.lightModel, LightingModel::LunarLambertModel))
         {
             float photometricNormFactor = std::max(1.0f, 1.0f + cosPhaseAngle * 0.5f);
             lightColor *= photometricNormFactor;
         }
+#endif
 
         lights[i].diffuse = lightColor.cwiseProduct(diffuseColor);
         lights[i].brightness = lightColor.maxCoeff();

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -3065,16 +3065,12 @@ CelestiaGLProgram::setLightParameters(const LightingState& ls,
 
         // Include a phase-based normalization factor to prevent planets from appearing
         // too dim when rendered with non-Lambertian photometric functions.
-        // Disabled: this was a gamma-space compensation that over-brightens planets
-        // in the linear-light rendering pipeline.
-#if 0
         float cosPhaseAngle = light.direction_obj.dot(ls.eyeDir_obj);
         if (util::is_set(props.lightModel, LightingModel::LunarLambertModel))
         {
             float photometricNormFactor = std::max(1.0f, 1.0f + cosPhaseAngle * 0.5f);
             lightColor *= photometricNormFactor;
         }
-#endif
 
         lights[i].diffuse = lightColor.cwiseProduct(diffuseColor);
         lights[i].brightness = lightColor.maxCoeff();

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -37,6 +37,7 @@ enum class StaticShader
     Globular,
     LargeStar,
     Passthrough,
+    sRGB,
     SelPointer,
     Star,
     Text,

--- a/src/celengine/starcolors.h
+++ b/src/celengine/starcolors.h
@@ -20,6 +20,7 @@
 
 #include <celmath/vecgl.h>
 #include <celutil/color.h>
+#include "glsupport.h"
 
 enum class ColorTableType
 {
@@ -37,18 +38,18 @@ class ColorTemperatureTable
     Color lookupColor(float temp) const
     {
         assert(temp >= 0.0f);
-        
-        float colorTableIndex = std::nearbyint(temp * tempScale);
-        if (colorTableIndex >= static_cast<float>(colors.size()))
-            return colors.back().linearize();
 
-        return colors[static_cast<std::size_t>(colorTableIndex)].linearize();
+        float colorTableIndex = std::nearbyint(temp * tempScale);
+        Color c = colorTableIndex >= static_cast<float>(colors.size())
+            ? colors.back()
+            : colors[static_cast<std::size_t>(colorTableIndex)];
+        return c.linearize(celestia::gl::sRGBRendering);
     }
 
     Color lookupTintColor(float temp, float saturation, float fadeFactor) const
     {
         Eigen::Vector3f color = celestia::math::mix(Eigen::Vector3f::Ones(),
-                                                    lookupColor(temp).linearize().toVector3(),
+                                                    lookupColor(temp).toVector3(),
                                                     saturation) * fadeFactor;
         return Color(color);
     }

--- a/src/celengine/starcolors.h
+++ b/src/celengine/starcolors.h
@@ -40,15 +40,15 @@ class ColorTemperatureTable
         
         float colorTableIndex = std::nearbyint(temp * tempScale);
         if (colorTableIndex >= static_cast<float>(colors.size()))
-            return colors.back();
+            return colors.back().linearize();
 
-        return colors[static_cast<std::size_t>(colorTableIndex)];
+        return colors[static_cast<std::size_t>(colorTableIndex)].linearize();
     }
 
     Color lookupTintColor(float temp, float saturation, float fadeFactor) const
     {
         Eigen::Vector3f color = celestia::math::mix(Eigen::Vector3f::Ones(),
-                                                    lookupColor(temp).toVector3(),
+                                                    lookupColor(temp).linearize().toVector3(),
                                                     saturation) * fadeFactor;
         return Color(color);
     }

--- a/src/celengine/starcolors.h
+++ b/src/celengine/starcolors.h
@@ -20,7 +20,6 @@
 
 #include <celmath/vecgl.h>
 #include <celutil/color.h>
-#include "glsupport.h"
 
 enum class ColorTableType
 {
@@ -38,12 +37,12 @@ class ColorTemperatureTable
     Color lookupColor(float temp) const
     {
         assert(temp >= 0.0f);
-
+        
         float colorTableIndex = std::nearbyint(temp * tempScale);
-        Color c = colorTableIndex >= static_cast<float>(colors.size())
-            ? colors.back()
-            : colors[static_cast<std::size_t>(colorTableIndex)];
-        return c.linearize(celestia::gl::sRGBRendering);
+        if (colorTableIndex >= static_cast<float>(colors.size()))
+            return colors.back();
+
+        return colors[static_cast<std::size_t>(colorTableIndex)];
     }
 
     Color lookupTintColor(float temp, float saturation, float fadeFactor) const

--- a/src/celengine/texture.cpp
+++ b/src/celengine/texture.cpp
@@ -33,6 +33,29 @@ using celestia::engine::expandLuminanceAlphaToRGBA;
 namespace
 {
 
+// When sRGB rendering is disabled, strip sRGB pixel formats to their
+// non-sRGB equivalents so the GPU does not linearize on sample.
+PixelFormat
+effectiveFormat(PixelFormat format)
+{
+    if (gl::sRGBRendering)
+        return format;
+
+    switch (format)
+    {
+    case PixelFormat::sRGB:       return PixelFormat::RGB;
+    case PixelFormat::sRGB8:      return PixelFormat::RGB8;
+    case PixelFormat::sRGBA:      return PixelFormat::RGBA;
+    case PixelFormat::sRGBA8:     return PixelFormat::RGBA8;
+    case PixelFormat::sLuminance: return PixelFormat::Luminance;
+    case PixelFormat::sLumAlpha:  return PixelFormat::LumAlpha;
+    case PixelFormat::DXT1_sRGBA: return PixelFormat::DXT1;
+    case PixelFormat::DXT3_sRGBA: return PixelFormat::DXT3;
+    case PixelFormat::DXT5_sRGBA: return PixelFormat::DXT5;
+    default:                      return format;
+    }
+}
+
 struct TextureCaps
 {
     GLint preferredAnisotropy;
@@ -66,6 +89,7 @@ GetTextureCaps()
 bool
 needsRGBAExpansion(PixelFormat format, bool needsMipmap)
 {
+    format = effectiveFormat(format);
     if (celestia::gl::checkVersion(celestia::gl::GLES_3_0))
     {
         // GLES3 sRGB 3-component textures (sRGB/sRGB8) don't support mipmap generation. If we
@@ -114,6 +138,7 @@ expandToRGBA(const std::uint8_t* src, int width, int height, PixelFormat format)
 GLenum
 getInternalFormat(PixelFormat format, bool needsMipmap)
 {
+    format = effectiveFormat(format);
 #ifdef GL_ES
     switch (format)
     {
@@ -180,6 +205,7 @@ getInternalFormat(PixelFormat format, bool needsMipmap)
 GLenum
 getExternalFormat(PixelFormat format, bool needsMipmap)
 {
+    format = effectiveFormat(format);
 #ifdef GL_ES
     switch (format)
     {
@@ -324,6 +350,7 @@ SetBorderColor(Color borderColor, GLenum target)
 bool
 canGenerateMipmaps([[maybe_unused]] PixelFormat format)
 {
+    format = effectiveFormat(format);
 #ifdef GL_ES
     // All sRGB formats can generate mipmap (after expansion if necessary) on GLES3
     // No sRGB format can generate mipmap on GLES2

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2516,13 +2516,6 @@ bool CelestiaCore::initSimulation(const std::filesystem::path& configFileName,
             viewportEffects.push_back(std::move(effect));
     }
 
-    // Apply sRGB output correction via software post-process.
-    // The SRGBViewportEffect shader performs the linear→sRGB conversion
-    // as the final rendering step, keeping the pipeline consistent across
-    // all GL variants without relying on GL_FRAMEBUFFER_SRGB or
-    // platform-specific sRGB surface negotiation.
-    viewportEffects.push_back(std::make_unique<PassthroughViewportEffect>("srgb", true));
-
     if (!config->measurementSystem.empty())
     {
         if (compareIgnoringCase(config->measurementSystem, "imperial") == 0)
@@ -2624,6 +2617,28 @@ LoadFontHelper(const Renderer *renderer, const std::filesystem::path &p)
 bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
                                 [[maybe_unused]] bool useMesaPackInvert)
 {
+    // Resolve the effective sRGB rendering flag.
+    // On GLES 2.0, sRGB requires the EXT_sRGB extension.
+    // GLES 3.0+ has native sRGB support.
+    gl::sRGBRendering = config->renderDetails.sRGBRendering;
+#ifdef GL_ES
+    if (gl::sRGBRendering && !gl::checkVersion(gl::GLES_3_0) && !gl::EXT_sRGB)
+    {
+        GetLogger()->warn("sRGB rendering requested but GL_EXT_sRGB is not available; disabling.\n");
+        gl::sRGBRendering = false;
+    }
+#endif
+
+    if (gl::sRGBRendering)
+    {
+        // Apply sRGB output correction via software post-process.
+        // The SRGBViewportEffect shader performs the linear→sRGB conversion
+        // as the final rendering step, keeping the pipeline consistent across
+        // all GL variants without relying on GL_FRAMEBUFFER_SRGB or
+        // platform-specific sRGB surface negotiation.
+        viewportEffects.push_back(std::make_unique<PassthroughViewportEffect>("srgb", true));
+    }
+
     renderer->setRenderFlags(RenderFlags::ShowStars |
                              RenderFlags::ShowPlanets |
                              RenderFlags::ShowAtmospheres |
@@ -2654,7 +2669,7 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
         return false;
     }
 
-    renderer->colors = renderer->colors.linearize();
+    renderer->colors = renderer->colors.linearize(gl::sRGBRendering);
     m_scriptMaps.initColorMaps(renderer->colors);
 
     if (util::is_set(renderer->getRenderFlags(), RenderFlags::ShowAutoMag))

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2516,6 +2516,13 @@ bool CelestiaCore::initSimulation(const std::filesystem::path& configFileName,
             viewportEffects.push_back(std::move(effect));
     }
 
+    // Apply sRGB output correction via software post-process.
+    // The SRGBViewportEffect shader performs the linear→sRGB conversion
+    // as the final rendering step, keeping the pipeline consistent across
+    // all GL variants without relying on GL_FRAMEBUFFER_SRGB or
+    // platform-specific sRGB surface negotiation.
+    viewportEffects.push_back(std::make_unique<PassthroughViewportEffect>("srgb", true));
+
     if (!config->measurementSystem.empty())
     {
         if (compareIgnoringCase(config->measurementSystem, "imperial") == 0)
@@ -2647,6 +2654,7 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
         return false;
     }
 
+    renderer->colors = renderer->colors.linearize();
     m_scriptMaps.initColorMaps(renderer->colors);
 
     if (util::is_set(renderer->getRenderFlags(), RenderFlags::ShowAutoMag))

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2636,7 +2636,7 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
         // as the final rendering step, keeping the pipeline consistent across
         // all GL variants without relying on GL_FRAMEBUFFER_SRGB or
         // platform-specific sRGB surface negotiation.
-        viewportEffects.push_back(std::make_unique<PassthroughViewportEffect>("srgb", true));
+        viewportEffects.push_back(std::make_unique<PassthroughViewportEffect>(StaticShader::sRGB, true));
     }
 
     renderer->setRenderFlags(RenderFlags::ShowStars |

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -201,6 +201,7 @@ applyRenderDetails(CelestiaConfig::RenderDetails& renderDetails, const Associati
     renderDetails.SolarSystemMaxDistance = std::clamp(renderDetails.SolarSystemMaxDistance, 1.0f, 10.0f);
     applyNumber(renderDetails.ShadowMapSize, hash, "ShadowMapSize"sv);
     applyStringArray(renderDetails.ignoreGLExtensions, hash, "IgnoreGLExtensions"sv);
+    applyBoolean(renderDetails.sRGBRendering, hash, "SRGBRendering"sv);
 }
 
 void

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -93,6 +93,7 @@ struct CelestiaConfig
         float SolarSystemMaxDistance{ 1.0f };
         unsigned int ShadowMapSize{ 0 };
         std::vector<std::string> ignoreGLExtensions{ };
+        bool sRGBRendering{ false };
     };
 
     CelestiaConfig() = default;

--- a/src/celimage/avif.cpp
+++ b/src/celimage/avif.cpp
@@ -85,6 +85,25 @@ FStreamAVIFIORead(avifIO* io, std::uint32_t readFlags, std::uint64_t offset, std
     return AVIF_RESULT_OK;
 }
 
+// Detect whether the decoded AVIF image should be treated as linear-light
+// data.  Uses the CICP transfer characteristics stored in the AVIF container.
+bool
+IsLinearAVIF(const avifImage* img)
+{
+    switch (img->transferCharacteristics)
+    {
+    case AVIF_TRANSFER_CHARACTERISTICS_LINEAR:
+        return true;
+    case AVIF_TRANSFER_CHARACTERISTICS_SRGB:
+        return false;
+    case AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED:
+    default:
+        // No explicit metadata or an unknown value: assume sRGB
+        // (the overwhelmingly common case for 8-bit content).
+        return false;
+    }
+}
+
 } // end unnamed namespace
 
 Image*
@@ -132,7 +151,8 @@ LoadAVIFImage(const std::filesystem::path& filename)
         return nullptr;
     }
 
-    auto image = std::make_unique<Image>(PixelFormat::RGBA, rgb.width, rgb.height);
+    bool isLinear = IsLinearAVIF(decoder->image);
+    auto image = std::make_unique<Image>(isLinear ? PixelFormat::RGBA : PixelFormat::sRGBA, rgb.width, rgb.height);
     rgb.pixels = image->getPixels();
     rgb.rowBytes = image->getWidth() * image->getComponents();
 

--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -8,7 +8,9 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+#include <array>
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <fstream>
 #include <algorithm>
@@ -72,6 +74,27 @@ struct DDSurfaceDesc
     DDSCaps caps;
 
     std::uint32_t textureStage;
+};
+
+// DX10 extended header, present when fourCC == "DX10".
+struct DDSHeaderDXT10
+{
+    std::uint32_t dxgiFormat;
+    std::uint32_t resourceDimension;
+    std::uint32_t miscFlag;
+    std::uint32_t arraySize;
+    std::uint32_t miscFlags2;
+};
+
+// Subset of DXGI_FORMAT values relevant to Celestia.
+enum class DXGIFormat : std::uint32_t
+{
+    BC1_UNORM      = 71,
+    BC1_UNORM_SRGB = 72,
+    BC2_UNORM      = 74,
+    BC2_UNORM_SRGB = 75,
+    BC3_UNORM      = 77,
+    BC3_UNORM_SRGB = 78,
 };
 
 constexpr std::size_t DDS_MAX_BLOCK_SIZE = 16;
@@ -147,6 +170,23 @@ GetUncompressedFormat(const DDSurfaceDesc& ddsd)
 }
 
 PixelFormat
+GetDXT10Format(const DDSHeaderDXT10& dx10)
+{
+    switch (static_cast<DXGIFormat>(dx10.dxgiFormat))
+    {
+    case DXGIFormat::BC1_UNORM:           return PixelFormat::DXT1;
+    case DXGIFormat::BC1_UNORM_SRGB:      return PixelFormat::DXT1_sRGBA;
+    case DXGIFormat::BC2_UNORM:           return PixelFormat::DXT3;
+    case DXGIFormat::BC2_UNORM_SRGB:      return PixelFormat::DXT3_sRGBA;
+    case DXGIFormat::BC3_UNORM:           return PixelFormat::DXT5;
+    case DXGIFormat::BC3_UNORM_SRGB:      return PixelFormat::DXT5_sRGBA;
+    default:
+        util::GetLogger()->error("Unsupported DXGI format in DDS DX10 header: {}\n", dx10.dxgiFormat);
+        return PixelFormat::Invalid;
+    }
+}
+
+PixelFormat
 GetFormat(const DDSurfaceDesc& ddsd)
 {
     switch (ddsd.format.fourCC)
@@ -162,6 +202,8 @@ GetFormat(const DDSurfaceDesc& ddsd)
 
     case FourCC("DXT5"):
         return PixelFormat::DXT5;
+
+    // DX10 extended header is handled by the caller before reaching here.
 
     default:
         util::GetLogger()->error("Unknown FourCC in DDS file: {:08x}\n", ddsd.format.fourCC);
@@ -321,7 +363,24 @@ Image* LoadDDSImage(const std::filesystem::path& filename)
         return nullptr;
     }
 
-    PixelFormat format = GetFormat(ddsd);
+    PixelFormat format;
+    if (ddsd.format.fourCC == FourCC("DX10"))
+    {
+        std::array<char, sizeof(DDSHeaderDXT10)> dx10Bytes;
+        if (!in.read(dx10Bytes.data(), dx10Bytes.size()).good()) /* Flawfinder: ignore */
+        {
+            util::GetLogger()->error("DDS file {} has bad DX10 header.\n", filename);
+            return nullptr;
+        }
+        DDSHeaderDXT10 dx10;
+        std::memcpy(&dx10, dx10Bytes.data(), sizeof dx10);
+        LE_TO_CPU_INT32(dx10.dxgiFormat, dx10.dxgiFormat);
+        format = GetDXT10Format(dx10);
+    }
+    else
+    {
+        format = GetFormat(ddsd);
+    }
 
     if (format == PixelFormat::Invalid)
     {

--- a/src/celimage/jpeg.cpp
+++ b/src/celimage/jpeg.cpp
@@ -219,7 +219,9 @@ Image* LoadJPEGImage(const std::filesystem::path& filename)
     // Here we use the library's state variable cinfo.output_scanline as the
     // loop counter, so that we don't have to keep track ourselves.
 
-    PixelFormat format = PixelFormat::RGB;
+    // JPEG color images are always sRGB-encoded; grayscale channels are
+    // treated as linear (they're typically used as height/alpha data).
+    PixelFormat format = PixelFormat::sRGB;
     if (cinfo.output_components == 1)
         format = PixelFormat::Luminance;
 

--- a/src/celimage/jpeg.cpp
+++ b/src/celimage/jpeg.cpp
@@ -219,11 +219,12 @@ Image* LoadJPEGImage(const std::filesystem::path& filename)
     // Here we use the library's state variable cinfo.output_scanline as the
     // loop counter, so that we don't have to keep track ourselves.
 
-    // JPEG color images are always sRGB-encoded; grayscale channels are
-    // treated as linear (they're typically used as height/alpha data).
+    // JPEG images are sRGB-encoded by default. Callers that use the data as
+    // linear (bump/height maps, alpha masks) force a linear reinterpretation
+    // via Image::forceLinear() after load.
     PixelFormat format = PixelFormat::sRGB;
     if (cinfo.output_components == 1)
-        format = PixelFormat::Luminance;
+        format = PixelFormat::sLuminance;
 
     img = new Image(format, cinfo.image_width, cinfo.image_height);
 

--- a/src/celimage/png.cpp
+++ b/src/celimage/png.cpp
@@ -45,8 +45,27 @@ PNGWarn(png_structp pngPtr, png_const_charp warning) //NOSONAR
     util::GetLogger()->warn(_("PNG warning in '{}': {}\n"), *filename, warning);
 }
 
+// Detect whether the PNG's metadata marks it as linear-light data.
+// Returns true if the image should be treated as linear (not sRGB).
+bool
+IsLinearPNG(png_const_structp pngPtr, png_const_infop infoPtr)
+{
+    // An explicit sRGB chunk takes priority.
+    if (int srgbIntent; png_get_sRGB(pngPtr, infoPtr, &srgbIntent))
+        return false;
+
+    // A gAMA chunk with gamma == 1.0 (stored as 100000 in the file) means
+    // the data is linear.  Any other gamma value is treated as sRGB.
+    if (double gamma; png_get_gAMA(pngPtr, infoPtr, &gamma))
+        return gamma > 0.99; // gamma ≈ 1.0 → linear
+
+    // No colorspace metadata: assume sRGB (the modern default for PNG).
+    return false;
+}
+
 PixelFormat
-GetPixelFormat(png_structp pngPtr, png_const_infop infoPtr, int bitDepth, int colorType)
+GetPixelFormat(png_structp pngPtr, png_const_infop infoPtr, int bitDepth, int colorType,
+               bool isLinear)
 {
     if (colorType == PNG_COLOR_TYPE_PALETTE)
     {
@@ -54,10 +73,10 @@ GetPixelFormat(png_structp pngPtr, png_const_infop infoPtr, int bitDepth, int co
         if (png_get_valid(pngPtr, infoPtr, PNG_INFO_tRNS))
         {
             png_set_tRNS_to_alpha(pngPtr);
-            return PixelFormat::RGBA;
+            return isLinear ? PixelFormat::RGBA : PixelFormat::sRGBA;
         }
 
-        return PixelFormat::RGB;
+        return isLinear ? PixelFormat::RGB : PixelFormat::sRGB;
     }
 
     if (bitDepth < 8)
@@ -88,9 +107,9 @@ GetPixelFormat(png_structp pngPtr, png_const_infop infoPtr, int bitDepth, int co
     case PNG_COLOR_TYPE_GRAY_ALPHA:
         return PixelFormat::LumAlpha;
     case PNG_COLOR_TYPE_RGB:
-        return PixelFormat::RGB;
+        return isLinear ? PixelFormat::RGB : PixelFormat::sRGB;
     case PNG_COLOR_TYPE_RGB_ALPHA:
-        return PixelFormat::RGBA;
+        return isLinear ? PixelFormat::RGBA : PixelFormat::sRGBA;
     default:
         png_error(pngPtr, _("Unsupported color type"));
     }
@@ -156,7 +175,8 @@ LoadPNGImage(std::FILE* in, const std::filesystem::path& filename)
     if (height == 0 || height > Image::MAX_DIMENSION)
         png_error(pngPtr, _("Image height out of range"));
 
-    format = GetPixelFormat(pngPtr, infoPtr, bitDepth, colorType);
+    bool isLinear = IsLinearPNG(pngPtr, infoPtr);
+    format = GetPixelFormat(pngPtr, infoPtr, bitDepth, colorType, isLinear);
     img = new Image(format, static_cast<std::int32_t>(width), static_cast<std::int32_t>(height)); //NOSONAR
     pitch = img->getPitch();
 

--- a/src/celimage/png.cpp
+++ b/src/celimage/png.cpp
@@ -103,9 +103,9 @@ GetPixelFormat(png_structp pngPtr, png_const_infop infoPtr, int bitDepth, int co
     switch (colorType)
     {
     case PNG_COLOR_TYPE_GRAY:
-        return PixelFormat::Luminance;
+        return isLinear ? PixelFormat::Luminance : PixelFormat::sLuminance;
     case PNG_COLOR_TYPE_GRAY_ALPHA:
-        return PixelFormat::LumAlpha;
+        return isLinear ? PixelFormat::LumAlpha : PixelFormat::sLumAlpha;
     case PNG_COLOR_TYPE_RGB:
         return isLinear ? PixelFormat::RGB : PixelFormat::sRGB;
     case PNG_COLOR_TYPE_RGB_ALPHA:

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -214,13 +214,13 @@ AtmosphereRenderer::computeLegacy(
         m_skyContour.push_back(p);
     }
 
-    Eigen::Vector3f botColor = atmosphere.lowerColor.toVector3();
-    Eigen::Vector3f topColor = atmosphere.upperColor.toVector3();
-    Eigen::Vector3f sunsetColor = atmosphere.sunsetColor.toVector3();
+    Eigen::Vector3f botColor = atmosphere.lowerColor.linearize().toVector3();
+    Eigen::Vector3f topColor = atmosphere.upperColor.linearize().toVector3();
+    Eigen::Vector3f sunsetColor = atmosphere.sunsetColor.linearize().toVector3();
 
     if (within)
     {
-        Eigen::Vector3f skyColor = atmosphere.skyColor.toVector3();
+        Eigen::Vector3f skyColor = atmosphere.skyColor.linearize().toVector3();
         if (ellipDist < 0.0f)
             topColor = skyColor;
         else

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -214,13 +214,13 @@ AtmosphereRenderer::computeLegacy(
         m_skyContour.push_back(p);
     }
 
-    Eigen::Vector3f botColor = atmosphere.lowerColor.linearize().toVector3();
-    Eigen::Vector3f topColor = atmosphere.upperColor.linearize().toVector3();
-    Eigen::Vector3f sunsetColor = atmosphere.sunsetColor.linearize().toVector3();
+    Eigen::Vector3f botColor = atmosphere.lowerColor.linearize(gl::sRGBRendering).toVector3();
+    Eigen::Vector3f topColor = atmosphere.upperColor.linearize(gl::sRGBRendering).toVector3();
+    Eigen::Vector3f sunsetColor = atmosphere.sunsetColor.linearize(gl::sRGBRendering).toVector3();
 
     if (within)
     {
-        Eigen::Vector3f skyColor = atmosphere.skyColor.linearize().toVector3();
+        Eigen::Vector3f skyColor = atmosphere.skyColor.linearize(gl::sRGBRendering).toVector3();
         if (ellipDist < 0.0f)
             topColor = skyColor;
         else

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -210,13 +210,13 @@ AtmosphereRenderer::computeLegacy(
         m_skyContour.push_back(p);
     }
 
-    Eigen::Vector3f botColor = atmosphere.lowerColor.linearize().toVector3();
-    Eigen::Vector3f topColor = atmosphere.upperColor.linearize().toVector3();
-    Eigen::Vector3f sunsetColor = atmosphere.sunsetColor.linearize().toVector3();
+    Eigen::Vector3f botColor = atmosphere.lowerColor.linearize(gl::sRGBRendering).toVector3();
+    Eigen::Vector3f topColor = atmosphere.upperColor.linearize(gl::sRGBRendering).toVector3();
+    Eigen::Vector3f sunsetColor = atmosphere.sunsetColor.linearize(gl::sRGBRendering).toVector3();
 
     if (within)
     {
-        Eigen::Vector3f skyColor = atmosphere.skyColor.linearize().toVector3();
+        Eigen::Vector3f skyColor = atmosphere.skyColor.linearize(gl::sRGBRendering).toVector3();
         if (ellipDist < 0.0f)
             topColor = skyColor;
         else

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -210,13 +210,13 @@ AtmosphereRenderer::computeLegacy(
         m_skyContour.push_back(p);
     }
 
-    Eigen::Vector3f botColor = atmosphere.lowerColor.toVector3();
-    Eigen::Vector3f topColor = atmosphere.upperColor.toVector3();
-    Eigen::Vector3f sunsetColor = atmosphere.sunsetColor.toVector3();
+    Eigen::Vector3f botColor = atmosphere.lowerColor.linearize().toVector3();
+    Eigen::Vector3f topColor = atmosphere.upperColor.linearize().toVector3();
+    Eigen::Vector3f sunsetColor = atmosphere.sunsetColor.linearize().toVector3();
 
     if (within)
     {
-        Eigen::Vector3f skyColor = atmosphere.skyColor.toVector3();
+        Eigen::Vector3f skyColor = atmosphere.skyColor.linearize().toVector3();
         if (ellipDist < 0.0f)
             topColor = skyColor;
         else

--- a/src/celrender/galaxyrenderer.cpp
+++ b/src/celrender/galaxyrenderer.cpp
@@ -183,7 +183,9 @@ GalaxyRenderer::bindTextures()
 
     if (m_colorTex == nullptr)
     {
-        m_colorTex = ImageTexture::createProcedural(256, 1, engine::PixelFormat::RGBA,
+        // Color values are authored in sRGB; mark the texture accordingly so
+        // GL linearizes them when the shader samples the colour lookup table.
+        m_colorTex = ImageTexture::createProcedural(256, 1, engine::PixelFormat::sRGBA,
                                                     &colorTextureEval,
                                                     Texture::EdgeClamp,
                                                     Texture::NoMipMaps);

--- a/src/celrender/globularrenderer.cpp
+++ b/src/celrender/globularrenderer.cpp
@@ -462,7 +462,9 @@ GlobularRenderer::FormManager::getColorTex()
 {
     if (colorTex == nullptr)
     {
-        colorTex = ImageTexture::createProcedural(256, 1, engine::PixelFormat::RGBA,
+        // Color values are authored in sRGB; mark the texture accordingly so
+        // GL linearizes them when the shader samples the colour lookup table.
+        colorTex = ImageTexture::createProcedural(256, 1, engine::PixelFormat::sRGBA,
                                                   &colorTextureEval,
                                                   Texture::EdgeClamp,
                                                   Texture::NoMipMaps);

--- a/src/celutil/color.h
+++ b/src/celutil/color.h
@@ -139,6 +139,14 @@ class Color
                      linearizeScalar(blue()),
                      alpha());
     }
+
+    // Conditionally linearize: when \p enabled is true, returns linearize();
+    // otherwise returns *this unchanged.  Convenience for call sites that
+    // gate linearization on a runtime sRGB-rendering flag.
+    Color linearize(bool enabled) const noexcept
+    {
+        return enabled ? linearize() : *this;
+    }
 };
 
 constexpr bool operator==(Color a, Color b)


### PR DESCRIPTION
Render in linear light with a final post-process sRGB conversion instead of relying on hardware GL_FRAMEBUFFER_SRGB.

- Add SRGBViewportEffect as the final viewport effect for linear→sRGB conversion, with a GL_RGBA16F source FBO
- Pre-linearize input colours (HUD, labels, stars, galaxies, atmospheres) for correct blending in linear space
- Detect sRGB PNG/JPEG textures and use sRGB internal formats
- On GLES, expand sRGB luminance formats to GL_SRGB8_ALPHA8 at upload time since GL_SLUMINANCE is unavailable (ANGLE/Metal)