### PR TITLE
Overlay image improvements

### DIFF
--- a/src/celengine/overlayimage.cpp
+++ b/src/celengine/overlayimage.cpp
@@ -5,11 +5,11 @@
 #include "render.h"
 
 OverlayImage::OverlayImage(const std::filesystem::path& f, Renderer *r) :
+    texture(LoadTextureFromFile(f.is_relative() ? "images" / f : f,
+                                Texture::EdgeClamp,
+                                Texture::NoMipMaps)),
     renderer(r)
 {
-    texture = LoadTextureFromFile(f.is_relative() ? "images" / f : f,
-                                  Texture::EdgeClamp,
-                                  Texture::NoMipMaps);
 }
 
 void OverlayImage::setColor(const Color& c)

--- a/src/celengine/overlayimage.cpp
+++ b/src/celengine/overlayimage.cpp
@@ -4,11 +4,10 @@
 #include "rectangle.h"
 #include "render.h"
 
-OverlayImage::OverlayImage(std::filesystem::path f, Renderer *r) :
-    filename(std::move(f)),
+OverlayImage::OverlayImage(const std::filesystem::path& f, Renderer *r) :
     renderer(r)
 {
-    texture = LoadTextureFromFile(std::filesystem::path("images") / filename,
+    texture = LoadTextureFromFile(f.is_relative() ? "images" / f : f,
                                   Texture::EdgeClamp,
                                   Texture::NoMipMaps);
 }
@@ -28,8 +27,10 @@ void OverlayImage::render(float curr_time, int width, int height)
     if (renderer == nullptr || texture == nullptr || (curr_time >= start + duration))
         return;
 
-    float xSize = texture->getWidth();
-    float ySize = texture->getHeight();
+    // Honor explicit width/height set via setSize(); fall back to the
+    // texture's intrinsic dimensions when either is non-positive.
+    float xSize = overrideWidth  > 0.0f ? overrideWidth  : static_cast<float>(texture->getWidth());
+    float ySize = overrideHeight > 0.0f ? overrideHeight : static_cast<float>(texture->getHeight());
 
     // center overlay image horizontally if offsetX = 0
     float left = (width * (1 + offsetX) - xSize)/2;

--- a/src/celengine/overlayimage.h
+++ b/src/celengine/overlayimage.h
@@ -11,16 +11,18 @@ class Renderer;
 class OverlayImage
 {
  public:
-    OverlayImage(std::filesystem::path, Renderer*);
+    OverlayImage(const std::filesystem::path&, Renderer*);
     OverlayImage()               = delete;
     ~OverlayImage()              = default;
     OverlayImage(OverlayImage&)  = delete;
     OverlayImage(OverlayImage&&) = delete;
 
     void render(float, int, int);
-    bool isNewImage(const std::filesystem::path& f) const
+    // True once the image has fully faded out and no longer renders;
+    // mirrors the early-return check inside render().
+    bool isExpired(float curr_time) const
     {
-        return filename != f;
+        return curr_time >= start + duration;
     }
     void setStartTime(float t)
     {
@@ -43,19 +45,30 @@ class OverlayImage
     {
         fitscreen = t;
     }
+    // Override the image's drawn size in pixels. A non-positive value
+    // means "use the texture's intrinsic size for that axis." When
+    // fitscreen is true the rendered image is rescaled to fit the
+    // viewport, so explicit sizes only affect non-fitscreen rendering.
+    void setSize(float w, float h)
+    {
+        overrideWidth  = w;
+        overrideHeight = h;
+    }
     void setColor(const Color& c);
     void setColor(std::array<Color, 4>& c);
 
  private:
-    float start     { 0.0f };
-    float duration  { 0.0f };
-    float fadeafter { 0.0f };
-    float offsetX   { 0.0f };
-    float offsetY   { 0.0f };
-    bool  fitscreen { false };
+    float start          { 0.0f };
+    float duration       { 0.0f };
+    float fadeafter      { 0.0f };
+    float offsetX        { 0.0f };
+    float offsetY        { 0.0f };
+    // <=0 means "use the texture's intrinsic size for that axis."
+    float overrideWidth  { 0.0f };
+    float overrideHeight { 0.0f };
+    bool  fitscreen      { false };
     std::array<Color, 4> colors;
 
-    std::filesystem::path filename;
     std::unique_ptr<Texture> texture;
     Renderer *renderer { nullptr };
 };

--- a/src/celengine/overlayimage.h
+++ b/src/celengine/overlayimage.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 
@@ -11,6 +12,11 @@ class Renderer;
 class OverlayImage
 {
  public:
+    // Opaque handle assigned by Hud::addImage at insertion time. Returned to
+    // celx callers so they can remove a specific image later. 0 is reserved
+    // as "no id."
+    using Id = std::uint64_t;
+
     OverlayImage(const std::filesystem::path&, Renderer*);
     OverlayImage()               = delete;
     ~OverlayImage()              = default;
@@ -24,6 +30,8 @@ class OverlayImage
     {
         return curr_time >= start + duration;
     }
+    Id id() const { return imageId; }
+    void setId(Id i) { imageId = i; }
     void setStartTime(float t)
     {
         start = t;
@@ -67,6 +75,7 @@ class OverlayImage
     float overrideWidth  { 0.0f };
     float overrideHeight { 0.0f };
     bool  fitscreen      { false };
+    Id    imageId        { 0 };
     std::array<Color, 4> colors;
 
     std::unique_ptr<Texture> texture;

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2244,9 +2244,14 @@ int CelestiaCore::getTextWidth(std::string_view s) const
 }
 
 
-void CelestiaCore::addScriptImage(std::unique_ptr<OverlayImage>&& _image)
+OverlayImage::Id CelestiaCore::addScriptImage(std::unique_ptr<OverlayImage>&& _image)
 {
-    hud->addImage(std::move(_image), timeInfo.currentTime);
+    return hud->addImage(std::move(_image), timeInfo.currentTime);
+}
+
+bool CelestiaCore::removeScriptImage(OverlayImage::Id id)
+{
+    return hud->removeImage(id);
 }
 
 void CelestiaCore::clearScriptImages()

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2244,9 +2244,14 @@ int CelestiaCore::getTextWidth(std::string_view s) const
 }
 
 
-void CelestiaCore::setScriptImage(std::unique_ptr<OverlayImage>&& _image)
+void CelestiaCore::addScriptImage(std::unique_ptr<OverlayImage>&& _image)
 {
-    hud->setImage(std::move(_image), timeInfo.currentTime);
+    hud->addImage(std::move(_image), timeInfo.currentTime);
+}
+
+void CelestiaCore::clearScriptImages()
+{
+    hud->clearImages();
 }
 
 

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -360,7 +360,11 @@ public:
 
     // Append an overlay image. Each call adds another image without
     // displacing existing ones; expired images are pruned automatically.
-    void addScriptImage(std::unique_ptr<OverlayImage>&&);
+    // Returns the freshly-assigned image id (0 means the image was null).
+    OverlayImage::Id addScriptImage(std::unique_ptr<OverlayImage>&&);
+    // Remove a specific overlay image by id. Returns true when an image
+    // was actually removed.
+    bool removeScriptImage(OverlayImage::Id);
     // Remove every currently-displayed overlay image.
     void clearScriptImages();
 

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -358,7 +358,11 @@ public:
 
     void fatalError(const std::string&, bool visual = true);
 
-    void setScriptImage(std::unique_ptr<OverlayImage>&&);
+    // Append an overlay image. Each call adds another image without
+    // displacing existing ones; expired images are pruned automatically.
+    void addScriptImage(std::unique_ptr<OverlayImage>&&);
+    // Remove every currently-displayed overlay image.
+    void clearScriptImages();
 
     std::string_view getTypedText() const;
     void setTypedText(const char *);

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -1371,10 +1371,10 @@ Hud::addImage(std::unique_ptr<OverlayImage>&& _image, double currentTime)
 {
     if (_image == nullptr) return 0;
     _image->setStartTime(static_cast<float>(currentTime));
-    OverlayImage::Id id = ++m_nextImageId;
-    _image->setId(id);
+    ++m_nextImageId;
+    _image->setId(m_nextImageId);
     m_images.push_back(std::move(_image));
-    return id;
+    return m_nextImageId;
 }
 
 bool

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -951,7 +951,7 @@ Hud::renderOverlay(const WindowMetrics& metrics,
             // in insertion order (newest on top).
             m_images.erase(
                 std::remove_if(m_images.begin(), m_images.end(),
-                               [now](const auto& img) { return img == nullptr || img->isExpired(now); }),
+                               [now](const auto& img) { return img->isExpired(now); }),
                 m_images.end());
             for (const auto& img : m_images)
                 img->render(now, metrics.width, metrics.height);
@@ -1366,12 +1366,27 @@ Hud::showText(const TextPrintPosition& position,
     m_messageDuration = duration;
 }
 
-void
+OverlayImage::Id
 Hud::addImage(std::unique_ptr<OverlayImage>&& _image, double currentTime)
 {
-    if (_image == nullptr) return;
+    if (_image == nullptr) return 0;
     _image->setStartTime(static_cast<float>(currentTime));
+    OverlayImage::Id id = ++m_nextImageId;
+    _image->setId(id);
     m_images.push_back(std::move(_image));
+    return id;
+}
+
+bool
+Hud::removeImage(OverlayImage::Id id)
+{
+    if (id == 0) return false;
+    auto before = m_images.size();
+    m_images.erase(
+        std::remove_if(m_images.begin(), m_images.end(),
+                       [id](const auto& img) { return img->id() == id; }),
+        m_images.end());
+    return m_images.size() != before;
 }
 
 void

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -935,8 +935,28 @@ Hud::renderOverlay(const WindowMetrics& metrics,
 
     m_overlay->begin();
 
-    if (m_hudSettings.showOverlayImage && isScriptRunning && m_image != nullptr)
-        m_image->render(static_cast<float>(timeInfo.currentTime), metrics.width, metrics.height);
+    if (!m_images.empty())
+    {
+        if (!m_hudSettings.showOverlayImage || !isScriptRunning)
+        {
+            // Overlays are gated off (preference toggled or script ended).
+            // Drop the queue rather than letting it accumulate silently.
+            m_images.clear();
+        }
+        else
+        {
+            auto now = static_cast<float>(timeInfo.currentTime);
+            // Drop fully-faded images first so the loop doesn't pile up
+            // state across many short-lived overlays; render the survivors
+            // in insertion order (newest on top).
+            m_images.erase(
+                std::remove_if(m_images.begin(), m_images.end(),
+                               [now](const auto& img) { return img == nullptr || img->isExpired(now); }),
+                m_images.end());
+            for (const auto& img : m_images)
+                img->render(now, metrics.width, metrics.height);
+        }
+    }
 
     views.renderBorders(m_overlay.get(), metrics, timeInfo.currentTime);
 
@@ -1347,10 +1367,17 @@ Hud::showText(const TextPrintPosition& position,
 }
 
 void
-Hud::setImage(std::unique_ptr<OverlayImage>&& _image, double currentTime)
+Hud::addImage(std::unique_ptr<OverlayImage>&& _image, double currentTime)
 {
-    m_image = std::move(_image);
-    m_image->setStartTime(static_cast<float>(currentTime));
+    if (_image == nullptr) return;
+    _image->setStartTime(static_cast<float>(currentTime));
+    m_images.push_back(std::move(_image));
+}
+
+void
+Hud::clearImages()
+{
+    m_images.clear();
 }
 
 } // end namespace celestia

--- a/src/celestia/hud.h
+++ b/src/celestia/hud.h
@@ -24,6 +24,7 @@
 #include <Eigen/Core>
 
 #include <celastro/date.h>
+#include <celengine/overlayimage.h>
 #include <celengine/selection.h>
 #include <celestia/textinput.h>
 #include <celestia/textprintposition.h>
@@ -36,7 +37,6 @@
 
 class MovieCapture;
 class Overlay;
-class OverlayImage;
 class Simulation;
 
 namespace celestia
@@ -159,8 +159,13 @@ public:
     void showText(const TextPrintPosition&, std::string_view, double duration, double currentTime);
     // Push an overlay image onto the stack of currently-displayed images.
     // Each image is rendered until its own duration elapses, then dropped
-    // from the stack; calling this never replaces existing images.
-    void addImage(std::unique_ptr<OverlayImage>&&, double);
+    // from the stack; calling this never replaces existing images. Returns
+    // the freshly-assigned image id so callers can pass it to removeImage
+    // later. 0 is reserved as "no id" and is never returned on success.
+    OverlayImage::Id addImage(std::unique_ptr<OverlayImage>&&, double);
+    // Remove the overlay image with the given id, if any. No-op when the id
+    // is 0 or not currently active.
+    bool removeImage(OverlayImage::Id);
     // Drop every currently-displayed overlay image immediately.
     void clearImages();
 
@@ -182,6 +187,9 @@ private:
     // Active script overlays. New images are appended in `addImage`;
     // expired ones are pruned during renderOverlay.
     std::vector<std::unique_ptr<OverlayImage>> m_images;
+    // Counter for assigning image ids; pre-incremented so the first id is 1
+    // and the sentinel 0 is reserved for "no id."
+    OverlayImage::Id m_nextImageId { 0 };
 
     std::locale loc;
 

--- a/src/celestia/hud.h
+++ b/src/celestia/hud.h
@@ -19,6 +19,7 @@
 #include <string_view>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include <Eigen/Core>
 
@@ -156,7 +157,12 @@ public:
                        bool editMode);
 
     void showText(const TextPrintPosition&, std::string_view, double duration, double currentTime);
-    void setImage(std::unique_ptr<OverlayImage>&&, double);
+    // Push an overlay image onto the stack of currently-displayed images.
+    // Each image is rendered until its own duration elapses, then dropped
+    // from the stack; calling this never replaces existing images.
+    void addImage(std::unique_ptr<OverlayImage>&&, double);
+    // Drop every currently-displayed overlay image immediately.
+    void clearImages();
 
     HudSettings& hudSettings() noexcept { return m_hudSettings; }
     const HudSettings& hudSettings() const noexcept { return m_hudSettings; }
@@ -173,7 +179,9 @@ private:
 
     std::unique_ptr<Overlay> m_overlay;
 
-    std::unique_ptr<OverlayImage> m_image;
+    // Active script overlays. New images are appended in `addImage`;
+    // expired ones are pruned during renderOverlay.
+    std::vector<std::unique_ptr<OverlayImage>> m_images;
 
     std::locale loc;
 

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -945,8 +945,9 @@ void CommandScriptImage::processInstantaneous(ExecutionEnvironment& env)
     // Preserve that contract by clearing existing images before adding
     // the new one; scripts that want multiple should use the celx
     // celestia:addoverlay method instead.
-    env.getCelestiaCore()->clearScriptImages();
-    env.getCelestiaCore()->addScriptImage(std::move(image));
+    auto* core = env.getCelestiaCore();
+    core->clearScriptImages();
+    core->addScriptImage(std::move(image));
 }
 
 // Verbosity command

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -944,7 +944,7 @@ void CommandScriptImage::processInstantaneous(ExecutionEnvironment& env)
     // Legacy `overlay {}` historically allowed only one image on screen.
     // Preserve that contract by clearing existing images before adding
     // the new one; scripts that want multiple should use the celx
