### PR TITLE
Fix return of minimumFeatureSize from GalaxyRenderer::getRenderInfo

### DIFF
--- a/src/celrender/galaxyrenderer.cpp
+++ b/src/celrender/galaxyrenderer.cpp
@@ -124,7 +124,7 @@ GalaxyRenderer::render()
 }
 
 bool
-GalaxyRenderer::getRenderInfo(const GalaxyRenderer::Object &obj, float &brightness, float &size, float minimumFeatureSize, Eigen::Matrix4f &m, Eigen::Matrix4f &pr, int &nPoints) const
+GalaxyRenderer::getRenderInfo(const GalaxyRenderer::Object &obj, float &brightness, float &size, float &minimumFeatureSize, Eigen::Matrix4f &m, Eigen::Matrix4f &pr, int &nPoints) const
 {
     const auto* galacticForm = GalacticFormManager::get()->getForm(obj.galaxy->getFormId());
     if (galacticForm == nullptr)

--- a/src/celrender/galaxyrenderer.h
+++ b/src/celrender/galaxyrenderer.h
@@ -44,7 +44,7 @@ private:
     bool getRenderInfo(const GalaxyRenderer::Object &obj,
                        float &brightness,
                        float &size,
-                       float minimumFeatureSize,
+                       float &minimumFeatureSize,
                        Eigen::Matrix4f &m,
                        Eigen::Matrix4f &pr,
                        int &nPoints) const;


### PR DESCRIPTION
- The GL3 shader uses this as an input parameter, so this needs to be an out parameter not a value parameter.