### PR TITLE
Prepare for sRGB

### DIFF
--- a/src/celengine/framebuffer.cpp
+++ b/src/celengine/framebuffer.cpp
@@ -12,13 +12,14 @@
 
 #include <cassert>
 
-FramebufferObject::FramebufferObject(GLuint width, GLuint height, unsigned int attachments, int samples) :
+FramebufferObject::FramebufferObject(GLuint width, GLuint height, unsigned int attachments, int samples, bool useFloatColor) :
     m_width(width),
     m_height(height),
     m_colorTexId(0),
     m_depthTexId(0),
     m_fboId(0),
     m_samples(samples > 1 ? samples : 1),
+    m_useFloatColor(useFloatColor),
     m_status(GL_FRAMEBUFFER_UNSUPPORTED),
     m_owned(true)
 {
@@ -35,6 +36,7 @@ FramebufferObject::FramebufferObject(GLuint fboId) :
     m_depthTexId(0),
     m_fboId(fboId),
     m_samples(1),
+    m_useFloatColor(false),
     m_status(GL_FRAMEBUFFER_COMPLETE),
     m_owned(false)
 {
@@ -57,6 +59,7 @@ FramebufferObject::FramebufferObject(FramebufferObject &&other) noexcept:
     m_colorRboId(other.m_colorRboId),
     m_depthRboId(other.m_depthRboId),
     m_samples(other.m_samples),
+    m_useFloatColor(other.m_useFloatColor),
     m_status(other.m_status),
     m_owned(other.m_owned)
 {
@@ -70,17 +73,18 @@ FramebufferObject::FramebufferObject(FramebufferObject &&other) noexcept:
 
 FramebufferObject& FramebufferObject::operator=(FramebufferObject &&other) noexcept
 {
-    m_width       = other.m_width;
-    m_height      = other.m_height;
-    m_colorTexId  = other.m_colorTexId;
-    m_depthTexId  = other.m_depthTexId;
-    m_fboId       = other.m_fboId;
-    m_msaaFboId   = other.m_msaaFboId;
-    m_colorRboId  = other.m_colorRboId;
-    m_depthRboId  = other.m_depthRboId;
-    m_samples     = other.m_samples;
-    m_status      = other.m_status;
-    m_owned       = other.m_owned;
+    m_width         = other.m_width;
+    m_height        = other.m_height;
+    m_colorTexId    = other.m_colorTexId;
+    m_depthTexId    = other.m_depthTexId;
+    m_fboId         = other.m_fboId;
+    m_msaaFboId     = other.m_msaaFboId;
+    m_colorRboId    = other.m_colorRboId;
+    m_depthRboId    = other.m_depthRboId;
+    m_samples       = other.m_samples;
+    m_useFloatColor = other.m_useFloatColor;
+    m_status        = other.m_status;
+    m_owned         = other.m_owned;
 
     other.m_owned      = false;
     other.m_fboId      = 0;
@@ -132,10 +136,25 @@ FramebufferObject::generateColorTexture()
 
     // Set the texture dimensions
 #ifdef GL_ES
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_width, m_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    GLenum format = GL_RGBA;
+    GLint internalFormat;
+    GLenum type;
+    if (celestia::gl::checkVersion(celestia::gl::GLES_3_0))
+    {
+        internalFormat = m_useFloatColor ? GL_RGBA16F : GL_RGBA8;
+        type = m_useFloatColor ? GL_HALF_FLOAT : GL_UNSIGNED_BYTE;
+    }
+    else
+    {
+        internalFormat = GL_RGBA;
+        type = m_useFloatColor ? GL_HALF_FLOAT_OES : GL_UNSIGNED_BYTE;
+    }
 #else
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, m_width, m_height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+    GLint internalFormat = m_useFloatColor ? GL_RGBA16F : GL_RGB8;
+    GLenum format = m_useFloatColor ? GL_RGBA : GL_RGB;
+    GLenum type = m_useFloatColor ? GL_FLOAT : GL_UNSIGNED_BYTE;
 #endif
+    glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, m_width, m_height, 0, format, type, nullptr);
 
     // Unbind the texture
     glBindTexture(GL_TEXTURE_2D, 0);
@@ -165,13 +184,23 @@ FramebufferObject::generateDepthTexture()
 
     // Set the texture dimensions
 #ifdef GL_ES
-    if (celestia::gl::checkVersion(celestia::gl::GLES_3_0) || celestia::gl::OES_depth24)
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, m_width, m_height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
+    GLint internalFormat;
+    GLenum type;
+    if (celestia::gl::checkVersion(celestia::gl::GLES_3_0))
+    {
+        internalFormat = GL_DEPTH_COMPONENT24;
+        type = GL_UNSIGNED_INT;
+    }
     else
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT16, m_width, m_height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, nullptr);
+    {
+        internalFormat = GL_DEPTH_COMPONENT;
+        type = celestia::gl::OES_depth24 ? GL_UNSIGNED_INT :  GL_UNSIGNED_SHORT;
+    }
 #else
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, m_width, m_height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_BYTE, nullptr);
+    GLint internalFormat = GL_DEPTH_COMPONENT;
+    GLenum type = GL_UNSIGNED_BYTE;
 #endif
+    glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, m_width, m_height, 0, GL_DEPTH_COMPONENT, type, nullptr);
 
     // Unbind the texture
     glBindTexture(GL_TEXTURE_2D, 0);
