### PR TITLE
Use bolometric luminosity instead of luminosity

### DIFF
--- a/src/celengine/stardbbuilder.cpp
+++ b/src/celengine/stardbbuilder.cpp
@@ -528,8 +528,7 @@ applyTemperatureBoloCorrection(const StarDatabaseBuilder::StcHeader& header,
                 // Astronomical Society of Canada, Vol 92. p36.
 
                 double logT = std::log10(static_cast<double>(*temperature)) - 4.0;
-                double bc = -8.499 * std::pow(logT, 4) + 13.421 * std::pow(logT, 3)
-                            - 8.131 * logT * logT - 3.901 * logT - 0.438;
+                double bc = -0.438 + logT * (-3.901 + logT * (-8.131 + logT * (13.421 - logT * 8.499)));
 
                 StarDetails::setBolometricCorrection(details, static_cast<float>(bc));
             }

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -455,9 +455,9 @@ displayStarInfo(const util::NumberFormatter& formatter,
         }
         overlay.printf(_("Class: %s\n"), star_class);
 
-        if (star.getLuminosity() > 1.0e-10f)
+        if (star.getBolometricLuminosity() > 1.0e-10f)
             overlay.print(loc, fmt::runtime(_("Luminosity: {}× Sun\n")),
-                          formatter.format(star.getLuminosity(), 3, SigDigitNum));
+                          formatter.format(star.getBolometricLuminosity(), 3, SigDigitNum));
 
         if (detail > 1)
         {


### PR DESCRIPTION
In astronomy, "luminosity" generally refers to bolometric luminosity, so this should be used instead of V-band luminosity.