### PR TITLE
Remove Synchronous Orbit

### DIFF
--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -1594,25 +1594,6 @@ CreateOrbit(const Selection& centralObject,
         GetLogger()->error("Object has incorrect FixedPosition syntax.\n");
     }
 
-    // LongLat will make an object fixed relative to the surface of its center
-    // object. This is done by creating an orbit with a period equal to the
-    // rotation rate of the parent object. A body-fixed reference frame is a
-    // much better way to accomplish this.
-    if (auto longlat = planetData->getSphericalTuple("LongLat"); longlat.has_value())
-    {
-        if (const Body* centralBody = centralObject.body(); centralBody != nullptr)
-        {
-#if 0 // TODO: This should be enabled after #542 is fixed
-            Eigen::Vector3d pos = centralBody->geodeticToCartesian(*longlat);
-#else
-            Eigen::Vector3d pos = centralBody->planetocentricToCartesian(longlat->x(), longlat->y(), longlat->z());
-#endif
-            return std::make_shared<ephem::SynchronousOrbit>(*centralBody, pos);
-        }
-        // TODO: Allow fixing objects to the surface of stars.
-        return nullptr;
-    }
-
     return nullptr;
 }
 
@@ -1663,39 +1644,36 @@ CreateLegacyRotationModel(const AssociativeArray* planetData,
         precessionRate = *precessionVal;
     }
 
-    if (specified)
-    {
-        if (period == 0.0)
-        {
-            // No period was specified, and the default synchronous
-            // rotation period is zero, indicating that the object
-            // doesn't have a periodic orbit. Default to a constant
-            // orientation instead.
-            return CreateFixedRotationModel(offset, inclination, ascendingNode);
-        }
-
-        if (precessionRate == 0.0)
-        {
-            return std::make_shared<ephem::UniformRotationModel>(period,
-                                                                 offset,
-                                                                 epoch,
-                                                                 inclination,
-                                                                 ascendingNode);
-        }
-
-        return std::make_shared<ephem::PrecessingRotationModel>(period,
-                                                                offset,
-                                                                epoch,
-                                                                inclination,
-                                                                ascendingNode,
-                                                                -360.0 / precessionRate);
-    }
-    else
+    if (!specified)
     {
         // No rotation fields specified
         return nullptr;
     }
 
