### PR TITLE
miniaudio: share one ma_context/ma_engine across every audio channel

### DIFF
--- a/src/celestia/miniaudiosession.cpp
+++ b/src/celestia/miniaudiosession.cpp
@@ -68,7 +68,7 @@ struct AudioBackend
     AudioBackend &operator=(AudioBackend&&)      = delete;
 };
 
-std::weak_ptr<AudioBackend> g_audioBackend;
+std::weak_ptr<AudioBackend> g_audioBackend; //NOSONAR
 
 // Returns the live shared backend, creating it on demand. The caller
 // pins it for the lifetime of its session by holding the returned

--- a/src/celestia/miniaudiosession.cpp
+++ b/src/celestia/miniaudiosession.cpp
@@ -1,4 +1,7 @@
 #include "miniaudiosession.h"
+
+#include <memory>
+
 #include <celutil/logger.h>
 
 #define MINIAUDIO_IMPLEMENTATION
@@ -8,6 +11,84 @@ using namespace celestia::util;
 
 namespace celestia
 {
+
+namespace
+{
+
+// RAII-managed shared ma_context + ma_engine. A single instance is shared
+// across every live MiniAudioSession via shared_ptr; the weak_ptr at file
+// scope below lets new sessions latch onto the existing instance, and the
+// last session out lets the shared_ptr's refcount destroy it.
+//
+// Why share at all? On iOS each ma_context_init / ma_context_uninit
+// reconfigures the process-wide AVAudioSession singleton (we set
+// ma_ios_session_category_playback on each one), so per-channel teardowns
+// would suspend playback on the other channels. With one context shared
+// for as long as anything is playing, AVAudioSession is configured once
+// and only released after the very last session goes away.
+struct AudioBackend
+{
+    ma_context context;
+    ma_engine  engine;
+    bool       valid = false;
+
+    AudioBackend()
+    {
+        auto config = ma_context_config_init();
+        // on iOS, explicitly set the correct category for correct routing
+        config.coreaudio.sessionCategory = ma_ios_session_category_playback;
+        if (ma_context_init(nullptr, 0, &config, &context) != MA_SUCCESS)
+        {
+            GetLogger()->error("Failed to init miniaudio context");
+            return;
+        }
+        auto engineConfig = ma_engine_config_init();
+        engineConfig.pContext = &context;
+        if (ma_engine_init(&engineConfig, &engine) != MA_SUCCESS)
+        {
+            ma_context_uninit(&context);
+            GetLogger()->error("Failed to start miniaudio engine");
+            return;
+        }
+        valid = true;
+    }
+
+    ~AudioBackend()
+    {
+        if (valid)
+        {
+            ma_engine_uninit(&engine);
+            ma_context_uninit(&context);
+        }
+    }
+
+    AudioBackend(const AudioBackend&)            = delete;
+    AudioBackend(AudioBackend&&)                 = delete;
+    AudioBackend &operator=(const AudioBackend&) = delete;
+    AudioBackend &operator=(AudioBackend&&)      = delete;
+};
+
+std::weak_ptr<AudioBackend> g_audioBackend;
+
+// Returns the live shared backend, creating it on demand. The caller
+// pins it for the lifetime of its session by holding the returned
+// shared_ptr; when the last holder lets go, ~AudioBackend uninits the
+// engine and context.
+std::shared_ptr<AudioBackend>
+acquireAudioBackend()
+{
+    auto backend = g_audioBackend.lock();
+    if (backend)
+        return backend;
+
+    backend = std::make_shared<AudioBackend>();
+    if (!backend->valid)
+        return nullptr;
+    g_audioBackend = backend;
+    return backend;
+}
+
+} // namespace
 
 class MiniAudioSessionPrivate
 {
@@ -28,8 +109,10 @@ class MiniAudioSessionPrivate
     MiniAudioSessionPrivate &operator=(const MiniAudioSessionPrivate&) = delete;
     MiniAudioSessionPrivate &operator=(MiniAudioSessionPrivate&&) = delete;
 
-    ma_context context;
-    ma_engine engine;
+    // backend must outlive `sound` since ma_sound is bound to the
+    // backend's ma_engine. Declare it first so it's destroyed last
+    // (member destruction order is the reverse of declaration).
+    std::shared_ptr<AudioBackend> backend;
     ma_sound sound;
     State state         { State::NotInitialized };
 };
@@ -44,9 +127,11 @@ MiniAudioSessionPrivate::~MiniAudioSessionPrivate()
     case State::SoundInitialzied:
         ma_sound_uninit(&sound);
     case State::EngineStarted:
-        ma_engine_uninit(&engine);
-        ma_context_uninit(&context);
     case State::NotInitialized:
+        // `backend` (declared above `sound`) is released after `sound`
+        // is destroyed. If we hold the last reference, ~AudioBackend
+        // uninits the engine + context; otherwise other live sessions
+        // keep them alive.
         break;
     }
 }
