### PR TITLE
Use AntialiasingSamples in SDL front end, default to 4

### DIFF
--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -382,7 +382,7 @@ StarTextures
 # 1. "Asterism": The lines connecting the stars in the constellation.
 # 2. "Boundary": The boundary of the constellation.
 # 3. "Label": The name of the constellation.
-# 
+#
 # "FadeStartDist" ->
 # The maximum distance of the observer to the origin of coordinates
 # before the specified component starts to linearly fade out.
@@ -410,7 +410,7 @@ StarTextures
 # rendering speed.  4 is a sensible setting for recent, higher-end
 # graphics hardware; 2 is probably better mid-range graphics.  The
 # default value is 1, which disables antialiasing.
-# AntialiasingSamples        4
+  AntialiasingSamples        4
 
 
 #------------------------------------------------------------------------

--- a/src/celestia/sdl/CMakeLists.txt
+++ b/src/celestia/sdl/CMakeLists.txt
@@ -40,6 +40,8 @@ target_include_directories(imgui PUBLIC "${IMGUI_DIR}" "${IMGUI_DIR}/backends" "
 set(SDL_SOURCES
     aboutdialog.cpp
     aboutdialog.h
+    alerter.cpp
+    alerter.h
     appwindow.cpp
     appwindow.h
     clipboard.cpp

--- a/src/celestia/sdl/alerter.cpp
+++ b/src/celestia/sdl/alerter.cpp
@@ -1,0 +1,23 @@
+// alerter.cpp
+//
+// Copyright (C) 2020-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "alerter.h"
+
+#include <SDL_messagebox.h>
+
+namespace celestia::sdl
+{
+
+void
+Alerter::fatalError(const std::string& msg)
+{
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", msg.c_str(), m_window);
+}
+
+}

--- a/src/celestia/sdl/alerter.h
+++ b/src/celestia/sdl/alerter.h
@@ -1,0 +1,31 @@
+// alerter.h
+//
+// Copyright (C) 2020-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <string>
+
+#include <SDL_video.h>
+
+#include <celestia/celestiacore.h>
+
+namespace celestia::sdl
+{
+
+class Alerter : public CelestiaCore::Alerter
+{
+public:
+    void setWindow(SDL_Window* window) noexcept { m_window = window; }
+    void fatalError(const std::string& msg) override;
+
+private:
+    SDL_Window* m_window{ nullptr };
+};
+
+}

--- a/src/celestia/sdl/appwindow.cpp
+++ b/src/celestia/sdl/appwindow.cpp
@@ -27,6 +27,7 @@
 #include <celestia/celestiacore.h>
 #include <celutil/gettext.h>
 #include <celutil/tzutil.h>
+#include "alerter.h"
 #include "clipboard.h"
 #include "gui.h"
 #include "settings.h"
@@ -135,33 +136,21 @@ mainRunLoopHandler(void* arg)
 
 } // end unnamed namespace
 
-class AppWindow::Alerter : public CelestiaCore::Alerter
-{
-public:
-    explicit Alerter(SDL_Window* win) : window(win) {}
-
-    void fatalError(const std::string& msg) override;
-
-private:
-    SDL_Window* window;
-};
-
-void
-AppWindow::Alerter::fatalError(const std::string& msg)
-{
-    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", msg.c_str(), window);
-}
-
 AppWindow::AppWindow(Private,
                      const std::shared_ptr<Environment>& environment,
+                     std::unique_ptr<CelestiaCore>&& celestiaCore,
+                     std::unique_ptr<Alerter>&& alerter,
                      UniqueWindow&& window,
                      UniqueGLContext&& context,
                      bool isFullscreen) :
     m_environment(environment),
     m_window(std::move(window)),
     m_context(std::move(context)),
+    m_appCore(std::move(celestiaCore)),
+    m_alerter(std::move(alerter)),
     m_isFullscreen(isFullscreen)
 {
+    m_alerter->setWindow(m_window.get());
 }
 
 AppWindow::~AppWindow() = default;
@@ -190,12 +179,6 @@ AppWindow::dumpGLInfo() const
 bool
 AppWindow::run(const Settings& settings)
 {
-    m_appCore = std::make_unique<CelestiaCore>();
-    m_alerter = std::make_unique<Alerter>(m_window.get());
-    m_appCore->setAlerter(m_alerter.get());
-    if (!m_appCore->initSimulation())
-        return false;
-
     m_appCore->initRenderer(settings.textureResolution);
 
     auto renderer = m_appCore->getRenderer();

--- a/src/celestia/sdl/appwindow.h
+++ b/src/celestia/sdl/appwindow.h
@@ -27,6 +27,7 @@ namespace celestia::sdl
 
 using UniqueWindow = util::UniquePtrDel<SDL_Window, &SDL_DestroyWindow>;
 
+class Alerter;
 class Gui;
 class Settings;
 
@@ -35,7 +36,13 @@ class AppWindow //NOSONAR
     struct Private { explicit Private() = default; };
 
 public:
-    AppWindow(Private, const std::shared_ptr<Environment>&, UniqueWindow&&, UniqueGLContext&&, bool);
+    AppWindow(Private,
+              const std::shared_ptr<Environment>&,
+              std::unique_ptr<CelestiaCore>&&,
+              std::unique_ptr<Alerter>&&,
+              UniqueWindow&&,
+              UniqueGLContext&&,
+              bool);
     ~AppWindow();
 
     void dumpGLInfo() const;
@@ -47,8 +54,6 @@ public:
     inline bool isFullscreen() const { return m_isFullscreen; }
 
 private:
-    class Alerter;
-
     void handleTextInputEvent(const SDL_TextInputEvent&);
     void handleKeyDownEvent(const SDL_KeyboardEvent&);
     void handleKeyUpEvent(const SDL_KeyboardEvent&);

--- a/src/celestia/sdl/environment.cpp
+++ b/src/celestia/sdl/environment.cpp
@@ -13,11 +13,12 @@
 #include <fstream>
 #include <string_view>
 #include <system_error>
+#include <utility>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
 #include <SDL.h>
 
+#include <celestia/celestiacore.h>
+#include "alerter.h"
 #include "appwindow.h"
 #include "gui.h"
 #include "helpers.h"
@@ -63,7 +64,7 @@ Environment::init()
 }
 
 bool
-Environment::setGLAttributes() const
+Environment::setGLAttributes(int aaSamples) const
 {
     if (SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1) != 0)
     {
@@ -92,11 +93,20 @@ Environment::setGLAttributes() const
     }
 #endif
 
+    if (aaSamples > 1 &&
+        (SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1) != 0 ||
+         SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, aaSamples) != 0))
+    {
+        fmt::print("Could not set multisample anti-aliasing\n");
+    }
+
     return true;
 }
 
 std::unique_ptr<AppWindow>