-    // celestia:addoverlay method instead.
+    // celestia:addimageoverlay method instead.
     auto* core = env.getCelestiaCore();
     core->clearScriptImages();
     core->addScriptImage(std::move(image));

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -941,7 +941,12 @@ void CommandScriptImage::processInstantaneous(ExecutionEnvironment& env)
     image->setOffset(xoffset, yoffset);
     image->setColor(colors);
     image->fitScreen(fitscreen);
-    env.getCelestiaCore()->setScriptImage(std::move(image));
+    // Legacy `overlay {}` historically allowed only one image on screen.
+    // Preserve that contract by clearing existing images before adding
+    // the new one; scripts that want multiple should use the celx
+    // celestia:addoverlay method instead.
+    env.getCelestiaCore()->clearScriptImages();
+    env.getCelestiaCore()->addScriptImage(std::move(image));
 }
 
 // Verbosity command

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
+#include <optional>
 #include <string_view>
 
 #include <fmt/format.h>
@@ -27,6 +28,7 @@
 #include <celestia/view.h>
 #include <celscript/common/scriptmaps.h>
 #include <celttf/truetypefont.h>
+#include <celutil/color.h>
 #include <celutil/gettext.h>
 #include <celutil/logger.h>
 #include <celutil/stringutils.h>