@@ -65,14 +150,15 @@ bool MiniAudioSession::play(double startTime)
     switch (p->state)
     {
     case MiniAudioSessionPrivate::State::NotInitialized:
-        // start the engine
+        // ensure the shared engine is up
         if (!startEngine())
             return false;
         p->state = MiniAudioSessionPrivate::State::EngineStarted;
 
     case MiniAudioSessionPrivate::State::EngineStarted:
-        // load sound file from disk
-        result = ma_sound_init_from_file(&p->engine, path().string().c_str(), MA_SOUND_FLAG_ASYNC, nullptr, nullptr, &p->sound);
+        // load sound file from disk into our own ma_sound, but bound to
+        // the shared engine
+        result = ma_sound_init_from_file(&p->backend->engine, path().string().c_str(), MA_SOUND_FLAG_ASYNC, nullptr, nullptr, &p->sound);
         if (result != MA_SUCCESS)
         {
             GetLogger()->error("Failed to load sound file {}", path());
@@ -152,7 +238,7 @@ bool MiniAudioSession::seek(double seconds)
 {
     if (p->state >= MiniAudioSessionPrivate::State::SoundInitialzied)
     {
-        ma_result result = ma_sound_seek_to_pcm_frame(&p->sound, static_cast<ma_uint64>(seconds * ma_engine_get_sample_rate(&p->engine)));
+        ma_result result = ma_sound_seek_to_pcm_frame(&p->sound, static_cast<ma_uint64>(seconds * ma_engine_get_sample_rate(&p->backend->engine)));
         if (result != MA_SUCCESS)
         {
             GetLogger()->error("Failed to seek to {}", seconds);
@@ -184,27 +270,8 @@ bool MiniAudioSession::startEngine()
 {
     if (p->state >= MiniAudioSessionPrivate::State::EngineStarted)
         return true;
-
-    auto config = ma_context_config_init();
-    // on iOS, explicitly set the correct category for correct routing
-    config.coreaudio.sessionCategory = ma_ios_session_category_playback;
-    ma_result result = ma_context_init(nullptr, 0, &config, &p->context);
-    if (result != MA_SUCCESS)
-    {
-        GetLogger()->error("Failed to init miniaudio context");
-        return false;
-    }
-    auto engineConfig = ma_engine_config_init();
-    engineConfig.pContext = &p->context;
-    result = ma_engine_init(&engineConfig, &p->engine);
-    if (result != MA_SUCCESS)
-    {
-        ma_context_uninit(&p->context);
-        GetLogger()->error("Failed to start miniaudio engine");
-        return false;
-    }
-    p->state = MiniAudioSessionPrivate::State::EngineStarted;
-    return true;
+    p->backend = acquireAudioBackend();
+    return p->backend != nullptr;
 }
 
 }


### PR DESCRIPTION
I've observed that on iOS (macOS is fine). If I do

1. playaudio on channel 0
2. playaudio on channel 1
3. playaudio on channel 1 with another audio file (which internally stopaudio on channel 1 first)

channel 0 stops playing. This fixes that by using a shared context and engine.