### PR TITLE
Analytical anti-aliasing for triangulated lines

### DIFF
--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -13,6 +13,7 @@ CELAPI bool OES_texture_border_clamp             = false;
 CELAPI bool OES_geometry_shader                  = false;
 CELAPI bool OES_depth24                          = false;
 CELAPI bool OES_texture_half_float               = false;
+CELAPI bool OES_standard_derivatives             = false;
 CELAPI bool EXT_sRGB                             = false;
 CELAPI bool EXT_sRGB_write_control               = false;
 #else
@@ -87,6 +88,10 @@ bool init(util::array_view<std::string> ignore) noexcept
     OES_geometry_shader                = check_extension(ignore, "GL_OES_geometry_shader") || check_extension(ignore, "GL_EXT_geometry_shader");
     OES_depth24                        = check_extension(ignore, "GL_OES_depth24");
     OES_texture_half_float             = check_extension(ignore, "GL_OES_texture_half_float");
+    // Derivative functions are core in GLSL ES 3.0, so any GLES 3.0+ context
+    // has them regardless of whether the legacy extension is advertised.
+    OES_standard_derivatives           = check_extension(ignore, "GL_OES_standard_derivatives")
+                                         || checkVersion(celestia::gl::GLES_3_0);
     EXT_sRGB                           = check_extension(ignore, "GL_EXT_sRGB");
     EXT_sRGB_write_control             = check_extension(ignore, "GL_EXT_sRGB_write_control");
 #else

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -49,6 +49,7 @@ extern CELAPI bool OES_texture_border_clamp; //NOSONAR
 extern CELAPI bool OES_geometry_shader; //NOSONAR
 extern CELAPI bool OES_depth24; //NOSONAR
 extern CELAPI bool OES_texture_half_float; //NOSONAR
+extern CELAPI bool OES_standard_derivatives; //NOSONAR
 extern CELAPI bool EXT_sRGB; //NOSONAR
 extern CELAPI bool EXT_sRGB_write_control; //NOSONAR
 #else

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -152,6 +152,7 @@ constexpr std::string_view LineVertexPosition = R"glsl(
     vec2 transform = normalize(nextPos.xy - thisPos.xy);
     transform = vec2(transform.y * lineWidthX, -transform.x * lineWidthY) * in_ScaleFactor;
     gl_Position = vec4((thisPos.xy + transform) * thisPos.w, thisPos.zw);
+    lineU = in_LineSide;
 )glsl"sv;
 
 std::string_view
@@ -964,14 +965,25 @@ StaticPointSize()
     return source;
 }
 
-static std::string
+std::string
 LineDeclaration()
 {
     std::string source;
     source += DeclareAttribute("in_PositionNext", Shader_Vector4);
     source += DeclareAttribute("in_ScaleFactor", Shader_Float);
+    source += DeclareAttribute("in_LineSide", Shader_Float);
     source += DeclareUniform("lineWidthX", Shader_Float);
     source += DeclareUniform("lineWidthY", Shader_Float);
+    source += DeclareOutput("lineU", Shader_Float);
+    return source;
+}
+
+std::string
+LineFragmentDeclaration()
+{
+    std::string source;
+    source += DeclareInput("lineU", Shader_Float);
+    source += DeclareUniform("lineEdge", Shader_Float);
     return source;
 }
 
@@ -1031,6 +1043,7 @@ BindAttribLocations(const GLProgramBuilder& prog)
     prog.bindAttribute(CelestiaGLProgram::IntensityAttributeIndex,     "in_Intensity");
     prog.bindAttribute(CelestiaGLProgram::NextVCoordAttributeIndex,    "in_PositionNext");
     prog.bindAttribute(CelestiaGLProgram::ScaleFactorAttributeIndex,   "in_ScaleFactor");