@@ -2280,31 +2282,136 @@ static int celestia_geturl(lua_State* l)
 }
 
 
-static int celestia_overlay(lua_State* l)
+// Build an OverlayImage from celestia:overlay / celestia:addoverlay args.
+// Returns nullptr if the filename argument was missing or invalid.
+// `methodName` is used for argc/error messages so each method reports its
+// own name.
+static std::unique_ptr<OverlayImage>
+buildOverlayImage(lua_State* l, CelestiaCore* appCore, std::string_view methodName)
 {
-    Celx_CheckArgs(l, 2, 7, "One to Six arguments expected to function celestia:overlay");
-
-    CelestiaCore* appCore = this_celestia(l);
-    float duration = Celx_SafeGetNumber(l, 2, WrongType, "First argument to celestia:overlay must be a number (duration)", 3.0);
-    float xoffset = Celx_SafeGetNumber(l, 3, WrongType, "Second argument to celestia:overlay must be a number (xoffset)", 0.0);
-    float yoffset = Celx_SafeGetNumber(l, 4, WrongType, "Third argument to celestia:overlay must be a number (yoffset)", 0.0);
-    float alpha = Celx_SafeGetNumber(l, 5, WrongType, "Fourth argument to celestia:overlay must be a number (alpha)", 1.0);
-    const char* filename = Celx_SafeGetString(l, 6, AllErrors, "Fifth argument to celestia:overlay must be a string (filename)");
+    float duration = static_cast<float>(Celx_SafeGetNumber(l, 2, WrongType, fmt::format("First argument to celestia:{} must be a number (duration)", methodName).c_str(), 3.0));
+    float xoffset = static_cast<float>(Celx_SafeGetNumber(l, 3, WrongType, fmt::format("Second argument to celestia:{} must be a number (xoffset)", methodName).c_str(), 0.0));
+    float yoffset = static_cast<float>(Celx_SafeGetNumber(l, 4, WrongType, fmt::format("Third argument to celestia:{} must be a number (yoffset)", methodName).c_str(), 0.0));
+    // alpha is optional: when omitted (or nil), the corner colors keep
+    // their own alpha channels, matching parseOverlayCommand which only
+    // overrides alpha when the user explicitly passed it.
+    std::optional<float> alpha = std::nullopt;
+    if (lua_gettop(l) >= 5 && !lua_isnil(l, 5))
+    {
+        alpha = static_cast<float>(Celx_SafeGetNumber(l, 5, WrongType, fmt::format("Fourth argument to celestia:{} must be a number (alpha)", methodName).c_str(), 1.0));
+    }
+    const char* filename = Celx_SafeGetString(l, 6, AllErrors, fmt::format("Fifth argument to celestia:{} must be a string (filename)", methodName).c_str());
+    if (filename == nullptr)
+        return nullptr;
     bool fitscreen;
     if (lua_isboolean(l, 7))
-        fitscreen = lua_toboolean(l, 7);
+        fitscreen = lua_toboolean(l, 7) != 0;
     else
-        fitscreen = (bool) Celx_SafeGetNumber(l, 7, WrongType, "Sixth argument to celestia:overlay must be a number or a boolean(fitscreen)", 0);
+        fitscreen = Celx_SafeGetNumber(l, 7, WrongType, fmt::format("Sixth argument to celestia:{} must be a number or a boolean(fitscreen)", methodName).c_str(), 0.0) != 0.0;
+
+    // fadeafter: seconds-from-start at which fading begins. Default matches
+    // the legacy parseOverlayCommand: `fadeafter = duration` (no fade).
+    float fadeafter = static_cast<float>(Celx_SafeGetNumber(l, 8, WrongType, fmt::format("Seventh argument to celestia:{} must be a number (fadeafter)", methodName).c_str(), duration));
+
+    // width / height override the rendered size in pixels. A non-positive
+    // value (or missing arg) falls back to the texture's intrinsic
+    // dimension along that axis. Ignored when `fitscreen` is true.
+    float overrideWidth  = static_cast<float>(Celx_SafeGetNumber(l, 9, WrongType, fmt::format("Eighth argument to celestia:{} must be a number (width)", methodName).c_str(), 0.0));
+    float overrideHeight = static_cast<float>(Celx_SafeGetNumber(l, 10, WrongType, fmt::format("Ninth argument to celestia:{} must be a number (height)", methodName).c_str(), 0.0));
+
+    // colors: optional Lua table mirroring the legacy overlay command's
+    // per-corner palette. Supported keys (string: named color or
+    // "#rrggbb" / "#rrggbbaa"): `color` (all four corners),
+    // `colortop` / `colorbottom` (two corners each), and the per-corner
+    // overrides `colortopleft`, `colortopright`, `colorbottomright`,
+    // `colorbottomleft`. Missing keys default to white. If the user
+    // explicitly passed `alpha`, it then replaces each corner's alpha
+    // channel; otherwise the corner colors keep their own alpha
+    // (matching parseOverlayCommand).
+    std::array<Color, 4> colors;
+    colors.fill(Color::White);
+    if (lua_gettop(l) >= 11 && !lua_isnil(l, 11))
+    {
+        if (lua_istable(l, 11))
+        {
+            auto readColor = [l, methodName](const char* key, Color& out) -> bool {
+                lua_getfield(l, 11, key);
+                int type = lua_type(l, -1);
+                if (type == LUA_TNIL || type == LUA_TNONE)
+                {
+                    lua_pop(l, 1);
+                    return false;
+                }
+                // Use lua_type instead of lua_isstring -- the latter coerces
+                // numbers, which we don't want for color slots.
+                if (type != LUA_TSTRING)
+                    Celx_DoError(l, fmt::format("colors.{} in celestia:{} must be a string", key, methodName).c_str());
+                const char* s = lua_tostring(l, -1);
+                Color parsed;
+                if (!Color::parse(s, parsed))
+                    Celx_DoError(l, fmt::format("colors.{} in celestia:{} is not a valid color: \"{}\"", key, methodName, s).c_str());
+                out = parsed;
+                lua_pop(l, 1);
+                return true;
+            };
+
+            Color c;
+            if (readColor("color", c))            colors.fill(c);
+            if (readColor("colortop", c))         { colors[0] = c; colors[1] = c; }
+            if (readColor("colorbottom", c))      { colors[2] = c; colors[3] = c; }
+            if (readColor("colortopleft", c))       colors[0] = c;
+            if (readColor("colortopright", c))      colors[1] = c;
+            if (readColor("colorbottomright", c))   colors[2] = c;
+            if (readColor("colorbottomleft", c))    colors[3] = c;
+        }
+        else
+        {
+            Celx_DoError(l, fmt::format("Tenth argument to celestia:{} must be a table (colors)", methodName).c_str());
+        }
+    }
+
+    if (alpha.has_value())
+    {
+        for (Color& color : colors)
+            color.alpha(*alpha);
+    }
 
     auto image = std::make_unique<OverlayImage>(filename, appCore->getRenderer());
     image->setDuration(duration);
-    image->setFadeAfter(duration); // FIXME
+    image->setFadeAfter(fadeafter);
     image->setOffset(xoffset, yoffset);
-    image->setColor({Color::White, alpha}); // FIXME
+    image->setColor(colors);
     image->fitScreen(fitscreen);
+    image->setSize(overrideWidth, overrideHeight);
+    return image;
+}
 