@@ -180,29 +209,7 @@ FramebufferObject::generateDepthTexture()
 void
 FramebufferObject::generateFbo(unsigned int attachments)
 {
-    // Determine MSAA strategy.
-    //
-    // Desktop GL:  renderbuffer MSAA + glBlitFramebuffer (ARB_framebuffer_object is required)
-    // GLES 3.0+:   same as desktop GL
-    // GLES 2.0:    no MSAA support
-    //
-    // The "renderbuffer MSAA" strategy uses two FBOs:
-    //   m_msaaFboId  – MSAA renderbuffers, scene is rendered here
-    //   m_fboId      – plain textures, used as resolve target and sampled by the effect shader
-
-    bool useRenderbufferMSAA = false;
-
-    if (m_samples > 1 && (attachments & ColorAttachment) != 0)
-    {
-#ifdef GL_ES
-        if (celestia::gl::checkVersion(celestia::gl::GLES_3_0))
-            useRenderbufferMSAA = true;
-        else
-            m_samples = 1; // no MSAA support on GLES2
-#else
-        useRenderbufferMSAA = true;
-#endif
-    }
+    bool useRenderbufferMSAA = m_samples > 1 && (attachments & ColorAttachment) != 0;
 
     // Create the texture-based FBO (resolve target for renderbuffer MSAA,
     // or the sole FBO for non-MSAA paths).
@@ -291,10 +298,11 @@ FramebufferObject::generateMSAAFbo(unsigned int attachments)
         glGenRenderbuffers(1, &m_colorRboId);
         glBindRenderbuffer(GL_RENDERBUFFER, m_colorRboId);
 #ifdef GL_ES
-        glRenderbufferStorageMultisample(GL_RENDERBUFFER, m_samples, GL_RGBA8, m_width, m_height);
+        GLenum fmt = m_useFloatColor ? GL_RGBA16F : GL_RGBA8;
 #else
-        glRenderbufferStorageMultisample(GL_RENDERBUFFER, m_samples, GL_RGB8, m_width, m_height);
+        GLenum fmt = m_useFloatColor ? GL_RGBA16F : GL_RGB8;
 #endif
+        glRenderbufferStorageMultisample(GL_RENDERBUFFER, m_samples, fmt, m_width, m_height);
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorRboId);
     }
 

--- a/src/celengine/framebuffer.h
+++ b/src/celengine/framebuffer.h
@@ -21,7 +21,7 @@ class FramebufferObject
         DepthAttachment = 0x2
     };
     FramebufferObject() = delete;
-    FramebufferObject(GLuint width, GLuint height, unsigned int attachments, int samples = 1);
+    FramebufferObject(GLuint width, GLuint height, unsigned int attachments, int samples = 1, bool useFloatColor = false);
     FramebufferObject(const FramebufferObject&) = delete;
     FramebufferObject(FramebufferObject&&) noexcept;
     FramebufferObject& operator=(const FramebufferObject&) = delete;
@@ -46,6 +46,11 @@ class FramebufferObject
     int samples() const
     {
         return m_samples;
+    }
+
+    bool useFloatColor() const
+    {
+        return m_useFloatColor;
     }
 
     GLuint colorTexture() const;