+    prog.bindAttribute(CelestiaGLProgram::LineSideAttributeIndex,      "in_LineSide");
     prog.bindAttribute(CelestiaGLProgram::TangentAttributeIndex,       "in_Tangent");
     prog.bindAttribute(CelestiaGLProgram::PointSizeAttributeIndex,     "in_PointSize");
 }
@@ -1400,11 +1413,26 @@ R"glsl(
 GLFragmentShader
 buildFragmentShader(const ShaderProperties& props)
 {
+    // Whether the analytical line-edge AA path is available. Desktop GL has
+    // fwidth() in core (#version 110+); GLSL ES 1.0 needs the optional
+    // GL_OES_standard_derivatives extension. If the extension is missing on
+    // a GLES2 device we fall back silently to the original (unaliased)
+    // triangulated lines.
+    const bool emitLineAA = util::is_set(props.texUsage, TexUsage::LineAsTriangles)
+#ifdef GL_ES
+                            && gl::OES_standard_derivatives
+#endif
+        ;
+
     std::string source(VersionHeader);
     // Without GL_ARB_shader_texture_lod enabled one can use texture2DLod
     // in vertext shaders only
     if (gl::ARB_shader_texture_lod)
         source += "#extension GL_ARB_shader_texture_lod : enable\n";
+#ifdef GL_ES
+    if (emitLineAA)
+        source += "#extension GL_OES_standard_derivatives : enable\n";
+#endif
     source += CommonHeader;
 
     std::string diffTexCoord("diffTexCoord");
@@ -1490,6 +1518,9 @@ buildFragmentShader(const ShaderProperties& props)
 
     if (props.usePointSize())
         source += DeclareInput("pointFade", Shader_Float);
+
+    if (emitLineAA)
+        source += LineFragmentDeclaration();
 
     if (props.hasShadowMap())
     {
@@ -1745,6 +1776,16 @@ buildFragmentShader(const ShaderProperties& props)
         source += DeclareLocal("scatterColor", Shader_Vector3);
         source += AtmosphericEffects(props);
         source += "gl_FragColor.rgb = gl_FragColor.rgb * scatterEx + scatterColor;\n";
+    }
+
+    if (emitLineAA)
+    {
+        // Analytical edge anti-aliasing. Geometry is inflated 1px past the
+        // visible edge (lineEdge < 1.0). Feather is 1px wide centered on the
+        // visible edge — fwidth(lineU) is ~2/inflatedPx, so 0.5*fwidth gives
+        // a half-pixel half-width.
+        source += "float lineHalfPx = fwidth(lineU) * 0.5;\n";
+        source += "gl_FragColor.a *= 1.0 - smoothstep(lineEdge - lineHalfPx, lineEdge + lineHalfPx, abs(lineU));\n";
     }
 
     source += "}\n";
@@ -2960,6 +3001,7 @@ CelestiaGLProgram::initParameters()
     {
         lineWidthX           = floatParam("lineWidthX");
         lineWidthY           = floatParam("lineWidthY");
+        lineEdge             = floatParam("lineEdge");
     }
 }
 

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -228,6 +228,7 @@ public:
         IntensityAttributeIndex     = 9,
         NextVCoordAttributeIndex    = 10,
         ScaleFactorAttributeIndex   = 11,
+        LineSideAttributeIndex      = 12,
     };
 
     CelestiaGLProgramLight lights[MaxShaderLights];
@@ -292,6 +293,9 @@ public:
     // Used to draw line as triangles
     FloatShaderParameter lineWidthX;
     FloatShaderParameter lineWidthY;
+    // Position of the visible edge in lineU varying space (visibleHalf / inflatedHalf).
+    // Used by the analytical AA in the fragment shader.
+    FloatShaderParameter lineEdge;
 
     // Color sent as a uniform
     Vec4ShaderParameter color;