-    appCore->setScriptImage(std::move(image));
+// celestia:overlay(...) -- replace any currently-displayed overlay images
+// with the new one. Matches the historical single-image behavior.
+static int celestia_overlay(lua_State* l)
+{
+    Celx_CheckArgs(l, 2, 11, "One to ten arguments expected to function celestia:overlay");
 
+    CelestiaCore* appCore = this_celestia(l);
+    auto image = buildOverlayImage(l, appCore, "overlay");
+    if (image != nullptr)
+    {
+        appCore->clearScriptImages();
+        appCore->addScriptImage(std::move(image));
+    }
+    return 0;
+}
+
+// celestia:addoverlay(...) -- append an overlay image without clearing the
+// existing ones. Same argument list as celestia:overlay.
+static int celestia_addoverlay(lua_State* l)
+{
+    Celx_CheckArgs(l, 2, 11, "One to ten arguments expected to function celestia:addoverlay");
+
+    CelestiaCore* appCore = this_celestia(l);
+    auto image = buildOverlayImage(l, appCore, "addoverlay");
+    if (image != nullptr)
+        appCore->addScriptImage(std::move(image));
     return 0;
 }
 
@@ -2688,6 +2795,7 @@ void CreateCelestiaMetaTable(lua_State* l)
     Celx_RegisterMethod(l, "seturl", celestia_seturl);
     Celx_RegisterMethod(l, "geturl", celestia_geturl);
     Celx_RegisterMethod(l, "overlay", celestia_overlay);