+    if (period == 0.0)
+    {
+        // No period was specified, and the default synchronous
+        // rotation period is zero, indicating that the object
+        // doesn't have a periodic orbit. Default to a constant
+        // orientation instead.
+        return CreateFixedRotationModel(offset, inclination, ascendingNode);
+    }
+
+    if (precessionRate == 0.0)
+    {
+        return std::make_shared<ephem::UniformRotationModel>(period,
+                                                                offset,
+                                                                epoch,
+                                                                inclination,
+                                                                ascendingNode);
+    }
+
+    return std::make_shared<ephem::PrecessingRotationModel>(period,
+                                                            offset,
+                                                            epoch,
+                                                            inclination,
+                                                            ascendingNode,
+                                                            -360.0 / precessionRate);
 }
 
 /**

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -267,6 +267,31 @@ Selection GetParentObject(PlanetarySystem* system)
     return parent;
 }
 
+std::shared_ptr<const ephem::Orbit>
+CreateLongLat(const AssociativeArray& planetData, ReferenceFrame::SharedConstPtr& frame)
+{
+    // LongLat will make an object fixed relative to the surface of its center
+    // object. This is done by creating an orbit with a period equal to the
+    // rotation rate of the parent object. A body-fixed reference frame is a
+    // much better way to accomplish this.
+    auto longlat = planetData.getSphericalTuple("LongLat");
+    if (!longlat.has_value())
+        return nullptr;
+
+    Body* centralBody = frame->getCenter().body();
+    if (!centralBody)
+        return nullptr;
+
+#if 0 // TODO: This should be enabled after #542 is fixed
+    Eigen::Vector3d pos = centralBody->geodeticToCartesian(*longlat);
+#else
+    Eigen::Vector3d pos = centralBody->planetocentricToCartesian(180.0 + longlat->x(), longlat->y(), longlat->z());
+#endif
+
+    frame = std::make_shared<BodyFixedFrame>(centralBody, centralBody);
+    double period = centralBody->getRotationModel(0.0)->getPeriod(); // backwards compatibility use t=0
+    return std::make_shared<ephem::FixedOrbit>(pos, period);
+}
 
 std::unique_ptr<TimelinePhase>
 CreateTimelinePhase(Body* body,
@@ -340,6 +365,9 @@ CreateTimelinePhase(Body* body,
 
     // Get the orbit
     auto orbit = CreateOrbit(orbitFrame->getCenter(), phaseData, path, usePlanetUnits);
+    if (!orbit)
+        orbit = CreateLongLat(*phaseData, orbitFrame);
+
     if (!orbit)
     {
         GetLogger()->error("Error: missing orbit in timeline phase.\n");
@@ -557,6 +585,8 @@ bool CreateTimeline(Body* body,
     orbitsPlanet = orbitFrame->getCenter().star() == nullptr;
 
     auto newOrbit = CreateOrbit(orbitFrame->getCenter(), planetData, path, !orbitsPlanet);
+    if (!newOrbit)
+        newOrbit = CreateLongLat(*planetData, orbitFrame);
     if (newOrbit == nullptr && orbit == nullptr)
     {
         if (body->getTimeline() && disposition == DataDisposition::Modify)

--- a/src/celephem/orbit.cpp
+++ b/src/celephem/orbit.cpp
@@ -636,36 +636,37 @@ void MixedOrbit::sample(double startTime, double endTime, OrbitSampleProc& proc)
 
 /*** FixedOrbit ***/
 
-FixedOrbit::FixedOrbit(const Eigen::Vector3d& pos) :
-    position(pos)
+FixedOrbit::FixedOrbit(const Eigen::Vector3d& position, std::optional<double> period) :
+    m_position(position),
+    m_period(period)
 {
 }
 
 Eigen::Vector3d
 FixedOrbit::positionAtTime(double /*tjd*/) const
 {
-    return position;
+    return m_position;
 }
 
 
 bool
 FixedOrbit::isPeriodic() const
 {
-    return false;
+    return m_period.has_value();
 }
 
 
 double
 FixedOrbit::getPeriod() const
 {
-    return 1.0;
+    return m_period.value_or(1.0);
 }
 
 
 double
 FixedOrbit::getBoundingRadius() const
 {
-    return position.norm() * 1.1;
+    return m_position.norm() * 1.1;
 }
 
 
@@ -674,40 +675,6 @@ FixedOrbit::sample(double /* startTime */, double /* endTime */, OrbitSampleProc
 {
     // Don't add any samples. This will prevent a fixed trajectory from
     // every being drawn when orbit visualization is enabled.
-}
-
-
-/*** SynchronousOrbit ***/
-// TODO: eliminate this class once body-fixed reference frames are implemented
-SynchronousOrbit::SynchronousOrbit(const Body& _body,
-                                   const Eigen::Vector3d& _position) :
-    body(_body),
-    position(_position)
-{
-}
-
-
-Eigen::Vector3d SynchronousOrbit::positionAtTime(double jd) const
-{
-    return body.getEquatorialToBodyFixed(jd).conjugate() * position;
-}
-
-
-double SynchronousOrbit::getPeriod() const
-{
-    return body.getRotationModel(0.0)->getPeriod();
-}
-
-
-double SynchronousOrbit::getBoundingRadius() const
-{
-    return position.norm();
-}
-
-
-void SynchronousOrbit::sample(double /* startTime */, double /* endTime */, OrbitSampleProc& /*proc*/) const
-{
-    // Empty method--we never want to show a synchronous orbit.
 }
 
 } // end namespace celestia::ephem