@@ -74,6 +79,7 @@ class FramebufferObject
     GLuint m_colorRboId{ 0 };
     GLuint m_depthRboId{ 0 };
     int    m_samples;
+    bool   m_useFloatColor;
     GLenum m_status;
     bool   m_owned;
 };

--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -12,6 +12,7 @@ CELAPI bool OES_vertex_array_object              = false;
 CELAPI bool OES_texture_border_clamp             = false;
 CELAPI bool OES_geometry_shader                  = false;
 CELAPI bool OES_depth24                          = false;
+CELAPI bool OES_texture_half_float               = false;
 #else
 CELAPI bool ARB_vertex_array_object        = false;
 CELAPI bool ARB_framebuffer_object         = false;
@@ -83,6 +84,7 @@ bool init(util::array_view<std::string> ignore) noexcept
     OES_texture_border_clamp           = check_extension(ignore, "GL_OES_texture_border_clamp") || check_extension(ignore, "GL_EXT_texture_border_clamp");
     OES_geometry_shader                = check_extension(ignore, "GL_OES_geometry_shader") || check_extension(ignore, "GL_EXT_geometry_shader");
     OES_depth24                        = check_extension(ignore, "GL_OES_depth24");
+    OES_texture_half_float             = check_extension(ignore, "GL_OES_texture_half_float");
 #else
     ARB_vertex_array_object        = check_extension(ignore, "GL_ARB_vertex_array_object");
     if (!has_extension("GL_ARB_framebuffer_object"))

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -48,6 +48,7 @@ extern CELAPI bool OES_vertex_array_object; //NOSONAR
 extern CELAPI bool OES_texture_border_clamp; //NOSONAR
 extern CELAPI bool OES_geometry_shader; //NOSONAR
 extern CELAPI bool OES_depth24; //NOSONAR