+    Celx_RegisterMethod(l, "addoverlay", celestia_addoverlay);
     Celx_RegisterMethod(l, "verbosity", celestia_verbosity);
 
     // Compatibility audio playback

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -2321,7 +2321,7 @@ parseOverlayColors(lua_State* l, int slot, std::string_view methodName)
     return colors;
 }
 
-// Build an OverlayImage from celestia:overlay / celestia:addoverlay args.
+// Build an OverlayImage from celestia:overlay / celestia:addimageoverlay args.
 // Returns nullptr if the filename argument was missing or invalid.
 // `methodName` is used for argc/error messages so each method reports its
 // own name.
@@ -2392,7 +2392,7 @@ buildOverlayImage(lua_State* l, const CelestiaCore* appCore, std::string_view me
 
 // celestia:overlay(...) -- replace any currently-displayed overlay images
 // with the new one. Matches the historical single-image behavior; returns
-// nothing (use celestia:addoverlay if you need the image id for later
+// nothing (use celestia:addimageoverlay if you need the image id for later
 // removal).
 static int celestia_overlay(lua_State* l)
 {
@@ -2407,15 +2407,15 @@ static int celestia_overlay(lua_State* l)
     return 0;
 }
 
-// celestia:addoverlay(...) -- append an overlay image without clearing the
+// celestia:addimageoverlay(...) -- append an overlay image without clearing the
 // existing ones. Same argument list as celestia:overlay. Returns the id of
-// the freshly-added image so callers can later remove it via removeoverlay.
-static int celestia_addoverlay(lua_State* l)
+// the freshly-added image so callers can later remove it via removeimageoverlay.
+static int celestia_addimageoverlay(lua_State* l)
 {
-    Celx_CheckArgs(l, 2, 11, "One to ten arguments expected to function celestia:addoverlay");
+    Celx_CheckArgs(l, 2, 11, "One to ten arguments expected to function celestia:addimageoverlay");
 
     CelestiaCore* appCore = this_celestia(l);
-    auto image = buildOverlayImage(l, appCore, "addoverlay");
+    auto image = buildOverlayImage(l, appCore, "addimageoverlay");
     if (image == nullptr)
     {
         lua_pushnil(l);
@@ -2426,22 +2426,22 @@ static int celestia_addoverlay(lua_State* l)
     return 1;
 }
 
-// celestia:removeoverlay(id) -- drop a single overlay image previously added
-// by overlay()/addoverlay(). Returns true if an image was removed.
-static int celestia_removeoverlay(lua_State* l)
+// celestia:removeimageoverlay(id) -- drop a single overlay image previously added
+// by overlay()/addimageoverlay(). Returns true if an image was removed.
+static int celestia_removeimageoverlay(lua_State* l)
 {
-    Celx_CheckArgs(l, 2, 2, "One argument expected to function celestia:removeoverlay");
+    Celx_CheckArgs(l, 2, 2, "One argument expected to function celestia:removeimageoverlay");
     auto id = static_cast<OverlayImage::Id>(Celx_SafeGetNumber(
         l, 2, AllErrors,
-        "First argument to celestia:removeoverlay must be a number (overlay id)"));
+        "First argument to celestia:removeimageoverlay must be a number (overlay id)"));
     lua_pushboolean(l, this_celestia(l)->removeScriptImage(id) ? 1 : 0);
     return 1;
 }
 
