### PR TITLE
Add an sRGB rendering settings to QT

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2615,12 +2615,13 @@ LoadFontHelper(const Renderer *renderer, const std::filesystem::path &p)
 }
 
 bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
+                                std::optional<bool> sRGBRendering,
                                 [[maybe_unused]] bool useMesaPackInvert)
 {
     // Resolve the effective sRGB rendering flag.
     // On GLES 2.0, sRGB requires the EXT_sRGB extension.
     // GLES 3.0+ has native sRGB support.
-    gl::sRGBRendering = config->renderDetails.sRGBRendering;
+    gl::sRGBRendering = sRGBRendering.value_or(config->renderDetails.sRGBRendering);
 #ifdef GL_ES
     if (gl::sRGBRendering && !gl::checkVersion(gl::GLES_3_0) && !gl::EXT_sRGB)
     {

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -188,7 +188,9 @@ public:
     bool initSimulation(const std::filesystem::path& configFileName = std::filesystem::path(),
                         const std::vector<std::filesystem::path>& extrasDirs = {},
                         ProgressNotifier* progressNotifier = nullptr);
-    bool initRenderer(celestia::engine::TextureResolution, bool useMesaPackInvert = true);
+    bool initRenderer(celestia::engine::TextureResolution,
+                      std::optional<bool> sRGBRendering = std::nullopt,
+                      bool useMesaPackInvert = true);
     void start(double t);
     void start();
     void getLightTravelDelay(double distanceKm, int&, int&, float&);

--- a/src/celestia/qt/preferences.ui
+++ b/src/celestia/qt/preferences.ui
@@ -1006,6 +1006,20 @@
              </widget>
             </item>
             <item>
+             <layout class="QHBoxLayout">
+              <item>
+               <widget class="QLabel" name="sRGBRenderingLabel">
+                <property name="text">
+                 <string>sRGB rendering:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="sRGBRenderingCombo"/>
+              </item>
+             </layout>
+            </item>
+            <item>
              <spacer name="verticalSpacer_13">
               <property name="orientation">
                <enum>Qt::Vertical</enum>

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -135,7 +135,11 @@ CelestiaGlWidget::initializeGL()
     if (textureResolution < 0 || textureResolution > static_cast<int>(engine::TextureResolution::hires))
         textureResolution = DEFAULT_TEXTURE_RESOLUTION;
 
-    if (!appCore->initRenderer(static_cast<engine::TextureResolution>(textureResolution), std::nullopt, false))
+    std::optional<bool> sRGBOverride;
+    if (settings.contains("sRGBRendering"))
+        sRGBOverride = settings.value("sRGBRendering").toBool();
+
+    if (!appCore->initRenderer(static_cast<engine::TextureResolution>(textureResolution), sRGBOverride, false))
     {
         // cerr << "Failed to initialize renderer.\n";
         exit(1);

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -135,7 +135,7 @@ CelestiaGlWidget::initializeGL()
     if (textureResolution < 0 || textureResolution > static_cast<int>(engine::TextureResolution::hires))
         textureResolution = DEFAULT_TEXTURE_RESOLUTION;
 
-    if (!appCore->initRenderer(static_cast<engine::TextureResolution>(textureResolution), false))
+    if (!appCore->initRenderer(static_cast<engine::TextureResolution>(textureResolution), std::nullopt, false))
     {
         // cerr << "Failed to initialize renderer.\n";
         exit(1);

--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -19,6 +19,7 @@
 #include <Qt>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QSettings>
 #include <QRadioButton>
 #include <QSlider>
 #include <QSpinBox>
@@ -220,6 +221,17 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
     ui.renderPathBox->addItem(_("OpenGL 2.1"), 0);
 
     ui.antialiasLinesCheck->setChecked(util::is_set(renderFlags, ::RenderFlags::ShowSmoothLines));
+
+    ui.sRGBRenderingCombo->addItem(_("Use config default"));
+    ui.sRGBRenderingCombo->addItem(_("Enabled"));
+    ui.sRGBRenderingCombo->addItem(_("Disabled"));
+    {
+        QSettings settings;
+        if (!settings.contains("sRGBRendering"))
+            ui.sRGBRenderingCombo->setCurrentIndex(0);
+        else
+            ui.sRGBRenderingCombo->setCurrentIndex(settings.value("sRGBRendering").toBool() ? 1 : 2);
+    }
 
     switch (renderer->getResolution())
     {
@@ -726,6 +738,16 @@ void
 PreferencesDialog::on_antialiasLinesCheck_stateChanged(int state)
 {
     setRenderFlag(appCore, ::RenderFlags::ShowSmoothLines, state);
+}
+
+void
+PreferencesDialog::on_sRGBRenderingCombo_currentIndexChanged(int index)
+{
+    QSettings settings;
+    if (index == 0)
+        settings.remove("sRGBRendering");
+    else
+        settings.setValue("sRGBRendering", index == 1);
 }
 
 // Texture resolution

--- a/src/celestia/qt/qtpreferencesdialog.h
+++ b/src/celestia/qt/qtpreferencesdialog.h
@@ -107,6 +107,7 @@ private slots:
 
     void on_renderPathBox_currentIndexChanged(int index) const;
     void on_antialiasLinesCheck_stateChanged(int state);
+    void on_sRGBRenderingCombo_currentIndexChanged(int index);
 
     void on_lowResolutionButton_clicked() const;
     void on_mediumResolutionButton_clicked() const;


### PR DESCRIPTION
Adds an argument to `initRenderer` to override sRGBRendering in celestia.cfg.