+extern CELAPI bool OES_texture_half_float; //NOSONAR
 #else
 extern CELAPI bool ARB_vertex_array_object; //NOSONAR
 #endif

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2886,13 +2886,14 @@ void Renderer::renderPlanet(Body& body,
 
     if (body.isVisibleAsPoint())
     {
-        if (float maxCoeff = body.getSurface().color.toVector3().maxCoeff(); maxCoeff > 0.0f) // ignore [ 0 0 0 ]; used by old addons to make objects not get rendered as point
+        const auto& surfaceColor = body.getSurface().color;
+        if (float maxCoeff = surfaceColor.toVector3().maxCoeff(); maxCoeff > 0.0f) // ignore [ 0 0 0 ]; used by old addons to make objects not get rendered as point
         {
             renderObjectAsPoint(pos,
                                 body.getRadius(),
                                 appMag,
                                 discSizeInPixels,
-                                body.getSurface().color * (1.0f / maxCoeff), // normalize point color; 'darkness' is handled by size of point determined by GeomAlbedo.
+                                surfaceColor * (1.0f / maxCoeff), // normalize point color; 'darkness' is handled by size of point determined by GeomAlbedo.
                                 false, false, m);
         }
     }

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -28,8 +28,7 @@ bool ViewportEffect::preprocess(Renderer* renderer, FramebufferObject* fbo)
 bool ViewportEffect::prerender(Renderer* renderer, FramebufferObject* fbo, FramebufferObject* dst)
 {
     // For renderbuffer MSAA (desktop GL / GLES3), blit the MSAA color buffer into
-    // the resolve texture before switching to the destination framebuffer.
-    // For the GLES2 EXT path the resolve happens implicitly when the FBO is unbound.
+    // the resolve texture before switching to the destination framebuffer
     if (!fbo->resolve())
         return false;
 

--- a/src/celengine/viewporteffect.h
+++ b/src/celengine/viewporteffect.h
@@ -30,6 +30,9 @@ public:
     virtual bool render(Renderer*, FramebufferObject*, int width, int height) = 0;
     virtual bool distortXY(float& x, float& y);
 
+    // Whether this effect needs its source FBO to use a floating-point
+    // color buffer (GL_RGBA16F) instead of the default GL_RGBA8.
+    virtual bool needsFloatSource() const { return false; }
 };
 
 class PassthroughViewportEffect : public ViewportEffect

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2000,7 +2000,7 @@ void CelestiaCore::draw(View* view)
     if (nEffects > 0)
     {
         // create/update FBOs for viewport effect chain
-        view->updateFBOs(nEffects, metrics.width, metrics.height);
+        view->updateFBOs(viewportEffects, metrics.width, metrics.height);
         fbo = view->getFBO(0);
     }
     bool process = fbo != nullptr && viewportEffects[0]->preprocess(renderer, fbo);

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -59,6 +59,12 @@ namespace celestia
 namespace
 {
 
+constexpr Color InfoColor        = Color(0.7f, 0.7f, 1.0f, 1.0f);
+constexpr Color FrameInfoColor   = Color(0.6f, 0.6f, 1.0f, 1.0f);
+constexpr Color LightTravelColor = Color(0.42f, 1.0f, 1.0f, 1.0f);
+constexpr Color WarningColor     = Color(1.0f, 0.0f, 0.0f, 1.0f);
+constexpr Color EditModeColor    = Color(1.0f, 0.0f, 1.0f, 1.0f);
+
 // Ye olde wolde conſtantes for ye olde wolde units
 constexpr double OneMiInKm = 1.609344;
 constexpr double OneFtInKm = 0.0003048;
@@ -943,7 +949,7 @@ Hud::renderOverlay(const WindowMetrics& metrics,
         m_overlay->savePos();
         m_overlay->moveBy(metrics.getSafeAreaStart(),
                           metrics.getSafeAreaBottom(m_hudFonts.fontHeight() * 2 + static_cast<int>(static_cast<float>(metrics.screenDpi) / 25.4f * 1.3f)));
-        m_overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+        m_overlay->setColor(InfoColor);
 
         m_overlay->beginText();
         m_overlay->print("\n");
@@ -983,7 +989,7 @@ Hud::renderOverlay(const WindowMetrics& metrics,
         m_overlay->beginText();
         int x = (metrics.getSafeAreaWidth() - engine::TextLayout::getTextWidth(_("Edit Mode"), m_hudFonts.font().get())) / 2;
         m_overlay->moveBy(metrics.getSafeAreaStart(x), metrics.getSafeAreaTop(m_hudFonts.fontHeight()));
-        m_overlay->setColor(1, 0, 1, 1);
+        m_overlay->setColor(EditModeColor);
         m_overlay->print(_("Edit Mode"));
         m_overlay->endText();
         m_overlay->restorePos();
@@ -1014,7 +1020,7 @@ Hud::renderTimeInfo(const WindowMetrics& metrics, const Simulation* sim, const T
 
     // Time and date
     m_overlay->savePos();
-    m_overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+    m_overlay->setColor(InfoColor);
     m_overlay->moveBy(metrics.getSafeAreaEnd(m_dateStrWidth), metrics.getSafeAreaTop(m_hudFonts.fontHeight()));
     m_overlay->beginText();
 
@@ -1022,9 +1028,9 @@ Hud::renderTimeInfo(const WindowMetrics& metrics, const Simulation* sim, const T
 
     if (timeInfo.lightTravelFlag && lt > 0.0)
     {
-        m_overlay->setColor(0.42f, 1.0f, 1.0f, 1.0f);
+        m_overlay->setColor(LightTravelColor);
         m_overlay->print(_("  LT"));
-        m_overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+        m_overlay->setColor(InfoColor);
     }
     m_overlay->print("\n");
 
@@ -1050,7 +1056,7 @@ Hud::renderTimeInfo(const WindowMetrics& metrics, const Simulation* sim, const T
 
     if (sim->getPauseState() == true)
     {
-        m_overlay->setColor(1.0f, 0.0f, 0.0f, 1.0f);
+        m_overlay->setColor(WarningColor);
         m_overlay->print(_(" (Paused)"));
     }
 
@@ -1067,7 +1073,7 @@ Hud::renderFrameInfo(const WindowMetrics& metrics, const Simulation* sim)
                       metrics.getSafeAreaBottom(m_hudFonts.fontHeight() * 3 +
                           static_cast<int>(static_cast<float>(metrics.screenDpi) / 25.4f * 1.3f)));
     m_overlay->beginText();
-    m_overlay->setColor(0.6f, 0.6f, 1.0f, 1);
+    m_overlay->setColor(FrameInfoColor);
 
     if (sim->getObserverMode() == Observer::ObserverMode::Travelling)
     {
@@ -1116,7 +1122,7 @@ Hud::renderFrameInfo(const WindowMetrics& metrics, const Simulation* sim)
         break;
     }
 
-    m_overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+    m_overlay->setColor(InfoColor);
 
     // Field of view
     const Observer* activeObserver = sim->getActiveObserver();
@@ -1133,7 +1139,7 @@ Hud::renderSelectionInfo(const WindowMetrics& metrics,
                          const Eigen::Vector3d& v)
 {
     m_overlay->savePos();
-    m_overlay->setColor(0.7f, 0.7f, 1.0f, 1.0f);
+    m_overlay->setColor(InfoColor);
     m_overlay->moveBy(metrics.getSafeAreaStart(), metrics.getSafeAreaTop(m_hudFonts.titleFontHeight()));
 
     m_overlay->beginText();
@@ -1282,7 +1288,7 @@ Hud::renderMovieCapture(const WindowMetrics& metrics, const MovieCapture& movieC
     int movieWidth = movieCapture.getWidth();
     int movieHeight = movieCapture.getHeight();
     m_overlay->savePos();
-    Color color(1.0f, 0.0f, 0.0f, 1.0f);
+    const Color& color = WarningColor;
     m_overlay->setColor(color);
     celestia::Rect r(static_cast<float>((metrics.width - movieWidth) / 2 - 1),
                      static_cast<float>((metrics.height - movieHeight) / 2 - 1),

--- a/src/celestia/textinput.cpp
+++ b/src/celestia/textinput.cpp
@@ -30,7 +30,9 @@ namespace celestia
 
 namespace
 {
-constexpr Color consoleColor{ 0.7f, 0.7f, 1.0f, 0.2f };
+constexpr Color consoleColor       = Color(0.7f, 0.7f, 1.0f, 0.2f);
+constexpr Color inputTextColor     = Color(0.6f, 0.6f, 1.0f, 1.0f);
+constexpr Color selectedCompletion = Color(1.0f, 0.6f, 0.6f, 1.0f);
 }
 
 std::string_view
@@ -188,7 +190,7 @@ TextInput::render(Overlay* overlay,
     r.setColor(consoleColor);
     overlay->drawRectangle(r);
     overlay->moveBy(metrics.getSafeAreaStart(), metrics.getSafeAreaBottom(rectHeight - hudFonts.titleFontHeight()));
-    overlay->setColor(0.6f, 0.6f, 1.0f, 1.0f);
+    overlay->setColor(inputTextColor);
     overlay->beginText();
     overlay->print(fmt::runtime(_("Target name: {}")), m_text);
     overlay->endText();
@@ -224,9 +226,9 @@ TextInput::renderCompletion(Overlay* overlay, const WindowMetrics& metrics, int 
         for (int j = 0; iter < m_completion.end() && j < nb_lines; iter++, j++)
         {
             if (i * nb_lines + j == typedTextCompletionIdx - start)
-                overlay->setColor(1.0f, 0.6f, 0.6f, 1);
+                overlay->setColor(selectedCompletion);
             else
-                overlay->setColor(0.6f, 0.6f, 1.0f, 1);
+                overlay->setColor(inputTextColor);
             overlay->print(iter->getName());
             overlay->print("\n");
         }

--- a/src/celestia/view.cpp
+++ b/src/celestia/view.cpp
@@ -14,6 +14,7 @@
 #include <celengine/overlay.h>
 #include <celengine/rectangle.h>
 #include <celengine/shadermanager.h>
+#include <celengine/viewporteffect.h>
 #include <celutil/logger.h>
 
 using celestia::util::GetLogger;
@@ -261,8 +262,9 @@ View::drawBorder(Overlay* overlay, int gWidth, int gHeight, const Color &color, 
 
 
 void
-View::updateFBOs(int count, int gWidth, int gHeight)
+View::updateFBOs(const std::vector<std::unique_ptr<ViewportEffect>>& effects, int gWidth, int gHeight)
 {
+    int count = static_cast<int>(effects.size());
     auto newWidth = static_cast<GLuint>(width * gWidth);
     auto newHeight = static_cast<GLuint>(height * gHeight);
 
@@ -274,6 +276,12 @@ View::updateFBOs(int count, int gWidth, int gHeight)
     if (currentSamples < 1)
         currentSamples = 1;
 
+#ifdef GL_ES
+    int samplesToRequest = celestia::gl::checkVersion(celestia::gl::GLES_3_0) ? currentSamples : 1;
+#else
+    int samplesToRequest = currentSamples;
+#endif
+
     if (static_cast<int>(fbos.size()) != count)
         fbos.resize(count);
 
@@ -281,18 +289,29 @@ View::updateFBOs(int count, int gWidth, int gHeight)
     {
         // Only the first FBO needs MSAA to match the output framebuffer.
         // Subsequent FBOs receive already-resolved blits so samples=1 suffices.
-        int samples = (i == 0) ? currentSamples : 1;
+        int samples = (i == 0) ? samplesToRequest : 1;
+
+        // Use a float color buffer only when the consuming effect requires it
+        // (e.g. the sRGB tonemap needs linear-light precision).
+        bool useFloat = effects[i]->needsFloatSource();
+#ifdef GL_ES
+        if (useFloat && !celestia::gl::checkVersion(celestia::gl::GLES_3_0) && !celestia::gl::OES_texture_half_float)
+            useFloat = false;
+#endif
+
         auto& fbo = fbos[i];
 
         if (fbo
-            && fbo->width()   == newWidth
-            && fbo->height()  == newHeight
-            && fbo->samples() == samples)
+            && fbo->width()         == newWidth
+            && fbo->height()        == newHeight
+            && fbo->samples()       == samples
+            && fbo->useFloatColor() == useFloat)
             continue;
 
         fbo = std::make_unique<FramebufferObject>(newWidth, newHeight,
                                                   FramebufferObject::ColorAttachment | FramebufferObject::DepthAttachment,
-                                                  samples);
+                                                  samples,
+                                                  useFloat);
         if (!fbo->isValid())
         {
             GetLogger()->error("Error creating view FBO {}.\n", i);

--- a/src/celestia/view.h
+++ b/src/celestia/view.h
@@ -17,6 +17,7 @@ class Color;
 class FramebufferObject;
 class Observer;
 class Overlay;
+class ViewportEffect;
 
 namespace celestia
 {
@@ -50,7 +51,7 @@ public:
     void reset();
     static View* remove(View*);
     void drawBorder(Overlay*, int gWidth, int gHeight, const Color &color, float linewidth = 1.0f) const;
-    void updateFBOs(int count, int gWidth, int gHeight);
+    void updateFBOs(const std::vector<std::unique_ptr<ViewportEffect>>& effects, int gWidth, int gHeight);
     FramebufferObject *getFBO(int index) const;
 
     Type           type;

--- a/src/celutil/color.h
+++ b/src/celutil/color.h
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <string_view>
 
@@ -118,6 +119,26 @@ class Color
     static Color fromHSV(float h, float s, float v);
 
     static bool parse(std::string_view, Color&);
+
+    // Return a copy with RGB components converted from sRGB encoding to linear
+    // light (IEC 61966-2-1).  Use this when passing designer-specified sRGB
+    // Linearize a single scalar component from sRGB to linear light.
+    static float linearizeScalar(float c) noexcept
+    {
+        return c <= 0.04045f
+            ? c / 12.92f
+            : std::pow((c + 0.055f) / 1.055f, 2.4f);
+    }
+
+    // colors as GL uniforms into a linear-light rendering pipeline.
+    // Alpha is passed through unchanged.
+    Color linearize() const noexcept
+    {
+        return Color(linearizeScalar(red()),
+                     linearizeScalar(green()),
+                     linearizeScalar(blue()),
+                     alpha());
+    }
 };
 
 constexpr bool operator==(Color a, Color b)


### PR DESCRIPTION
Taken from #2483 no behavior change yet

Fix a bug that iOS ES2 has OES_depth24 extension and will try to call this. GL_DEPTH_COMPONENT24 is not valid for ES2. 
```
glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, m_width, m_height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
```

I've tested viewport effects with:
iOS (ES2, ES3) and macOS (desktop GL), with MSAA on/off (ES2 FBO's MSAA is always off), with float or non-float storage.