-// celestia:clearoverlays() -- drop every currently-displayed overlay image.
-static int celestia_clearoverlays(lua_State* l)
+// celestia:clearimageoverlays() -- drop every currently-displayed overlay image.
+static int celestia_clearimageoverlays(lua_State* l)
 {
-    Celx_CheckArgs(l, 1, 1, "No arguments expected for celestia:clearoverlays");
+    Celx_CheckArgs(l, 1, 1, "No arguments expected for celestia:clearimageoverlays");
     this_celestia(l)->clearScriptImages();
     return 0;
 }
@@ -2826,9 +2826,9 @@ void CreateCelestiaMetaTable(lua_State* l)
     Celx_RegisterMethod(l, "seturl", celestia_seturl);
     Celx_RegisterMethod(l, "geturl", celestia_geturl);
     Celx_RegisterMethod(l, "overlay", celestia_overlay);
-    Celx_RegisterMethod(l, "addoverlay", celestia_addoverlay);
-    Celx_RegisterMethod(l, "removeoverlay", celestia_removeoverlay);
-    Celx_RegisterMethod(l, "clearoverlays", celestia_clearoverlays);
+    Celx_RegisterMethod(l, "addimageoverlay", celestia_addimageoverlay);
+    Celx_RegisterMethod(l, "removeimageoverlay", celestia_removeimageoverlay);
+    Celx_RegisterMethod(l, "clearimageoverlays", celestia_clearimageoverlays);
     Celx_RegisterMethod(l, "verbosity", celestia_verbosity);
 
     // Compatibility audio playback

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -2387,7 +2387,9 @@ buildOverlayImage(lua_State* l, CelestiaCore* appCore, std::string_view methodNa
 }
 
 // celestia:overlay(...) -- replace any currently-displayed overlay images
-// with the new one. Matches the historical single-image behavior.
+// with the new one. Matches the historical single-image behavior; returns
+// nothing (use celestia:addoverlay if you need the image id for later
+// removal).
 static int celestia_overlay(lua_State* l)
 {
     Celx_CheckArgs(l, 2, 11, "One to ten arguments expected to function celestia:overlay");
@@ -2403,16 +2405,34 @@ static int celestia_overlay(lua_State* l)
 }
 
 // celestia:addoverlay(...) -- append an overlay image without clearing the
