### PR TITLE
Fix LANGUAGE translation in tr, nb, and pt_BR locales

### DIFF
--- a/po/nb.po
+++ b/po/nb.po
@@ -4320,7 +4320,7 @@ msgstr "Laster inn bilde fra fil "
 
 #: ../src/celestia/win32/winmain.cpp:628 ../src/celutil/fsutils.cpp:103
 msgid "LANGUAGE"
-msgstr "Språk"
+msgstr "nb"
 
 #: ../src/celestia/win32/winmain.cpp:648
 #, c++-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4152,7 +4152,7 @@ msgstr "Carregando arquivos de dados..."
 
 #: ../src/celestia/win32/winmain.cpp:628 ../src/celutil/fsutils.cpp:103
 msgid "LANGUAGE"
-msgstr "pt"
+msgstr "pt_BR"
 
 #: ../src/celestia/win32/winmain.cpp:648
 #, c++-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -4167,7 +4167,7 @@ msgstr "Veri dosyaları yükleniyor.."
 
 #: ../src/celestia/win32/winmain.cpp:628 ../src/celutil/fsutils.cpp:103
 msgid "LANGUAGE"
-msgstr "DİL"
+msgstr "tr"
 
 #: ../src/celestia/win32/winmain.cpp:648
 #, c++-format


### PR DESCRIPTION
The LANGUAGE msgstr must be a language code used for locale-specific file path lookup, not a translated word. tr had "DİL", nb had "Språk"; pt_BR had "pt" instead of "pt_BR".