--- a/src/celrender/linerenderer.cpp
+++ b/src/celrender/linerenderer.cpp
@@ -101,8 +101,36 @@ LineRenderer::setup_shader()
 
     if (m_useTriangles)
     {
-        m_prog->lineWidthX = m_width * width_multiplyer() * m_renderer.getPointWidth();
-        m_prog->lineWidthY = m_width * width_multiplyer() * m_renderer.getPointHeight();
+        // The fragment-shader analytical AA needs fwidth(), which is core on
+        // desktop GL but optional on GLES2. If the extension isn't there,
+        // skip the inflation and emit the visible width — the FS in that
+        // build won't reference lineEdge either, so we fall back to the
+        // pre-AA behavior cleanly.
+#ifdef GL_ES
+        const bool aaSupported = celestia::gl::OES_standard_derivatives;
+#else
+        const bool aaSupported = true;
+#endif
+        if (aaSupported)
+        {
+            // Inflate the rendered quad by 1 device pixel on each side so the
+            // analytical AA in the fragment shader has room to fade to zero
+            // before hitting the geometry boundary. lineEdge tells the FS where
+            // the visible edge sits inside the inflated quad (in lineU space,
+            // which spans [-1, +1] across the inflated width).
+            float visiblePx    = rasterized_width();
+            float inflateRatio = (visiblePx + 2.0f) / visiblePx;
+            float w = m_width * width_multiplyer() * inflateRatio;
+            m_prog->lineWidthX = w * m_renderer.getPointWidth();
+            m_prog->lineWidthY = w * m_renderer.getPointHeight();
+            m_prog->lineEdge   = 1.0f / inflateRatio;
+        }
+        else
+        {
+            float w =  m_width * width_multiplyer();
+            m_prog->lineWidthX = w * m_renderer.getPointWidth();
+            m_prog->lineWidthY = w * m_renderer.getPointHeight();
+        }
     }
     else
     {
@@ -166,7 +194,7 @@ LineRenderer::create_vbo_triangles()
     m_trBO = std::make_unique<gl::Buffer>();
 
     GLsizei                    stride;
-    std::array<std::size_t, 4> offset;
+    std::array<std::size_t, 5> offset;
     if (m_primType == PrimType::Lines || (m_hints & PREFER_SIMPLE_TRIANGLES) != 0)
     {
         stride = static_cast<GLsizei>(sizeof(LineSegment));
@@ -175,6 +203,7 @@ LineRenderer::create_vbo_triangles()
             offsetof(LineSegment, point1),
             offsetof(LineSegment, point2),
             offsetof(LineSegment, scale),
+            offsetof(LineSegment, side),
             offsetof(LineSegment, point1) + offsetof(Vertex, color)
         };
 
@@ -189,6 +218,7 @@ LineRenderer::create_vbo_triangles()
             offsetof(LineVertex, point),
             2 * stride + offsetof(LineVertex, point),
             offsetof(LineVertex, scale),
+            offsetof(LineVertex, side),
             offsetof(LineVertex, point) + offsetof(Vertex, color)
         };
 
@@ -219,6 +249,14 @@ LineRenderer::create_vbo_triangles()
         false,
         stride,
         static_cast<GLsizeiptr>(offset[2]));
+    m_trVO->addVertexBuffer(
+        *m_trBO,
+        CelestiaGLProgram::LineSideAttributeIndex,
+        1,
+        gl::VertexObject::DataType::Float,
+        false,
+        stride,
+        static_cast<GLsizeiptr>(offset[3]));
     if (color_count() != 0)
     {
         m_trVO->addVertexBuffer(
@@ -228,7 +266,7 @@ LineRenderer::create_vbo_triangles()
             color_type() == VF_UBYTE ? gl::VertexObject::DataType::UnsignedByte : gl::VertexObject::DataType::Float,
             color_type() == VF_UBYTE,
             stride,
-            static_cast<GLsizeiptr>(offset[3]));
+            static_cast<GLsizeiptr>(offset[4]));
     }
 }
 
@@ -269,15 +307,22 @@ LineRenderer::setup_vbo()
 }
 
 //! Add new triagles for a line segment (when primitive is Lines).