-// existing ones. Same argument list as celestia:overlay.
+// existing ones. Same argument list as celestia:overlay. Returns the id of
+// the freshly-added image so callers can later remove it via removeoverlay.
 static int celestia_addoverlay(lua_State* l)
 {
     Celx_CheckArgs(l, 2, 11, "One to ten arguments expected to function celestia:addoverlay");
 
     CelestiaCore* appCore = this_celestia(l);
     auto image = buildOverlayImage(l, appCore, "addoverlay");
-    if (image != nullptr)
-        appCore->addScriptImage(std::move(image));
-    return 0;
+    if (image == nullptr)
+    {
+        lua_pushnil(l);
+        return 1;
+    }
+    auto id = appCore->addScriptImage(std::move(image));
+    lua_pushnumber(l, static_cast<lua_Number>(id));
+    return 1;
+}
+
+// celestia:removeoverlay(id) -- drop a single overlay image previously added
+// by overlay()/addoverlay(). Returns true if an image was removed.
+static int celestia_removeoverlay(lua_State* l)
+{
+    Celx_CheckArgs(l, 2, 2, "One argument expected to function celestia:removeoverlay");
+    auto id = static_cast<OverlayImage::Id>(Celx_SafeGetNumber(
+        l, 2, AllErrors,
+        "First argument to celestia:removeoverlay must be a number (overlay id)"));
+    lua_pushboolean(l, this_celestia(l)->removeScriptImage(id) ? 1 : 0);
+    return 1;
 }
 
 // celestia:clearoverlays() -- drop every currently-displayed overlay image.
@@ -2804,6 +2824,7 @@ void CreateCelestiaMetaTable(lua_State* l)
     Celx_RegisterMethod(l, "geturl", celestia_geturl);
     Celx_RegisterMethod(l, "overlay", celestia_overlay);
     Celx_RegisterMethod(l, "addoverlay", celestia_addoverlay);
+    Celx_RegisterMethod(l, "removeoverlay", celestia_removeoverlay);
     Celx_RegisterMethod(l, "clearoverlays", celestia_clearoverlays);
     Celx_RegisterMethod(l, "verbosity", celestia_verbosity);
 

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -2415,6 +2415,14 @@ static int celestia_addoverlay(lua_State* l)
     return 0;
 }
 
+// celestia:clearoverlays() -- drop every currently-displayed overlay image.
+static int celestia_clearoverlays(lua_State* l)
+{
+    Celx_CheckArgs(l, 1, 1, "No arguments expected for celestia:clearoverlays");
+    this_celestia(l)->clearScriptImages();
+    return 0;
+}
+
 static int celestia_verbosity(lua_State* l)
 {
     Celx_CheckArgs(l, 2, 2, "One argument expected to function celestia:verbosity");
@@ -2796,6 +2804,7 @@ void CreateCelestiaMetaTable(lua_State* l)
     Celx_RegisterMethod(l, "geturl", celestia_geturl);
     Celx_RegisterMethod(l, "overlay", celestia_overlay);
     Celx_RegisterMethod(l, "addoverlay", celestia_addoverlay);
+    Celx_RegisterMethod(l, "clearoverlays", celestia_clearoverlays);
     Celx_RegisterMethod(l, "verbosity", celestia_verbosity);
 
     // Compatibility audio playback

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
-#include <optional>
 #include <string_view>
 
 #include <fmt/format.h>
@@ -2282,27 +2281,60 @@ static int celestia_geturl(lua_State* l)
 }
 
 
+// Read overlay table slot `slot` (assumed to be a table) and return the
+// per-corner palette. Raises a Lua error if a recognized key is present
+// but has the wrong type or fails to parse as a color.
+static std::array<Color, 4>
+parseOverlayColors(lua_State* l, int slot, std::string_view methodName)
+{
+    auto readColor = [l, slot, methodName](const char* key, Color& out) {
+        lua_getfield(l, slot, key);
+        int type = lua_type(l, -1);
+        if (type == LUA_TNIL || type == LUA_TNONE)
+        {
+            lua_pop(l, 1);
+            return false;
+        }
+        // Use lua_type instead of lua_isstring -- the latter coerces
+        // numbers, which we don't want for color slots.
+        if (type != LUA_TSTRING)
+            Celx_DoError(l, fmt::format("colors.{} in celestia:{} must be a string", key, methodName).c_str());
+        const char* s = lua_tostring(l, -1);
+        Color parsed;
+        if (!Color::parse(s, parsed))
+            Celx_DoError(l, fmt::format("colors.{} in celestia:{} is not a valid color: \"{}\"", key, methodName, s).c_str());
+        out = parsed;
+        lua_pop(l, 1);
+        return true;
+    };
+
+    std::array<Color, 4> colors;
+    colors.fill(Color::White);
+    Color c;
+    if (readColor("color", c))            colors.fill(c);
+    if (readColor("colortop", c))         { colors[0] = c; colors[1] = c; }
+    if (readColor("colorbottom", c))      { colors[2] = c; colors[3] = c; }
+    if (readColor("colortopleft", c))       colors[0] = c;
+    if (readColor("colortopright", c))      colors[1] = c;
+    if (readColor("colorbottomright", c))   colors[2] = c;
+    if (readColor("colorbottomleft", c))    colors[3] = c;
+    return colors;
+}
+
 // Build an OverlayImage from celestia:overlay / celestia:addoverlay args.
 // Returns nullptr if the filename argument was missing or invalid.
 // `methodName` is used for argc/error messages so each method reports its
 // own name.
 static std::unique_ptr<OverlayImage>