--- a/src/celephem/orbit.h
+++ b/src/celephem/orbit.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include <Eigen/Core>
 
@@ -146,7 +147,7 @@ public:
  */
 class CachingOrbit : public Orbit
 {
- public:
+public:
     CachingOrbit() = default;
     ~CachingOrbit() override = default;
 
@@ -156,7 +157,7 @@ class CachingOrbit : public Orbit
     Eigen::Vector3d positionAtTime(double jd) const override;
     Eigen::Vector3d velocityAtTime(double jd) const override;
 
- private:
+private:
     mutable Eigen::Vector3d lastPosition;
     mutable Eigen::Vector3d lastVelocity;
     mutable double lastTime{ -1.0e30 };
@@ -173,7 +174,7 @@ class CachingOrbit : public Orbit
  */
 class MixedOrbit : public Orbit
 {
- public:
+public:
     MixedOrbit(const std::shared_ptr<const Orbit>& orbit, double t0, double t1, double mass);
     ~MixedOrbit() override = default;
 
@@ -183,7 +184,7 @@ class MixedOrbit : public Orbit
     double getBoundingRadius() const override;
     void sample(double startTime, double endTime, OrbitSampleProc& proc) const override;
 
- private:
+private:
     std::shared_ptr<const Orbit> primary;
     std::shared_ptr<const Orbit> afterApprox;
     std::shared_ptr<const Orbit> beforeApprox;
@@ -193,36 +194,14 @@ class MixedOrbit : public Orbit
 };
 
 
-// TODO: eliminate this once body-fixed reference frames are implemented
-/*! An object in a synchronous orbit will always hover of the same spot on
- *  the surface of the body it orbits.  Only equatorial orbits of a certain
- *  radius are stable in the real world.  In Celestia, synchronous orbits are
- *  a convenient way to fix objects to a planet surface.
- */
-class SynchronousOrbit : public Orbit
-{
- public:
-    SynchronousOrbit(const Body& _body, const Eigen::Vector3d& _position);
-    ~SynchronousOrbit() override = default;
-
-    Eigen::Vector3d positionAtTime(double jd) const override;
-    double getPeriod() const override;
-    double getBoundingRadius() const override;
-    void sample(double, double, OrbitSampleProc& proc) const override;
-
- private:
-    const Body& body;
-    Eigen::Vector3d position;
-};
-
-
 /*! A FixedOrbit is used for an object that remains at a constant
- *  position within its reference frame.
+ *  position within its reference frame. The period is only used to
+ *  set default rotations for child objects.
  */
 class FixedOrbit : public Orbit
 {
- public:
-    FixedOrbit(const Eigen::Vector3d& pos);
+public:
+    explicit FixedOrbit(const Eigen::Vector3d& pos, std::optional<double> p = std::nullopt);
     ~FixedOrbit() override = default;
 
     Eigen::Vector3d positionAtTime(double) const override;
@@ -232,8 +211,9 @@ class FixedOrbit : public Orbit
     double getBoundingRadius() const override;
     void sample(double, double, OrbitSampleProc&) const override;
 
- private:
-    Eigen::Vector3d position;
+private:
+    Eigen::Vector3d m_position;
+    std::optional<double> m_period;
 };
 
 }


### PR DESCRIPTION
As suggested in the code comments, `SynchronousOrbit` should be replaced with frame-based orbits.

The `LongLat` directive now overrides the `OrbitFrame` and uses a `FixedPosition` orbit. In order to support the defaulting of the rotation model, and keep consistency for sub-objects, the `FixedPosition` orbit now has an optional period.

This will cause observable changes in behaviour if the .ssc file uses a `LongLat` orbit in combination with a reference frame that isn't the default. It does fix the issue that `LongLat` does not work for class `surfacefeature`, since this always produces a FixedPosition in the BodyFixed frame.