### PR TITLE
Prepare for sRGB p2

### DIFF
--- a/src/celengine/CMakeLists.txt
+++ b/src/celengine/CMakeLists.txt
@@ -96,6 +96,8 @@ set(CELENGINE_SOURCES
   rendcontext.h
   render.cpp
   render.h
+  rendercolors.cpp
+  rendercolors.h
   renderflags.h
   renderglsl.cpp
   renderglsl.h

--- a/src/celengine/dsorenderer.cpp
+++ b/src/celengine/dsorenderer.cpp
@@ -150,25 +150,25 @@ void DSORenderer::process(const std::unique_ptr<DeepSkyObject>& dso, //NOSONAR
         {
         case RenderLabels::NebulaLabels:
             rep = &renderer->nebulaRep;
-            labelColor = Renderer::NebulaLabelColor;
+            labelColor = renderer->colors.NebulaLabel;
             appMagEff = astro::absToAppMag(-7.5f, (float)distanceToDSO);
             symbolSize = (float)(dso->getRadius() / distanceToDSO) / pixelSize;
             step = 6.0f;
             break;
         case RenderLabels::OpenClusterLabels:
             rep = &renderer->openClusterRep;
-            labelColor = Renderer::OpenClusterLabelColor;
+            labelColor = renderer->colors.OpenClusterLabel;
             appMagEff = astro::absToAppMag(-6.0f, (float)distanceToDSO);
             symbolSize = (float)(dso->getRadius() / distanceToDSO) / pixelSize;
             step = 4.0f;
             break;
         case RenderLabels::GalaxyLabels:
-            labelColor = Renderer::GalaxyLabelColor;
+            labelColor = renderer->colors.GalaxyLabel;
             appMagEff = appMag;
             step = 6.0f;
             break;
         case RenderLabels::GlobularLabels:
-            labelColor = Renderer::GlobularLabelColor;
+            labelColor = renderer->colors.GlobularLabel;
             appMagEff = appMag;
             step = 3.0f;
             break;

--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -155,7 +155,7 @@ Renderer::renderSelectionPointer(const Observer& observer,
     prog->use();
     Eigen::Vector3f center = cameraMatrix.col(2);
     prog->setMVPMatrices(getProjectionMatrix(), getModelViewMatrix() * math::translate(Eigen::Vector3f(-center)));
-    prog->vec4Param("color") = Color(SelectionCursorColor, 0.6f).toVector4();
+    prog->vec4Param("color") = Color(colors.SelectionCursor, 0.6f).toVector4();
     prog->floatParam("pixelSize") = pixelSize * getScaleFactor();
     prog->floatParam("s") = s;
     prog->floatParam("c") = c;

--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -13,6 +13,8 @@ CELAPI bool OES_texture_border_clamp             = false;
 CELAPI bool OES_geometry_shader                  = false;
 CELAPI bool OES_depth24                          = false;
 CELAPI bool OES_texture_half_float               = false;
+CELAPI bool EXT_sRGB                             = false;
+CELAPI bool EXT_sRGB_write_control               = false;
 #else
 CELAPI bool ARB_vertex_array_object        = false;
 CELAPI bool ARB_framebuffer_object         = false;
@@ -85,6 +87,8 @@ bool init(util::array_view<std::string> ignore) noexcept
     OES_geometry_shader                = check_extension(ignore, "GL_OES_geometry_shader") || check_extension(ignore, "GL_EXT_geometry_shader");
     OES_depth24                        = check_extension(ignore, "GL_OES_depth24");
     OES_texture_half_float             = check_extension(ignore, "GL_OES_texture_half_float");
+    EXT_sRGB                           = check_extension(ignore, "GL_EXT_sRGB");
+    EXT_sRGB_write_control             = check_extension(ignore, "GL_EXT_sRGB_write_control");
 #else
     ARB_vertex_array_object        = check_extension(ignore, "GL_ARB_vertex_array_object");
     if (!has_extension("GL_ARB_framebuffer_object"))

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -49,6 +49,8 @@ extern CELAPI bool OES_texture_border_clamp; //NOSONAR
 extern CELAPI bool OES_geometry_shader; //NOSONAR
 extern CELAPI bool OES_depth24; //NOSONAR
 extern CELAPI bool OES_texture_half_float; //NOSONAR
+extern CELAPI bool EXT_sRGB; //NOSONAR
+extern CELAPI bool EXT_sRGB_write_control; //NOSONAR
 #else
 extern CELAPI bool ARB_vertex_array_object; //NOSONAR
 #endif

--- a/src/celengine/planetgrid.cpp
+++ b/src/celengine/planetgrid.cpp
@@ -84,7 +84,7 @@ void longLatLabel(const std::string& labelText,
         labelPos *= planetZ / z;
 
         renderer.addObjectAnnotation(nullptr, labelText,
-                                     Renderer::PlanetographicGridLabelColor,
+                                     renderer.colors.PlanetographicGridLabel,
                                      labelPos.cast<float>(),
                                      Renderer::LabelHorizontalAlignment::Start,
                                      Renderer::LabelVerticalAlignment::Bottom);
@@ -215,14 +215,14 @@ RenderDetails::renderLatitude(int latitudeStep,
         {
             latitudeRenderer.finish();
             equatorRenderer.render({&projection, &mvcur},
-                                   Renderer::PlanetEquatorColor,
+                                   renderer.colors.PlanetEquator,
                                    circleSubdivisions+1);
             equatorRenderer.finish();
         }
         else
         {
             latitudeRenderer.render({&projection, &mvcur},
-                                    Renderer::PlanetographicGridColor,
+                                    renderer.colors.PlanetographicGrid,
                                     circleSubdivisions+1);
         }
 
@@ -250,7 +250,7 @@ RenderDetails::renderLongitude(int longitudeStep,
                                                                            Eigen::Vector3f::UnitY()));
 
         longitudeRenderer.render({&projection, &mvcur},
-                                 Renderer::PlanetographicGridColor,
+                                 renderer.colors.PlanetographicGrid,
                                  circleSubdivisions + 1);
 
         if (!showCoordinateLabels)

--- a/src/celengine/pointstarrenderer.cpp
+++ b/src/celengine/pointstarrenderer.cpp
@@ -119,7 +119,7 @@ void PointStarRenderer::process(const Star& star, float distance, float appMag)
                 if (starDir.dot(viewNormal) > cosFOV)
                 {
                     float distr = min(1.0f, 3.5f * (labelThresholdMag - appMag)/labelThresholdMag);
-                    Color color = Color(Renderer::StarLabelColor, distr * Renderer::StarLabelColor.alpha());
+                    Color color = Color(renderer->colors.StarLabel, distr * renderer->colors.StarLabel.alpha());
                     renderer->addBackgroundAnnotation(nullptr,
                                                       starDB->getStarName(star, true),
                                                       color,
@@ -158,7 +158,7 @@ void PointStarRenderer::process(const Star& star, float distance, float appMag)
 
                 renderer->addSortedAnnotation(nullptr,
                                               starDB->getStarName(star, true),
-                                              Renderer::StarLabelColor,
+                                              renderer->colors.StarLabel,
                                               pos);
             }
         }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -129,47 +129,6 @@ static constexpr unsigned int OrbitCacheCullThreshold = 200;
 // Age in frames at which unused orbit paths may be eliminated from the cache
 static constexpr std::uint32_t OrbitCacheRetireAge = 16;
 
-Color Renderer::StarLabelColor          (0.471f, 0.356f, 0.682f);
-Color Renderer::PlanetLabelColor        (0.407f, 0.333f, 0.964f);
-Color Renderer::DwarfPlanetLabelColor   (0.557f, 0.235f, 0.576f);
-Color Renderer::MoonLabelColor          (0.231f, 0.733f, 0.792f);
-Color Renderer::MinorMoonLabelColor     (0.231f, 0.733f, 0.792f);
-Color Renderer::AsteroidLabelColor      (0.596f, 0.305f, 0.164f);
-Color Renderer::CometLabelColor         (0.768f, 0.607f, 0.227f);
-Color Renderer::SpacecraftLabelColor    (0.93f,  0.93f,  0.93f);
-Color Renderer::LocationLabelColor      (0.24f,  0.89f,  0.43f);
-Color Renderer::GalaxyLabelColor        (0.0f,   0.45f,  0.5f);
-Color Renderer::GlobularLabelColor      (0.8f,   0.45f,  0.5f);
-Color Renderer::NebulaLabelColor        (0.541f, 0.764f, 0.278f);
-Color Renderer::OpenClusterLabelColor   (0.239f, 0.572f, 0.396f);
-Color Renderer::ConstellationLabelColor (0.225f, 0.301f, 0.36f);
-Color Renderer::EquatorialGridLabelColor(0.64f,  0.72f,  0.88f);
-Color Renderer::PlanetographicGridLabelColor(0.8f, 0.8f, 0.8f);
-Color Renderer::GalacticGridLabelColor  (0.88f,  0.72f,  0.64f);
-Color Renderer::EclipticGridLabelColor  (0.72f,  0.64f,  0.88f);
-Color Renderer::HorizonGridLabelColor   (0.72f,  0.72f,  0.72f);
-
-Color Renderer::StarOrbitColor          (0.5f,   0.5f,   0.8f);
-Color Renderer::PlanetOrbitColor        (0.3f,   0.323f, 0.833f);
-Color Renderer::DwarfPlanetOrbitColor   (0.557f, 0.235f, 0.576f);
-Color Renderer::MoonOrbitColor          (0.08f,  0.407f, 0.392f);
-Color Renderer::MinorMoonOrbitColor     (0.08f,  0.407f, 0.392f);
-Color Renderer::AsteroidOrbitColor      (0.58f,  0.152f, 0.08f);
-Color Renderer::CometOrbitColor         (0.639f, 0.487f, 0.168f);
-Color Renderer::SpacecraftOrbitColor    (0.4f,   0.4f,   0.4f);
-Color Renderer::SelectionOrbitColor     (1.0f,   0.0f,   0.0f);
-
-Color Renderer::ConstellationColor      (0.0f,   0.24f,  0.36f);
-Color Renderer::BoundaryColor           (0.24f,  0.10f,  0.12f);
-Color Renderer::EquatorialGridColor     (0.28f,  0.28f,  0.38f);
-Color Renderer::PlanetographicGridColor (0.8f,   0.8f,   0.8f);
-Color Renderer::PlanetEquatorColor      (0.5f,   1.0f,   1.0f);
-Color Renderer::GalacticGridColor       (0.38f,  0.38f,  0.28f);
-Color Renderer::EclipticGridColor       (0.38f,  0.28f,  0.38f);
-Color Renderer::HorizonGridColor        (0.38f,  0.38f,  0.38f);
-Color Renderer::EclipticColor           (0.5f,   0.1f,   0.1f);
-
-Color Renderer::SelectionCursorColor    (1.0f,   0.0f,   0.0f);
 
 // Some useful unit conversions
 inline float mmToInches(float mm)
@@ -943,14 +902,15 @@ void Renderer::addObjectAnnotation(const celestia::MarkerRepresentation* markerR
     }
 }
 
-Vector4f renderOrbitColor(const Body *body, bool selected, float opacity)
+Vector4f renderOrbitColor(const Body *body, bool selected, float opacity,
+                          const celestia::engine::RendererColors& colors)
 {
     Color orbitColor;
 
     if (selected)
     {
         // Highlight the orbit of the selected object in red
-        orbitColor = Renderer::SelectionOrbitColor;
+        orbitColor = colors.SelectionOrbit;
     }
     else if (body == nullptr || !GetBodyFeaturesManager()->getOrbitColor(body, orbitColor))
     {
@@ -961,30 +921,30 @@ Vector4f renderOrbitColor(const Body *body, bool selected, float opacity)
         switch (classification)
         {
         case BodyClassification::Moon:
-            orbitColor = Renderer::MoonOrbitColor;
+            orbitColor = colors.MoonOrbit;
             break;
         case BodyClassification::MinorMoon:
-            orbitColor = Renderer::MinorMoonOrbitColor;
+            orbitColor = colors.MinorMoonOrbit;
             break;
         case BodyClassification::Asteroid:
-            orbitColor = Renderer::AsteroidOrbitColor;
+            orbitColor = colors.AsteroidOrbit;
             break;
         case BodyClassification::Comet:
-            orbitColor = Renderer::CometOrbitColor;
+            orbitColor = colors.CometOrbit;
             break;
         case BodyClassification::Spacecraft:
-            orbitColor = Renderer::SpacecraftOrbitColor;
+            orbitColor = colors.SpacecraftOrbit;
             break;
         case BodyClassification::Stellar:
-            orbitColor = Renderer::StarOrbitColor;
+            orbitColor = colors.StarOrbit;
             break;
         case BodyClassification::DwarfPlanet:
-            orbitColor = Renderer::DwarfPlanetOrbitColor;
+            orbitColor = colors.DwarfPlanetOrbit;
             break;
         case BodyClassification::Planet:
             [[fallthrough]];
         default:
-            orbitColor = Renderer::PlanetOrbitColor;
+            orbitColor = colors.PlanetOrbit;
             break;
         }
     }
@@ -1144,7 +1104,7 @@ void Renderer::renderOrbit(const OrbitPathListEntry& orbitPath,
     }
 
     bool highlight = body != nullptr ? highlightObject.body() == body : highlightObject.star() == orbitPath.star;
-    Vector4f orbitColor = renderOrbitColor(body, highlight, orbitPath.opacity);
+    Vector4f orbitColor = renderOrbitColor(body, highlight, orbitPath.opacity, colors);
 
 #ifdef STIPPLED_LINES
     glLineStipple(3, 0x5555);
@@ -1897,7 +1857,7 @@ Renderer::locationsToAnnotations(const Body& body,
 
         Color labelColor = location->isLabelColorOverridden()
             ? location->getLabelColor()
-            : LocationLabelColor;
+            : colors.LocationLabel;
 
         addObjectAnnotation(locationMarker,
                             location->getName(true),
@@ -2871,11 +2831,11 @@ void Renderer::renderPlanet(Body& body,
         {
             // Set up location markers for this body
             using namespace celestia;
-            mountainRep    = MarkerRepresentation(MarkerRepresentation::Triangle, 8.0f, LocationLabelColor);
-            craterRep      = MarkerRepresentation(MarkerRepresentation::Circle,   8.0f, LocationLabelColor);
-            observatoryRep = MarkerRepresentation(MarkerRepresentation::Plus,     8.0f, LocationLabelColor);
-            cityRep        = MarkerRepresentation(MarkerRepresentation::X,        3.0f, LocationLabelColor);
-            genericLocationRep = MarkerRepresentation(MarkerRepresentation::Square, 8.0f, LocationLabelColor);
+            mountainRep    = MarkerRepresentation(MarkerRepresentation::Triangle, 8.0f, colors.LocationLabel);
+            craterRep      = MarkerRepresentation(MarkerRepresentation::Circle,   8.0f, colors.LocationLabel);
+            observatoryRep = MarkerRepresentation(MarkerRepresentation::Plus,     8.0f, colors.LocationLabel);
+            cityRep        = MarkerRepresentation(MarkerRepresentation::X,        3.0f, colors.LocationLabel);
+            genericLocationRep = MarkerRepresentation(MarkerRepresentation::Square, 8.0f, colors.LocationLabel);
 
             // We need a double precision body-relative position of the
             // observer, otherwise location labels will tend to jitter.
@@ -3048,7 +3008,7 @@ void Renderer::renderAsterisms(const Universe& universe, float dist, const Matri
     ps.smoothLines = true;
     setPipelineState(ps);
 
-    m_asterismRenderer->render(Color(ConstellationColor, opacity), mvp);
+    m_asterismRenderer->render(Color(colors.Constellation, opacity), mvp);
 }
 
 
@@ -3087,7 +3047,7 @@ void Renderer::renderBoundaries(const Universe& universe, float dist, const Matr
     ps.smoothLines = true;
     setPipelineState(ps);
 
-    m_boundariesRenderer->render(Color(BoundaryColor, opacity), mvp);
+    m_boundariesRenderer->render(Color(colors.Boundary, opacity), mvp);
 }
 
 
@@ -3538,24 +3498,25 @@ void Renderer::buildOrbitLists(const Vector3d& astrocentricObserverPos,
 }
 
 
-static Color getBodyLabelColor(BodyClassification classification)
+static Color getBodyLabelColor(BodyClassification classification,
+                               const celestia::engine::RendererColors& colors)
 {
     switch (classification)
     {
     case BodyClassification::Planet:
-        return Renderer::PlanetLabelColor;
+        return colors.PlanetLabel;
     case BodyClassification::DwarfPlanet:
-        return Renderer::DwarfPlanetLabelColor;
+        return colors.DwarfPlanetLabel;
     case BodyClassification::Moon:
-        return Renderer::MoonLabelColor;
+        return colors.MoonLabel;
     case BodyClassification::MinorMoon:
-        return Renderer::MinorMoonLabelColor;
+        return colors.MinorMoonLabel;
     case BodyClassification::Asteroid:
-        return Renderer::AsteroidLabelColor;
+        return colors.AsteroidLabel;
     case BodyClassification::Comet:
-        return Renderer::CometLabelColor;
+        return colors.CometLabel;
     case BodyClassification::Spacecraft:
-        return Renderer::SpacecraftLabelColor;
+        return colors.SpacecraftLabel;
     default:
         return Color::Black;
     }
@@ -3667,7 +3628,7 @@ void Renderer::buildLabelLists(const math::InfiniteFrustum& viewFrustum,
             }
         }
 
-        Color labelColor = getBodyLabelColor(ri.body->getOrbitClassification());
+        Color labelColor = getBodyLabelColor(ri.body->getOrbitClassification(), colors);
         float opacity = sizeFade(boundingRadiusSize, minOrbitSize, 2.0f);
         labelColor.alpha(opacity * labelColor.alpha());
         addSortedAnnotation(nullptr, body->getName(true), labelColor, pos);
@@ -3841,10 +3802,10 @@ void Renderer::renderDeepSkyObjects(const Universe& universe,
     dsoRenderer.labelThresholdMag = 2.0f * max(1.0f, (faintestMag - 4.0f) * (1.0f - 0.5f * log10(effDistanceToScreen)));
 
     using namespace celestia;
-    galaxyRep      = MarkerRepresentation(MarkerRepresentation::Triangle, 8.0f, GalaxyLabelColor);
-    nebulaRep      = MarkerRepresentation(MarkerRepresentation::Square,   8.0f, NebulaLabelColor);
-    openClusterRep = MarkerRepresentation(MarkerRepresentation::Circle,   8.0f, OpenClusterLabelColor);
-    globularRep    = MarkerRepresentation(MarkerRepresentation::Circle,   8.0f, GlobularLabelColor);
+    galaxyRep      = MarkerRepresentation(MarkerRepresentation::Triangle, 8.0f, colors.GalaxyLabel);
+    nebulaRep      = MarkerRepresentation(MarkerRepresentation::Square,   8.0f, colors.NebulaLabel);
+    openClusterRep = MarkerRepresentation(MarkerRepresentation::Circle,   8.0f, colors.OpenClusterLabel);
+    globularRep    = MarkerRepresentation(MarkerRepresentation::Circle,   8.0f, colors.GlobularLabel);
 
     dsoDB->findVisibleDSOs(dsoRenderer,
                            obsPos,
@@ -3875,8 +3836,8 @@ void Renderer::renderSkyGrids(const Observer& observer)
     {
         SkyGrid grid;
         grid.orientation = Quaterniond(AngleAxis<double>(astro::J2000Obliquity, Vector3d::UnitX()));
-        grid.lineColor = EquatorialGridColor;
-        grid.labelColor = EquatorialGridLabelColor;
+        grid.lineColor = colors.EquatorialGrid;
+        grid.labelColor = colors.EquatorialGridLabel;
         m_skyGridRenderer->render(grid, observer.getZoom());
     }
 
@@ -3884,8 +3845,8 @@ void Renderer::renderSkyGrids(const Observer& observer)
     {
         SkyGrid galacticGrid;
         galacticGrid.orientation = (astro::eclipticToEquatorial() * astro::equatorialToGalactic()).conjugate();
-        galacticGrid.lineColor = GalacticGridColor;
-        galacticGrid.labelColor = GalacticGridLabelColor;
+        galacticGrid.lineColor = colors.GalacticGrid;
+        galacticGrid.labelColor = colors.GalacticGridLabel;
         galacticGrid.longitudeUnits = SkyGrid::LongitudeDegrees;
         m_skyGridRenderer->render(galacticGrid, observer.getZoom());
     }
@@ -3894,8 +3855,8 @@ void Renderer::renderSkyGrids(const Observer& observer)
     {
         SkyGrid grid;
         grid.orientation = Quaterniond::Identity();
-        grid.lineColor = EclipticGridColor;
-        grid.labelColor = EclipticGridLabelColor;
+        grid.lineColor = colors.EclipticGrid;
+        grid.labelColor = colors.EclipticGridLabel;
         grid.longitudeUnits = SkyGrid::LongitudeDegrees;
         m_skyGridRenderer->render(grid, observer.getZoom());
     }
@@ -3909,8 +3870,8 @@ void Renderer::renderSkyGrids(const Observer& observer)
         if (body != nullptr)
         {
             SkyGrid grid;
-            grid.lineColor = HorizonGridColor;
-            grid.labelColor = HorizonGridLabelColor;
+            grid.lineColor = colors.HorizonGrid;
+            grid.labelColor = colors.HorizonGridLabel;
             grid.longitudeUnits = SkyGrid::LongitudeDegrees;
             grid.longitudeDirection = SkyGrid::IncreasingClockwise;
 
@@ -3984,7 +3945,7 @@ void Renderer::labelConstellations(const AsterismList& asterisms,
 
             // Use the default label color unless the constellation has an
             // override color set.
-            Color labelColor = ConstellationLabelColor;
+            Color labelColor = colors.ConstellationLabel;
             if (ast.isColorOverridden())
                 labelColor = ast.getOverrideColor();
 
@@ -4904,20 +4865,20 @@ Renderer::selectionToAnnotation(const Selection &sel,
     // both markers are drawn and cursor appears much brighter as a result.
     if (distance < astro::lightYearsToKilometers(1.0))
     {
-        addSortedAnnotation(&cursorRep, "", SelectionCursorColor,
+        addSortedAnnotation(&cursorRep, "", colors.SelectionCursor,
                             offset.cast<float>(),
                             LabelHorizontalAlignment::Start, LabelVerticalAlignment::Top, symbolSize);
     }
     else
     {
-        addBackgroundAnnotation(&cursorRep, "", SelectionCursorColor,
+        addBackgroundAnnotation(&cursorRep, "", colors.SelectionCursor,
                                 offset.cast<float>(),
                                 LabelHorizontalAlignment::Start, LabelVerticalAlignment::Top, symbolSize);
     }
 
-    Color occludedCursorColor(SelectionCursorColor.red(),
-                              SelectionCursorColor.green() + 0.3f,
-                              SelectionCursorColor.blue(),
+    Color occludedCursorColor(colors.SelectionCursor.red(),
+                              colors.SelectionCursor.green() + 0.3f,
+                              colors.SelectionCursor.blue(),
                               0.4f);
     addForegroundAnnotation(&cursorRep, "", occludedCursorColor,
                             offset.cast<float>(),

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -33,6 +33,7 @@
 #include <celengine/textlayout.h>
 #include <celimage/pixelformat.h>
 #include <celrender/rendererfwd.h>
+#include "rendercolors.h"
 #include "renderflags.h"
 
 class RendererWatcher;
@@ -751,47 +752,7 @@ class Renderer
     std::list<RendererWatcher*> watchers;
 
     // Colors for all lines and labels
-    static Color StarLabelColor;
-    static Color PlanetLabelColor;
-    static Color DwarfPlanetLabelColor;
-    static Color MoonLabelColor;
-    static Color MinorMoonLabelColor;
-    static Color AsteroidLabelColor;
-    static Color CometLabelColor;
-    static Color SpacecraftLabelColor;
-    static Color LocationLabelColor;
-    static Color GalaxyLabelColor;
-    static Color GlobularLabelColor;
-    static Color NebulaLabelColor;
-    static Color OpenClusterLabelColor;
-    static Color ConstellationLabelColor;
-    static Color EquatorialGridLabelColor;
-    static Color PlanetographicGridLabelColor;
-    static Color GalacticGridLabelColor;
-    static Color EclipticGridLabelColor;
-    static Color HorizonGridLabelColor;
-
-    static Color StarOrbitColor;
-    static Color PlanetOrbitColor;
-    static Color DwarfPlanetOrbitColor;
-    static Color MoonOrbitColor;
-    static Color MinorMoonOrbitColor;
-    static Color AsteroidOrbitColor;
-    static Color CometOrbitColor;
-    static Color SpacecraftOrbitColor;
-    static Color SelectionOrbitColor;
-
-    static Color ConstellationColor;
-    static Color BoundaryColor;
-    static Color EquatorialGridColor;
-    static Color PlanetographicGridColor;
-    static Color PlanetEquatorColor;
-    static Color GalacticGridColor;
-    static Color EclipticGridColor;
-    static Color HorizonGridColor;
-    static Color EclipticColor;
-
-    static Color SelectionCursorColor;
+    celestia::engine::RendererColors colors{ celestia::engine::RendererColors::defaults() };
 
     friend class celestia::render::AtmosphereRenderer;
     friend class PointStarRenderer;

--- a/src/celengine/rendercolors.cpp
+++ b/src/celengine/rendercolors.cpp
@@ -1,6 +1,6 @@
 // rendercolors.cpp
 //
-// Copyright (C) 2001-2025, the Celestia Development Team
+// Copyright (C) 2026-present, the Celestia Development Team
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License

--- a/src/celengine/rendercolors.cpp
+++ b/src/celengine/rendercolors.cpp
@@ -1,0 +1,116 @@
+// rendercolors.cpp
+//
+// Copyright (C) 2001-2025, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "rendercolors.h"
+
+namespace celestia::engine
+{
+
+// All colors are authored as sRGB values.
+RendererColors RendererColors::defaults()
+{
+    return RendererColors
+    {
+        // label colors
+        /* StarLabel               */ Color(0.471f, 0.356f, 0.682f),
+        /* PlanetLabel             */ Color(0.407f, 0.333f, 0.964f),
+        /* DwarfPlanetLabel        */ Color(0.557f, 0.235f, 0.576f),
+        /* MoonLabel               */ Color(0.231f, 0.733f, 0.792f),
+        /* MinorMoonLabel          */ Color(0.231f, 0.733f, 0.792f),
+        /* AsteroidLabel           */ Color(0.596f, 0.305f, 0.164f),
+        /* CometLabel              */ Color(0.768f, 0.607f, 0.227f),
+        /* SpacecraftLabel         */ Color(0.93f,  0.93f,  0.93f ),
+        /* LocationLabel           */ Color(0.24f,  0.89f,  0.43f ),
+        /* GalaxyLabel             */ Color(0.0f,   0.45f,  0.5f  ),
+        /* GlobularLabel           */ Color(0.8f,   0.45f,  0.5f  ),
+        /* NebulaLabel             */ Color(0.541f, 0.764f, 0.278f),
+        /* OpenClusterLabel        */ Color(0.239f, 0.572f, 0.396f),
+        /* ConstellationLabel      */ Color(0.225f, 0.301f, 0.36f ),
+        /* EquatorialGridLabel     */ Color(0.64f,  0.72f,  0.88f ),
+        /* PlanetographicGridLabel */ Color(0.8f,   0.8f,   0.8f  ),
+        /* GalacticGridLabel       */ Color(0.88f,  0.72f,  0.64f ),
+        /* EclipticGridLabel       */ Color(0.72f,  0.64f,  0.88f ),
+        /* HorizonGridLabel        */ Color(0.72f,  0.72f,  0.72f ),
+
+        // orbit colors
+        /* StarOrbit               */ Color(0.5f,   0.5f,   0.8f  ),
+        /* PlanetOrbit             */ Color(0.3f,   0.323f, 0.833f),
+        /* DwarfPlanetOrbit        */ Color(0.557f, 0.235f, 0.576f),
+        /* MoonOrbit               */ Color(0.08f,  0.407f, 0.392f),
+        /* MinorMoonOrbit          */ Color(0.08f,  0.407f, 0.392f),
+        /* AsteroidOrbit           */ Color(0.58f,  0.152f, 0.08f ),
+        /* CometOrbit              */ Color(0.639f, 0.487f, 0.168f),
+        /* SpacecraftOrbit         */ Color(0.4f,   0.4f,   0.4f  ),
+        /* SelectionOrbit          */ Color(1.0f,   0.0f,   0.0f  ),
+
+        // grid, boundary, and overlay colors
+        /* Constellation           */ Color(0.0f,   0.24f,  0.36f ),
+        /* Boundary                */ Color(0.24f,  0.10f,  0.12f ),
+        /* EquatorialGrid          */ Color(0.28f,  0.28f,  0.38f ),
+        /* PlanetographicGrid      */ Color(0.8f,   0.8f,   0.8f  ),
+        /* PlanetEquator           */ Color(0.5f,   1.0f,   1.0f  ),
+        /* GalacticGrid            */ Color(0.38f,  0.38f,  0.28f ),
+        /* EclipticGrid            */ Color(0.38f,  0.28f,  0.38f ),
+        /* HorizonGrid             */ Color(0.38f,  0.38f,  0.38f ),
+        /* Ecliptic                */ Color(0.5f,   0.1f,   0.1f  ),
+        /* SelectionCursor         */ Color(1.0f,   0.0f,   0.0f  ),
+    };
+}
+
+RendererColors RendererColors::linearize() const
+{
+    return RendererColors
+    {
+        // label colors
+        /* StarLabel               */ StarLabel.linearize(),
+        /* PlanetLabel             */ PlanetLabel.linearize(),
+        /* DwarfPlanetLabel        */ DwarfPlanetLabel.linearize(),
+        /* MoonLabel               */ MoonLabel.linearize(),
+        /* MinorMoonLabel          */ MinorMoonLabel.linearize(),
+        /* AsteroidLabel           */ AsteroidLabel.linearize(),
+        /* CometLabel              */ CometLabel.linearize(),
+        /* SpacecraftLabel         */ SpacecraftLabel.linearize(),
+        /* LocationLabel           */ LocationLabel.linearize(),
+        /* GalaxyLabel             */ GalaxyLabel.linearize(),
+        /* GlobularLabel           */ GlobularLabel.linearize(),
+        /* NebulaLabel             */ NebulaLabel.linearize(),
+        /* OpenClusterLabel        */ OpenClusterLabel.linearize(),
+        /* ConstellationLabel      */ ConstellationLabel.linearize(),
+        /* EquatorialGridLabel     */ EquatorialGridLabel.linearize(),
+        /* PlanetographicGridLabel */ PlanetographicGridLabel.linearize(),
+        /* GalacticGridLabel       */ GalacticGridLabel.linearize(),
+        /* EclipticGridLabel       */ EclipticGridLabel.linearize(),
+        /* HorizonGridLabel        */ HorizonGridLabel.linearize(),
+
+        // orbit colors
+        /* StarOrbit               */ StarOrbit.linearize(),
+        /* PlanetOrbit             */ PlanetOrbit.linearize(),
+        /* DwarfPlanetOrbit        */ DwarfPlanetOrbit.linearize(),
+        /* MoonOrbit               */ MoonOrbit.linearize(),
+        /* MinorMoonOrbit          */ MinorMoonOrbit.linearize(),
+        /* AsteroidOrbit           */ AsteroidOrbit.linearize(),
+        /* CometOrbit              */ CometOrbit.linearize(),
+        /* SpacecraftOrbit         */ SpacecraftOrbit.linearize(),
+        /* SelectionOrbit          */ SelectionOrbit.linearize(),
+
+        // grid, boundary, and overlay colors
+        /* Constellation           */ Constellation.linearize(),
+        /* Boundary                */ Boundary.linearize(),
+        /* EquatorialGrid          */ EquatorialGrid.linearize(),
+        /* PlanetographicGrid      */ PlanetographicGrid.linearize(),
+        /* PlanetEquator           */ PlanetEquator.linearize(),
+        /* GalacticGrid            */ GalacticGrid.linearize(),
+        /* EclipticGrid            */ EclipticGrid.linearize(),
+        /* HorizonGrid             */ HorizonGrid.linearize(),
+        /* Ecliptic                */ Ecliptic.linearize(),
+        /* SelectionCursor         */ SelectionCursor.linearize(),
+    };
+}
+
+} // namespace celestia::engine

--- a/src/celengine/rendercolors.h
+++ b/src/celengine/rendercolors.h
@@ -2,7 +2,7 @@
 
 // rendercolors.h
 //
-// Copyright (C) 2001-2025, the Celestia Development Team
+// Copyright (C) 2026-present, the Celestia Development Team
 //
 // Centralized default colors for the renderer.  All values are authored as
 // sRGB.

--- a/src/celengine/rendercolors.h
+++ b/src/celengine/rendercolors.h
@@ -1,0 +1,77 @@
+#pragma once
+
+// rendercolors.h
+//
+// Copyright (C) 2001-2025, the Celestia Development Team
+//
+// Centralized default colors for the renderer.  All values are authored as
+// sRGB.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <celutil/color.h>
+
+namespace celestia::engine
+{
+
+// A plain aggregate holding one default Color per renderer visual element.
+// Construct a fresh set of defaults via RendererColors::defaults(), then
+// apply individual members to Renderer::*Color fields as needed.
+struct RendererColors
+{
+    // --- label colors ---
+    Color StarLabel;
+    Color PlanetLabel;
+    Color DwarfPlanetLabel;
+    Color MoonLabel;
+    Color MinorMoonLabel;
+    Color AsteroidLabel;
+    Color CometLabel;
+    Color SpacecraftLabel;
+    Color LocationLabel;
+    Color GalaxyLabel;
+    Color GlobularLabel;
+    Color NebulaLabel;
+    Color OpenClusterLabel;
+    Color ConstellationLabel;
+    Color EquatorialGridLabel;
+    Color PlanetographicGridLabel;
+    Color GalacticGridLabel;
+    Color EclipticGridLabel;
+    Color HorizonGridLabel;
+
+    // --- orbit colors ---
+    Color StarOrbit;
+    Color PlanetOrbit;
+    Color DwarfPlanetOrbit;
+    Color MoonOrbit;
+    Color MinorMoonOrbit;
+    Color AsteroidOrbit;
+    Color CometOrbit;
+    Color SpacecraftOrbit;
+    Color SelectionOrbit;
+
+    // --- grid, boundary, and overlay colors ---
+    Color Constellation;
+    Color Boundary;
+    Color EquatorialGrid;
+    Color PlanetographicGrid;
+    Color PlanetEquator;
+    Color GalacticGrid;
+    Color EclipticGrid;
+    Color HorizonGrid;
+    Color Ecliptic;
+    Color SelectionCursor;
+
+    // Returns a RendererColors populated with the built-in default sRGB values.
+    static RendererColors defaults();
+
+    // Returns a copy of this RendererColors with every color converted from
+    // sRGB to linear light, ready for use in a linear-light rendering pipeline.
+    RendererColors linearize() const;
+};
+
+} // namespace celestia::engine

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -45,14 +45,16 @@ bool ViewportEffect::distortXY(float &x, float &y)
     return true;
 }
 
-PassthroughViewportEffect::PassthroughViewportEffect() :
-    ViewportEffect()
+PassthroughViewportEffect::PassthroughViewportEffect(std::string_view shaderName,
+                                                     bool needsFloatSource) :
+    m_shaderName(shaderName),
+    m_needsFloatSource(needsFloatSource)
 {
 }
 
 bool PassthroughViewportEffect::render(Renderer* renderer, FramebufferObject* fbo, int width, int height)
 {
-    auto *prog = renderer->getShaderManager().getShader("passthrough");
+    auto *prog = renderer->getShaderManager().getShader(m_shaderName);
     if (prog == nullptr)
         return false;
 

--- a/src/celengine/viewporteffect.h
+++ b/src/celengine/viewporteffect.h
@@ -11,6 +11,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
@@ -38,12 +40,17 @@ public:
 class PassthroughViewportEffect : public ViewportEffect
 {
 public:
-    PassthroughViewportEffect();
+    explicit PassthroughViewportEffect(std::string_view shaderName = "passthrough",
+                                       bool needsFloatSource = false);
     ~PassthroughViewportEffect() override = default;
 
+    bool needsFloatSource() const override { return m_needsFloatSource; }
     bool render(Renderer*, FramebufferObject*, int width, int height) override;
 
 private:
+    std::string m_shaderName;
+    bool m_needsFloatSource;
+
     celestia::gl::VertexObject vo{ celestia::util::NoCreateT{} };
     celestia::gl::Buffer bo{ celestia::util::NoCreateT{} };
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2647,6 +2647,8 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
         return false;
     }
 
+    m_scriptMaps.initColorMaps(renderer->colors);
+
     if (util::is_set(renderer->getRenderFlags(), RenderFlags::ShowAutoMag))
     {
         renderer->setFaintestAM45deg(renderer->getFaintestAM45deg());

--- a/src/celrender/eclipticlinerenderer.cpp
+++ b/src/celrender/eclipticlinerenderer.cpp
@@ -56,7 +56,7 @@ EclipticLineRenderer::render()
     ps.smoothLines = true;
     m_renderer.setPipelineState(ps);
 
-    m_lineRenderer.render({&m_renderer.getProjectionMatrix(), &m_renderer.getModelViewMatrix()}, Renderer::EclipticColor, kEclipticCount);
+    m_lineRenderer.render({&m_renderer.getProjectionMatrix(), &m_renderer.getModelViewMatrix()}, m_renderer.colors.Ecliptic, kEclipticCount);
     m_lineRenderer.finish();
 }
 

--- a/src/celscript/common/scriptmaps.cpp
+++ b/src/celscript/common/scriptmaps.cpp
@@ -3,6 +3,7 @@
 #include <celengine/body.h>
 #include <celengine/location.h>
 #include <celengine/render.h>
+#include <celengine/rendercolors.h>
 #include <celestia/celestiacore.h>
 #include <celestia/hud.h>
 
@@ -164,50 +165,49 @@ void initOrbitVisibilityMap(ScriptMap<std::uint32_t>& OrbitVisibilityMap)
     OrbitVisibilityMap["always"sv]         = Body::AlwaysVisible;
 }
 
-void initLabelColorMap(ScriptMap<Color*>& LabelColorMap)
+void initLabelColorMap(ScriptMap<Color*>& LabelColorMap, engine::RendererColors& colors)
 {
-    LabelColorMap["stars"sv]               = &Renderer::StarLabelColor;
-    LabelColorMap["planets"sv]             = &Renderer::PlanetLabelColor;
-    LabelColorMap["dwarfplanets"sv]        = &Renderer::DwarfPlanetLabelColor;
-    LabelColorMap["moons"sv]               = &Renderer::MoonLabelColor;
-    LabelColorMap["minormoons"sv]          = &Renderer::MinorMoonLabelColor;
-    LabelColorMap["asteroids"sv]           = &Renderer::AsteroidLabelColor;
-    LabelColorMap["comets"sv]              = &Renderer::CometLabelColor;
-    LabelColorMap["spacecraft"sv]          = &Renderer::SpacecraftLabelColor;
-    LabelColorMap["locations"sv]           = &Renderer::LocationLabelColor;
-    LabelColorMap["galaxies"sv]            = &Renderer::GalaxyLabelColor;
-    LabelColorMap["globulars"sv]           = &Renderer::GlobularLabelColor;
-    LabelColorMap["nebulae"sv]             = &Renderer::NebulaLabelColor;
-    LabelColorMap["openclusters"sv]        = &Renderer::OpenClusterLabelColor;
-    LabelColorMap["constellations"sv]      = &Renderer::ConstellationLabelColor;
-    LabelColorMap["equatorialgrid"sv]      = &Renderer::EquatorialGridLabelColor;
-    LabelColorMap["galacticgrid"sv]        = &Renderer::GalacticGridLabelColor;
-    LabelColorMap["eclipticgrid"sv]        = &Renderer::EclipticGridLabelColor;
-    LabelColorMap["horizontalgrid"sv]      = &Renderer::HorizonGridLabelColor;
-    LabelColorMap["planetographicgrid"sv]  = &Renderer::PlanetographicGridLabelColor;
-
+    LabelColorMap["stars"sv]               = &colors.StarLabel;
+    LabelColorMap["planets"sv]             = &colors.PlanetLabel;
+    LabelColorMap["dwarfplanets"sv]        = &colors.DwarfPlanetLabel;
+    LabelColorMap["moons"sv]               = &colors.MoonLabel;
+    LabelColorMap["minormoons"sv]          = &colors.MinorMoonLabel;
+    LabelColorMap["asteroids"sv]           = &colors.AsteroidLabel;
+    LabelColorMap["comets"sv]              = &colors.CometLabel;
+    LabelColorMap["spacecraft"sv]          = &colors.SpacecraftLabel;
+    LabelColorMap["locations"sv]           = &colors.LocationLabel;
+    LabelColorMap["galaxies"sv]            = &colors.GalaxyLabel;
+    LabelColorMap["globulars"sv]           = &colors.GlobularLabel;
+    LabelColorMap["nebulae"sv]             = &colors.NebulaLabel;
+    LabelColorMap["openclusters"sv]        = &colors.OpenClusterLabel;
+    LabelColorMap["constellations"sv]      = &colors.ConstellationLabel;
+    LabelColorMap["equatorialgrid"sv]      = &colors.EquatorialGridLabel;
+    LabelColorMap["galacticgrid"sv]        = &colors.GalacticGridLabel;
+    LabelColorMap["eclipticgrid"sv]        = &colors.EclipticGridLabel;
+    LabelColorMap["horizontalgrid"sv]      = &colors.HorizonGridLabel;
+    LabelColorMap["planetographicgrid"sv]  = &colors.PlanetographicGridLabel;
 }
 
-void initLineColorMap(ScriptMap<Color*>& LineColorMap)
+void initLineColorMap(ScriptMap<Color*>& LineColorMap, engine::RendererColors& colors)
 {
-    LineColorMap["starorbits"sv]           = &Renderer::StarOrbitColor;
-    LineColorMap["planetorbits"sv]         = &Renderer::PlanetOrbitColor;
-    LineColorMap["dwarfplanetorbits"sv]    = &Renderer::DwarfPlanetOrbitColor;
-    LineColorMap["moonorbits"sv]           = &Renderer::MoonOrbitColor;
-    LineColorMap["minormoonorbits"sv]      = &Renderer::MinorMoonOrbitColor;
-    LineColorMap["asteroidorbits"sv]       = &Renderer::AsteroidOrbitColor;
-    LineColorMap["cometorbits"sv]          = &Renderer::CometOrbitColor;
-    LineColorMap["spacecraftorbits"sv]     = &Renderer::SpacecraftOrbitColor;
-    LineColorMap["constellations"sv]       = &Renderer::ConstellationColor;
-    LineColorMap["boundaries"sv]           = &Renderer::BoundaryColor;
-    LineColorMap["equatorialgrid"sv]       = &Renderer::EquatorialGridColor;
-    LineColorMap["galacticgrid"sv]         = &Renderer::GalacticGridColor;
-    LineColorMap["eclipticgrid"sv]         = &Renderer::EclipticGridColor;
-    LineColorMap["horizontalgrid"sv]       = &Renderer::HorizonGridColor;
-    LineColorMap["planetographicgrid"sv]   = &Renderer::PlanetographicGridColor;
-    LineColorMap["planetequator"sv]        = &Renderer::PlanetEquatorColor;
-    LineColorMap["ecliptic"sv]             = &Renderer::EclipticColor;
-    LineColorMap["selectioncursor"sv]      = &Renderer::SelectionCursorColor;
+    LineColorMap["starorbits"sv]           = &colors.StarOrbit;
+    LineColorMap["planetorbits"sv]         = &colors.PlanetOrbit;
+    LineColorMap["dwarfplanetorbits"sv]    = &colors.DwarfPlanetOrbit;
+    LineColorMap["moonorbits"sv]           = &colors.MoonOrbit;
+    LineColorMap["minormoonorbits"sv]      = &colors.MinorMoonOrbit;
+    LineColorMap["asteroidorbits"sv]       = &colors.AsteroidOrbit;
+    LineColorMap["cometorbits"sv]          = &colors.CometOrbit;
+    LineColorMap["spacecraftorbits"sv]     = &colors.SpacecraftOrbit;
+    LineColorMap["constellations"sv]       = &colors.Constellation;
+    LineColorMap["boundaries"sv]           = &colors.Boundary;
+    LineColorMap["equatorialgrid"sv]       = &colors.EquatorialGrid;
+    LineColorMap["galacticgrid"sv]         = &colors.GalacticGrid;
+    LineColorMap["eclipticgrid"sv]         = &colors.EclipticGrid;
+    LineColorMap["horizontalgrid"sv]       = &colors.HorizonGrid;
+    LineColorMap["planetographicgrid"sv]   = &colors.PlanetographicGrid;
+    LineColorMap["planetequator"sv]        = &colors.PlanetEquator;
+    LineColorMap["ecliptic"sv]             = &colors.Ecliptic;
+    LineColorMap["selectioncursor"sv]      = &colors.SelectionCursor;
 }
 
 ScriptMaps::ScriptMaps()
@@ -218,8 +218,12 @@ ScriptMaps::ScriptMaps()
     initLocationFlagMap(LocationFlagMap);
     initOverlayElementMap(OverlayElementMap);
     initOrbitVisibilityMap(OrbitVisibilityMap);
-    initLabelColorMap(LabelColorMap);
-    initLineColorMap(LineColorMap);
+}
+
+void ScriptMaps::initColorMaps(engine::RendererColors& colors)
+{
+    initLabelColorMap(LabelColorMap, colors);
+    initLineColorMap(LineColorMap, colors);
 }
 
 } // end namespace celestia::scripts

--- a/src/celscript/common/scriptmaps.h
+++ b/src/celscript/common/scriptmaps.h
@@ -10,6 +10,8 @@
 class Color;
 enum class BodyClassification : std::uint32_t;
 
+namespace celestia::engine { struct RendererColors; }
+
 namespace celestia::scripts
 {
 
@@ -23,6 +25,9 @@ struct ScriptMaps
 {
     ScriptMaps();
     ~ScriptMaps() = default;
+
+    void initColorMaps(celestia::engine::RendererColors&);
+
     ScriptMaps(const ScriptMaps&) = delete;
     ScriptMaps(ScriptMaps&&) = delete;
     ScriptMaps& operator=(const ScriptMaps&) = delete;


### PR DESCRIPTION
1. create a struct holding label/line/etc colors used in renderer
2. add check for GL_EXT_sRGB/GL_EXT_sRGB_write_control (not used for now)
3. make shader name and needsFloatSource configuration in passthroughviewporteffect's constructor so we don't have to create a new class for future sRGB effect