+//!
+//! Vertices for the (point2)-end use a reversed (this, next) pair so that
+//! the vertex shader can compute a tangent direction from in_PositionNext -
+//! in_Position. That reverses the perpendicular as well, so a `scale` of
+//! -0.5 at point2 actually puts the vertex on the "+" physical side of the
+//! line. The `side` argument is the *physical* side regardless of that
+//! tangent flip and is what the AA shader interpolates as `lineU`.
 void
 LineRenderer::add_segment_points(const Vertex &point1, const Vertex &point2)
 {
-    m_segments.emplace_back(point1, point2, -0.5f);
-    m_segments.emplace_back(point1, point2,  0.5f);
-    m_segments.emplace_back(point2, point1, -0.5f);
-    m_segments.emplace_back(point2, point1, -0.5f);
-    m_segments.emplace_back(point2, point1,  0.5f);
-    m_segments.emplace_back(point1, point2, -0.5f);
+    m_segments.emplace_back(point1, point2, -0.5f, -1.0f); // P1, "-" side
+    m_segments.emplace_back(point1, point2,  0.5f,  1.0f); // P1, "+" side
+    m_segments.emplace_back(point2, point1, -0.5f,  1.0f); // P2, "+" side (tangent flipped)
+    m_segments.emplace_back(point2, point1, -0.5f,  1.0f); // P2, "+" side
+    m_segments.emplace_back(point2, point1,  0.5f, -1.0f); // P2, "-" side
+    m_segments.emplace_back(point1, point2, -0.5f, -1.0f); // P1, "-" side
 }
 
 //! Convert line segments into triangles.

--- a/src/celrender/linerenderer.h
+++ b/src/celrender/linerenderer.h
@@ -225,28 +225,38 @@ public:
     void render(const Matrices &mvp, const Color &color, int count, int offset = 0);
 
 private:
-    //! LineVertex is used to draw lines with triangles with GL_TRIANGLE_STRIP
+    //! LineVertex is used to draw lines with triangles with GL_TRIANGLE_STRIP.
+    //! `side` is the signed normalized perpendicular position used by the AA
+    //! shader (-1 / +1 for the two physical edges of the line). It is tracked
+    //! separately from `scale` because close_strip flips `scale` on the last
+    //! two vertices to compensate for a reversed tangent — but the *physical*
+    //! side of those vertices is unchanged, so `side` must stay put.
     struct LineVertex
     {
         LineVertex(const Vertex &point, float scale) :
             point(point),
-            scale(scale)
+            scale(scale),
+            side(scale * 2.0f)
         {}
         Vertex point;
         float  scale;
+        float  side;
     };
 
-    //! LineSegment is used to draw lines with triangles with GL_TRIANGLES
+    //! LineSegment is used to draw lines with triangles with GL_TRIANGLES.
+    //! See LineVertex for why `side` is tracked separately from `scale`.
     struct LineSegment
     {
-        LineSegment(const Vertex &point1, const Vertex &point2, float scale) :
+        LineSegment(const Vertex &point1, const Vertex &point2, float scale, float side) :
             point1(point1),
             point2(point2),
-            scale(scale)
+            scale(scale),
+            side(side)
         {}
         Vertex point1;
         Vertex point2;
         float  scale;
+        float  side;
     };
 
     void draw_lines(int count, int offset) const;


### PR DESCRIPTION
Max line width on ANGLE is 1.0 so on HiDPI device or with smooth line enabled (1.5x line width), we are drawing triangulated lines which there is no AA support.

This implements analytical anti-aliasing for triangulated lines

Before:
<img width="1136" height="880" alt="Screenshot 2026-04-27 at 6 46 46 PM" src="https://github.com/user-attachments/assets/e92ca295-6ec3-49fa-af3b-d29a1730734a" />

After:
<img width="1136" height="880" alt="Screenshot 2026-04-27 at 6 43 16 PM" src="https://github.com/user-attachments/assets/bb0e0b61-0936-444a-95c2-bd353ea49415" />