-Environment::createAppWindow(const Settings& settings)
+Environment::createAppWindow(const Settings& settings,
+                             std::unique_ptr<CelestiaCore>&& celestiaCore,
+                             std::unique_ptr<Alerter>&& alerter)
 {
     Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
     if (settings.isFullscreen)
@@ -134,6 +144,8 @@ Environment::createAppWindow(const Settings& settings)
 
     return std::make_unique<AppWindow>(AppWindow::Private{},
                                        shared_from_this(),
+                                       std::move(celestiaCore),
+                                       std::move(alerter),
                                        std::move(window),
                                        std::move(context),
                                        settings.isFullscreen);

--- a/src/celestia/sdl/environment.h
+++ b/src/celestia/sdl/environment.h
@@ -14,9 +14,12 @@
 
 #include <SDL_video.h>
 
+class CelestiaCore;
+
 namespace celestia::sdl
 {
 
+class Alerter;
 class AppWindow;
 class Settings;
 
@@ -35,8 +38,10 @@ public:
 
     static std::shared_ptr<Environment> init();
 
-    bool setGLAttributes() const;
-    std::unique_ptr<AppWindow> createAppWindow(const Settings&);
+    bool setGLAttributes(int aaSamples) const;
+    std::unique_ptr<AppWindow> createAppWindow(const Settings&,
+                                               std::unique_ptr<CelestiaCore>&&,
+                                               std::unique_ptr<Alerter>&&);
 
     std::filesystem::path getSettingsPath() const;
     std::filesystem::path getImguiSettingsPath() const;

--- a/src/celestia/sdl/sdlmain.cpp
+++ b/src/celestia/sdl/sdlmain.cpp
@@ -10,9 +10,11 @@
 #include <cerrno>
 #include <cstdlib>
 #include <system_error>
+#include <utility>
 
 #include <celestia/celestiacore.h>
 #include <celutil/gettext.h>
+#include "alerter.h"
 #include "appwindow.h"
 #include "environment.h"
 #include "settings.h"
@@ -68,7 +70,14 @@ main(int argc, char **argv)
     if (!environment)
         return EXIT_FAILURE;
 
-    if (!environment->setGLAttributes())
+    auto celestiaCore = std::make_unique<CelestiaCore>();
+    auto alerter = std::make_unique<celestia::sdl::Alerter>();
+    celestiaCore->setAlerter(alerter.get());
+
+    if (!celestiaCore->initSimulation())
+        return EXIT_FAILURE;
+
+    if (!environment->setGLAttributes(celestiaCore->getConfig()->renderDetails.aaSamples))
         return EXIT_FAILURE;
 
     std::filesystem::path dataDir = getDataDir();
@@ -80,7 +89,7 @@ main(int argc, char **argv)
 
     Settings settings = Settings::load(environment->getSettingsPath());
 
-    auto window = environment->createAppWindow(settings);
+    auto window = environment->createAppWindow(settings, std::move(celestiaCore), std::move(alerter));
     if (!window)
         return EXIT_FAILURE;
 


### PR DESCRIPTION
- Load the celestia.cfg file before SDL window initialization so that we can read the AntialiasingSamples parameter
- Default AntialiasingSamples to 4 in the configuration file.