-buildOverlayImage(lua_State* l, CelestiaCore* appCore, std::string_view methodName)
+buildOverlayImage(lua_State* l, const CelestiaCore* appCore, std::string_view methodName)
 {
-    float duration = static_cast<float>(Celx_SafeGetNumber(l, 2, WrongType, fmt::format("First argument to celestia:{} must be a number (duration)", methodName).c_str(), 3.0));
-    float xoffset = static_cast<float>(Celx_SafeGetNumber(l, 3, WrongType, fmt::format("Second argument to celestia:{} must be a number (xoffset)", methodName).c_str(), 0.0));
-    float yoffset = static_cast<float>(Celx_SafeGetNumber(l, 4, WrongType, fmt::format("Third argument to celestia:{} must be a number (yoffset)", methodName).c_str(), 0.0));
-    // alpha is optional: when omitted (or nil), the corner colors keep
-    // their own alpha channels, matching parseOverlayCommand which only
-    // overrides alpha when the user explicitly passed it.
-    std::optional<float> alpha = std::nullopt;
-    if (lua_gettop(l) >= 5 && !lua_isnil(l, 5))
-    {
-        alpha = static_cast<float>(Celx_SafeGetNumber(l, 5, WrongType, fmt::format("Fourth argument to celestia:{} must be a number (alpha)", methodName).c_str(), 1.0));
-    }
     const char* filename = Celx_SafeGetString(l, 6, AllErrors, fmt::format("Fifth argument to celestia:{} must be a string (filename)", methodName).c_str());
     if (filename == nullptr)
         return nullptr;
+
+    float duration = static_cast<float>(Celx_SafeGetNumber(l, 2, WrongType, fmt::format("First argument to celestia:{} must be a number (duration)", methodName).c_str(), 3.0));
+    float xoffset = static_cast<float>(Celx_SafeGetNumber(l, 3, WrongType, fmt::format("Second argument to celestia:{} must be a number (xoffset)", methodName).c_str(), 0.0));
+    float yoffset = static_cast<float>(Celx_SafeGetNumber(l, 4, WrongType, fmt::format("Third argument to celestia:{} must be a number (yoffset)", methodName).c_str(), 0.0));
     bool fitscreen;
     if (lua_isboolean(l, 7))
         fitscreen = lua_toboolean(l, 7) != 0;
@@ -2333,47 +2365,19 @@ buildOverlayImage(lua_State* l, CelestiaCore* appCore, std::string_view methodNa
     if (lua_gettop(l) >= 11 && !lua_isnil(l, 11))
     {
         if (lua_istable(l, 11))
-        {
-            auto readColor = [l, methodName](const char* key, Color& out) -> bool {
-                lua_getfield(l, 11, key);
-                int type = lua_type(l, -1);
-                if (type == LUA_TNIL || type == LUA_TNONE)
-                {
-                    lua_pop(l, 1);
-                    return false;
-                }
-                // Use lua_type instead of lua_isstring -- the latter coerces
-                // numbers, which we don't want for color slots.
-                if (type != LUA_TSTRING)
-                    Celx_DoError(l, fmt::format("colors.{} in celestia:{} must be a string", key, methodName).c_str());
-                const char* s = lua_tostring(l, -1);
-                Color parsed;
-                if (!Color::parse(s, parsed))
-                    Celx_DoError(l, fmt::format("colors.{} in celestia:{} is not a valid color: \"{}\"", key, methodName, s).c_str());
-                out = parsed;
-                lua_pop(l, 1);
-                return true;
-            };
-
-            Color c;
-            if (readColor("color", c))            colors.fill(c);
-            if (readColor("colortop", c))         { colors[0] = c; colors[1] = c; }
-            if (readColor("colorbottom", c))      { colors[2] = c; colors[3] = c; }
-            if (readColor("colortopleft", c))       colors[0] = c;
-            if (readColor("colortopright", c))      colors[1] = c;
-            if (readColor("colorbottomright", c))   colors[2] = c;
-            if (readColor("colorbottomleft", c))    colors[3] = c;
-        }
+            colors = parseOverlayColors(l, 11, methodName);
         else
-        {
             Celx_DoError(l, fmt::format("Tenth argument to celestia:{} must be a table (colors)", methodName).c_str());
-        }
     }
 
-    if (alpha.has_value())
+    // alpha is optional: when omitted (or nil), the corner colors keep
+    // their own alpha channels, matching parseOverlayCommand which only
+    // overrides alpha when the user explicitly passed it.
+    if (lua_gettop(l) >= 5 && !lua_isnil(l, 5))
     {
+        float alpha = static_cast<float>(Celx_SafeGetNumber(l, 5, WrongType, fmt::format("Fourth argument to celestia:{} must be a number (alpha)", methodName).c_str(), 1.0));
         for (Color& color : colors)
-            color.alpha(*alpha);
+            color.alpha(alpha);
     }
 
     auto image = std::make_unique<OverlayImage>(filename, appCore->getRenderer());
@@ -2395,8 +2399,7 @@ static int celestia_overlay(lua_State* l)
     Celx_CheckArgs(l, 2, 11, "One to ten arguments expected to function celestia:overlay");
 
     CelestiaCore* appCore = this_celestia(l);
-    auto image = buildOverlayImage(l, appCore, "overlay");
-    if (image != nullptr)
+    if (auto image = buildOverlayImage(l, appCore, "overlay"); image != nullptr)
     {
         appCore->clearScriptImages();
         appCore->addScriptImage(std::move(image));


### PR DESCRIPTION
1. Add support for stacking multiple overlay images, removing overlay by id in Hud and celx scripts
2. Add support for override width/height in overlay images and in celx scripts
3. Add support for fadeafter/colors (as table of color strings) in celx scripts
4. Add support for overlay image of absolute paths
5. Clear expired images in Hud