### PR TITLE
Frame refactor

### DIFF
--- a/src/celengine/axisarrow.cpp
+++ b/src/celengine/axisarrow.cpp
@@ -24,6 +24,7 @@
 #include "axisarrow.h"
 #include "body.h"
 #include "frame.h"
+#include "frametree.h"
 #include "render.h"
 #include "selection.h"
 #include "shadermanager.h"
@@ -244,17 +245,13 @@ Eigen::Vector3d
 SunDirectionArrow::getDirection(double tdb) const
 {
     const Body* b = &body;
-    const Star* sun = nullptr;
-    while (b != nullptr)
+    while (b)
     {
-        Selection center = b->getOrbitFrame(tdb)->getCenter();
-        if (center.star() != nullptr)
-            sun = center.star();
+        Selection center = b->getTimeline()->findPhase(tdb).getFrameTree()->getOwner();
+        if (const Star* sun = center.star(); sun)
+            return sun->getPosition(tdb).offsetFromKm(body.getPosition(tdb));
         b = center.body();
     }
-
-    if (sun != nullptr)
-        return sun->getPosition(tdb).offsetFromKm(body.getPosition(tdb));
 
     return Eigen::Vector3d::Zero();
 }

--- a/src/celengine/axisarrow.cpp
+++ b/src/celengine/axisarrow.cpp
@@ -244,16 +244,10 @@ SunDirectionArrow::SunDirectionArrow(const Body& _body) :
 Eigen::Vector3d
 SunDirectionArrow::getDirection(double tdb) const
 {
-    const Body* b = &body;
-    while (b)
-    {
-        Selection center = b->getTimeline()->findPhase(tdb).getFrameTree()->getOwner();
-        if (const Star* sun = center.star(); sun)
-            return sun->getPosition(tdb).offsetFromKm(body.getPosition(tdb));
-        b = center.body();
-    }
-
-    return Eigen::Vector3d::Zero();
+    const Star* sun = body.getTimeline()->findPhase(tdb).getFrameTree()->getRoot(tdb);
+    return sun
+        ? sun->getPosition(tdb).offsetFromKm(body.getPosition(tdb))
+        : Eigen::Vector3d::Zero();
 }
 
 std::string_view

--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -590,7 +590,7 @@ Body::getPosition(double tdb) const
         const ReferenceFrame* frame = phase.orbitFrame().get();
         position += frame->getOrientation(tdb).conjugate() * p;
         Selection center = phase.getFrameTree()->getOwner();
-        const Body* body = center.body();
+        body = center.body();
         if (!body)
             return center.getPosition(tdb).offsetKm(position);
     }

--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -589,9 +589,9 @@ Body::getPosition(double tdb) const
         Eigen::Vector3d p = phase.orbit()->positionAtTime(tdb);
         const ReferenceFrame* frame = phase.orbitFrame().get();
         position += frame->getOrientation(tdb).conjugate() * p;
-        if (auto center = frame->getCenter(); center.getType() == SelectionType::Body)
-            body = center.body();
-        else
+        Selection center = phase.getFrameTree()->getOwner();
+        const Body* body = center.body();
+        if (!body)
             return center.getPosition(tdb).offsetKm(position);
     }
 }
@@ -615,11 +615,11 @@ Body::getVelocity(double tdb) const
     const ReferenceFrame* orbitFrame = phase.orbitFrame().get();
 
     Eigen::Vector3d v = phase.orbit()->velocityAtTime(tdb);
-    v = orbitFrame->getOrientation(tdb).conjugate() * v + orbitFrame->getCenter().getVelocity(tdb);
+    v = orbitFrame->getOrientation(tdb).conjugate() * v + phase.getFrameTree()->getOwner().getVelocity(tdb);
 
     if (!orbitFrame->isInertial())
     {
-        Eigen::Vector3d r = getPosition(tdb).offsetFromKm(orbitFrame->getCenter().getPosition(tdb));
+        Eigen::Vector3d r = getPosition(tdb).offsetFromKm(phase.getFrameTree()->getOwner().getPosition(tdb));
         v += orbitFrame->getAngularVelocity(tdb).cross(r);
     }
 
@@ -672,7 +672,7 @@ Body::getAstrocentricPosition(double tdb) const
         Eigen::Vector3d p = phase.orbit()->positionAtTime(tdb);
         const ReferenceFrame* frame = phase.orbitFrame().get();
         position += frame->getOrientation(tdb).conjugate() * p;
-        body = frame->getCenter().body();
+        body = phase.getFrameTree()->getOwner().body();
     } while (body);
 
     return position;

--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -384,12 +384,8 @@ Body::getTemperature(double time) const
     if (temperature > 0)
         return temperature;
 
-    const PlanetarySystem* system = getSystem();
-    if (system == nullptr)
-        return 0;
-
-    const Star* sun = system->getStar();
-    if (sun == nullptr)
+    const Star* sun = timeline->findPhase(time).getFrameTree()->getRoot(time);
+    if (!sun)
         return 0;
 
     float temp = 0.0f;

--- a/src/celengine/frame.cpp
+++ b/src/celengine/frame.cpp
@@ -486,7 +486,7 @@ FrameCache::createFrame(const FrameKey& key, std::size_t index)
     class FrameKeyVisitor
     {
     public:
-        FrameKeyVisitor(const FrameCache& cache) : m_cache(cache) {}
+        explicit FrameKeyVisitor(const FrameCache& cache) : m_cache(cache) {}
 
         ReferenceFrame::SharedConstPtr operator()(SimpleFrameKey k) const
         {
@@ -546,7 +546,7 @@ FrameCache::getFrameVectorId(const FrameVectorKey& key)
     class FrameVectorVisitor
     {
     public:
-        FrameVectorVisitor(const FrameCache& cache) : m_cache(cache) {}
+        explicit FrameVectorVisitor(const FrameCache& cache) : m_cache(cache) {}
 
         FrameVector operator()(const RelativePositionKey& k) const
         {

--- a/src/celengine/frame.cpp
+++ b/src/celengine/frame.cpp
@@ -439,10 +439,10 @@ FrameVector::direction(double tjd) const
 void
 FrameVector::visitChildren(FrameVisitor& visitor) const
 {
-    class ChildVisitor
+    class ReferenceVisitor
     {
     public:
-        ChildVisitor(FrameVisitor& v) : m_visitor(v) {}
+        explicit ReferenceVisitor(FrameVisitor& v) : m_visitor(v) {}
 
         void operator()(const RelativePosition& pos) const
         {
@@ -465,7 +465,7 @@ FrameVector::visitChildren(FrameVisitor& visitor) const
         FrameVisitor& m_visitor;
     };
 
-    std::visit(ChildVisitor(visitor), m_data);
+    std::visit(ReferenceVisitor(visitor), m_data);
 }
 
 std::size_t

--- a/src/celengine/frame.cpp
+++ b/src/celengine/frame.cpp
@@ -534,17 +534,6 @@ FrameCache::getFrameId(const FrameKey& key)
     return it->second;
 }
 
-bool
-FrameCache::getFrameId(FrameId& frameId, const ReferenceFrame* frame) const
-{
-    auto it = m_frameIdMap.find(frame);
-    if (it == m_frameIdMap.end())
-        return false;
-
-    frameId = it->second;
-    return true;
-}
-
 void
 FrameCache::createFrame(const FrameKey& key, std::size_t index)
 {
@@ -597,8 +586,6 @@ FrameCache::createFrame(const FrameKey& key, std::size_t index)
         m_frames.emplace_back(ptr);
     else
         m_frames[index] = ptr;
-
-    m_frameIdMap.insert_or_assign(ptr.get(), static_cast<FrameId>(index));
 }
 
 FrameVectorId

--- a/src/celengine/frame.cpp
+++ b/src/celengine/frame.cpp
@@ -637,10 +637,3 @@ FrameCache::getFrameVectorId(const FrameVectorKey& key)
     m_frameVectors.emplace_back(std::visit(FrameVectorVisitor(*this), key));
     return it->second;
 }
-
-FrameCache*
-GetFrameCache()
-{
-    static FrameCache cache;
-    return &cache;
-}

--- a/src/celengine/frame.cpp
+++ b/src/celengine/frame.cpp
@@ -132,12 +132,31 @@ BodyFixedFrame::getAngularVelocity(double tjd) const
     case SelectionType::Star:
         return m_fixObject.star()->getRotationModel()->angularVelocityAtTime(tjd);
     case SelectionType::Location:
-        if (m_fixObject.location()->getParentBody())
-            return m_fixObject.location()->getParentBody()->getAngularVelocity(tjd);
+        if (const Body* parentBody = m_fixObject.location()->getParentBody(); parentBody)
+            return parentBody->getAngularVelocity(tjd);
         else
             return Eigen::Vector3d::Zero();
     default:
         return Eigen::Vector3d::Zero();
+    }
+}
+
+void
+BodyFixedFrame::visitChildren(FrameVisitor& visitor) const
+{
+    switch (m_fixObject.getType())
+    {
+    case SelectionType::Body:
+        visitor.visitBodyFrame(m_fixObject.body());
+        break;
+
+    case SelectionType::Location:
+        if (const Body* parentBody = m_fixObject.location()->getParentBody(); parentBody)
+            visitor.visitBodyFrame(parentBody);
+        break;
+
+    default:
+        break;
     }
 }
 
@@ -193,6 +212,13 @@ BodyMeanEquatorFrame::isInertial() const
     }
 
     return true;
+}
+
+void
+BodyMeanEquatorFrame::visitChildren(FrameVisitor& visitor) const
+{
+    if (const Body* body = m_equatorObject.body(); body)
+        visitor.visitBodyFrame(body, m_freezeEpoch);
 }
 
 /*** CachingFrame ***/
@@ -359,6 +385,13 @@ TwoVectorFrame::isInertial() const
     return false;
 }
 
+void
+TwoVectorFrame::visitChildren(FrameVisitor& visitor) const
+{
+    m_primaryVector.visitChildren(visitor);
+    m_secondaryVector.visitChildren(visitor);
+}
+
 FrameVector::FrameVector(const RelativePosition& pos) : m_data(pos)
 {
 }
@@ -401,6 +434,38 @@ FrameVector::direction(double tjd) const
     };
 
     return std::visit(DirectionVisitor{ tjd }, m_data);
+}
+
+void
+FrameVector::visitChildren(FrameVisitor& visitor) const
+{
+    class ChildVisitor
+    {
+    public:
+        ChildVisitor(FrameVisitor& v) : m_visitor(v) {}
+
+        void operator()(const RelativePosition& pos) const
+        {
+            m_visitor.visitPosition(pos.observer);
+            m_visitor.visitPosition(pos.target);
+        }
+
+        void operator()(const RelativeVelocity& vel) const
+        {
+            m_visitor.visitPosition(vel.observer);
+            m_visitor.visitPosition(vel.target);
+        }
+
+        void operator()(const ConstVector& vec) const
+        {
+            m_visitor.visitReferenceFrame(vec.frame.get());
+        }
+
+    private:
+        FrameVisitor& m_visitor;
+    };
+
+    std::visit(ChildVisitor(visitor), m_data);
 }
 
 std::size_t

--- a/src/celengine/frame.cpp
+++ b/src/celengine/frame.cpp
@@ -16,6 +16,8 @@
 #include <cassert>
 #include <cmath>
 
+#include <boost/container_hash/hash.hpp>
+
 #include <celastro/date.h>
 #include <celephem/rotation.h>
 #include <celmath/geomutil.h>
@@ -58,7 +60,35 @@ ReferenceFrame::getAngularVelocity(double tjd) const
     return dq.vec().normalized() * (2.0 * std::acos(dq.w()) / ANGULAR_VELOCITY_DIFF_DELTA);
 }
 
+/*** J2000EclipticFrame ***/
+
+J2000EclipticFrame::SharedConstPtr
+J2000EclipticFrame::getInstance()
+{
+    static std::weak_ptr<const J2000EclipticFrame> instance;
+    auto ptr = instance.lock();
+    if (ptr)
+        return ptr;
+
+    ptr = std::make_shared<J2000EclipticFrame>(CreateToken{});
+    instance = ptr;
+    return ptr;
+}
+
 /*** J2000EquatorFrame ***/
+
+J2000EquatorFrame::SharedConstPtr
+J2000EquatorFrame::getInstance()
+{
+    static std::weak_ptr<const J2000EquatorFrame> instance;
+    auto ptr = instance.lock();
+    if (ptr)
+        return ptr;
+
+    ptr = std::make_shared<J2000EquatorFrame>(CreateToken{});
+    instance = ptr;
+    return ptr;
+}
 
 Eigen::Quaterniond
 J2000EquatorFrame::getOrientation(double /* tjd */) const
@@ -371,4 +401,181 @@ FrameVector::direction(double tjd) const
     };
 
     return std::visit(DirectionVisitor{ tjd }, m_data);
+}
+
+std::size_t
+std::hash<BodyMeanEquatorFrameKey>::operator()(const BodyMeanEquatorFrameKey& obj) const
+{
+    std::size_t seed = 0;
+    boost::hash_combine(seed, obj.target);
+    boost::hash_combine(seed, obj.freezeEpoch);
+    return seed;
+}
+
+std::size_t
+std::hash<TwoVectorFrameKey>::operator()(const TwoVectorFrameKey& obj) const
+{
+    std::size_t seed = 0;
+    boost::hash_combine(seed, obj.frameVectorId1);
+    boost::hash_combine(seed, obj.axis1);
+    boost::hash_combine(seed, obj.frameVectorId2);
+    boost::hash_combine(seed, obj.axis2);
+    return seed;
+}
+
+std::size_t
+std::hash<RelativePositionKey>::operator()(const RelativePositionKey& obj) const
+{
+    std::size_t seed = 0;
+    boost::hash_combine(seed, obj.observer);
+    boost::hash_combine(seed, obj.target);
+    return seed;
+}
+
+std::size_t
+std::hash<RelativeVelocityKey>::operator()(const RelativeVelocityKey& obj) const
+{
+    std::size_t seed = 0;
+    boost::hash_combine(seed, obj.observer);
+    boost::hash_combine(seed, obj.target);
+    return seed;
+}
+
+std::size_t
+std::hash<ConstVectorKey>::operator()(const ConstVectorKey& obj) const
+{
+    std::size_t seed = 0;
+    boost::hash_combine(seed, obj.vec.x());
+    boost::hash_combine(seed, obj.vec.y());
+    boost::hash_combine(seed, obj.vec.z());
+    boost::hash_combine(seed, obj.frameId);
+    return seed;
+}
+
+ReferenceFrame::SharedConstPtr
+FrameCache::getFrame(FrameId frameId) const
+{
+    assert(static_cast<std::size_t>(frameId) < m_frames.size());
+    return m_frames[static_cast<std::size_t>(frameId)];
+}
+
+FrameId
+FrameCache::getFrameId(const FrameKey& key)
+{
+    auto [it, inserted] = m_frameMap.try_emplace(key, static_cast<FrameId>(m_frames.size()));
+    if (inserted)
+        createFrame(key, static_cast<std::size_t>(it->second));
+
+    return it->second;
+}
+
+bool
+FrameCache::getFrameId(FrameId& frameId, const ReferenceFrame* frame) const
+{
+    auto it = m_frameIdMap.find(frame);
+    if (it == m_frameIdMap.end())
+        return false;
+
+    frameId = it->second;
+    return true;
+}
+
+void
+FrameCache::createFrame(const FrameKey& key, std::size_t index)
+{
+    class FrameKeyVisitor
+    {
+    public:
+        FrameKeyVisitor(const FrameCache& cache) : m_cache(cache) {}
+
+        ReferenceFrame::SharedConstPtr operator()(SimpleFrameKey k) const
+        {
+            switch (k)
+            {
+            case SimpleFrameKey::J2000Ecliptic:
+                return J2000EclipticFrame::getInstance();
+
+            case SimpleFrameKey::J2000Equator:
+                return J2000EquatorFrame::getInstance();
+
+            default:
+                assert(0);
+                return nullptr;
+            }
+        }
+
+        ReferenceFrame::SharedConstPtr operator()(const BodyFixedFrameKey& k) const
+        {
+            return std::make_shared<BodyFixedFrame>(k.target);
+        }
+
+        ReferenceFrame::SharedConstPtr operator()(const BodyMeanEquatorFrameKey& k) const
+        {
+            return std::make_shared<BodyMeanEquatorFrame>(k.target, k.freezeEpoch);
+        }
+
+        ReferenceFrame::SharedConstPtr operator()(const TwoVectorFrameKey& k) const
+        {
+            assert(static_cast<std::size_t>(k.frameVectorId1) < m_cache.m_frameVectors.size());
+            assert(static_cast<std::size_t>(k.frameVectorId2) < m_cache.m_frameVectors.size());
+            const FrameVector& vec1 = m_cache.m_frameVectors[static_cast<std::size_t>(k.frameVectorId1)];
+            const FrameVector& vec2 = m_cache.m_frameVectors[static_cast<std::size_t>(k.frameVectorId2)];
+            return std::make_shared<TwoVectorFrame>(vec1, k.axis1, vec2, k.axis2);
+        }
+
+    private:
+        const FrameCache& m_cache;
+    };
+
+    auto ptr = std::visit(FrameKeyVisitor(*this), key);
+    if (index >= m_frames.size())
+        m_frames.emplace_back(ptr);
+    else
+        m_frames[index] = ptr;
+
+    m_frameIdMap.insert_or_assign(ptr.get(), static_cast<FrameId>(index));
+}
+
+FrameVectorId
+FrameCache::getFrameVectorId(const FrameVectorKey& key)
+{
+    auto [it, inserted] = m_frameVectorMap.try_emplace(key, static_cast<FrameVectorId>(m_frameVectorMap.size()));
+    if (!inserted)
+        return it->second;
+
+    class FrameVectorVisitor
+    {
+    public:
+        FrameVectorVisitor(const FrameCache& cache) : m_cache(cache) {}
+
+        FrameVector operator()(const RelativePositionKey& k) const
+        {
+            return FrameVector(FrameVector::RelativePosition(k.observer, k.target));
+        }
+
+        FrameVector operator()(const RelativeVelocityKey& k) const
+        {
+            return FrameVector(FrameVector::RelativeVelocity(k.observer, k.target));
+        }
+
+        FrameVector operator()(const ConstVectorKey& k) const
+        {
+            assert(static_cast<std::size_t>(k.frameId) < m_cache.m_frames.size());
+            const ReferenceFrame::SharedConstPtr& frame = m_cache.m_frames[static_cast<std::size_t>(k.frameId)];
+            return FrameVector(FrameVector::ConstVector(k.vec, frame));
+        }
+
+    private:
+        const FrameCache& m_cache;
+    };
+
+    m_frameVectors.emplace_back(std::visit(FrameVectorVisitor(*this), key));
+    return it->second;
+}
+
+FrameCache*
+GetFrameCache()
+{
+    static FrameCache cache;
+    return &cache;
 }

--- a/src/celengine/frame.cpp
+++ b/src/celengine/frame.cpp
@@ -23,6 +23,7 @@
 #include "location.h"
 #include "selection.h"
 #include "star.h"
+#include "timeline.h"
 #include "univcoord.h"
 
 namespace astro = celestia::astro;
@@ -45,19 +46,6 @@ const Eigen::Quaterniond J2000Orientation{ Eigen::AngleAxis<double>(astro::J2000
 
 /*** ReferenceFrame ***/
 
-ReferenceFrame::ReferenceFrame(Selection center) :
-    centerObject(center)
-{
-}
-
-/*! Return the object that is the defined origin of the reference frame.
- */
-Selection
-ReferenceFrame::getCenter() const
-{
-    return centerObject;
-}
-
 Eigen::Vector3d
 ReferenceFrame::getAngularVelocity(double tjd) const
 {
@@ -70,84 +58,7 @@ ReferenceFrame::getAngularVelocity(double tjd) const
     return dq.vec().normalized() * (2.0 * std::acos(dq.w()) / ANGULAR_VELOCITY_DIFF_DELTA);
 }
 
-unsigned int
-ReferenceFrame::nestingDepth(unsigned int maxDepth) const
-{
-    return nestingDepth(0, maxDepth);
-}
-
-unsigned int
-ReferenceFrame::getFrameDepth(const Selection& sel,
-                              unsigned int depth,
-                              unsigned int maxDepth,
-                              FrameType frameType)
-{
-    if (depth > maxDepth)
-        return depth;
-
-    const Body* body = sel.body();
-    if (sel.location() != nullptr)
-        body = sel.location()->getParentBody();
-
-    if (body == nullptr)
-        return depth;
-
-    unsigned int frameDepth;
-    // TODO: need to check /all/ orbit frames of body
-    switch (frameType)
-    {
-    case FrameType::PositionFrame:
-        if (const ReferenceFrame* orbitFrame = body->getOrbitFrame(0.0).get();
-            orbitFrame != nullptr)
-        {
-            frameDepth = orbitFrame->nestingDepth(depth + 1, maxDepth);
-            if (frameDepth > maxDepth)
-                return frameDepth;
-        }
-        break;
-
-    case FrameType::OrientationFrame:
-        if (const ReferenceFrame* bodyFrame = body->getBodyFrame(0.0).get();
-            bodyFrame != nullptr)
-        {
-            frameDepth = bodyFrame->nestingDepth(depth + 1, maxDepth);
-        }
-        break;
-
-    default:
-        assert(0);
-        return depth;
-    }
-
-    return std::max(frameDepth, depth);
-}
-
-/*** J2000EclipticFrame ***/
-
-J2000EclipticFrame::J2000EclipticFrame(Selection center) :
-    ReferenceFrame(center)
-{
-}
-
-bool
-J2000EclipticFrame::isInertial() const
-{
-    return true;
-}
-
-unsigned int
-J2000EclipticFrame::nestingDepth(unsigned int depth,
-                                 unsigned int maxDepth) const
-{
-    return getFrameDepth(getCenter(), depth, maxDepth, FrameType::PositionFrame);
-}
-
 /*** J2000EquatorFrame ***/
-
-J2000EquatorFrame::J2000EquatorFrame(Selection center) :
-    ReferenceFrame(center)
-{
-}
 
 Eigen::Quaterniond
 J2000EquatorFrame::getOrientation(double /* tjd */) const
@@ -155,39 +66,25 @@ J2000EquatorFrame::getOrientation(double /* tjd */) const
     return J2000Orientation;
 }
 
-bool
-J2000EquatorFrame::isInertial() const
-{
-    return true;
-}
-
-unsigned int
-J2000EquatorFrame::nestingDepth(unsigned int depth,
-                                unsigned int maxDepth) const
-{
-    return getFrameDepth(getCenter(), depth, maxDepth, FrameType::PositionFrame);
-}
-
 /*** BodyFixedFrame ***/
 
-BodyFixedFrame::BodyFixedFrame(Selection center, Selection obj) :
-    ReferenceFrame(center),
-    fixObject(obj)
+BodyFixedFrame::BodyFixedFrame(Selection obj) :
+    m_fixObject(obj)
 {
 }
 
 Eigen::Quaterniond
 BodyFixedFrame::getOrientation(double tjd) const
 {
-    switch (fixObject.getType())
+    switch (m_fixObject.getType())
     {
     case SelectionType::Body:
-        return math::YRot180<double> * fixObject.body()->getEclipticToBodyFixed(tjd);
+        return math::YRot180<double> * m_fixObject.body()->getEclipticToBodyFixed(tjd);
     case SelectionType::Star:
-        return math::YRot180<double> * fixObject.star()->getRotationModel()->orientationAtTime(tjd);
+        return math::YRot180<double> * m_fixObject.star()->getRotationModel()->orientationAtTime(tjd);
     case SelectionType::Location:
-        if (fixObject.location()->getParentBody())
-            return math::YRot180<double> * fixObject.location()->getParentBody()->getEclipticToBodyFixed(tjd);
+        if (m_fixObject.location()->getParentBody())
+            return math::YRot180<double> * m_fixObject.location()->getParentBody()->getEclipticToBodyFixed(tjd);
         else
             return math::YRot180<double>;
     default:
@@ -198,15 +95,15 @@ BodyFixedFrame::getOrientation(double tjd) const
 Eigen::Vector3d
 BodyFixedFrame::getAngularVelocity(double tjd) const
 {
-    switch (fixObject.getType())
+    switch (m_fixObject.getType())
     {
     case SelectionType::Body:
-        return fixObject.body()->getAngularVelocity(tjd);
+        return m_fixObject.body()->getAngularVelocity(tjd);
     case SelectionType::Star:
-        return fixObject.star()->getRotationModel()->angularVelocityAtTime(tjd);
+        return m_fixObject.star()->getRotationModel()->angularVelocityAtTime(tjd);
     case SelectionType::Location:
-        if (fixObject.location()->getParentBody())
-            return fixObject.location()->getParentBody()->getAngularVelocity(tjd);
+        if (m_fixObject.location()->getParentBody())
+            return m_fixObject.location()->getParentBody()->getAngularVelocity(tjd);
         else
             return Eigen::Vector3d::Zero();
     default:
@@ -214,56 +111,25 @@ BodyFixedFrame::getAngularVelocity(double tjd) const
     }
 }
 
-bool
-BodyFixedFrame::isInertial() const
-{
-    return false;
-}
-
-unsigned int
-BodyFixedFrame::nestingDepth(unsigned int depth,
-                             unsigned int maxDepth) const
-{
-    unsigned int n = getFrameDepth(getCenter(), depth, maxDepth, FrameType::PositionFrame);
-    if (n > maxDepth)
-        return n;
-
-    unsigned int m = getFrameDepth(fixObject, depth, maxDepth, FrameType::OrientationFrame);
-    return std::max(m, n);
-}
-
 /*** BodyMeanEquatorFrame ***/
 
-BodyMeanEquatorFrame::BodyMeanEquatorFrame(Selection center,
-                                           Selection obj) :
-    ReferenceFrame(center),
-    equatorObject(obj),
-    freezeEpoch(astro::J2000),
-    isFrozen(false)
-{
-}
-
-BodyMeanEquatorFrame::BodyMeanEquatorFrame(Selection center,
-                                           Selection obj,
-                                           double freeze) :
-    ReferenceFrame(center),
-    equatorObject(obj),
-    freezeEpoch(freeze),
-    isFrozen(true)
+BodyMeanEquatorFrame::BodyMeanEquatorFrame(Selection obj,
+                                           std::optional<double> freeze) :
+    m_equatorObject(obj),
+    m_freezeEpoch(freeze)
 {
 }
 
 Eigen::Quaterniond
 BodyMeanEquatorFrame::getOrientation(double tjd) const
 {
-    double t = isFrozen ? freezeEpoch : tjd;
-
-    switch (equatorObject.getType())
+    double t = m_freezeEpoch.value_or(tjd);
+    switch (m_equatorObject.getType())
     {
     case SelectionType::Body:
-        return equatorObject.body()->getEclipticToEquatorial(t);
+        return m_equatorObject.body()->getEclipticToEquatorial(t);
     case SelectionType::Star:
-        return equatorObject.star()->getRotationModel()->equatorOrientationAtTime(t);
+        return m_equatorObject.star()->getRotationModel()->equatorOrientationAtTime(t);
     default:
         return Eigen::Quaterniond::Identity();
     }
@@ -272,11 +138,11 @@ BodyMeanEquatorFrame::getOrientation(double tjd) const
 Eigen::Vector3d
 BodyMeanEquatorFrame::getAngularVelocity(double tjd) const
 {
-    if (isFrozen)
+    if (m_freezeEpoch.has_value())
         return Eigen::Vector3d::Zero();
 
-    if (equatorObject.body() != nullptr)
-        return equatorObject.body()->getBodyFrame(tjd)->getAngularVelocity(tjd);
+    if (const Body* body = m_equatorObject.body(); body)
+        return body->getBodyFrame(tjd)->getAngularVelocity(tjd);
 
     return Eigen::Vector3d::Zero();
 }
@@ -287,29 +153,19 @@ BodyMeanEquatorFrame::isInertial() const
     // Although the mean equator of an object may vary slightly due to precession,
     // treat it as an inertial frame as long as the body frame of the object is
     // also inertial.
-    return isFrozen ||
-           equatorObject.body() == nullptr ||
-           equatorObject.body()->getBodyFrame(0.0)->isInertial();
-}
+    if (m_freezeEpoch.has_value())
+        return true;
 
-unsigned int
-BodyMeanEquatorFrame::nestingDepth(unsigned int depth,
-                                   unsigned int maxDepth) const
-{
-    // Test origin and equator object (typically the same) frames
-    unsigned int n =  getFrameDepth(getCenter(), depth, maxDepth, FrameType::PositionFrame);
-    if (n > maxDepth)
-        return n;
+    if (const Body* body = m_equatorObject.body(); body)
+    {
+        return body->getTimeline()->phaseCount() == 1
+            && body->getTimeline()->findPhase(0).bodyFrame()->isInertial();
+    }
 
-    unsigned int m = getFrameDepth(equatorObject, depth, maxDepth, FrameType::OrientationFrame);
-    return std::max(m, n);
+    return true;
 }
 
 /*** CachingFrame ***/
-
-CachingFrame::CachingFrame(Selection _center) : ReferenceFrame(_center)
-{
-}
 
 Eigen::Quaterniond
 CachingFrame::getOrientation(double tjd) const
@@ -374,44 +230,42 @@ CachingFrame::computeAngularVelocity(double tjd) const
 
 /*** TwoVectorFrame ***/
 
-TwoVectorFrame::TwoVectorFrame(Selection center,
-                               const FrameVector& prim,
+TwoVectorFrame::TwoVectorFrame(const FrameVector& prim,
                                int primAxis,
                                const FrameVector& sec,
                                int secAxis) :
-    CachingFrame(center),
-    primaryVector(prim),
-    primaryAxis(primAxis),
-    secondaryVector(sec),
-    secondaryAxis(secAxis)
+    m_primaryVector(prim),
+    m_primaryAxis(primAxis),
+    m_secondaryVector(sec),
+    m_secondaryAxis(secAxis)
 {
     // Verify that primary and secondary axes are valid
-    assert(primaryAxis != 0 && secondaryAxis != 0);
-    assert(std::abs(primaryAxis) <= 3 && std::abs(secondaryAxis) <= 3);
+    assert(m_primaryAxis != 0 && m_secondaryAxis != 0);
+    assert(std::abs(m_primaryAxis) <= 3 && std::abs(m_secondaryAxis) <= 3);
     // Verify that the primary and secondary axes aren't collinear
-    assert(std::abs(primaryAxis) != std::abs(secondaryAxis));
+    assert(std::abs(m_primaryAxis) != std::abs(m_secondaryAxis));
 
-    if (std::abs(primaryAxis) != 1 && std::abs(secondaryAxis) != 1)
-        tertiaryAxis = 1;
-    else if (std::abs(primaryAxis) != 2 && std::abs(secondaryAxis) != 2)
-        tertiaryAxis = 2;
+    if (std::abs(m_primaryAxis) != 1 && std::abs(m_secondaryAxis) != 1)
+        m_tertiaryAxis = 1;
+    else if (std::abs(m_primaryAxis) != 2 && std::abs(m_secondaryAxis) != 2)
+        m_tertiaryAxis = 2;
     else
-        tertiaryAxis = 3;
+        m_tertiaryAxis = 3;
 }
 
 Eigen::Quaterniond
 TwoVectorFrame::computeOrientation(double tjd) const
 {
-    Eigen::Vector3d v0 = primaryVector.direction(tjd);
-    Eigen::Vector3d v1 = secondaryVector.direction(tjd);
+    Eigen::Vector3d v0 = m_primaryVector.direction(tjd);
+    Eigen::Vector3d v1 = m_secondaryVector.direction(tjd);
 
     // TODO: verify that v0 and v1 aren't zero length
     v0.normalize();
     v1.normalize();
 
-    if (primaryAxis < 0)
+    if (m_primaryAxis < 0)
         v0 = -v0;
-    if (secondaryAxis < 0)
+    if (m_secondaryAxis < 0)
         v1 = -v1;
 
     Eigen::Vector3d v2 = v0.cross(v1);
@@ -430,26 +284,26 @@ TwoVectorFrame::computeOrientation(double tjd) const
 
     // Determine whether the primary and secondary axes are in
     // right hand order.
-    int rhAxis = std::abs(primaryAxis) + 1;
+    int rhAxis = std::abs(m_primaryAxis) + 1;
     if (rhAxis > 3)
         rhAxis = 1;
-    bool rhOrder = rhAxis == std::abs(secondaryAxis);
+    bool rhOrder = rhAxis == std::abs(m_secondaryAxis);
 
     // Set the rotation matrix axes
     Eigen::Matrix3d m;
-    m.row(std::abs(primaryAxis) - 1) = v0;
+    m.row(std::abs(m_primaryAxis) - 1) = v0;
 
     // Reverse the cross products if the axes are not in right
     // hand order.
     if (rhOrder)
     {
-        m.row(std::abs(secondaryAxis) - 1) = v2.cross(v0);
-        m.row(std::abs(tertiaryAxis) - 1)  = v2;
+        m.row(std::abs(m_secondaryAxis) - 1) = v2.cross(v0);
+        m.row(std::abs(m_tertiaryAxis) - 1)  = v2;
     }
     else
     {
-        m.row(std::abs(secondaryAxis) - 1) = v0.cross(-v2);
-        m.row(std::abs(tertiaryAxis) - 1)  = -v2;
+        m.row(std::abs(m_secondaryAxis) - 1) = v0.cross(-v2);
+        m.row(std::abs(m_tertiaryAxis) - 1)  = -v2;
     }
 
     // The axes are the rows of a rotation matrix. The getOrientation
@@ -472,26 +326,7 @@ TwoVectorFrame::isInertial() const
     // Although it's possible to specify an inertial two-vector frame, we won't
     // bother trying to distinguish these cases: all two-vector frames will be
     // treated as non-inertial.
-    return true;
-}
-
-unsigned int
-TwoVectorFrame::nestingDepth(unsigned int depth,
-                             unsigned int maxDepth) const
-{
-    // Check nesting of the origin object as well as frames references by
-    // the primary and secondary axes.
-    unsigned int n = getFrameDepth(getCenter(), depth, maxDepth, FrameType::PositionFrame);
-    if (n > maxDepth)
-        return n;
-
-    unsigned int m = primaryVector.nestingDepth(depth, maxDepth);
-    n = std::max(m, n);
-    if (n > maxDepth)
-        return n;
-
-    m = secondaryVector.nestingDepth(depth, maxDepth);
-    return std::max(m, n);
+    return false;
 }
 
 FrameVector::FrameVector(const RelativePosition& pos) : m_data(pos)
@@ -504,27 +339,6 @@ FrameVector::FrameVector(const RelativeVelocity& vel) : m_data(vel)
 
 FrameVector::FrameVector(ConstVector&& vec) : m_data(std::move(vec))
 {
-}
-
-FrameVector
-FrameVector::createRelativePositionVector(const Selection& _observer,
-                                          const Selection& _target)
-{
-    return FrameVector(RelativePosition { _observer, _target });
-}
-
-FrameVector
-FrameVector::createRelativeVelocityVector(const Selection& _observer,
-                                          const Selection& _target)
-{
-    return FrameVector(RelativeVelocity { _observer, _target });
-}
-
-FrameVector
-FrameVector::createConstantVector(const Eigen::Vector3d& _vec,
-                                  const ReferenceFrame::SharedConstPtr& _frame)
-{
-    return FrameVector(ConstVector { _vec, _frame });
 }
 
 Eigen::Vector3d
@@ -557,57 +371,4 @@ FrameVector::direction(double tjd) const
     };
 
     return std::visit(DirectionVisitor{ tjd }, m_data);
-}
-
-unsigned int
-FrameVector::nestingDepth(unsigned int depth,
-                          unsigned int maxDepth) const
-{
-    class NestingVisitor
-    {
-    public:
-        NestingVisitor(unsigned int d, unsigned int md)
-            : _depth(d), _maxDepth(md)
-        {
-        }
-
-        unsigned int operator()(const RelativePosition& pos) const
-        {
-            return relativeDepth(pos.observer, pos.target);
-        }
-
-        unsigned int operator()(const RelativeVelocity& vel) const
-        {
-            return relativeDepth(vel.observer, vel.target);
-        }
-
-        unsigned int operator()(const ConstVector& vec) const
-        {
-            return _depth > _maxDepth
-                ? _depth
-                : vec.frame->nestingDepth(_depth + 1, _maxDepth);
-        }
-
-    private:
-        unsigned int relativeDepth(const Selection& _observer, const Selection& _target) const
-        {
-            unsigned int n = ReferenceFrame::getFrameDepth(_observer,
-                                                           _depth,
-                                                           _maxDepth,
-                                                           ReferenceFrame::FrameType::PositionFrame);
-            if (n > _maxDepth)
-                return n;
-
-            unsigned int m = ReferenceFrame::getFrameDepth(_target,
-                                                           _depth,
-                                                           _maxDepth,
-                                                           ReferenceFrame::FrameType::PositionFrame);
-            return std::max(m, n);
-        }
-
-        unsigned int _depth;
-        unsigned int _maxDepth;
-    };
-
-    return std::visit(NestingVisitor{ depth, maxDepth }, m_data);
 }

--- a/src/celengine/frame.cpp
+++ b/src/celengine/frame.cpp
@@ -529,13 +529,13 @@ FrameCache::getFrameId(const FrameKey& key)
 {
     auto [it, inserted] = m_frameMap.try_emplace(key, static_cast<FrameId>(m_frames.size()));
     if (inserted)
-        createFrame(key, static_cast<std::size_t>(it->second));
+        createFrame(key);
 
     return it->second;
 }
 
 void
-FrameCache::createFrame(const FrameKey& key, std::size_t index)
+FrameCache::createFrame(const FrameKey& key)
 {
     class FrameKeyVisitor
     {
@@ -581,11 +581,8 @@ FrameCache::createFrame(const FrameKey& key, std::size_t index)
         const FrameCache& m_cache;
     };
 
-    auto ptr = std::visit(FrameKeyVisitor(*this), key);
-    if (index >= m_frames.size())
-        m_frames.emplace_back(ptr);
-    else
-        m_frames[index] = ptr;
+    m_frames.emplace_back(std::visit(FrameKeyVisitor(*this), key));
+    m_uncommittedFrames.emplace_back(key);
 }
 
 FrameVectorId
@@ -622,5 +619,35 @@ FrameCache::getFrameVectorId(const FrameVectorKey& key)
     };
 
     m_frameVectors.emplace_back(std::visit(FrameVectorVisitor(*this), key));
+    m_uncommittedVectors.emplace_back(key);
     return it->second;
+}
+
+// Marks all generated frames and frame vectors up to this point as committed.
+void
+FrameCache::commit()
+{
+    m_uncommittedFrameIndex = m_frames.size();
+    m_uncommittedVectorIndex = m_frameVectors.size();
+    m_uncommittedFrames.clear();
+    m_uncommittedVectors.clear();
+}
+
+// Removes all generated frames and frame vectors created since the last commit
+// This allows us to remove any dangling pointers if the validation fails and
+// the Body object is deleted.
+void
+FrameCache::rollback()
+{
+    m_frames.erase(m_frames.begin() + m_uncommittedFrameIndex, m_frames.end());
+    m_frameVectors.erase(m_frameVectors.begin() + m_uncommittedVectorIndex, m_frameVectors.end());
+
+    for (const FrameKey& key : m_uncommittedFrames)
+        m_frameMap.erase(key);
+
+    for (const FrameVectorKey& key : m_uncommittedVectors)
+        m_frameVectorMap.erase(key);
+
+    m_uncommittedFrames.clear();
+    m_uncommittedVectors.clear();
 }

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -80,7 +80,7 @@ private:
     struct CreateToken { explicit CreateToken() = default; };
 
 public:
-    J2000EclipticFrame(CreateToken) {}
+    explicit J2000EclipticFrame(CreateToken) {}
 
     static SharedConstPtr getInstance();
 
@@ -99,7 +99,7 @@ private:
     struct CreateToken { explicit CreateToken() = default; };
 
 public:
-    J2000EquatorFrame(CreateToken) {}
+    explicit J2000EquatorFrame(CreateToken) {}
 
     static SharedConstPtr getInstance();
 
@@ -117,7 +117,7 @@ class BodyFixedFrame final : public ReferenceFrame
 {
 public:
     explicit BodyFixedFrame(Selection obj);
-    ~BodyFixedFrame() override = default;
+
     Eigen::Quaterniond getOrientation(double tjd) const override;
     Eigen::Vector3d getAngularVelocity(double tjd) const override;
     bool isInertial() const override { return false; }
@@ -129,8 +129,8 @@ private:
 class BodyMeanEquatorFrame final : public ReferenceFrame
 {
 public:
-    BodyMeanEquatorFrame(Selection obj, std::optional<double> freeze = std::nullopt);
-    ~BodyMeanEquatorFrame() override = default;
+    explicit BodyMeanEquatorFrame(Selection obj, std::optional<double> freeze = std::nullopt);
+
     Eigen::Quaterniond getOrientation(double tjd) const override;
     Eigen::Vector3d getAngularVelocity(double tjd) const override;
     bool isInertial() const override;
@@ -203,7 +203,6 @@ public:
                    int primAxis,
                    const FrameVector& sec,
                    int secAxis);
-    ~TwoVectorFrame() override = default;
 
     bool isInertial() const override;
 

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <optional>
 #include <variant>
 
 #include <Eigen/Core>
@@ -31,35 +32,15 @@ class ReferenceFrame
 public:
     SHARED_TYPES(ReferenceFrame)
 
-    explicit ReferenceFrame(Selection center);
     virtual ~ReferenceFrame() = default;
-
-    Selection getCenter() const;
 
     virtual Eigen::Quaterniond getOrientation(double tjd) const = 0;
     virtual Eigen::Vector3d getAngularVelocity(double tdb) const;
 
     virtual bool isInertial() const = 0;
 
-    unsigned int nestingDepth(unsigned int maxDepth) const;
-
 protected:
-    enum class FrameType
-    {
-        PositionFrame,
-        OrientationFrame,
-    };
-
-    static unsigned int getFrameDepth(const Selection& sel,
-                                      unsigned int depth,
-                                      unsigned int maxDepth,
-                                      FrameType frameType);
-
-    virtual unsigned int nestingDepth(unsigned int depth,
-                                      unsigned int maxDepth) const = 0;
-
-private:
-    Selection centerObject;
+    explicit ReferenceFrame() = default;
 
     friend class FrameVector;
 };
@@ -72,13 +53,12 @@ class CachingFrame : public ReferenceFrame
 public:
     SHARED_TYPES(CachingFrame)
 
-    explicit CachingFrame(Selection _center);
-    ~CachingFrame() override = default;
-
     Eigen::Quaterniond getOrientation(double tjd) const final;
     Eigen::Vector3d getAngularVelocity(double tjd) const final;
 
 protected:
+    CachingFrame() = default;
+
     virtual Eigen::Quaterniond computeOrientation(double tjd) const = 0;
     virtual Eigen::Vector3d computeAngularVelocity(double tjd) const;
 
@@ -91,40 +71,31 @@ private:
 };
 
 //! J2000.0 Earth ecliptic frame
-class J2000EclipticFrame : public ReferenceFrame
+class J2000EclipticFrame final : public ReferenceFrame
 {
 public:
     SHARED_TYPES(J2000EclipticFrame)
 
-    explicit J2000EclipticFrame(Selection center);
-    ~J2000EclipticFrame() override = default;
+    J2000EclipticFrame() = default;
 
     Eigen::Quaterniond getOrientation(double /* tjd */) const override
     {
         return Eigen::Quaterniond::Identity();
     }
 
-    bool isInertial() const override;
-
-protected:
-    unsigned int nestingDepth(unsigned int depth,
-                              unsigned int maxDepth) const override;
+    bool isInertial() const override { return true; }
 };
 
 //! J2000.0 Earth Mean Equator
-class J2000EquatorFrame : public ReferenceFrame
+class J2000EquatorFrame final : public ReferenceFrame
 {
 public:
     SHARED_TYPES(J2000EquatorFrame)
 
-    explicit J2000EquatorFrame(Selection center);
-    ~J2000EquatorFrame() override = default;
-    Eigen::Quaterniond getOrientation(double tjd) const override;
-    bool isInertial() const override;
+    J2000EquatorFrame() = default;
 
-protected:
-    unsigned int nestingDepth(unsigned int depth,
-                              unsigned int maxDepth) const override;
+    Eigen::Quaterniond getOrientation(double tjd) const override;
+    bool isInertial() const override { return true; }
 };
 
 /*! A BodyFixed frame is a coordinate system with the x-axis pointing
@@ -133,45 +104,35 @@ protected:
  *  y-axis is the cross product of x and z, and points toward the 90
  *  meridian.
  */
-class BodyFixedFrame : public ReferenceFrame
+class BodyFixedFrame final : public ReferenceFrame
 {
 public:
     SHARED_TYPES(BodyFixedFrame)
 
-    BodyFixedFrame(Selection center, Selection obj);
+    explicit BodyFixedFrame(Selection obj);
     ~BodyFixedFrame() override = default;
     Eigen::Quaterniond getOrientation(double tjd) const override;
     Eigen::Vector3d getAngularVelocity(double tjd) const override;
-    bool isInertial() const override;
-
-protected:
-    unsigned int nestingDepth(unsigned int depth,
-                              unsigned int maxDepth) const override;
+    bool isInertial() const override { return false; }
 
 private:
-    Selection fixObject;
+    Selection m_fixObject;
 };
 
-class BodyMeanEquatorFrame : public ReferenceFrame
+class BodyMeanEquatorFrame final : public ReferenceFrame
 {
 public:
     SHARED_TYPES(BodyMeanEquatorFrame)
 
-    BodyMeanEquatorFrame(Selection center, Selection obj, double freeze);
-    BodyMeanEquatorFrame(Selection center, Selection obj);
+    BodyMeanEquatorFrame(Selection obj, std::optional<double> freeze = std::nullopt);
     ~BodyMeanEquatorFrame() override = default;
     Eigen::Quaterniond getOrientation(double tjd) const override;
     Eigen::Vector3d getAngularVelocity(double tjd) const override;
     bool isInertial() const override;
 
-protected:
-    unsigned int nestingDepth(unsigned int depth,
-                              unsigned int maxDepth) const override;
-
 private:
-    Selection equatorObject;
-    double freezeEpoch;
-    bool isFrozen;
+    Selection m_equatorObject;
+    std::optional<double> m_freezeEpoch;
 };
 
 /*! FrameVectors are used to define the axes for TwoVector frames
@@ -179,23 +140,6 @@ private:
 class FrameVector
 {
 public:
-    Eigen::Vector3d direction(double tjd) const;
-
-    /*! Frames can be defined in reference to other frames; this method
-     *  counts the depth of such nesting, up to some specified maximum
-     *  level. This method is used to test for circular references in
-     *  frames.
-     */
-    unsigned int nestingDepth(unsigned int depth, unsigned int maxDepth) const;
-
-    static FrameVector createRelativePositionVector(const Selection& _observer,
-                                                    const Selection& _target);
-    static FrameVector createRelativeVelocityVector(const Selection& _observer,
-                                                    const Selection& _target);
-    static FrameVector createConstantVector(const Eigen::Vector3d& _vec,
-                                            const ReferenceFrame::SharedConstPtr& _frame);
-
-private:
     struct RelativePosition
     {
         Selection observer;
@@ -218,6 +162,9 @@ private:
     explicit FrameVector(const RelativeVelocity&);
     explicit FrameVector(ConstVector&&);
 
+    Eigen::Vector3d direction(double tjd) const;
+
+private:
     std::variant<RelativePosition, RelativeVelocity, ConstVector> m_data;
 };
 
@@ -228,15 +175,14 @@ private:
  *  vector. The third axis is the cross product of the primary and
  *  secondary axis.
  */
-class TwoVectorFrame : public CachingFrame
+class TwoVectorFrame final : public CachingFrame
 {
 public:
     /*! primAxis and secAxis are the labels of the axes defined by
      *  the primary and secondary vectors:
      *  1 = x, 2 = y, 3 = z, -1 = -x, -2 = -y, -3 = -z
      */
-    TwoVectorFrame(Selection center,
-                   const FrameVector& prim,
+    TwoVectorFrame(const FrameVector& prim,
                    int primAxis,
                    const FrameVector& sec,
                    int secAxis);
@@ -246,13 +192,11 @@ public:
 
 protected:
     Eigen::Quaterniond computeOrientation(double tjd) const override;
-    unsigned int nestingDepth(unsigned int depth,
-                              unsigned int maxDepth) const override;
 
 private:
-    FrameVector primaryVector;
-    int primaryAxis;
-    FrameVector secondaryVector;
-    int secondaryAxis;
-    int tertiaryAxis;
+    FrameVector m_primaryVector;
+    int m_primaryAxis;
+    FrameVector m_secondaryVector;
+    int m_secondaryAxis;
+    int m_tertiaryAxis;
 };

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -417,7 +417,6 @@ public:
     ReferenceFrame::SharedConstPtr getFrame(FrameId) const;
 
     FrameId getFrameId(const FrameKey&);
-    bool getFrameId(FrameId&, const ReferenceFrame*) const;
     FrameVectorId getFrameVectorId(const FrameVectorKey&);
 
 private:
@@ -427,5 +426,4 @@ private:
     std::vector<FrameVector> m_frameVectors;
     std::unordered_map<FrameKey, FrameId> m_frameMap;
     std::unordered_map<FrameVectorKey, FrameVectorId> m_frameVectorMap;
-    std::unordered_map<const ReferenceFrame*, FrameId> m_frameIdMap;
 };

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -24,7 +24,19 @@
 #include "selection.h"
 #include "shared.h"
 
-class FrameVector;
+class ReferenceFrame;
+
+class FrameVisitor
+{
+public:
+    virtual void visitPosition(const Selection& sel) = 0;
+    virtual void visitBodyFrame(const Body* body, std::optional<double> epoch = std::nullopt) = 0;
+    virtual void visitReferenceFrame(const ReferenceFrame*) = 0;
+
+protected:
+    FrameVisitor() = default;
+    ~FrameVisitor() = default;
+};
 
 /*! A ReferenceFrame object has a center and set of orthogonal axes.
  *
@@ -44,10 +56,10 @@ public:
 
     virtual bool isInertial() const = 0;
 
+    virtual void visitChildren(FrameVisitor&) const = 0;
+
 protected:
     explicit ReferenceFrame() = default;
-
-    friend class FrameVector;
 };
 
 /*! Base class for complex frames where there may be some benefit
@@ -90,6 +102,7 @@ public:
     }
 
     bool isInertial() const override { return true; }
+    void visitChildren(FrameVisitor&) const override { /* no-op */ }
 };
 
 //! J2000.0 Earth Mean Equator
@@ -105,6 +118,7 @@ public:
 
     Eigen::Quaterniond getOrientation(double tjd) const override;
     bool isInertial() const override { return true; }
+    void visitChildren(FrameVisitor&) const override { /* no-op*/ }
 };
 
 /*! A BodyFixed frame is a coordinate system with the x-axis pointing
@@ -121,6 +135,7 @@ public:
     Eigen::Quaterniond getOrientation(double tjd) const override;
     Eigen::Vector3d getAngularVelocity(double tjd) const override;
     bool isInertial() const override { return false; }
+    void visitChildren(FrameVisitor&) const override;
 
 private:
     Selection m_fixObject;
@@ -134,6 +149,7 @@ public:
     Eigen::Quaterniond getOrientation(double tjd) const override;
     Eigen::Vector3d getAngularVelocity(double tjd) const override;
     bool isInertial() const override;
+    void visitChildren(FrameVisitor&) const override;
 
 private:
     Selection m_equatorObject;
@@ -180,6 +196,7 @@ public:
     explicit FrameVector(ConstVector&&);
 
     Eigen::Vector3d direction(double tjd) const;
+    void visitChildren(FrameVisitor&) const;
 
 private:
     std::variant<RelativePosition, RelativeVelocity, ConstVector> m_data;
@@ -205,6 +222,7 @@ public:
                    int secAxis);
 
     bool isInertial() const override;
+    void visitChildren(FrameVisitor&) const override;
 
 protected:
     Eigen::Quaterniond computeOrientation(double tjd) const override;

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -429,5 +429,3 @@ private:
     std::unordered_map<FrameVectorKey, FrameVectorId> m_frameVectorMap;
     std::unordered_map<const ReferenceFrame*, FrameId> m_frameIdMap;
 };
-
-FrameCache* GetFrameCache();

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -10,12 +10,17 @@
 
 #pragma once
 
+#include <cstddef>
+#include <functional>
 #include <optional>
+#include <unordered_map>
 #include <variant>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <celutil/classops.h>
 #include "selection.h"
 #include "shared.h"
 
@@ -73,10 +78,15 @@ private:
 //! J2000.0 Earth ecliptic frame
 class J2000EclipticFrame final : public ReferenceFrame
 {
+private:
+    struct CreateToken { explicit CreateToken() = default; };
+
 public:
     SHARED_TYPES(J2000EclipticFrame)
 
-    J2000EclipticFrame() = default;
+    J2000EclipticFrame(CreateToken) {}
+
+    static SharedConstPtr getInstance();
 
     Eigen::Quaterniond getOrientation(double /* tjd */) const override
     {
@@ -89,10 +99,15 @@ public:
 //! J2000.0 Earth Mean Equator
 class J2000EquatorFrame final : public ReferenceFrame
 {
+private:
+    struct CreateToken { explicit CreateToken() = default; };
+
 public:
     SHARED_TYPES(J2000EquatorFrame)
 
-    J2000EquatorFrame() = default;
+    J2000EquatorFrame(CreateToken) {}
+
+    static SharedConstPtr getInstance();
 
     Eigen::Quaterniond getOrientation(double tjd) const override;
     bool isInertial() const override { return true; }
@@ -212,3 +227,200 @@ private:
     int m_secondaryAxis;
     int m_tertiaryAxis;
 };
+
+enum class FrameId : std::size_t
+{
+};
+
+enum class FrameVectorId : std::size_t
+{
+};
+
+enum class SimpleFrameKey
+{
+    J2000Ecliptic,
+    J2000Equator,
+};
+
+struct BodyFixedFrameKey
+{
+    explicit BodyFixedFrameKey(const Selection& tgt) : target(tgt) {}
+
+    Selection target;
+};
+
+inline bool operator==(const BodyFixedFrameKey& lhs, const BodyFixedFrameKey& rhs)
+{
+    return lhs.target == rhs.target;
+}
+
+inline bool operator!=(const BodyFixedFrameKey& lhs, const BodyFixedFrameKey& rhs)
+{
+    return !(lhs == rhs);
+}
+
+template<>
+struct std::hash<BodyFixedFrameKey>
+{
+    std::size_t operator()(const BodyFixedFrameKey& obj) const { return hash<Selection>{}(obj.target); }
+};
+
+struct BodyMeanEquatorFrameKey
+{
+    explicit BodyMeanEquatorFrameKey(Selection tgt, std::optional<double> freeze = std::nullopt) :
+        target(tgt), freezeEpoch(freeze)
+    {}
+
+    Selection target;
+    std::optional<double> freezeEpoch;
+};
+
+inline bool operator==(const BodyMeanEquatorFrameKey& lhs, const BodyMeanEquatorFrameKey& rhs)
+{
+    return lhs.target == rhs.target && lhs.freezeEpoch == rhs.freezeEpoch;
+}
+
+inline bool operator!=(const BodyMeanEquatorFrameKey& lhs, const BodyMeanEquatorFrameKey& rhs)
+{
+    return !(lhs == rhs);
+}
+
+template<>
+struct std::hash<BodyMeanEquatorFrameKey>
+{
+    std::size_t operator()(const BodyMeanEquatorFrameKey&) const;
+};
+
+struct TwoVectorFrameKey
+{
+    TwoVectorFrameKey(FrameVectorId f1, int a1, FrameVectorId f2, int a2) :
+        frameVectorId1(f1), axis1(a1), frameVectorId2(f2), axis2(a2)
+    {}
+
+    FrameVectorId frameVectorId1;
+    int axis1;
+    FrameVectorId frameVectorId2;
+    int axis2;
+};
+
+inline bool operator==(const TwoVectorFrameKey& lhs, const TwoVectorFrameKey& rhs)
+{
+    return lhs.frameVectorId1 == rhs.frameVectorId1 &&
+           lhs.axis1 == rhs.axis1 &&
+           lhs.frameVectorId2 == rhs.frameVectorId2 &&
+           lhs.axis2 == rhs.axis2;
+}
+
+inline bool operator!=(const TwoVectorFrameKey& lhs, const TwoVectorFrameKey& rhs)
+{
+    return !(lhs == rhs);
+}
+
+template<>
+struct std::hash<TwoVectorFrameKey>
+{
+    std::size_t operator()(const TwoVectorFrameKey&) const;
+};
+
+using FrameKey = std::variant<SimpleFrameKey, BodyFixedFrameKey, BodyMeanEquatorFrameKey, TwoVectorFrameKey>;
+
+struct RelativePositionKey
+{
+    RelativePositionKey(const Selection& obs, const Selection& tgt) :
+        observer(obs), target(tgt)
+    {}
+
+    Selection observer;
+    Selection target;
+};
+
+inline bool operator==(const RelativePositionKey& lhs, const RelativePositionKey& rhs)
+{
+    return lhs.observer == rhs.observer && lhs.target == rhs.target;
+}
+
+inline bool operator!=(const RelativePositionKey& lhs, const RelativePositionKey& rhs)
+{
+    return !(lhs == rhs);
+}
+
+template<>
+struct std::hash<RelativePositionKey>
+{
+    std::size_t operator()(const RelativePositionKey&) const;
+};
+
+struct RelativeVelocityKey
+{
+    RelativeVelocityKey(const Selection& obs, const Selection& tgt) :
+        observer(obs), target(tgt)
+    {}
+
+    Selection observer;
+    Selection target;
+};
+
+inline bool operator==(const RelativeVelocityKey& lhs, const RelativeVelocityKey& rhs)
+{
+    return lhs.observer == rhs.observer && lhs.target == rhs.target;
+}
+
+inline bool operator!=(const RelativeVelocityKey& lhs, const RelativeVelocityKey& rhs)
+{
+    return !(lhs == rhs);
+}
+
+template<>
+struct std::hash<RelativeVelocityKey>
+{
+    std::size_t operator()(const RelativeVelocityKey&) const;
+};
+
+struct ConstVectorKey
+{
+    ConstVectorKey(const Eigen::Vector3d& v, FrameId fid) :
+        vec(v), frameId(fid)
+    {}
+
+    Eigen::Vector3d vec;
+    FrameId frameId;
+};
+
+inline bool operator==(const ConstVectorKey& lhs, const ConstVectorKey& rhs)
+{
+    return lhs.vec == rhs.vec && lhs.frameId == rhs.frameId;
+}
+
+inline bool operator!=(const ConstVectorKey& lhs, const ConstVectorKey& rhs)
+{
+    return !(lhs == rhs);
+}
+
+template<>
+struct std::hash<ConstVectorKey>
+{
+    std::size_t operator()(const ConstVectorKey&) const;
+};
+
+using FrameVectorKey = std::variant<RelativePositionKey, RelativeVelocityKey, ConstVectorKey>;
+
+class FrameCache : private celestia::util::NoCopy
+{
+public:
+    ReferenceFrame::SharedConstPtr getFrame(FrameId) const;
+
+    FrameId getFrameId(const FrameKey&);
+    bool getFrameId(FrameId&, const ReferenceFrame*) const;
+    FrameVectorId getFrameVectorId(const FrameVectorKey&);
+
+private:
+    void createFrame(const FrameKey&, std::size_t);
+
+    std::vector<ReferenceFrame::SharedConstPtr> m_frames;
+    std::vector<FrameVector> m_frameVectors;
+    std::unordered_map<FrameKey, FrameId> m_frameMap;
+    std::unordered_map<FrameVectorKey, FrameVectorId> m_frameVectorMap;
+    std::unordered_map<const ReferenceFrame*, FrameId> m_frameIdMap;
+};
+
+FrameCache* GetFrameCache();

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -419,11 +419,19 @@ public:
     FrameId getFrameId(const FrameKey&);
     FrameVectorId getFrameVectorId(const FrameVectorKey&);
 
+    void commit();
+    void rollback();
+
 private:
-    void createFrame(const FrameKey&, std::size_t);
+    void createFrame(const FrameKey&);
 
     std::vector<ReferenceFrame::SharedConstPtr> m_frames;
     std::vector<FrameVector> m_frameVectors;
     std::unordered_map<FrameKey, FrameId> m_frameMap;
     std::unordered_map<FrameVectorKey, FrameVectorId> m_frameVectorMap;
+
+    std::size_t m_uncommittedFrameIndex{ 0 };
+    std::size_t m_uncommittedVectorIndex{ 0 };
+    std::vector<FrameKey> m_uncommittedFrames;
+    std::vector<FrameVectorKey> m_uncommittedVectors;
 };

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -56,8 +56,6 @@ protected:
 class CachingFrame : public ReferenceFrame
 {
 public:
-    SHARED_TYPES(CachingFrame)
-
     Eigen::Quaterniond getOrientation(double tjd) const final;
     Eigen::Vector3d getAngularVelocity(double tjd) const final;
 
@@ -82,8 +80,6 @@ private:
     struct CreateToken { explicit CreateToken() = default; };
 
 public:
-    SHARED_TYPES(J2000EclipticFrame)
-
     J2000EclipticFrame(CreateToken) {}
 
     static SharedConstPtr getInstance();
@@ -103,8 +99,6 @@ private:
     struct CreateToken { explicit CreateToken() = default; };
 
 public:
-    SHARED_TYPES(J2000EquatorFrame)
-
     J2000EquatorFrame(CreateToken) {}
 
     static SharedConstPtr getInstance();
@@ -122,8 +116,6 @@ public:
 class BodyFixedFrame final : public ReferenceFrame
 {
 public:
-    SHARED_TYPES(BodyFixedFrame)
-
     explicit BodyFixedFrame(Selection obj);
     ~BodyFixedFrame() override = default;
     Eigen::Quaterniond getOrientation(double tjd) const override;
@@ -137,8 +129,6 @@ private:
 class BodyMeanEquatorFrame final : public ReferenceFrame
 {
 public:
-    SHARED_TYPES(BodyMeanEquatorFrame)
-
     BodyMeanEquatorFrame(Selection obj, std::optional<double> freeze = std::nullopt);
     ~BodyMeanEquatorFrame() override = default;
     Eigen::Quaterniond getOrientation(double tjd) const override;

--- a/src/celengine/frame.h
+++ b/src/celengine/frame.h
@@ -142,18 +142,30 @@ class FrameVector
 public:
     struct RelativePosition
     {
+        RelativePosition(const Selection& obs, const Selection& tgt) :
+            observer(obs), target(tgt)
+        {}
+
         Selection observer;
         Selection target;
     };
 
     struct RelativeVelocity
     {
+        RelativeVelocity(const Selection& obs, const Selection& tgt) :
+            observer(obs), target(tgt)
+        {}
+
         Selection observer;
         Selection target;
     };
 
     struct ConstVector
     {
+        ConstVector(const Eigen::Vector3d& v, ReferenceFrame::SharedConstPtr f) :
+            vec(v), frame(f)
+        {}
+
         Eigen::Vector3d vec;
         ReferenceFrame::SharedConstPtr frame;
     };

--- a/src/celengine/frametree.cpp
+++ b/src/celengine/frametree.cpp
@@ -42,7 +42,7 @@
 /*! Create a frame tree associated with a star.
  */
 FrameTree::FrameTree(Star* star) :
-    starParent(star),
+    m_owner(star),
     // Default frame for a star is J2000 ecliptical, centered
     // on the star.
     defaultFrame(std::make_shared<J2000EclipticFrame>(star))
@@ -52,7 +52,7 @@ FrameTree::FrameTree(Star* star) :
 /*! Create a frame tree associated with a planet or other solar system body.
  */
 FrameTree::FrameTree(Body* body) :
-    bodyParent(body),
+    m_owner(body),
     // Default frame for a solar system body is the mean equatorial frame of the body.
     defaultFrame(std::make_shared<BodyMeanEquatorFrame>(body, body))
 {
@@ -60,7 +60,7 @@ FrameTree::FrameTree(Body* body) :
 
 FrameTree::~FrameTree()
 {
-    for (const auto& phase : children)
+    for (const auto& phase : m_children)
         phase->m_owner = nullptr;
 }
 
@@ -82,8 +82,8 @@ FrameTree::markChanged()
     if (!m_changed)
     {
         m_changed = true;
-        if (bodyParent != nullptr)
-            bodyParent->markChanged();
+        if (Body* body = m_owner.body(); body)
+            body->markChanged();
     }
 }
 
@@ -97,7 +97,7 @@ FrameTree::markUpdated()
     if (m_changed)
     {
         m_changed = false;
-        for (const auto &child : children)
+        for (const auto &child : m_children)
             child->body()->markUpdated();
     }
 }
@@ -119,7 +119,7 @@ FrameTree::recomputeBoundingSphere()
     m_containsSecondaryIlluminators = false;
     m_childClassMask = BodyClassification::EmptyMask;
 
-    for (const auto &phase : children)
+    for (const auto &phase : m_children)
     {
         double bodyRadius = phase->body()->getRadius();
         double r = phase->body()->getCullingRadius() + phase->orbit()->getBoundingRadius();
@@ -147,7 +147,7 @@ FrameTree::addChild(TimelinePhase* phase)
 {
     assert(phase->m_owner == nullptr);
     phase->m_owner = this;
-    children.push_back(phase);
+    m_children.push_back(phase);
     markChanged();
 }
 
@@ -157,27 +157,27 @@ FrameTree::addChild(TimelinePhase* phase)
 void
 FrameTree::removeChild(TimelinePhase* phase)
 {
-    auto iter = std::find(children.begin(), children.end(), phase);
-    if (iter != children.end())
-    {
-        children.erase(iter);
-        assert(phase->m_owner == this);
-        phase->m_owner = nullptr;
-        markChanged();
-    }
+    auto iter = std::find(m_children.begin(), m_children.end(), phase);
+    if (iter == m_children.end())
+        return;
+
+    m_children.erase(iter);
+    assert(phase->m_owner == this);
+    phase->m_owner = nullptr;
+    markChanged();
 }
 
 /*! Return the child at the specified index. */
 const TimelinePhase*
 FrameTree::getChild(unsigned int n) const
 {
-    assert(n < children.size());
-    return children[n];
+    assert(n < m_children.size());
+    return m_children[n];
 }
 
 /*! Get the number of immediate children of this tree. */
 unsigned int
 FrameTree::childCount() const
 {
-    return static_cast<unsigned int>(children.size());
+    return static_cast<unsigned int>(m_children.size());
 }

--- a/src/celengine/frametree.cpp
+++ b/src/celengine/frametree.cpp
@@ -45,7 +45,7 @@ FrameTree::FrameTree(Star* star) :
     m_owner(star),
     // Default frame for a star is J2000 ecliptical, centered
     // on the star.
-    defaultFrame(std::make_shared<J2000EclipticFrame>())
+    defaultFrame(J2000EclipticFrame::getInstance())
 {
 }
 
@@ -62,15 +62,6 @@ FrameTree::~FrameTree()
 {
     for (const auto& phase : m_children)
         phase->m_owner = nullptr;
-}
-
-/*! Return the default reference frame for the object a frame tree is associated
- *  with.
- */
-const std::shared_ptr<const ReferenceFrame>&
-FrameTree::getDefaultReferenceFrame() const
-{
-    return defaultFrame;
 }
 
 /*! Mark this node of the frame hierarchy as changed. The changed flag

--- a/src/celengine/frametree.cpp
+++ b/src/celengine/frametree.cpp
@@ -45,7 +45,7 @@ FrameTree::FrameTree(Star* star) :
     m_owner(star),
     // Default frame for a star is J2000 ecliptical, centered
     // on the star.
-    defaultFrame(std::make_shared<J2000EclipticFrame>(star))
+    defaultFrame(std::make_shared<J2000EclipticFrame>())
 {
 }
 
@@ -54,7 +54,7 @@ FrameTree::FrameTree(Star* star) :
 FrameTree::FrameTree(Body* body) :
     m_owner(body),
     // Default frame for a solar system body is the mean equatorial frame of the body.
-    defaultFrame(std::make_shared<BodyMeanEquatorFrame>(body, body))
+    defaultFrame(std::make_shared<BodyMeanEquatorFrame>(body))
 {
 }
 

--- a/src/celengine/frametree.cpp
+++ b/src/celengine/frametree.cpp
@@ -17,6 +17,7 @@
 
 #include <celephem/orbit.h>
 #include "frame.h"
+#include "timeline.h"
 #include "timelinephase.h"
 
 /* A FrameTree is hierarchy of solar system bodies organized according to
@@ -57,6 +58,19 @@ FrameTree::~FrameTree()
 {
     for (const auto& phase : m_children)
         phase->m_owner = nullptr;
+}
+
+Star*
+FrameTree::getRoot(double tjd) const
+{
+    Selection current = m_owner;
+    for (;;)
+    {
+        if (const Body* body = current.body())
+            current = body->getTimeline()->findPhase(tjd).getFrameTree()->getOwner();
+        else
+            return current.star();
+    }
 }
 
 /*! Mark this node of the frame hierarchy as changed. The changed flag

--- a/src/celengine/frametree.cpp
+++ b/src/celengine/frametree.cpp
@@ -42,19 +42,14 @@
 /*! Create a frame tree associated with a star.
  */
 FrameTree::FrameTree(Star* star) :
-    m_owner(star),
-    // Default frame for a star is J2000 ecliptical, centered
-    // on the star.
-    defaultFrame(J2000EclipticFrame::getInstance())
+    m_owner(star)
 {
 }
 
 /*! Create a frame tree associated with a planet or other solar system body.
  */
 FrameTree::FrameTree(Body* body) :
-    m_owner(body),
-    // Default frame for a solar system body is the mean equatorial frame of the body.
-    defaultFrame(std::make_shared<BodyMeanEquatorFrame>(body))
+    m_owner(body)
 {
 }
 

--- a/src/celengine/frametree.h
+++ b/src/celengine/frametree.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "body.h"
+#include "selection.h"
 
 class ReferenceFrame;
 class Star;
@@ -33,13 +34,9 @@ public:
     FrameTree(FrameTree&&) = delete;
     FrameTree& operator=(FrameTree&&) = delete;
 
-    /*! Return the star that this tree is associated with; it will be
-     *  nullptr for frame trees associated with solar system bodies.
+    /*! Return the object that this tree is associated with.
      */
-    Star* getStar() const
-    {
-        return starParent;
-    }
+    Selection getOwner() const noexcept { return m_owner; }
 
     const std::shared_ptr<const ReferenceFrame>& getDefaultReferenceFrame() const;
 
@@ -50,54 +47,33 @@ public:
     void markUpdated();
     void recomputeBoundingSphere();
 
-    bool isRoot() const
-    {
-        return bodyParent == nullptr;
-    }
-
-    bool updateRequired() const
-    {
-        return m_changed;
-    }
+    bool updateRequired() const noexcept { return m_changed; }
 
     /*! Get the radius of a sphere large enough to contain all
      *  objects in the tree.
      */
-    double boundingSphereRadius() const
-    {
-        return m_boundingSphereRadius;
-    }
+    double boundingSphereRadius() const noexcept { return m_boundingSphereRadius; }
 
     /*! Get the radius of the largest body in the tree.
      */
-    double maxChildRadius() const
-    {
-        return m_maxChildRadius;
-    }
+    double maxChildRadius() const noexcept { return m_maxChildRadius; }
 
     /*! Return whether any of the children of this frame
      *  are secondary illuminators.
      */
-    bool containsSecondaryIlluminators() const
-    {
-        return m_containsSecondaryIlluminators;
-    }
+    bool containsSecondaryIlluminators() const noexcept { return m_containsSecondaryIlluminators; }
 
     /*! Return a bitmask with the classifications of all children
      *  in this tree.
      */
-    BodyClassification childClassMask() const
-    {
-        return m_childClassMask;
-    }
+    BodyClassification childClassMask() const noexcept { return m_childClassMask; }
 
 private:
     void addChild(TimelinePhase* phase);
     void removeChild(TimelinePhase* phase);
 
-    Star* starParent{ nullptr };
-    Body* bodyParent{ nullptr };
-    std::vector<TimelinePhase*> children;
+    Selection m_owner;
+    std::vector<TimelinePhase*> m_children;
 
     double m_boundingSphereRadius{ 0.0 };
     double m_maxChildRadius{ 0.0 };

--- a/src/celengine/frametree.h
+++ b/src/celengine/frametree.h
@@ -38,8 +38,6 @@ public:
      */
     Selection getOwner() const noexcept { return m_owner; }
 
-    const std::shared_ptr<const ReferenceFrame>& getDefaultReferenceFrame() const;
-
     const TimelinePhase* getChild(unsigned int n) const;
     unsigned int childCount() const;
 

--- a/src/celengine/frametree.h
+++ b/src/celengine/frametree.h
@@ -79,7 +79,5 @@ private:
     bool m_changed{ true };
     BodyClassification m_childClassMask{ BodyClassification::EmptyMask };
 
-    std::shared_ptr<const ReferenceFrame> defaultFrame;
-
     friend class TimelinePhase;
 };

--- a/src/celengine/frametree.h
+++ b/src/celengine/frametree.h
@@ -37,6 +37,7 @@ public:
     /*! Return the object that this tree is associated with.
      */
     Selection getOwner() const noexcept { return m_owner; }
+    Star* getRoot(double tjd) const;
 
     const TimelinePhase* getChild(unsigned int n) const;
     unsigned int childCount() const;

--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -335,65 +335,6 @@ interpolateOrientation(const Observer::JourneyParams& journey, double t)
     return journey.initialOrientation.slerp(v, journey.finalOrientation);
 }
 
-// Create the ReferenceFrame for the specified observer frame parameters.
-ReferenceFrame::SharedConstPtr
-createFrame(ObserverFrame::CoordinateSystem _coordSys,
-            const Selection& _refObject,
-            const Selection& _targetObject)
-{
-    switch (_coordSys)
-    {
-    case ObserverFrame::CoordinateSystem::Universal:
-        return std::make_shared<J2000EclipticFrame>(Selection());
-
-    case ObserverFrame::CoordinateSystem::Ecliptical:
-        return std::make_shared<J2000EclipticFrame>(_refObject);
-
-    case ObserverFrame::CoordinateSystem::Equatorial:
-        return std::make_shared<BodyMeanEquatorFrame>(_refObject, _refObject);
-
-    case ObserverFrame::CoordinateSystem::BodyFixed:
-        return std::make_shared<BodyFixedFrame>(_refObject, _refObject);
-
-    case ObserverFrame::CoordinateSystem::PhaseLock:
-        return std::make_shared<TwoVectorFrame>(_refObject,
-                                                FrameVector(FrameVector::RelativePosition(_refObject, _targetObject)), 1,
-                                                FrameVector(FrameVector::RelativeVelocity(_refObject, _targetObject)), 2);
-
-    case ObserverFrame::CoordinateSystem::Chase:
-        return std::make_shared<TwoVectorFrame>(_refObject,
-                                                FrameVector(FrameVector::RelativeVelocity(_refObject, _refObject.parent())), 1,
-                                                FrameVector(FrameVector::RelativePosition(_refObject, _refObject.parent())), 2);
-
-    case ObserverFrame::CoordinateSystem::PhaseLock_Old:
-    {
-        FrameVector rotAxis(FrameVector::ConstVector(Eigen::Vector3d::UnitY(),
-                                                     std::make_shared<BodyMeanEquatorFrame>(_refObject)));
-        return std::make_shared<TwoVectorFrame>(_refObject,
-                                                FrameVector(FrameVector::RelativePosition(_refObject, _targetObject)), 3,
-                                                rotAxis, 2);
-    }
-
-    case ObserverFrame::CoordinateSystem::Chase_Old:
-    {
-        FrameVector rotAxis(FrameVector::ConstVector(Eigen::Vector3d::UnitY(),
-                                                     std::make_shared<BodyMeanEquatorFrame>(_refObject)));
-
-        return std::make_shared<TwoVectorFrame>(_refObject,
-                                                FrameVector(FrameVector::RelativeVelocity(_refObject.parent(), _refObject)), 3,
-                                                rotAxis, 2);
-    }
-
-    case ObserverFrame::CoordinateSystem::ObserverLocal:
-        // TODO: This is only used for computing up vectors for orientation; it does
-        // define a proper frame for the observer position orientation.
-        return std::make_shared<J2000EclipticFrame>(Selection());
-
-    default:
-        return std::make_shared<J2000EclipticFrame>(_refObject);
-    }
-}
-
 // High-precision rotation using 64.64 fixed point path. Rotate uc by
 // the rotation specified by unit quaternion q.
 UniversalCoord
@@ -407,6 +348,30 @@ rotate(const UniversalCoord& uc, const Eigen::Quaterniond& q)
     uc1.z = uc.x * R128(r(0, 2)) + uc.y * R128(r(1, 2)) + uc.z * R128(r(2, 2));
 
     return uc1;
+}
+
+/*! Convert a position from one frame to another.
+ */
+UniversalCoord
+convert(const ObserverFrame::SharedConstPtr& fromFrame,
+        const ObserverFrame::SharedConstPtr& toFrame,
+        const UniversalCoord& uc,
+        double t)
+{
+    // Perform the conversion fromFrame -> universal -> toFrame
+    return toFrame->convertFromUniversal(fromFrame->convertToUniversal(uc, t), t);
+}
+
+/*! Convert an orientation from one frame to another.
+*/
+Eigen::Quaterniond
+convert(const ObserverFrame::SharedConstPtr& fromFrame,
+        const ObserverFrame::SharedConstPtr& toFrame,
+        const Eigen::Quaterniond& q,
+        double t)
+{
+    // Perform the conversion fromFrame -> universal -> toFrame
+    return toFrame->convertFromUniversal(fromFrame->convertToUniversal(q, t), t);
 }
 
 } // end unnamed namespace
@@ -860,7 +825,7 @@ Observer::computeGotoParameters(const Selection& destination,
     else
     {
         ObserverFrame offsetFrame(offsetCoordSys, destination);
-        jparams.to = targetPosition.offsetKm(offsetFrame.getFrame()->getOrientation(getTime()).conjugate() * offset);
+        jparams.to = targetPosition.offsetKm(offsetFrame.getOrientation(getTime()).conjugate() * offset);
     }
 
     Eigen::Vector3d upd = up.cast<double>();
@@ -871,7 +836,7 @@ Observer::computeGotoParameters(const Selection& destination,
     else
     {
         ObserverFrame upFrame(upCoordSys, destination);
-        upd = upFrame.getFrame()->getOrientation(getTime()).conjugate() * upd;
+        upd = upFrame.getOrientation(getTime()).conjugate() * upd;
     }
 
     jparams.initialOrientation = getOrientation();
@@ -909,7 +874,7 @@ Observer::computeGotoParametersGC(const Selection& destination,
     jparams.from = getPosition();
 
     ObserverFrame offsetFrame(offsetCoordSys, destination);
-    Eigen::Vector3d offsetTransformed = offsetFrame.getFrame()->getOrientation(getTime()).conjugate() * offset;
+    Eigen::Vector3d offsetTransformed = offsetFrame.getOrientation(getTime()).conjugate() * offset;
 
     jparams.to = targetPosition.offsetKm(offsetTransformed);
 
@@ -921,7 +886,7 @@ Observer::computeGotoParametersGC(const Selection& destination,
     else
     {
         ObserverFrame upFrame(upCoordSys, destination);
-        upd = upFrame.getFrame()->getOrientation(getTime()).conjugate() * upd;
+        upd = upFrame.getOrientation(getTime()).conjugate() * upd;
     }
 
     jparams.initialOrientation = getOrientation();
@@ -1039,10 +1004,10 @@ Observer::convertFrameCoordinates(const ObserverFrame::SharedConstPtr &newFrame)
     transformedOrientation = newFrame->convertFromUniversal(transformedOrientationUniv, now);
 
     // Convert goto parameters to the new frame
-    journey.from               = ObserverFrame::convert(frame, newFrame, journey.from, now);
-    journey.initialOrientation = ObserverFrame::convert(frame, newFrame, journey.initialOrientation, now);
-    journey.to                 = ObserverFrame::convert(frame, newFrame, journey.to, now);
-    journey.finalOrientation   = ObserverFrame::convert(frame, newFrame, journey.finalOrientation, now);
+    journey.from               = convert(frame, newFrame, journey.from, now);
+    journey.initialOrientation = convert(frame, newFrame, journey.initialOrientation, now);
+    journey.to                 = convert(frame, newFrame, journey.to, now);
+    journey.finalOrientation   = convert(frame, newFrame, journey.finalOrientation, now);
 }
 
 /*! Set the observer's reference frame. The position of the observer in
@@ -1077,14 +1042,6 @@ Observer::setFrame(const ObserverFrame::SharedConstPtr& f)
     if (frame)
         convertFrameCoordinates(f);
     frame = f;
-}
-
-/*! Get the current reference frame for the observer.
- */
-const ObserverFrame::SharedConstPtr&
-Observer::getFrame() const
-{
-    return frame;
 }
 
 /*! Rotate the observer about its center.
@@ -1357,7 +1314,7 @@ Observer::gotoSelectionGC(const Selection& selection,
     if (selection.empty())
         return;
 
-    Selection centerObj = selection.parent();
+    Selection centerObj = selection.frameParent(getTime());
 
     UniversalCoord pos = selection.getPosition(getTime());
     Eigen::Vector3d v = pos.offsetFromKm(centerObj.getPosition(getTime()));
@@ -1367,10 +1324,9 @@ Observer::gotoSelectionGC(const Selection& selection,
 
     if (selection.location() != nullptr)
     {
-        Selection parent = selection.parent();
-        double maintainDist = getPreferredDistance(parent);
-        Eigen::Vector3d parentPos = parent.getPosition(getTime()).offsetFromKm(getPosition());
-        double parentDist = parentPos.norm() - parent.radius();
+        double maintainDist = getPreferredDistance(centerObj);
+        Eigen::Vector3d parentPos = centerObj.getPosition(getTime()).offsetFromKm(getPosition());
+        double parentDist = parentPos.norm() - centerObj.radius();
 
         if (parentDist <= maintainDist && parentDist > orbitDistance)
             orbitDistance = parentDist;
@@ -1419,7 +1375,7 @@ Observer::gotoSelectionGC(const Selection& selection,
     if (selection.empty())
         return;
 
-    Selection centerObj = selection.parent();
+    Selection centerObj = selection.frameParent(getTime());
 
     UniversalCoord pos = selection.getPosition(getTime());
     Eigen::Vector3d v = pos.offsetFromKm(centerObj.getPosition(getTime()));
@@ -1696,66 +1652,31 @@ Observer::updateUniversal()
     updateOrientation();
 }
 
-/*! Create the default 'universal' observer frame, with a center at the
- *  Solar System barycenter and coordinate axes of the J200Ecliptic
- *  reference frame.
- */
-ObserverFrame::ObserverFrame() :
-    coordSys(CoordinateSystem::Universal),
-    frame(createFrame(CoordinateSystem::Universal, Selection(), Selection()))
-{
-}
-
-
 /*! Create a new frame with the specified coordinate system and
  *  reference object. The targetObject is only needed for phase
  *  lock frames; the argument is ignored for other frames.
  */
-ObserverFrame::ObserverFrame(CoordinateSystem _coordSys,
-                             const Selection& _refObject,
-                             const Selection& _targetObject) :
-    coordSys(_coordSys),
-    frame(nullptr),
-    targetObject(_targetObject)
+ObserverFrame::ObserverFrame(CoordinateSystem coordSys,
+                             const Selection& refObject,
+                             const Selection& targetObject) :
+    m_coordSys(coordSys),
+    m_refObject(refObject),
+    m_targetObject(targetObject)
 {
-    frame = createFrame(_coordSys, _refObject, _targetObject);
 }
-
 
 /*! Create a new ObserverFrame with the specified reference frame.
  *  The coordinate system of this frame will be marked as unknown.
  */
-ObserverFrame::ObserverFrame(const ReferenceFrame::SharedConstPtr &f) :
-    coordSys(CoordinateSystem::Unknown),
-    frame(f)
+ObserverFrame::ObserverFrame(const Selection& refObject,
+                             const ReferenceFrame::SharedConstPtr &frame) :
+    m_coordSys(CoordinateSystem::Unknown),
+    m_frame(frame),
+    m_refObject(refObject)
 {
 }
 
 ObserverFrame::~ObserverFrame() = default;
-
-ObserverFrame::CoordinateSystem
-ObserverFrame::getCoordinateSystem() const
-{
-    return coordSys;
-}
-
-Selection
-ObserverFrame::getRefObject() const
-{
-    return frame->getCenter();
-}
-
-Selection
-ObserverFrame::getTargetObject() const
-{
-    return targetObject;
-}
-
-const ReferenceFrame::SharedConstPtr&
-ObserverFrame::getFrame() const
-{
-    return frame;
-}
 
 /*! Convert from universal coordinates to frame coordinates. This method
  *  uses 64.64 fixed point arithmetic in conversion, and is thus /much/ slower
@@ -1766,8 +1687,8 @@ ObserverFrame::getFrame() const
 UniversalCoord
 ObserverFrame::convertFromUniversal(const UniversalCoord& uc, double tjd) const
 {
-    UniversalCoord uc1 = uc - frame->getCenter().getPosition(tjd);
-    return rotate(uc1, frame->getOrientation(tjd).conjugate());
+    UniversalCoord uc1 = uc - m_refObject.getPosition(tjd);
+    return rotate(uc1, getOrientation(tjd).conjugate());
 }
 
 /*! Convert from local coordinates to universal coordinates. This method
@@ -1784,41 +1705,49 @@ ObserverFrame::convertFromUniversal(const UniversalCoord& uc, double tjd) const
 UniversalCoord
 ObserverFrame::convertToUniversal(const UniversalCoord& uc, double tjd) const
 {
-    return frame->getCenter().getPosition(tjd) + rotate(uc, frame->getOrientation(tjd));
+    return m_refObject.getPosition(tjd) + rotate(uc, getOrientation(tjd));
 }
 
 Eigen::Quaterniond
 ObserverFrame::convertFromUniversal(const Eigen::Quaterniond& q, double tjd) const
 {
-    return q * frame->getOrientation(tjd).conjugate();
+    return q * getOrientation(tjd).conjugate();
 }
 
 Eigen::Quaterniond
 ObserverFrame::convertToUniversal(const Eigen::Quaterniond& q, double tjd) const
 {
-    return q * frame->getOrientation(tjd);
+    return q * getOrientation(tjd);
 }
 
-/*! Convert a position from one frame to another.
- */
-UniversalCoord
-ObserverFrame::convert(const ObserverFrame::SharedConstPtr& fromFrame,
-                       const ObserverFrame::SharedConstPtr& toFrame,
-                       const UniversalCoord& uc,
-                       double t)
-{
-    // Perform the conversion fromFrame -> universal -> toFrame
-    return toFrame->convertFromUniversal(fromFrame->convertToUniversal(uc, t), t);
-}
-
-/*! Convert an orientation from one frame to another.
-*/
 Eigen::Quaterniond
-ObserverFrame::convert(const ObserverFrame::SharedConstPtr& fromFrame,
-                       const ObserverFrame::SharedConstPtr& toFrame,
-                       const Eigen::Quaterniond& q,
-                       double t)
+ObserverFrame::getOrientation(double tjd) const
 {
-    // Perform the conversion fromFrame -> universal -> toFrame
-    return toFrame->convertFromUniversal(fromFrame->convertToUniversal(q, t), t);
+    switch (m_coordSys)
+    {
+    case ObserverFrame::CoordinateSystem::Equatorial:
+        return BodyMeanEquatorFrame(m_refObject).getOrientation(tjd);
+
+    case ObserverFrame::CoordinateSystem::BodyFixed:
+        return BodyFixedFrame(m_refObject).getOrientation(tjd);
+
+    case ObserverFrame::CoordinateSystem::PhaseLock:
+        return TwoVectorFrame(FrameVector(FrameVector::RelativePosition(m_refObject, m_targetObject)), 1,
+                              FrameVector(FrameVector::RelativeVelocity(m_refObject, m_targetObject)), 2).getOrientation(tjd);
+
+
+    case ObserverFrame::CoordinateSystem::Chase:
+        {
+            auto parent = m_refObject.frameParent(tjd);
+            return TwoVectorFrame(FrameVector(FrameVector::RelativeVelocity(m_refObject, parent)), 1,
+                                  FrameVector(FrameVector::RelativePosition(m_refObject, parent)), 2).getOrientation(tjd);
+        }
+
+    case ObserverFrame::CoordinateSystem::Unknown:
+        return m_frame->getOrientation(tjd);
+
+    default:
+        // J2000 ecliptic
+        return Eigen::Quaterniond::Identity();
+    }
 }

--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -27,6 +27,7 @@
 #include "frametree.h"
 #include "location.h"
 #include "star.h"
+#include "timeline.h"
 
 namespace astro = celestia::astro;
 namespace math = celestia::math;
@@ -223,16 +224,8 @@ interpolatePositionGreatCircle(const Observer::JourneyParams& journey,
                                double x)
 {
     Selection centerObj = frame->getRefObject();
-    if (const Body* body = centerObj.body(); body != nullptr)
-    {
-        if (const PlanetarySystem* system = body->getSystem(); system != nullptr)
-        {
-            if (Body* primaryBody = system->getPrimaryBody(); primaryBody != nullptr)
-                centerObj = primaryBody;
-            else
-                centerObj = system->getStar();
-        }
-    }
+    if (const Body* body = centerObj.body(); body)
+        centerObj = body->getTimeline()->findPhase(simTime).getFrameTree()->getOwner();
 
     UniversalCoord ufrom  = frame->convertToUniversal(journey.from, simTime);
     UniversalCoord uto    = frame->convertToUniversal(journey.to, simTime);
@@ -1580,13 +1573,14 @@ Observer::phaseLock(const Selection& selection)
         if (refObject.body() != nullptr || refObject.star() != nullptr)
             setFrame(ObserverFrame::CoordinateSystem::PhaseLock, refObject, selection);
     }
-    else if (selection.body() != nullptr)
+    else if (const Body* body = selection.body(); body)
     {
         // Selection and reference object are identical, so the frame is undefined.
         // We'll instead use the object's star as the target object.
+        double t = getTime();
         setFrame(ObserverFrame::CoordinateSystem::PhaseLock,
                  selection,
-                 selection.body()->getSystem()->getStar());
+                 body->getTimeline()->findPhase(t).getFrameTree()->getRoot(t));
     }
 }
 

--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -1044,6 +1044,14 @@ Observer::setFrame(const ObserverFrame::SharedConstPtr& f)
     frame = f;
 }
 
+/*! Get the current reference frame for the observer.
+ */
+const ObserverFrame::SharedConstPtr&
+Observer::getFrame() const
+{
+    return frame;
+}
+
 /*! Rotate the observer about its center.
  */
 void

--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -357,30 +357,30 @@ createFrame(ObserverFrame::CoordinateSystem _coordSys,
 
     case ObserverFrame::CoordinateSystem::PhaseLock:
         return std::make_shared<TwoVectorFrame>(_refObject,
-                                                FrameVector::createRelativePositionVector(_refObject, _targetObject), 1,
-                                                FrameVector::createRelativeVelocityVector(_refObject, _targetObject), 2);
+                                                FrameVector(FrameVector::RelativePosition(_refObject, _targetObject)), 1,
+                                                FrameVector(FrameVector::RelativeVelocity(_refObject, _targetObject)), 2);
 
     case ObserverFrame::CoordinateSystem::Chase:
         return std::make_shared<TwoVectorFrame>(_refObject,
-                                                FrameVector::createRelativeVelocityVector(_refObject, _refObject.parent()), 1,
-                                                FrameVector::createRelativePositionVector(_refObject, _refObject.parent()), 2);
+                                                FrameVector(FrameVector::RelativeVelocity(_refObject, _refObject.parent())), 1,
+                                                FrameVector(FrameVector::RelativePosition(_refObject, _refObject.parent())), 2);
 
     case ObserverFrame::CoordinateSystem::PhaseLock_Old:
     {
-        FrameVector rotAxis(FrameVector::createConstantVector(Eigen::Vector3d::UnitY(),
-                                                              std::make_shared<BodyMeanEquatorFrame>(_refObject, _refObject)));
+        FrameVector rotAxis(FrameVector::ConstVector(Eigen::Vector3d::UnitY(),
+                                                     std::make_shared<BodyMeanEquatorFrame>(_refObject)));
         return std::make_shared<TwoVectorFrame>(_refObject,
-                                                FrameVector::createRelativePositionVector(_refObject, _targetObject), 3,
+                                                FrameVector(FrameVector::RelativePosition(_refObject, _targetObject)), 3,
                                                 rotAxis, 2);
     }
 
     case ObserverFrame::CoordinateSystem::Chase_Old:
     {
-        FrameVector rotAxis(FrameVector::createConstantVector(Eigen::Vector3d::UnitY(),
-                                                              std::make_shared<BodyMeanEquatorFrame>(_refObject, _refObject)));
+        FrameVector rotAxis(FrameVector::ConstVector(Eigen::Vector3d::UnitY(),
+                                                     std::make_shared<BodyMeanEquatorFrame>(_refObject)));
 
         return std::make_shared<TwoVectorFrame>(_refObject,
-                                                FrameVector::createRelativeVelocityVector(_refObject.parent(), _refObject), 3,
+                                                FrameVector(FrameVector::RelativeVelocity(_refObject.parent(), _refObject)), 3,
                                                 rotAxis, 2);
     }
 

--- a/src/celengine/observer.h
+++ b/src/celengine/observer.h
@@ -78,12 +78,6 @@ public:
         PhaseLock       = 5,
         Chase           = 6,
 
-        // Previous versions of PhaseLock and Chase used the
-        // spin axis of the reference object as a secondary
-        // vector for the coordinate system.
-        PhaseLock_Old   = 100,
-        Chase_Old       = 101,
-
         // ObserverLocal is not a real frame; it's an optional
         // way to specify view vectors. Eventually, there will
         // be some other way to accomplish this and ObserverLocal
@@ -93,11 +87,15 @@ public:
         Unknown         = 1000,
     };
 
-    ObserverFrame();
+    /*! Create the default 'universal' observer frame, with a center at the
+     *  Solar System barycenter and coordinate axes of the J200Ecliptic
+     *  reference frame.
+     */
+    ObserverFrame() = default;
     ObserverFrame(CoordinateSystem cs,
-                  const Selection& _refObject,
-                  const Selection& _targetObj = Selection());
-    explicit ObserverFrame(const std::shared_ptr<const ReferenceFrame>& f);
+                  const Selection& refObject,
+                  const Selection& targetObj = Selection());
+    ObserverFrame(const Selection& refObject, const std::shared_ptr<const ReferenceFrame>& f);
 
     ~ObserverFrame();
 
@@ -106,30 +104,22 @@ public:
     ObserverFrame(ObserverFrame&&) noexcept = default;
     ObserverFrame& operator=(ObserverFrame&&) noexcept = default;
 
-    CoordinateSystem getCoordinateSystem() const;
-    Selection getRefObject() const;
-    Selection getTargetObject() const;
+    CoordinateSystem getCoordinateSystem() const noexcept { return m_coordSys; }
+    Selection getRefObject() const noexcept { return m_refObject; }
+    Selection getTargetObject() const noexcept { return m_targetObject; }
 
-    const std::shared_ptr<const ReferenceFrame>& getFrame() const;
+    Eigen::Quaterniond getOrientation(double tjd) const;
 
     UniversalCoord convertFromUniversal(const UniversalCoord &uc, double tjd) const;
     UniversalCoord convertToUniversal(const UniversalCoord &uc, double tjd) const;
     Eigen::Quaterniond convertFromUniversal(const Eigen::Quaterniond &q, double tjd) const;
     Eigen::Quaterniond convertToUniversal(const Eigen::Quaterniond &q, double tjd) const;
 
-    static UniversalCoord convert(const ObserverFrame::SharedConstPtr &fromFrame,
-                                  const ObserverFrame::SharedConstPtr &toFrame,
-                                  const UniversalCoord &uc,
-                                  double t);
-    static Eigen::Quaterniond convert(const ObserverFrame::SharedConstPtr &fromFrame,
-                                      const ObserverFrame::SharedConstPtr &toFrame,
-                                      const Eigen::Quaterniond &q,
-                                      double t);
-
 private:
-    CoordinateSystem coordSys;
-    std::shared_ptr<const ReferenceFrame> frame;
-    Selection targetObject;
+    CoordinateSystem m_coordSys{ CoordinateSystem::Universal };
+    std::shared_ptr<const ReferenceFrame> m_frame;
+    Selection m_refObject;
+    Selection m_targetObject;
 };
 
 class Observer

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -879,63 +879,75 @@ Selection
 getFrameCenter(const Universe& universe, const AssociativeArray* frameData, const Selection& defaultCenter)
 {
     const std::string* centerName = frameData->getString("Center");
-    if (centerName == nullptr)
-    {
-        if (defaultCenter.empty())
-            GetLogger()->warn("No center specified for reference frame.\n");
+    if (!centerName)
         return defaultCenter;
-    }
 
     Selection centerObject = universe.findPath(*centerName, {});
     if (centerObject.empty())
     {
         GetLogger()->error("Center object '{}' of reference frame not found.\n", *centerName);
-        return Selection();
+        return defaultCenter;
     }
 
     // Should verify that center object is a star or planet, and
     // that it is a member of the same star system as the body in which
     // the frame will be used.
+    switch (centerObject.getType())
+    {
+    case SelectionType::Star:
+    case SelectionType::Body:
+        // Should verify that it is in the same star system
+        return centerObject;
 
-    return centerObject;
+    default:
+        GetLogger()->error("Center object '{}' of reference frame is not a star or planet.\n", *centerName);
+        return defaultCenter;
+    }
 }
 
-BodyFixedFrame::SharedConstPtr
+std::optional<FrameId>
 CreateBodyFixedFrame(const Universe& universe,
                      const AssociativeArray* frameData,
-                     const Selection& defaultCenter)
+                     Selection& defaultCenter)
 {
-    Selection center = getFrameCenter(universe, frameData, defaultCenter);
-    if (center.empty())
-        return nullptr;
+    defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
+    if (defaultCenter.empty())
+    {
+        GetLogger()->error("No center object specified for BodyFixed frame.\n");
+        return std::nullopt;
+    }
 
-    return std::make_shared<BodyFixedFrame>(center, center);
+    return GetFrameCache()->getFrameId(BodyFixedFrameKey(defaultCenter));
 }
 
-BodyMeanEquatorFrame::SharedConstPtr
+std::optional<FrameId>
 CreateMeanEquatorFrame(const Universe& universe,
                        const AssociativeArray* frameData,
-                       const Selection& defaultCenter)
+                       Selection& defaultCenter)
 {
-    Selection center = getFrameCenter(universe, frameData, defaultCenter);
-    if (center.empty())
-        return nullptr;
+    defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
 
-    Selection obj = center;
+    Selection obj = defaultCenter;
     if (const std::string* objName = frameData->getString("Object"); objName != nullptr)
     {
         obj = universe.findPath(*objName, {});
         if (obj.empty())
         {
             GetLogger()->error("Object '{}' for mean equator frame not found.\n", *objName);
-            return nullptr;
+            return std::nullopt;
         }
     }
 
-    if (double freezeEpoch = 0.0; ParseDate(frameData, "Freeze", freezeEpoch))
-        return std::make_shared<BodyMeanEquatorFrame>(center, obj, freezeEpoch);
+    if (obj.empty())
+    {
+        GetLogger()->error("No Object specified for mean equator frame.\n");
+        return std::nullopt;
+    }
 
-    return std::make_shared<BodyMeanEquatorFrame>(center, obj);
+    if (double freezeEpoch = 0.0; ParseDate(frameData, "Freeze", freezeEpoch))
+        return GetFrameCache()->getFrameId(BodyMeanEquatorFrameKey(obj, freezeEpoch));
+
+    return GetFrameCache()->getFrameId(BodyMeanEquatorFrameKey(obj));
 }
 
 /**
@@ -1068,7 +1080,7 @@ getVectorObserver(const Universe& universe, const AssociativeArray* vectorData)
     return obsObject;
 }
 
-std::unique_ptr<FrameVector>
+std::optional<FrameVectorId>
 CreateFrameVector(const Universe& universe,
                   const Selection& center,
                   const AssociativeArray* vectorData)
@@ -1084,13 +1096,15 @@ CreateFrameVector(const Universe& universe,
                 observer = center;
 
             if (observer.empty() || target.empty())
-                return nullptr;
+            {
+                GetLogger()->error("Missing Observer and Target in RelativePosition.\n");
+                return std::nullopt;
+            }
 
-            return std::make_unique<FrameVector>(FrameVector::createRelativePositionVector(observer, target));
+            return GetFrameCache()->getFrameVectorId(RelativePositionKey(observer, target));
         }
     }
-
-    if (const Value* value = vectorData->getValue("RelativeVelocity"); value != nullptr)
+    else if (const Value* value = vectorData->getValue("RelativeVelocity"); value != nullptr)
     {
         if (const AssociativeArray* relVData = value->getHash(); relVData != nullptr)
         {
@@ -1101,13 +1115,14 @@ CreateFrameVector(const Universe& universe,
                 observer = center;
 
             if (observer.empty() || target.empty())
-                return nullptr;
+            {
+                GetLogger()->error("Missing Observer and Target in RelativeVelocity.\n");
+            }
 
-            return std::make_unique<FrameVector>(FrameVector::createRelativeVelocityVector(observer, target));
+            return GetFrameCache()->getFrameVectorId(RelativeVelocityKey(observer, target));
         }
     }
-
-    if (const Value* value = vectorData->getValue("ConstantVector"); value != nullptr)
+    else if (const Value* value = vectorData->getValue("ConstantVector"); value != nullptr)
     {
         if (const AssociativeArray* constVecData = value->getHash(); constVecData != nullptr)
         {
@@ -1115,65 +1130,71 @@ CreateFrameVector(const Universe& universe,
             if (vec.norm() == 0.0)
             {
                 GetLogger()->error("Bad two-vector frame: constant vector has length zero\n");
-                return nullptr;
+                return std::nullopt;
             }
             vec.normalize();
             vec = Eigen::Vector3d(vec.x(), vec.z(), -vec.y());
 
             // The frame for the vector is optional; a nullptr frame indicates
             // J2000 ecliptic.
-            ReferenceFrame::SharedConstPtr f;
-            if (const Value* frameValue = constVecData->getValue("Frame"); frameValue != nullptr)
+            FrameId frameId;
+            if (const Value* frameValue = constVecData->getValue("Frame"); frameValue)
             {
-                f = CreateReferenceFrame(universe, frameValue, center, nullptr);
-                if (f == nullptr)
-                    return nullptr;
+                if (auto f = CreateReferenceFrame(universe, frameValue, nullptr); f.has_value())
+                    frameId = *f;
+                else
+                    return std::nullopt;
+            }
+            else
+            {
+                frameId = GetFrameCache()->getFrameId(SimpleFrameKey::J2000Ecliptic);
             }
 
-            return std::make_unique<FrameVector>(FrameVector::createConstantVector(vec, f));
+            return GetFrameCache()->getFrameVectorId(ConstVectorKey(vec, frameId));
         }
     }
 
     GetLogger()->error("Bad two-vector frame: unknown vector type\n");
-    return nullptr;
+    return std::nullopt;
 }
 
-std::shared_ptr<const TwoVectorFrame>
+std::optional<FrameId>
 CreateTwoVectorFrame(const Universe& universe,
                      const AssociativeArray* frameData,
-                     const Selection& defaultCenter)
+                     Selection& defaultCenter)
 {
-    Selection center = getFrameCenter(universe, frameData, defaultCenter);
-    if (center.empty())
-        return nullptr;
+    defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
 
-    // Primary and secondary vector definitions are required
-    const Value* primaryValue = frameData->getValue("Primary");
-    if (primaryValue == nullptr)
+    const AssociativeArray* primaryData;
+    if (const Value* primaryValue = frameData->getValue("Primary"); primaryValue)
+    {
+        primaryData = primaryValue->getHash();
+        if (!primaryData)
+        {
+            GetLogger()->error("Bad syntax for primary axis of two-vector frame.\n");
+            return std::nullopt;
+        }
+    }
+    else
     {
         GetLogger()->error("Primary axis missing from two-vector frame.\n");
-        return nullptr;
+        return std::nullopt;
     }
 
-    const AssociativeArray* primaryData = primaryValue->getHash();
-    if (primaryData == nullptr)
+    const AssociativeArray* secondaryData;
+    if (const Value* secondaryValue = frameData->getValue("Secondary"); secondaryValue)
     {
-        GetLogger()->error("Bad syntax for primary axis of two-vector frame.\n");
-        return nullptr;
+        secondaryData = secondaryValue->getHash();
+        if (!secondaryData)
+        {
+            GetLogger()->error("Bad syntax for secondary axis of two-vector frame.\n");
+            return std::nullopt;
+        }
     }
-
-    const Value* secondaryValue = frameData->getValue("Secondary");
-    if (secondaryValue == nullptr)
+    else
     {
         GetLogger()->error("Secondary axis missing from two-vector frame.\n");
-        return nullptr;
-    }
-
-    const AssociativeArray* secondaryData = secondaryValue->getHash();
-    if (secondaryData == nullptr)
-    {
-        GetLogger()->error("Bad syntax for secondary axis of two-vector frame.\n");
-        return nullptr;
+        return std::nullopt;
     }
 
     // Get and validate the axes for the direction vectors
@@ -1184,54 +1205,43 @@ CreateTwoVectorFrame(const Universe& universe,
     assert(std::abs(secondaryAxis) <= 3);
     if (primaryAxis == 0 || secondaryAxis == 0)
     {
-        return nullptr;
+        return std::nullopt;
     }
 
     if (std::abs(primaryAxis) == std::abs(secondaryAxis))
     {
         GetLogger()->error("Bad two-vector frame: axes for vectors are collinear.\n");
-        return nullptr;
+        return std::nullopt;
     }
 
-    auto primaryVector = CreateFrameVector(universe, center, primaryData);
-    auto secondaryVector = CreateFrameVector(universe, center, secondaryData);
+    auto primaryVector = CreateFrameVector(universe, defaultCenter, primaryData);
+    auto secondaryVector = CreateFrameVector(universe, defaultCenter, secondaryData);
 
-    if (primaryVector != nullptr && secondaryVector != nullptr)
+    if (primaryVector.has_value() && secondaryVector.has_value())
     {
-        return std::make_shared<TwoVectorFrame>(center,
-                                                *primaryVector,
-                                                primaryAxis,
-                                                *secondaryVector,
-                                                secondaryAxis);
+        return GetFrameCache()->getFrameId(TwoVectorFrameKey(*primaryVector, primaryAxis,
+                                                             *secondaryVector, secondaryAxis));
     }
 
-    return nullptr;
+    return std::nullopt;
 }
 
-std::shared_ptr<const J2000EclipticFrame>
+std::optional<FrameId>
 CreateJ2000EclipticFrame(const Universe& universe,
                          const AssociativeArray* frameData,
-                         const Selection& defaultCenter)
+                         Selection& defaultCenter)
 {
-    Selection center = getFrameCenter(universe, frameData, defaultCenter);
-
-    if (center.empty())
-        return nullptr;
-
-    return std::make_shared<J2000EclipticFrame>(center);
+    defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
+    return GetFrameCache()->getFrameId(SimpleFrameKey::J2000Ecliptic);
 }
 
-std::shared_ptr<const J2000EquatorFrame>
+std::optional<FrameId>
 CreateJ2000EquatorFrame(const Universe& universe,
                         const AssociativeArray* frameData,
-                        const Selection& defaultCenter)
+                        Selection& defaultCenter)
 {
-    Selection center = getFrameCenter(universe, frameData, defaultCenter);
-
-    if (center.empty())
-        return nullptr;
-
-    return std::make_shared<J2000EquatorFrame>(center);
+    defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
+    return GetFrameCache()->getFrameId(SimpleFrameKey::J2000Equator);
 }
 
 /**
@@ -1274,28 +1284,28 @@ CreateJ2000EquatorFrame(const Universe& universe,
  *     ...
  * } </pre>
  */
-std::shared_ptr<const TwoVectorFrame>
+std::optional<FrameId>
 CreateTopocentricFrame(const Universe& universe,
                        const AssociativeArray* frameData,
-                       const Selection& defaultTarget,
+                       Selection& defaultTarget,
                        const Selection& defaultObserver)
 {
     Selection target;
     Selection observer;
-    Selection center;
 
     if (const std::string* centerName = frameData->getString("Center"); centerName != nullptr)
     {
         // If a center is provided, the default observer is the center and
         // the default target is the center's parent. This gives sensible results
         // when a topocentric frame is used as an orbit frame.
-        center = universe.findPath(*centerName, {});
+        Selection center = universe.findPath(*centerName, {});
         if (center.empty())
         {
             GetLogger()->error("Center object '{}' for topocentric frame not found.\n", *centerName);
-            return nullptr;
+            return std::nullopt;
        }
 
+       defaultTarget = center;
        observer = center;
        target = center.parent();
     }
@@ -1306,7 +1316,6 @@ CreateTopocentricFrame(const Universe& universe,
         // is usually the object itself.
         target = defaultTarget;
         observer = defaultObserver;
-        center = defaultObserver;
     }
 
     if (const std::string* targetName = frameData->getString("Target"); targetName == nullptr)
@@ -1314,7 +1323,7 @@ CreateTopocentricFrame(const Universe& universe,
         if (target.empty())
         {
             GetLogger()->error("No target specified for topocentric frame.\n");
-            return nullptr;
+            return std::nullopt;
         }
     }
     else
@@ -1323,7 +1332,7 @@ CreateTopocentricFrame(const Universe& universe,
         if (target.empty())
         {
             GetLogger()->error("Target object '{}' for topocentric frame not found.\n", *targetName);
-            return nullptr;
+            return std::nullopt;
         }
 
         // Should verify that center object is a star or planet, and
@@ -1336,7 +1345,7 @@ CreateTopocentricFrame(const Universe& universe,
         if (observer.empty())
         {
             GetLogger()->error("No observer specified for topocentric frame.\n");
-            return nullptr;
+            return std::nullopt;
         }
     }
     else
@@ -1345,38 +1354,38 @@ CreateTopocentricFrame(const Universe& universe,
         if (observer.empty())
         {
             GetLogger()->error("Observer object '{}' for topocentric frame not found.\n", *observerName);
-            return nullptr;
+            return std::nullopt;
         }
     }
 
-    return CreateTopocentricFrame(center, target, observer);
+    return CreateTopocentricFrame(target, observer);
 }
 
-ReferenceFrame::SharedConstPtr
+std::optional<FrameId>
 CreateComplexFrame(const Universe& universe,
                    const AssociativeArray* frameData,
-                   const Selection& defaultCenter,
+                   Selection& defaultCenter,
                    Body* defaultObserver)
 {
-    if (const Value* value = frameData->getValue("BodyFixed"); value != nullptr)
+    if (const Value* value = frameData->getValue("BodyFixed"); value)
     {
         const AssociativeArray* bodyFixedData = value->getHash();
-        if (bodyFixedData == nullptr)
+        if (!bodyFixedData)
         {
             GetLogger()->error("Object has incorrect body-fixed frame syntax.\n");
-            return nullptr;
+            return std::nullopt;
         }
 
         return CreateBodyFixedFrame(universe, bodyFixedData, defaultCenter);
     }
 
-    if (const Value* value = frameData->getValue("MeanEquator"); value != nullptr)
+    if (const Value* value = frameData->getValue("MeanEquator"); value)
     {
         const AssociativeArray* meanEquatorData = value->getHash();
-        if (meanEquatorData == nullptr)
+        if (!meanEquatorData)
         {
             GetLogger()->error("Object has incorrect mean equator frame syntax.\n");
-            return nullptr;
+            return std::nullopt;
         }
 
         return CreateMeanEquatorFrame(universe, meanEquatorData, defaultCenter);
@@ -1388,7 +1397,7 @@ CreateComplexFrame(const Universe& universe,
         if (twoVectorData == nullptr)
         {
             GetLogger()->error("Object has incorrect two-vector frame syntax.\n");
-            return nullptr;
+            return std::nullopt;
         }
 
        return CreateTwoVectorFrame(universe, twoVectorData, defaultCenter);
@@ -1400,10 +1409,10 @@ CreateComplexFrame(const Universe& universe,
         if (topocentricData == nullptr)
         {
             GetLogger()->error("Object has incorrect topocentric frame syntax.\n");
-            return nullptr;
+            return std::nullopt;
         }
 
-        return CreateTopocentricFrame(universe, topocentricData, defaultCenter, Selection(defaultObserver));
+        return CreateTopocentricFrame(universe, topocentricData, defaultCenter, defaultObserver);
     }
 
     if (const Value* value = frameData->getValue("EclipticJ2000"); value != nullptr)
@@ -1412,7 +1421,7 @@ CreateComplexFrame(const Universe& universe,
         if (eclipticData == nullptr)
         {
             GetLogger()->error("Object has incorrect J2000 ecliptic frame syntax.\n");
-            return nullptr;
+            return std::nullopt;
         }
 
         return CreateJ2000EclipticFrame(universe, eclipticData, defaultCenter);
@@ -1424,7 +1433,7 @@ CreateComplexFrame(const Universe& universe,
         if (equatorData == nullptr)
         {
             GetLogger()->error("Object has incorrect J2000 equator frame syntax.\n");
-            return nullptr;
+            return std::nullopt;
         }
 
         return CreateJ2000EquatorFrame(universe, equatorData, defaultCenter);
@@ -1432,7 +1441,7 @@ CreateComplexFrame(const Universe& universe,
 
     GetLogger()->error("Frame definition does not have a valid frame type.\n");
 
-    return nullptr;
+    return std::nullopt;
 }
 
 } // end unnamed namespace
@@ -1779,31 +1788,55 @@ CreateDefaultRotationModel(double syncRotationPeriod)
  * Helper function for CreateTopocentricFrame().
  * Creates a two-vector frame with the specified center, target, and observer.
  */
-std::shared_ptr<const TwoVectorFrame>
-CreateTopocentricFrame(const Selection& center,
-                       const Selection& target,
+FrameId
+CreateTopocentricFrame(const Selection& target,
                        const Selection& observer)
 {
-    auto eqFrame = std::make_shared<BodyMeanEquatorFrame>(target, target);
-    FrameVector north = FrameVector::createConstantVector(Eigen::Vector3d::UnitY(), eqFrame);
-    FrameVector up = FrameVector::createRelativePositionVector(observer, target);
-
-    return std::make_shared<TwoVectorFrame>(center, up, -2, north, -3);
+    auto frameCache = GetFrameCache();
+    auto eqFrameId = frameCache->getFrameId(BodyMeanEquatorFrameKey(target));
+    auto north = frameCache->getFrameVectorId(ConstVectorKey(Eigen::Vector3d::UnitY(), eqFrameId));
+    auto up = frameCache->getFrameVectorId(RelativePositionKey(observer, target));
+    return frameCache->getFrameId(TwoVectorFrameKey(up, -2, north, -3));
 }
 
-ReferenceFrame::SharedConstPtr CreateReferenceFrame(const Universe& universe,
-                                                    const Value* frameValue,
-                                                    const Selection& defaultCenter,
-                                                    Body* defaultObserver)
+std::optional<FrameId>
+CreateOrbitFrame(FrameId& frame,
+                 const Universe& universe,
+                 const Value* frameValue,
+                 Selection& defaultCenter,
+                 Body* defaultObserver)
 {
-    // TODO: handle named frames
-
     const AssociativeArray* frameData = frameValue->getHash();
     if (frameData == nullptr)
     {
         GetLogger()->error("Invalid syntax for frame definition.\n");
-        return nullptr;
+        return std::nullopt;
     }
 
-    return CreateComplexFrame(universe, frameData, defaultCenter, defaultObserver);
+    // Allow specifying Center directly in the OrbitFrame block
+    defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
+    std::optional<FrameId> result = CreateComplexFrame(universe, frameData, defaultCenter, defaultObserver);
+    if (result.has_value() && defaultCenter.empty())
+    {
+        GetLogger()->error("No center specified for OrbitFrame\n");
+        return std::nullopt;
+    }
+
+    return result;
+}
+
+std::optional<FrameId>
+CreateReferenceFrame(const Universe& universe,
+                     const Value* frameValue,
+                     Body* defaultObserver)
+{
+    const AssociativeArray* frameData = frameValue->getHash();
+    if (frameData == nullptr)
+    {
+        GetLogger()->error("Invalid syntax for frame definition.\n");
+        return std::nullopt;
+    }
+
+    Selection center;
+    return CreateComplexFrame(universe, frameData, center, defaultObserver);
 }

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -908,7 +908,8 @@ getFrameCenter(const Universe& universe, const AssociativeArray* frameData, cons
 std::optional<FrameId>
 CreateBodyFixedFrame(const Universe& universe,
                      const AssociativeArray* frameData,
-                     Selection& defaultCenter)
+                     Selection& defaultCenter,
+                     FrameCache& frameCache)
 {
     defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
     if (defaultCenter.empty())
@@ -917,13 +918,14 @@ CreateBodyFixedFrame(const Universe& universe,
         return std::nullopt;
     }
 
-    return GetFrameCache()->getFrameId(BodyFixedFrameKey(defaultCenter));
+    return frameCache.getFrameId(BodyFixedFrameKey(defaultCenter));
 }
 
 std::optional<FrameId>
 CreateMeanEquatorFrame(const Universe& universe,
                        const AssociativeArray* frameData,
-                       Selection& defaultCenter)
+                       Selection& defaultCenter,
+                       FrameCache& frameCache)
 {
     defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
 
@@ -945,9 +947,9 @@ CreateMeanEquatorFrame(const Universe& universe,
     }
 
     if (double freezeEpoch = 0.0; ParseDate(frameData, "Freeze", freezeEpoch))
-        return GetFrameCache()->getFrameId(BodyMeanEquatorFrameKey(obj, freezeEpoch));
+        return frameCache.getFrameId(BodyMeanEquatorFrameKey(obj, freezeEpoch));
 
-    return GetFrameCache()->getFrameId(BodyMeanEquatorFrameKey(obj));
+    return frameCache.getFrameId(BodyMeanEquatorFrameKey(obj));
 }
 
 /**
@@ -1083,7 +1085,8 @@ getVectorObserver(const Universe& universe, const AssociativeArray* vectorData)
 std::optional<FrameVectorId>
 CreateFrameVector(const Universe& universe,
                   const Selection& center,
-                  const AssociativeArray* vectorData)
+                  const AssociativeArray* vectorData,
+                  FrameCache& frameCache)
 {
     if (const Value* value = vectorData->getValue("RelativePosition"); value)
     {
@@ -1101,7 +1104,7 @@ CreateFrameVector(const Universe& universe,
                 return std::nullopt;
             }
 
-            return GetFrameCache()->getFrameVectorId(RelativePositionKey(observer, target));
+            return frameCache.getFrameVectorId(RelativePositionKey(observer, target));
         }
     }
 
@@ -1120,7 +1123,7 @@ CreateFrameVector(const Universe& universe,
                 GetLogger()->error("Missing Observer and Target in RelativeVelocity.\n");
             }
 
-            return GetFrameCache()->getFrameVectorId(RelativeVelocityKey(observer, target));
+            return frameCache.getFrameVectorId(RelativeVelocityKey(observer, target));
         }
     }
 
@@ -1142,17 +1145,17 @@ CreateFrameVector(const Universe& universe,
             FrameId frameId;
             if (const Value* frameValue = constVecData->getValue("Frame"); frameValue)
             {
-                if (auto f = CreateReferenceFrame(universe, frameValue, nullptr); f.has_value())
+                if (auto f = CreateReferenceFrame(universe, frameValue, nullptr, frameCache); f.has_value())
                     frameId = *f;
                 else
                     return std::nullopt;
             }
             else
             {
-                frameId = GetFrameCache()->getFrameId(SimpleFrameKey::J2000Ecliptic);
+                frameId = frameCache.getFrameId(SimpleFrameKey::J2000Ecliptic);
             }
 
-            return GetFrameCache()->getFrameVectorId(ConstVectorKey(vec, frameId));
+            return frameCache.getFrameVectorId(ConstVectorKey(vec, frameId));
         }
     }
 
@@ -1163,7 +1166,8 @@ CreateFrameVector(const Universe& universe,
 std::optional<FrameId>
 CreateTwoVectorFrame(const Universe& universe,
                      const AssociativeArray* frameData,
-                     Selection& defaultCenter)
+                     Selection& defaultCenter,
+                     FrameCache& frameCache)
 {
     defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
 
@@ -1216,34 +1220,36 @@ CreateTwoVectorFrame(const Universe& universe,
         return std::nullopt;
     }
 
-    auto primaryVector = CreateFrameVector(universe, defaultCenter, primaryData);
+    auto primaryVector = CreateFrameVector(universe, defaultCenter, primaryData, frameCache);
     if (!primaryVector.has_value())
         return std::nullopt;
 
-    auto secondaryVector = CreateFrameVector(universe, defaultCenter, secondaryData);
+    auto secondaryVector = CreateFrameVector(universe, defaultCenter, secondaryData, frameCache);
     if (!secondaryVector.has_value())
         return std::nullopt;
 
-    return GetFrameCache()->getFrameId(TwoVectorFrameKey(*primaryVector, primaryAxis,
-                                                         *secondaryVector, secondaryAxis));
+    return frameCache.getFrameId(TwoVectorFrameKey(*primaryVector, primaryAxis,
+                                                   *secondaryVector, secondaryAxis));
 }
 
 std::optional<FrameId>
 CreateJ2000EclipticFrame(const Universe& universe,
                          const AssociativeArray* frameData,
-                         Selection& defaultCenter)
+                         Selection& defaultCenter,
+                         FrameCache& frameCache)
 {
     defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
-    return GetFrameCache()->getFrameId(SimpleFrameKey::J2000Ecliptic);
+    return frameCache.getFrameId(SimpleFrameKey::J2000Ecliptic);
 }
 
 std::optional<FrameId>
 CreateJ2000EquatorFrame(const Universe& universe,
                         const AssociativeArray* frameData,
-                        Selection& defaultCenter)
+                        Selection& defaultCenter,
+                        FrameCache& frameCache)
 {
     defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
-    return GetFrameCache()->getFrameId(SimpleFrameKey::J2000Equator);
+    return frameCache.getFrameId(SimpleFrameKey::J2000Equator);
 }
 
 /**
@@ -1290,7 +1296,8 @@ std::optional<FrameId>
 CreateTopocentricFrame(const Universe& universe,
                        const AssociativeArray* frameData,
                        Selection& defaultTarget,
-                       const Selection& defaultObserver)
+                       const Selection& defaultObserver,
+                       FrameCache& frameCache)
 {
     Selection target;
     Selection observer;
@@ -1360,14 +1367,15 @@ CreateTopocentricFrame(const Universe& universe,
         }
     }
 
-    return CreateTopocentricFrame(target, observer);
+    return CreateTopocentricFrame(target, observer, frameCache);
 }
 
 std::optional<FrameId>
 CreateComplexFrame(const Universe& universe,
                    const AssociativeArray* frameData,
                    Selection& defaultCenter,
-                   Body* defaultObserver)
+                   Body* defaultObserver,
+                   FrameCache& frameCache)
 {
     if (const Value* value = frameData->getValue("BodyFixed"); value)
     {
@@ -1378,7 +1386,7 @@ CreateComplexFrame(const Universe& universe,
             return std::nullopt;
         }
 
-        return CreateBodyFixedFrame(universe, bodyFixedData, defaultCenter);
+        return CreateBodyFixedFrame(universe, bodyFixedData, defaultCenter, frameCache);
     }
 
     if (const Value* value = frameData->getValue("MeanEquator"); value)
@@ -1390,7 +1398,7 @@ CreateComplexFrame(const Universe& universe,
             return std::nullopt;
         }
 
-        return CreateMeanEquatorFrame(universe, meanEquatorData, defaultCenter);
+        return CreateMeanEquatorFrame(universe, meanEquatorData, defaultCenter, frameCache);
     }
 
     if (const Value* value = frameData->getValue("TwoVector"); value != nullptr)
@@ -1402,7 +1410,7 @@ CreateComplexFrame(const Universe& universe,
             return std::nullopt;
         }
 
-       return CreateTwoVectorFrame(universe, twoVectorData, defaultCenter);
+       return CreateTwoVectorFrame(universe, twoVectorData, defaultCenter, frameCache);
     }
 
     if (const Value* value = frameData->getValue("Topocentric"); value != nullptr)
@@ -1414,7 +1422,7 @@ CreateComplexFrame(const Universe& universe,
             return std::nullopt;
         }
 
-        return CreateTopocentricFrame(universe, topocentricData, defaultCenter, defaultObserver);
+        return CreateTopocentricFrame(universe, topocentricData, defaultCenter, defaultObserver, frameCache);
     }
 
     if (const Value* value = frameData->getValue("EclipticJ2000"); value != nullptr)
@@ -1426,7 +1434,7 @@ CreateComplexFrame(const Universe& universe,
             return std::nullopt;
         }
 
-        return CreateJ2000EclipticFrame(universe, eclipticData, defaultCenter);
+        return CreateJ2000EclipticFrame(universe, eclipticData, defaultCenter, frameCache);
     }
 
     if (const Value* value = frameData->getValue("EquatorJ2000"); value != nullptr)
@@ -1438,7 +1446,7 @@ CreateComplexFrame(const Universe& universe,
             return std::nullopt;
         }
 
-        return CreateJ2000EquatorFrame(universe, equatorData, defaultCenter);
+        return CreateJ2000EquatorFrame(universe, equatorData, defaultCenter, frameCache);
     }
 
     GetLogger()->error("Frame definition does not have a valid frame type.\n");
@@ -1792,20 +1800,21 @@ CreateDefaultRotationModel(double syncRotationPeriod)
  */
 FrameId
 CreateTopocentricFrame(const Selection& target,
-                       const Selection& observer)
+                       const Selection& observer,
+                       FrameCache& frameCache)
 {
-    auto frameCache = GetFrameCache();
-    auto eqFrameId = frameCache->getFrameId(BodyMeanEquatorFrameKey(target));
-    auto north = frameCache->getFrameVectorId(ConstVectorKey(Eigen::Vector3d::UnitY(), eqFrameId));
-    auto up = frameCache->getFrameVectorId(RelativePositionKey(observer, target));
-    return frameCache->getFrameId(TwoVectorFrameKey(up, -2, north, -3));
+    auto eqFrameId = frameCache.getFrameId(BodyMeanEquatorFrameKey(target));
+    auto north = frameCache.getFrameVectorId(ConstVectorKey(Eigen::Vector3d::UnitY(), eqFrameId));
+    auto up = frameCache.getFrameVectorId(RelativePositionKey(observer, target));
+    return frameCache.getFrameId(TwoVectorFrameKey(up, -2, north, -3));
 }
 
 std::optional<FrameId>
 CreateOrbitFrame(const Universe& universe,
                  const Value* frameValue,
                  Selection& defaultCenter,
-                 Body* defaultObserver)
+                 Body* defaultObserver,
+                 FrameCache& frameCache)
 {
     const AssociativeArray* frameData = frameValue->getHash();
     if (frameData == nullptr)
@@ -1816,7 +1825,7 @@ CreateOrbitFrame(const Universe& universe,
 
     // Allow specifying Center directly in the OrbitFrame block
     defaultCenter = getFrameCenter(universe, frameData, defaultCenter);
-    std::optional<FrameId> result = CreateComplexFrame(universe, frameData, defaultCenter, defaultObserver);
+    std::optional<FrameId> result = CreateComplexFrame(universe, frameData, defaultCenter, defaultObserver, frameCache);
     if (result.has_value() && defaultCenter.empty())
     {
         GetLogger()->error("No center specified for OrbitFrame\n");
@@ -1829,7 +1838,8 @@ CreateOrbitFrame(const Universe& universe,
 std::optional<FrameId>
 CreateReferenceFrame(const Universe& universe,
                      const Value* frameValue,
-                     Body* defaultObserver)
+                     Body* defaultObserver,
+                     FrameCache& frameCache)
 {
     const AssociativeArray* frameData = frameValue->getHash();
     if (frameData == nullptr)
@@ -1839,5 +1849,5 @@ CreateReferenceFrame(const Universe& universe,
     }
 
     Selection center;
-    return CreateComplexFrame(universe, frameData, center, defaultObserver);
+    return CreateComplexFrame(universe, frameData, center, defaultObserver, frameCache);
 }

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -1307,7 +1307,7 @@ CreateTopocentricFrame(const Universe& universe,
 
        defaultTarget = center;
        observer = center;
-       target = center.parent();
+       target = center.nameParent();
     }
     else
     {

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -1800,8 +1800,7 @@ CreateTopocentricFrame(const Selection& target,
 }
 
 std::optional<FrameId>
-CreateOrbitFrame(FrameId& frame,
-                 const Universe& universe,
+CreateOrbitFrame(const Universe& universe,
                  const Value* frameValue,
                  Selection& defaultCenter,
                  Body* defaultObserver)

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -1085,9 +1085,9 @@ CreateFrameVector(const Universe& universe,
                   const Selection& center,
                   const AssociativeArray* vectorData)
 {
-    if (const Value* value = vectorData->getValue("RelativePosition"); value != nullptr)
+    if (const Value* value = vectorData->getValue("RelativePosition"); value)
     {
-        if (const AssociativeArray* relPosData = value->getHash(); relPosData != nullptr)
+        if (const AssociativeArray* relPosData = value->getHash(); relPosData)
         {
             Selection observer = getVectorObserver(universe, relPosData);
             Selection target = getVectorTarget(universe, relPosData);
@@ -1104,9 +1104,10 @@ CreateFrameVector(const Universe& universe,
             return GetFrameCache()->getFrameVectorId(RelativePositionKey(observer, target));
         }
     }
-    else if (const Value* value = vectorData->getValue("RelativeVelocity"); value != nullptr)
+
+    if (const Value* value = vectorData->getValue("RelativeVelocity"); value)
     {
-        if (const AssociativeArray* relVData = value->getHash(); relVData != nullptr)
+        if (const AssociativeArray* relVData = value->getHash(); relVData)
         {
             Selection observer = getVectorObserver(universe, relVData);
             Selection target = getVectorTarget(universe, relVData);
@@ -1122,9 +1123,10 @@ CreateFrameVector(const Universe& universe,
             return GetFrameCache()->getFrameVectorId(RelativeVelocityKey(observer, target));
         }
     }
-    else if (const Value* value = vectorData->getValue("ConstantVector"); value != nullptr)
+
+    if (const Value* value = vectorData->getValue("ConstantVector"); value)
     {
-        if (const AssociativeArray* constVecData = value->getHash(); constVecData != nullptr)
+        if (const AssociativeArray* constVecData = value->getHash(); constVecData)
         {
             auto vec = constVecData->getVector3<double>("Vector").value_or(Eigen::Vector3d::UnitZ());
             if (vec.norm() == 0.0)

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -1215,15 +1215,15 @@ CreateTwoVectorFrame(const Universe& universe,
     }
 
     auto primaryVector = CreateFrameVector(universe, defaultCenter, primaryData);
+    if (!primaryVector.has_value())
+        return std::nullopt;
+
     auto secondaryVector = CreateFrameVector(universe, defaultCenter, secondaryData);
+    if (!secondaryVector.has_value())
+        return std::nullopt;
 
-    if (primaryVector.has_value() && secondaryVector.has_value())
-    {
-        return GetFrameCache()->getFrameId(TwoVectorFrameKey(*primaryVector, primaryAxis,
-                                                             *secondaryVector, secondaryAxis));
-    }
-
-    return std::nullopt;
+    return GetFrameCache()->getFrameId(TwoVectorFrameKey(*primaryVector, primaryAxis,
+                                                         *secondaryVector, secondaryAxis));
 }
 
 std::optional<FrameId>

--- a/src/celengine/parseobject.cpp
+++ b/src/celengine/parseobject.cpp
@@ -1121,6 +1121,7 @@ CreateFrameVector(const Universe& universe,
             if (observer.empty() || target.empty())
             {
                 GetLogger()->error("Missing Observer and Target in RelativeVelocity.\n");
+                return std::nullopt;
             }
 
             return frameCache.getFrameVectorId(RelativeVelocityKey(observer, target));

--- a/src/celengine/parseobject.h
+++ b/src/celengine/parseobject.h
@@ -63,13 +63,17 @@ CreateRotationModel(const celestia::util::AssociativeArray* rotationData,
 std::shared_ptr<const celestia::ephem::RotationModel>
 CreateDefaultRotationModel(double syncRotationPeriod);
 
-ReferenceFrame::SharedConstPtr
+std::optional<FrameId>
+CreateOrbitFrame(const Universe& universe,
+                 const celestia::util::Value* frameValue,
+                 Selection& defaultCenter,
+                 Body* defaultObserver);
+
+std::optional<FrameId>
 CreateReferenceFrame(const Universe& universe,
                      const celestia::util::Value* frameValue,
-                     const Selection& defaultCenter,
                      Body* defaultObserver);
 
-std::shared_ptr<const TwoVectorFrame>
-CreateTopocentricFrame(const Selection& center,
-                       const Selection& target,
+FrameId
+CreateTopocentricFrame(const Selection& target,
                        const Selection& observer);

--- a/src/celengine/parseobject.h
+++ b/src/celengine/parseobject.h
@@ -67,13 +67,16 @@ std::optional<FrameId>
 CreateOrbitFrame(const Universe& universe,
                  const celestia::util::Value* frameValue,
                  Selection& defaultCenter,
-                 Body* defaultObserver);
+                 Body* defaultObserver,
+                 FrameCache& frameCache);
 
 std::optional<FrameId>
 CreateReferenceFrame(const Universe& universe,
                      const celestia::util::Value* frameValue,
-                     Body* defaultObserver);
+                     Body* defaultObserver,
+                     FrameCache& frameCache);
 
 FrameId
 CreateTopocentricFrame(const Selection& target,
-                       const Selection& observer);
+                       const Selection& observer,
+                       FrameCache& frameCache);

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -3449,11 +3449,9 @@ void Renderer::buildOrbitLists(const Vector3d& astrocentricObserverPos,
              (orbitVis == Body::UseClassVisibility && util::is_set(body->getOrbitClassification(), orbitMask))))
         {
             Vector3d orbitOrigin = Vector3d::Zero();
-            Selection centerObject = phase->orbitFrame()->getCenter();
-            if (centerObject.body() != nullptr)
-            {
-                orbitOrigin = centerObject.body()->getAstrocentricPosition(now);
-            }
+            Selection centerObject = phase->getFrameTree()->getOwner();
+            if (const Body* centerBody = centerObject.body(); centerBody)
+                orbitOrigin = centerBody->getAstrocentricPosition(now);
 
             // Calculate the origin of the orbit relative to the observer
             Vector3d relOrigin = orbitOrigin - astrocentricObserverPos;
@@ -3567,13 +3565,7 @@ void Renderer::buildLabelLists(const math::InfiniteFrustum& viewFrustum,
             continue;
 
         const TimelinePhase& phase = body->getTimeline()->findPhase(now);
-        const Body* primary = phase.orbitFrame()->getCenter().body();
-        if (primary != nullptr && util::is_set(primary->getClassification(), BodyClassification::Invisible))
-        {
-            const Body* parent = phase.orbitFrame()->getCenter().body();
-            if (parent != nullptr)
-                primary = parent;
-        }
+        const Body* primary = phase.getFrameTree()->getOwner().body();
 
         // Position the label slightly in front of the object along a line from
         // object center to viewer.

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2708,9 +2708,8 @@ void Renderer::renderPlanet(Body& body,
         }
 
         // Calculate eclipse circumstances
-        if (util::is_set(renderFlags, RenderFlags::ShowEclipseShadows) && body.getSystem() != nullptr)
+        if (util::is_set(renderFlags, RenderFlags::ShowEclipseShadows))
         {
-            const Body* parent = body.getTimeline()->findPhase(now).getFrameTree()->getOwner().body();
             const Body* testBody = &body;
             for (;;)
             {

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2466,6 +2466,9 @@ bool Renderer::testEclipse(const Body& receiver,
                            unsigned int lightIndex,
                            double now)
 {
+    if (!lightingState.lights[lightIndex].castsShadows)
+        return false;
+
     bool isReceiverShadowed = false;
 
     // Ignore situations where the shadow casting body is much smaller than
@@ -2707,56 +2710,34 @@ void Renderer::renderPlanet(Body& body,
         // Calculate eclipse circumstances
         if (util::is_set(renderFlags, RenderFlags::ShowEclipseShadows) && body.getSystem() != nullptr)
         {
-            if (const auto *system = body.getSystem(); system->getPrimaryBody() == nullptr)
+            const Body* parent = body.getTimeline()->findPhase(now).getFrameTree()->getOwner().body();
+            const Body* testBody = &body;
+            for (;;)
             {
-                // The body is a planet.  Check for eclipse shadows
-                // from all of its satellites.
-                if (const auto *satellites = body.getSatellites(); satellites != nullptr)
+                // Check for eclipse shadows from the satellites of the current object
+                // Note this only test direct satellites, binary satellites won't work here.
+                // Hopefully the exoplanet astronomers don't find any binary exomoons in the
+                // near future...
+                if (const FrameTree* frameTree = testBody->getFrameTree(); frameTree)
                 {
-                    int nSatellites = satellites->getSystemSize();
-                    for (unsigned int li = 0; li < lights.nLights; li++)
+                    for (unsigned int i = 0, nPhases = frameTree->childCount(); i < nPhases; ++i)
                     {
-                        if (lights.lights[li].castsShadows)
-                        {
-                            for (int i = 0; i < nSatellites; i++)
-                            {
-                                testEclipse(body, *satellites->getBody(i), lights, li, now);
-                            }
-                        }
-                    }
-                }
-            }
-            else
-            {
-                for (unsigned int li = 0; li < lights.nLights; li++)
-                {
-                    if (lights.lights[li].castsShadows)
-                    {
-                        // The body is a moon.  Check for eclipse shadows from
-                        // the parent planet and all satellites in the system.
-                        // Traverse up the hierarchy so that any parent objects
-                        // of the parent are also considered (TODO: their child
-                        // objects will not be checked for shadows.)
-                        const Body* planet = system->getPrimaryBody();
-                        while (planet != nullptr)
-                        {
-                            testEclipse(body, *planet, lights, li, now);
-                            if (planet->getSystem() != nullptr)
-                                planet = planet->getSystem()->getPrimaryBody();
-                            else
-                                planet = nullptr;
-                        }
+                        const auto& phase = frameTree->getChild(i);
+                        if (phase->startTime() > now || phase->endTime() <= now)
+                            continue;
 
-                        int nSatellites = system->getSystemSize();
-                        for (int i = 0; i < nSatellites; i++)
-                        {
-                            if (system->getBody(i) != &body)
-                            {
-                                testEclipse(body, *system->getBody(i), lights, li, now);
-                            }
-                        }
+                        for (unsigned int li = 0; li < lights.nLights; ++li)
+                            testEclipse(body, *phase->body(), lights, li, now);
                     }
                 }
+
+                testBody = testBody->getTimeline()->findPhase(now).getFrameTree()->getOwner().body();
+                if (!testBody)
+                    break;
+
+                // Check for eclipses from the parent object
+                for (unsigned int li = 0; li < lights.nLights; ++li)
+                    testEclipse(body, *testBody, lights, li, now);
             }
         }
 
@@ -2765,80 +2746,75 @@ void Renderer::renderPlanet(Body& body,
         for (unsigned int li = 0; li < lights.nLights; li++)
         {
             RingSystem* rings = lights.ringShadows[li].ringSystem;
-            if (rings != nullptr)
+            if (!rings)
+                continue;
+
+            // Use the first set of ring shadows found (shadowing the brightest light
+            // source.)
+            if (lights.shadowingRingSystem == nullptr)
             {
-                // Use the first set of ring shadows found (shadowing the brightest light
-                // source.)
-                if (lights.shadowingRingSystem == nullptr)
-                {
-                    lights.shadowingRingSystem = rings;
-                    lights.ringPlaneNormal = (rp.orientation * lights.ringShadows[li].casterOrientation.conjugate()) * Vector3f::UnitY();
-                    lights.ringCenter = rp.orientation * lights.ringShadows[li].origin;
-                }
-
-                // Light sources have a finite size, which causes some blurring of the texture. Simulate
-                // this effect by using a lower LOD (i.e. a smaller mipmap level, indicated somewhat
-                // confusingly by a _higher_ LOD value.
-                float ringWidth = rings->outerRadius - rings->innerRadius;
-                float projectedRingSize = std::abs(lights.lights[li].direction_obj.dot(lights.ringPlaneNormal)) * ringWidth;
-                float projectedRingSizeInPixels = projectedRingSize / (max(nearPlaneDistance, altitude) * pixelSize);
-                const Texture* ringsTex = m_textureManager->find(rings->texture);
-                if (ringsTex != nullptr)
-                {
-                    // Calculate the approximate distance from the shadowed object to the rings
-                    Hyperplane<float, 3> ringPlane(lights.ringPlaneNormal, lights.ringCenter);
-                    float cosLightAngle = lights.lights[li].direction_obj.dot(ringPlane.normal());
-                    float approxRingDistance = rings->innerRadius;
-                    if (abs(cosLightAngle) < 0.99999f)
-                    {
-                        approxRingDistance = abs(ringPlane.offset() / cosLightAngle);
-                    }
-                    if (lights.ringCenter.norm() < rings->innerRadius)
-                    {
-                        approxRingDistance = max(approxRingDistance, rings->innerRadius - lights.ringCenter.norm());
-                    }
-
-                    // Calculate the LOD based on the size of the smallest
-                    // ring feature relative to the apparent size of the light source.
-                    float ringTextureWidth = ringsTex->getWidth();
-                    float ringFeatureSize = (projectedRingSize / ringTextureWidth) / approxRingDistance;
-                    float relativeFeatureSize = lights.lights[li].apparentSize / ringFeatureSize;
-                    //float areaLightLod = log(max(relativeFeatureSize, 1.0f)) / log(2.0f);
-                    float areaLightLod = log2(max(relativeFeatureSize, 1.0f));
-
-                    // Compute the LOD that would be automatically used by the GPU.
-                    float texelToPixelRatio = ringTextureWidth / projectedRingSizeInPixels;
-                    float gpuLod = log2(texelToPixelRatio);
-
-                    //float lod = max(areaLightLod, log(texelToPixelRatio) / log(2.0f));
-                    float lod = max(areaLightLod, gpuLod);
-
-                    // maxLOD is the index of the smallest mipmap (or close to it for non-power-of-two
-                    // textures.) We can't make the lod larger than this.
-                    float maxLod = log2((float) ringsTex->getWidth());
-                    if (maxLod > 1.0f)
-                    {
-                        // Avoid using the 1x1 mipmap, as it appears to cause 'bleeding' when
-                        // the light source is very close to the ring plane. This is probably
-                        // a numerical precision issue from calculating the intersection of
-                        // between a ray and plane that are nearly parallel.
-                        maxLod -= 1.0f;
-                    }
-                    lod = min(lod, maxLod);
-
-                    // Not all hardware/drivers support GLSL's textureXDLOD instruction, which lets
-                    // us explicitly set the LOD. But, they do all have an optional lodBias parameter
-                    // for the textureXD instruction. The bias is just the difference between the
-                    // area light LOD and the approximate GPU calculated LOD.
-                    if (!gl::ARB_shader_texture_lod)
-                        lod = max(0.0f, lod - gpuLod);
-                    lights.ringShadows[li].texLod = lod;
-                }
-                else
-                {
-                    lights.ringShadows[li].texLod = 0.0f;
-                }
+                lights.shadowingRingSystem = rings;
+                lights.ringPlaneNormal = (rp.orientation * lights.ringShadows[li].casterOrientation.conjugate()) * Vector3f::UnitY();
+                lights.ringCenter = rp.orientation * lights.ringShadows[li].origin;
             }
+
+            // Light sources have a finite size, which causes some blurring of the texture. Simulate
+            // this effect by using a lower LOD (i.e. a smaller mipmap level, indicated somewhat
+            // confusingly by a _higher_ LOD value.
+            float ringWidth = rings->outerRadius - rings->innerRadius;
+            float projectedRingSize = std::abs(lights.lights[li].direction_obj.dot(lights.ringPlaneNormal)) * ringWidth;
+            float projectedRingSizeInPixels = projectedRingSize / (max(nearPlaneDistance, altitude) * pixelSize);
+            const Texture* ringsTex = m_textureManager->find(rings->texture);
+            if (!ringsTex)
+            {
+                lights.ringShadows[li].texLod = 0.0f;
+                continue;
+            }
+
+            // Calculate the approximate distance from the shadowed object to the rings
+            Hyperplane<float, 3> ringPlane(lights.ringPlaneNormal, lights.ringCenter);
+            float cosLightAngle = lights.lights[li].direction_obj.dot(ringPlane.normal());
+            float approxRingDistance = rings->innerRadius;
+            if (abs(cosLightAngle) < 0.99999f)
+                approxRingDistance = abs(ringPlane.offset() / cosLightAngle);
+            if (lights.ringCenter.norm() < rings->innerRadius)
+                approxRingDistance = max(approxRingDistance, rings->innerRadius - lights.ringCenter.norm());
+
+            // Calculate the LOD based on the size of the smallest
+            // ring feature relative to the apparent size of the light source.
+            float ringTextureWidth = ringsTex->getWidth();
+            float ringFeatureSize = (projectedRingSize / ringTextureWidth) / approxRingDistance;
+            float relativeFeatureSize = lights.lights[li].apparentSize / ringFeatureSize;
+            //float areaLightLod = log(max(relativeFeatureSize, 1.0f)) / log(2.0f);
+            float areaLightLod = log2(max(relativeFeatureSize, 1.0f));
+
+            // Compute the LOD that would be automatically used by the GPU.
+            float texelToPixelRatio = ringTextureWidth / projectedRingSizeInPixels;
+            float gpuLod = log2(texelToPixelRatio);
+
+            //float lod = max(areaLightLod, log(texelToPixelRatio) / log(2.0f));
+            float lod = max(areaLightLod, gpuLod);
+
+            // maxLOD is the index of the smallest mipmap (or close to it for non-power-of-two
+            // textures.) We can't make the lod larger than this.
+            float maxLod = log2((float) ringsTex->getWidth());
+            if (maxLod > 1.0f)
+            {
+                // Avoid using the 1x1 mipmap, as it appears to cause 'bleeding' when
+                // the light source is very close to the ring plane. This is probably
+                // a numerical precision issue from calculating the intersection of
+                // between a ray and plane that are nearly parallel.
+                maxLod -= 1.0f;
+            }
+            lod = min(lod, maxLod);
+
+            // Not all hardware/drivers support GLSL's textureXDLOD instruction, which lets
+            // us explicitly set the LOD. But, they do all have an optional lodBias parameter
+            // for the textureXD instruction. The bias is just the difference between the
+            // area light LOD and the approximate GPU calculated LOD.
+            if (!gl::ARB_shader_texture_lod)
+                lod = max(0.0f, lod - gpuLod);
+            lights.ringShadows[li].texLod = lod;
         }
 
         renderObject(pos, distance, observer,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2722,10 +2722,10 @@ void Renderer::renderPlanet(Body& body,
                     for (unsigned int i = 0, nPhases = frameTree->childCount(); i < nPhases; ++i)
                     {
                         const auto& phase = frameTree->getChild(i);
-                        if (phase->startTime() > now || phase->endTime() <= now)
+                        if (phase->startTime() > now || phase->endTime() <= now) //NOSONAR
                             continue;
 
-                        for (unsigned int li = 0; li < lights.nLights; ++li)
+                        for (unsigned int li = 0; li < lights.nLights; ++li) //NOSONAR
                             testEclipse(body, *phase->body(), lights, li, now);
                     }
                 }

--- a/src/celengine/selection.cpp
+++ b/src/celengine/selection.cpp
@@ -14,10 +14,12 @@
 
 #include <fmt/format.h>
 
-#include <celengine/star.h>
-#include <celengine/body.h>
-#include <celengine/location.h>
-#include <celengine/deepskyobj.h>
+#include "body.h"
+#include "deepskyobj.h"
+#include "frametree.h"
+#include "location.h"
+#include "star.h"
+#include "timeline.h"
 
 namespace astro = celestia::astro;
 
@@ -35,6 +37,28 @@ UniversalCoord locationPosition(const Location* location, double t)
     // Bad location; all locations should have a parent.
     assert(0);
     return UniversalCoord::Zero();
+}
+
+Selection
+getNonBodyParent(SelectionType type, const void* obj)
+{
+    // For now only bodies have timelines and the potential for time-dependent
+    // frame parents. Everything else has the same logic for name and frame trees
+    switch(type)
+    {
+    case SelectionType::Star:
+        return static_cast<const Star*>(obj)->getOrbitBarycenter();
+
+    case SelectionType::DeepSky:
+        // Currently no hierarchy for stars and deep sky objects.
+        return Selection();
+
+    case SelectionType::Location:
+        return Selection(static_cast<const Location*>(obj)->getParentBody());
+
+    default:
+        return Selection();
+    }
 }
 
 } // end unnamed namespace
@@ -113,34 +137,32 @@ Selection::getVelocity(double t) const
 }
 
 Selection
-Selection::parent() const
+Selection::nameParent() const
 {
-    switch (type)
+    if (type == SelectionType::Body)
     {
-    case SelectionType::Star:
-        return Selection(static_cast<const Star*>(obj)->getOrbitBarycenter());
-
-    case SelectionType::Body:
-        if (auto system = static_cast<const Body*>(obj)->getSystem(); system != nullptr)
+        if (auto system = static_cast<const Body*>(obj)->getSystem(); system)
         {
-            if (auto primaryBody = system->getPrimaryBody(); primaryBody != nullptr)
+            if (auto primaryBody = system->getPrimaryBody(); primaryBody)
                 return Selection(primaryBody);
 
             return Selection(system->getStar());
         }
-
-        return Selection();
-
-    case SelectionType::DeepSky:
-        // Currently no hierarchy for stars and deep sky objects.
-        return Selection();
-
-    case SelectionType::Location:
-        return Selection(static_cast<const Location*>(obj)->getParentBody());
-
-    default:
-        return Selection();
     }
+
+    return getNonBodyParent(type, obj);
+}
+
+Selection
+Selection::frameParent(double t) const
+{
+    if (type == SelectionType::Body)
+    {
+        const auto& phase = static_cast<const Body*>(obj)->getTimeline()->findPhase(t);
+        return phase.getFrameTree()->getOwner();
+    }
+
+    return getNonBodyParent(type, obj);
 }
 
 /*! Return true if the selection's visibility flag is set. */

--- a/src/celengine/selection.cpp
+++ b/src/celengine/selection.cpp
@@ -40,7 +40,7 @@ UniversalCoord locationPosition(const Location* location, double t)
 }
 
 Selection
-getNonBodyParent(SelectionType type, const void* obj)
+getNonBodyParent(SelectionType type, const void* obj) //NOSONAR
 {
     // For now only bodies have timelines and the potential for time-dependent
     // frame parents. Everything else has the same logic for name and frame trees

--- a/src/celengine/selection.h
+++ b/src/celengine/selection.h
@@ -50,7 +50,8 @@ public:
     double radius() const;
     UniversalCoord getPosition(double t) const;
     Eigen::Vector3d getVelocity(double t) const;
-    Selection parent() const;
+    Selection nameParent() const;
+    Selection frameParent(double t) const;
 
     bool isVisible() const;
 

--- a/src/celengine/selection.h
+++ b/src/celengine/selection.h
@@ -12,8 +12,10 @@
 #include <cstddef>
 #include <functional>
 #include <string>
-#include <celengine/univcoord.h>
+
 #include <Eigen/Core>
+
+#include <celengine/univcoord.h>
 
 class Star;
 class Body;
@@ -95,14 +97,18 @@ inline bool operator!=(const Selection& s0, const Selection& s1)
     return s0.type != s1.type || s0.obj != s1.obj;
 }
 
-namespace std
-{
 template<>
-struct hash<Selection>
+struct std::hash<Selection>
 {
     std::size_t operator()(const Selection& sel) const noexcept
     {
-        return hash<const void*>()(sel.obj);
+        return std::hash<const void*>{}(sel.obj);
     }
 };
+
+// For boost::hash_combine
+inline std::size_t
+hash_value(const Selection& sel)
+{
+    return std::hash<Selection>{}(sel);
 }

--- a/src/celengine/simulation.cpp
+++ b/src/celengine/simulation.cpp
@@ -38,13 +38,6 @@ Simulation::~Simulation()
 }
 
 
-static const Star* getSun(const Body* body)
-{
-    const PlanetarySystem* system = body->getSystem();
-    return system ? system->getStar() : nullptr;
-}
-
-
 void Simulation::render(Renderer& renderer)
 {
     renderer.render(*activeObserver,
@@ -381,8 +374,7 @@ void Simulation::chase()
     activeObserver->chase(selection);
 }
 
-
-// Choose a planet around a star given it's index in the planetary system.
+// Choose a planet around a star given its index in the planetary system.
 // The planetary system is either the system of the selected object, or the
 // nearest planetary system if no object is selected.  If index is less than
 // zero, pick the star.  This function should probably be in celestiacore.cpp.
@@ -390,33 +382,29 @@ void Simulation::selectPlanet(int index)
 {
     if (index < 0)
     {
-        if (selection.getType() == SelectionType::Body)
+        if (const Body* body = selection.body(); body)
         {
-            PlanetarySystem* system = selection.body()->getSystem();
-            if (system != nullptr)
+            if (const PlanetarySystem* system = body->getSystem(); system)
                 setSelection(system->getStar());
         }
+        return;
     }
-    else
+
+    const Star* star = selection.star();
+    if (const Body* body = selection.body(); body)
     {
-        const Star* star = nullptr;
-        if (selection.getType() == SelectionType::Star)
-            star = selection.star();
-        else if (selection.getType() == SelectionType::Body)
-            star = getSun(selection.body());
-
-        SolarSystem* solarSystem = nullptr;
-        if (star != nullptr)
-            solarSystem = universe->getSolarSystem(star);
-        else
-            solarSystem = getNearestSolarSystem();
-
-        if (solarSystem != nullptr &&
-            index < solarSystem->getPlanets()->getSystemSize())
-        {
-            setSelection(Selection(solarSystem->getPlanets()->getBody(index)));
-        }
+        if (const PlanetarySystem* system = body->getSystem(); system)
+            star = system->getStar();
     }
+
+    SolarSystem* solarSystem = nullptr;
+    if (star)
+        solarSystem = universe->getSolarSystem(star);
+    else
+        solarSystem = getNearestSolarSystem();
+
+    if (solarSystem && index < solarSystem->getPlanets()->getSystemSize())
+        setSelection(Selection(solarSystem->getPlanets()->getBody(index)));
 }
 
 // Find an object from a path, for example Sol/Earth/Moon or Upsilon And/b

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -739,7 +739,7 @@ Selection GetParentObject(PlanetarySystem* system)
 }
 
 std::shared_ptr<const ephem::Orbit>
-CreateLongLat(const AssociativeArray& planetData, Body* centralBody, FrameId& frame)
+CreateLongLat(const AssociativeArray& planetData, Body* centralBody, FrameId& frame, FrameCache& frameCache)
 {
     if (!centralBody)
         return nullptr;
@@ -757,7 +757,7 @@ CreateLongLat(const AssociativeArray& planetData, Body* centralBody, FrameId& fr
     Eigen::Vector3d pos = centralBody->planetocentricToCartesian(180.0 + longlat->x(), longlat->y(), longlat->z());
 #endif
 
-    frame = GetFrameCache()->getFrameId(BodyFixedFrameKey(centralBody));
+    frame = frameCache.getFrameId(BodyFixedFrameKey(centralBody));
     double period = centralBody->getRotationModel(0.0)->getPeriod(); // backwards compatibility use t=0
     return std::make_shared<ephem::FixedOrbit>(pos, period);
 }
@@ -770,6 +770,7 @@ CreateTimelinePhase(Body* body,
                     const std::filesystem::path& path,
                     FrameId defaultOrbitFrame,
                     FrameId defaultBodyFrame,
+                    FrameCache& frameCache,
                     bool isFirstPhase,
                     bool isLastPhase,
                     double previousPhaseEnd)
@@ -799,7 +800,7 @@ CreateTimelinePhase(Body* body,
     FrameId orbitFrame;
     if (const Value* frameValue = phaseData->getValue("OrbitFrame"); frameValue)
     {
-        if (auto frame = CreateOrbitFrame(universe, frameValue, parent, body); frame.has_value())
+        if (auto frame = CreateOrbitFrame(universe, frameValue, parent, body, frameCache); frame.has_value())
             orbitFrame = *frame;
         else
             return nullptr;
@@ -814,7 +815,7 @@ CreateTimelinePhase(Body* body,
     FrameId bodyFrame;
     if (const Value* bodyFrameValue = phaseData->getValue("BodyFrame"); bodyFrameValue)
     {
-        if (auto frame = CreateReferenceFrame(universe, bodyFrameValue, body); frame.has_value())
+        if (auto frame = CreateReferenceFrame(universe, bodyFrameValue, body, frameCache); frame.has_value())
             bodyFrame = *frame;
         else
             return nullptr;
@@ -832,7 +833,7 @@ CreateTimelinePhase(Body* body,
     // Get the orbit
     auto orbit = CreateOrbit(parent, phaseData, path, usePlanetUnits);
     if (!orbit)
-        orbit = CreateLongLat(*phaseData, parent.body(), orbitFrame);
+        orbit = CreateLongLat(*phaseData, parent.body(), orbitFrame, frameCache);
 
     if (!orbit)
     {
@@ -852,14 +853,13 @@ CreateTimelinePhase(Body* body,
         rotationModel = ephem::ConstantOrientation::identity();
     }
 
-    const FrameCache* frameCache = GetFrameCache();
     auto phase = TimelinePhase::CreateTimelinePhase(universe,
                                                     body,
                                                     parent,
                                                     beginning, ending,
-                                                    frameCache->getFrame(orbitFrame),
+                                                    frameCache.getFrame(orbitFrame),
                                                     orbit,
-                                                    frameCache->getFrame(bodyFrame),
+                                                    frameCache.getFrame(bodyFrame),
                                                     rotationModel);
 
     // Frame ownership transfered to phase; release local references
@@ -874,7 +874,8 @@ CreateTimelineFromArray(Body* body,
                         const ValueArray* timelineArray,
                         const std::filesystem::path& path,
                         FrameId defaultOrbitFrame,
-                        FrameId defaultBodyFrame)
+                        FrameId defaultBodyFrame,
+                        FrameCache& frameCache)
 {
     auto timeline = std::make_unique<Timeline>();
     double previousEnding = -std::numeric_limits<double>::infinity();
@@ -902,6 +903,7 @@ CreateTimelineFromArray(Body* body,
                                          path,
                                          defaultOrbitFrame,
                                          defaultBodyFrame,
+                                         frameCache,
                                          isFirstPhase, isLastPhase, previousEnding);
         if (phase == nullptr)
         {
@@ -933,7 +935,8 @@ CreateLegacyTimeline(Body* body, //NOSONAR
                      const std::filesystem::path& path,
                      DataDisposition disposition,
                      FrameId defaultOrbitFrame,
-                     FrameId defaultBodyFrame)
+                     FrameId defaultBodyFrame,
+                     FrameCache& frameCache)
 {
     // Information required for the object timeline.
     std::optional<FrameId> orbitFrame;
@@ -947,8 +950,6 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     // be set to true.
     bool overrideOldTimeline = false;
 
-    const FrameCache* frameCache = GetFrameCache();
-
     // The interaction of Modify with timelines is slightly complicated. If the timeline
     // is specified by putting the OrbitFrame, Orbit, BodyFrame, or RotationModel directly
     // in the object definition (i.e. not inside a Timeline structure), it will completely
@@ -961,9 +962,9 @@ CreateLegacyTimeline(Body* body, //NOSONAR
         if (timeline->phaseCount() == 1)
         {
             const auto& phase = timeline->getPhase(0);
-            if (FrameId frame; frameCache->getFrameId(frame, phase.orbitFrame().get()))
+            if (FrameId frame; frameCache.getFrameId(frame, phase.orbitFrame().get()))
                 orbitFrame = frame;
-            if (FrameId frame; frameCache->getFrameId(frame, phase.bodyFrame().get()))
+            if (FrameId frame; frameCache.getFrameId(frame, phase.bodyFrame().get()))
                 bodyFrame = frame;
             parentObject      = phase.getFrameTree()->getOwner();
             orbit             = phase.orbit();
@@ -977,7 +978,7 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     bool newOrbitFrame = false;
     if (const Value* frameValue = planetData->getValue("OrbitFrame"); frameValue)
     {
-        if (auto frame = CreateOrbitFrame(universe, frameValue, parentObject, body); frame.has_value())
+        if (auto frame = CreateOrbitFrame(universe, frameValue, parentObject, body, frameCache); frame.has_value())
         {
             orbitFrame = frame;
             newOrbitFrame = true;
@@ -989,7 +990,7 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     bool newBodyFrame = false;
     if (const Value* bodyFrameValue = planetData->getValue("BodyFrame"); bodyFrameValue)
     {
-        if (auto frame = CreateReferenceFrame(universe, bodyFrameValue, body); frame.has_value())
+        if (auto frame = CreateReferenceFrame(universe, bodyFrameValue, body, frameCache); frame.has_value())
         {
             bodyFrame = frame;
             newBodyFrame = true;
@@ -1009,7 +1010,7 @@ CreateLegacyTimeline(Body* body, //NOSONAR
 
     auto newOrbit = CreateOrbit(parentObject, planetData, path, !orbitsPlanet);
     if (!newOrbit)
-        newOrbit = CreateLongLat(*planetData, parentObject.body(), *orbitFrame);
+        newOrbit = CreateLongLat(*planetData, parentObject.body(), *orbitFrame, frameCache);
 
     if (!newOrbit && !orbit)
     {
@@ -1080,9 +1081,9 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     auto phase = TimelinePhase::CreateTimelinePhase(universe,
                                                     body, parentObject,
                                                     beginning, ending,
-                                                    frameCache->getFrame(*orbitFrame),
+                                                    frameCache.getFrame(*orbitFrame),
                                                     orbit,
-                                                    frameCache->getFrame(*bodyFrame),
+                                                    frameCache.getFrame(*bodyFrame),
                                                     rotationModel);
 
     // We've already checked that beginning < ending; nothing else should go
@@ -1114,7 +1115,8 @@ bool CreateTimeline(Body* body,
                     const AssociativeArray* planetData,
                     const std::filesystem::path& path,
                     DataDisposition disposition,
-                    BodyType bodyType)
+                    BodyType bodyType,
+                    FrameCache& frameCache)
 {
     Selection parentObject = GetParentObject(system);
     if (SelectionType selType = parentObject.getType();
@@ -1128,14 +1130,14 @@ bool CreateTimeline(Body* body,
     FrameId defaultBodyFrame;
     if (bodyType == SurfaceObject)
     {
-        defaultOrbitFrame = GetFrameCache()->getFrameId(BodyFixedFrameKey(parentObject));
-        defaultBodyFrame = CreateTopocentricFrame(parentObject, body);
+        defaultOrbitFrame = frameCache.getFrameId(BodyFixedFrameKey(parentObject));
+        defaultBodyFrame = CreateTopocentricFrame(parentObject, body, frameCache);
     }
     else
     {
         defaultOrbitFrame = parentObject.getType() == SelectionType::Body
-            ? GetFrameCache()->getFrameId(BodyMeanEquatorFrameKey(parentObject))
-            : GetFrameCache()->getFrameId(SimpleFrameKey::J2000Ecliptic);
+            ? frameCache.getFrameId(BodyMeanEquatorFrameKey(parentObject))
+            : frameCache.getFrameId(SimpleFrameKey::J2000Ecliptic);
         defaultBodyFrame = defaultOrbitFrame;
     }
 
@@ -1151,7 +1153,8 @@ bool CreateTimeline(Body* body,
 
         std::unique_ptr<Timeline> timeline = CreateTimelineFromArray(body, parentObject, universe,
                                                                      timelineArray, path,
-                                                                     defaultOrbitFrame, defaultBodyFrame);
+                                                                     defaultOrbitFrame, defaultBodyFrame,
+                                                                     frameCache);
 
         if (!timeline)
             return false;
@@ -1162,7 +1165,8 @@ bool CreateTimeline(Body* body,
 
     return CreateLegacyTimeline(body, parentObject, universe,
                                 planetData, path, disposition,
-                                defaultOrbitFrame, defaultBodyFrame);
+                                defaultOrbitFrame, defaultBodyFrame,
+                                frameCache);
 }
 
 void
@@ -1333,7 +1337,8 @@ Body* CreateBody(const std::string& name,
                  DataDisposition disposition,
                  BodyType bodyType,
                  engine::GeometryPaths& geometryPaths,
-                 engine::TexturePaths& texturePaths)
+                 engine::TexturePaths& texturePaths,
+                 FrameCache& frameCache)
 {
     Body* body = nullptr;
 
@@ -1354,7 +1359,7 @@ Body* CreateBody(const std::string& name,
         }
     }
 
-    if (!CreateTimeline(body, system, universe, planetData, path, disposition, bodyType))
+    if (!CreateTimeline(body, system, universe, planetData, path, disposition, bodyType, frameCache))
     {
         // No valid timeline given; give up.
         if (body != existingBody)
@@ -1571,7 +1576,8 @@ Body* CreateReferencePoint(const std::string& name,
                            Body* existingBody,
                            const AssociativeArray* refPointData,
                            const std::filesystem::path& path,
-                           DataDisposition disposition)
+                           DataDisposition disposition,
+                           FrameCache& frameCache)
 {
     Body* body = nullptr;
     if (disposition == DataDisposition::Modify || disposition == DataDisposition::Replace)
@@ -1591,7 +1597,7 @@ Body* CreateReferencePoint(const std::string& name,
     body->setVisible(false);
     body->setClickable(false);
 
-    if (!CreateTimeline(body, system, universe, refPointData, path, disposition, ReferencePoint))
+    if (!CreateTimeline(body, system, universe, refPointData, path, disposition, ReferencePoint, frameCache))
     {
         // No valid timeline given; give up.
         if (body != existingBody)
@@ -1625,7 +1631,8 @@ bool LoadSolarSystemObjects(std::istream& in,
                             Universe& universe,
                             const std::filesystem::path& directory,
                             engine::GeometryPaths& geometryPaths,
-                            engine::TexturePaths& texturePaths)
+                            engine::TexturePaths& texturePaths,
+                            FrameCache& frameCache)
 {
     Tokenizer tokenizer(in);
     util::Parser parser(&tokenizer);
@@ -1767,9 +1774,16 @@ bool LoadSolarSystemObjects(std::istream& in,
 
                 Body* body;
                 if (bodyType == ReferencePoint)
-                    body = CreateReferencePoint(primaryName, parentSystem, universe, existingBody, objectData, directory, disposition);
+                {
+                    body = CreateReferencePoint(primaryName, parentSystem, universe, existingBody,
+                                                objectData, directory, disposition, frameCache);
+                }
                 else
-                    body = CreateBody(primaryName, parentSystem, universe, existingBody, objectData, directory, disposition, bodyType, geometryPaths, texturePaths);
+                {
+                    body = CreateBody(primaryName, parentSystem, universe, existingBody,
+                                      objectData, directory, disposition, bodyType,
+                                      geometryPaths, texturePaths, frameCache);
+                }
 
                 if (body != nullptr)
                 {

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -1356,7 +1356,7 @@ Body* CreateBody(const std::string& name,
     if (disposition == DataDisposition::Modify || disposition == DataDisposition::Replace)
         body = existingBody;
 
-    if (body == nullptr)
+    if (!body)
     {
         body = system->addBody(name);
         // If the body doesn't exist, always treat the disposition as 'Add'
@@ -1796,12 +1796,19 @@ bool LoadSolarSystemObjects(std::istream& in,
                                       geometryPaths, texturePaths, frameCache);
                 }
 
-                if (body != nullptr)
+                if (body)
                 {
                     UserCategory::loadCategories(body, *objectData, disposition, directory.string());
                     if (disposition == DataDisposition::Add)
                         for (const auto& name : names)
                             body->addAlias(name);
+
+                    frameCache.commit();
+                }
+                else
+                {
+                    // Remove any frames with dangling pointers
+                    frameCache.rollback();
                 }
             }
         }

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -138,7 +138,8 @@ unsigned int MaxFrameDepth = 50;
 
 bool isFrameCircular(const ReferenceFrame& frame)
 {
-    return frame.nestingDepth(MaxFrameDepth) > MaxFrameDepth;
+    // TODO
+    return false;
 }
 
 
@@ -268,18 +269,16 @@ Selection GetParentObject(PlanetarySystem* system)
 }
 
 std::shared_ptr<const ephem::Orbit>
-CreateLongLat(const AssociativeArray& planetData, ReferenceFrame::SharedConstPtr& frame)
+CreateLongLat(const AssociativeArray& planetData, Body* centralBody, FrameId& frame)
 {
-    // LongLat will make an object fixed relative to the surface of its center
-    // object. This is done by creating an orbit with a period equal to the
-    // rotation rate of the parent object. A body-fixed reference frame is a
-    // much better way to accomplish this.
-    auto longlat = planetData.getSphericalTuple("LongLat");
-    if (!longlat.has_value())
+    if (!centralBody)
         return nullptr;
 
-    Body* centralBody = frame->getCenter().body();
-    if (!centralBody)
+    // LongLat will make an object fixed relative to the surface of its center
+    // object. This is done by creating an orbit with a period equal to the
+    // rotation rate of the parent object.
+    auto longlat = planetData.getSphericalTuple("LongLat");
+    if (!longlat.has_value())
         return nullptr;
 
 #if 0 // TODO: This should be enabled after #542 is fixed
@@ -288,18 +287,19 @@ CreateLongLat(const AssociativeArray& planetData, ReferenceFrame::SharedConstPtr
     Eigen::Vector3d pos = centralBody->planetocentricToCartesian(180.0 + longlat->x(), longlat->y(), longlat->z());
 #endif
 
-    frame = std::make_shared<BodyFixedFrame>(centralBody, centralBody);
+    frame = GetFrameCache()->getFrameId(BodyFixedFrameKey(centralBody));
     double period = centralBody->getRotationModel(0.0)->getPeriod(); // backwards compatibility use t=0
     return std::make_shared<ephem::FixedOrbit>(pos, period);
 }
 
 std::unique_ptr<TimelinePhase>
 CreateTimelinePhase(Body* body,
+                    Selection parent,
                     Universe& universe,
                     const AssociativeArray* phaseData,
                     const std::filesystem::path& path,
-                    const ReferenceFrame::SharedConstPtr& defaultOrbitFrame,
-                    const ReferenceFrame::SharedConstPtr& defaultBodyFrame,
+                    FrameId defaultOrbitFrame,
+                    FrameId defaultBodyFrame,
                     bool isFirstPhase,
                     bool isLastPhase,
                     double previousPhaseEnd)
@@ -326,15 +326,13 @@ CreateTimelinePhase(Body* body,
     }
 
     // Get the orbit reference frame.
-    ReferenceFrame::SharedConstPtr orbitFrame;
-    const Value* frameValue = phaseData->getValue("OrbitFrame");
-    if (frameValue != nullptr)
+    FrameId orbitFrame;
+    if (const Value* frameValue = phaseData->getValue("OrbitFrame"); frameValue)
     {
-        orbitFrame = CreateReferenceFrame(universe, frameValue, defaultOrbitFrame->getCenter(), body);
-        if (orbitFrame == nullptr)
-        {
+        if (auto frame = CreateOrbitFrame(universe, frameValue, parent, body); frame.has_value())
+            orbitFrame = *frame;
+        else
             return nullptr;
-        }
     }
     else
     {
@@ -343,15 +341,13 @@ CreateTimelinePhase(Body* body,
     }
 
     // Get the body reference frame
-    ReferenceFrame::SharedConstPtr bodyFrame;
-    const Value* bodyFrameValue = phaseData->getValue("BodyFrame");
-    if (bodyFrameValue != nullptr)
+    FrameId bodyFrame;
+    if (const Value* bodyFrameValue = phaseData->getValue("BodyFrame"); bodyFrameValue)
     {
-        bodyFrame = CreateReferenceFrame(universe, bodyFrameValue, defaultBodyFrame->getCenter(), body);
-        if (bodyFrame == nullptr)
-        {
+        if (auto frame = CreateReferenceFrame(universe, bodyFrameValue, body); frame.has_value())
+            bodyFrame = *frame;
+        else
             return nullptr;
-        }
     }
     else
     {
@@ -361,12 +357,12 @@ CreateTimelinePhase(Body* body,
 
     // Use planet units (AU for semimajor axis) if the center of the orbit
     // reference frame is a star.
-    bool usePlanetUnits = orbitFrame->getCenter().star() != nullptr;
+    bool usePlanetUnits = parent.star() != nullptr;
 
     // Get the orbit
-    auto orbit = CreateOrbit(orbitFrame->getCenter(), phaseData, path, usePlanetUnits);
+    auto orbit = CreateOrbit(parent, phaseData, path, usePlanetUnits);
     if (!orbit)
-        orbit = CreateLongLat(*phaseData, orbitFrame);
+        orbit = CreateLongLat(*phaseData, parent.body(), orbitFrame);
 
     if (!orbit)
     {
@@ -386,12 +382,14 @@ CreateTimelinePhase(Body* body,
         rotationModel = ephem::ConstantOrientation::identity();
     }
 
+    const FrameCache* frameCache = GetFrameCache();
     auto phase = TimelinePhase::CreateTimelinePhase(universe,
                                                     body,
+                                                    parent,
                                                     beginning, ending,
-                                                    orbitFrame,
+                                                    frameCache->getFrame(orbitFrame),
                                                     orbit,
-                                                    bodyFrame,
+                                                    frameCache->getFrame(bodyFrame),
                                                     rotationModel);
 
     // Frame ownership transfered to phase; release local references
@@ -401,11 +399,12 @@ CreateTimelinePhase(Body* body,
 
 std::unique_ptr<Timeline>
 CreateTimelineFromArray(Body* body,
+                        Selection parent,
                         Universe& universe,
                         const ValueArray* timelineArray,
                         const std::filesystem::path& path,
-                        const ReferenceFrame::SharedConstPtr& defaultOrbitFrame,
-                        const ReferenceFrame::SharedConstPtr& defaultBodyFrame)
+                        FrameId defaultOrbitFrame,
+                        FrameId defaultBodyFrame)
 {
     auto timeline = std::make_unique<Timeline>();
     double previousEnding = -std::numeric_limits<double>::infinity();
@@ -429,7 +428,7 @@ CreateTimelineFromArray(Body* body,
         bool isFirstPhase = iter == timelineArray->begin();
         bool isLastPhase =  iter == finalIter;
 
-        auto phase = CreateTimelinePhase(body, universe, phaseData,
+        auto phase = CreateTimelinePhase(body, parent, universe, phaseData,
                                          path,
                                          defaultOrbitFrame,
                                          defaultBodyFrame,
@@ -450,72 +449,19 @@ CreateTimelineFromArray(Body* body,
     return timeline;
 }
 
-
-bool CreateTimeline(Body* body,
-                    PlanetarySystem* system,
-                    Universe& universe,
-                    const AssociativeArray* planetData,
-                    const std::filesystem::path& path,
-                    DataDisposition disposition,
-                    BodyType bodyType)
+bool
+CreateLegacyTimeline(Body* body,
+                     Selection parentObject,
+                     Universe& universe,
+                     const AssociativeArray* planetData,
+                     const std::filesystem::path& path,
+                     DataDisposition disposition,
+                     FrameId defaultOrbitFrame,
+                     FrameId defaultBodyFrame)
 {
-    FrameTree* parentFrameTree = nullptr;
-    Selection parentObject = GetParentObject(system);
-    bool orbitsPlanet = false;
-    if (parentObject.body())
-    {
-        parentFrameTree = parentObject.body()->getOrCreateFrameTree();
-        //orbitsPlanet = true;
-    }
-    else if (parentObject.star())
-    {
-        const SolarSystem* solarSystem = universe.getOrCreateSolarSystem(parentObject.star());
-        parentFrameTree = solarSystem->getFrameTree();
-    }
-    else
-    {
-        // Bad orbit barycenter specified
-        return false;
-    }
-
-    ReferenceFrame::SharedConstPtr defaultOrbitFrame;
-    ReferenceFrame::SharedConstPtr defaultBodyFrame;
-    if (bodyType == SurfaceObject)
-    {
-        defaultOrbitFrame = std::make_shared<BodyFixedFrame>(parentObject, parentObject);
-        defaultBodyFrame = CreateTopocentricFrame(parentObject, parentObject, Selection(body));
-    }
-    else
-    {
-        defaultOrbitFrame = parentFrameTree->getDefaultReferenceFrame();
-        defaultBodyFrame = parentFrameTree->getDefaultReferenceFrame();
-    }
-
-    // If there's an explicit timeline definition, parse that. Otherwise, we'll do
-    // things the old way.
-    const Value* value = planetData->getValue("Timeline");
-    if (value != nullptr)
-    {
-        const ValueArray* timelineArray = value->getArray();
-        if (timelineArray == nullptr)
-        {
-            GetLogger()->error("Error: Timeline must be an array\n");
-            return false;
-        }
-
-        std::unique_ptr<Timeline> timeline = CreateTimelineFromArray(body, universe, timelineArray, path,
-                                                                     defaultOrbitFrame, defaultBodyFrame);
-
-        if (!timeline)
-            return false;
-
-        body->setTimeline(std::move(timeline));
-        return true;
-    }
-
     // Information required for the object timeline.
-    ReferenceFrame::SharedConstPtr orbitFrame;
-    ReferenceFrame::SharedConstPtr bodyFrame;
+    std::optional<FrameId> orbitFrame;
+    std::optional<FrameId> bodyFrame;
     std::shared_ptr<const ephem::Orbit> orbit = nullptr;
     std::shared_ptr<const ephem::RotationModel> rotationModel = nullptr;
     double beginning  = -std::numeric_limits<double>::infinity();
@@ -524,6 +470,8 @@ bool CreateTimeline(Body* body,
     // If any new timeline values are specified, we need to overrideOldTimeline will
     // be set to true.
     bool overrideOldTimeline = false;
+
+    const FrameCache* frameCache = GetFrameCache();
 
     // The interaction of Modify with timelines is slightly complicated. If the timeline
     // is specified by putting the OrbitFrame, Orbit, BodyFrame, or RotationModel directly
@@ -537,22 +485,23 @@ bool CreateTimeline(Body* body,
         if (timeline->phaseCount() == 1)
         {
             const auto& phase = timeline->getPhase(0);
-            orbitFrame    = phase.orbitFrame();
-            bodyFrame     = phase.bodyFrame();
-            orbit         = phase.orbit();
-            rotationModel = phase.rotationModel();
-            beginning     = phase.startTime();
-            ending        = phase.endTime();
+            if (FrameId frame; frameCache->getFrameId(frame, phase.orbitFrame().get()))
+                orbitFrame = frame;
+            if (FrameId frame; frameCache->getFrameId(frame, phase.bodyFrame().get()))
+                bodyFrame = frame;
+            parentObject      = phase.getFrameTree()->getOwner();
+            orbit             = phase.orbit();
+            rotationModel     = phase.rotationModel();
+            beginning         = phase.startTime();
+            ending            = phase.endTime();
         }
     }
 
     // Get the object's orbit reference frame.
     bool newOrbitFrame = false;
-    const Value* frameValue = planetData->getValue("OrbitFrame");
-    if (frameValue != nullptr)
+    if (const Value* frameValue = planetData->getValue("OrbitFrame"); frameValue)
     {
-        auto frame = CreateReferenceFrame(universe, frameValue, parentObject, body);
-        if (frame != nullptr)
+        if (auto frame = CreateOrbitFrame(universe, frameValue, parentObject, body); frame.has_value())
         {
             orbitFrame = frame;
             newOrbitFrame = true;
@@ -562,11 +511,9 @@ bool CreateTimeline(Body* body,
 
     // Get the object's body frame.
     bool newBodyFrame = false;
-    const Value* bodyFrameValue = planetData->getValue("BodyFrame");
-    if (bodyFrameValue != nullptr)
+    if (const Value* bodyFrameValue = planetData->getValue("BodyFrame"); bodyFrameValue)
     {
-        auto frame = CreateReferenceFrame(universe, bodyFrameValue, parentObject, body);
-        if (frame != nullptr)
+        if (auto frame = CreateReferenceFrame(universe, bodyFrameValue, body); frame.has_value())
         {
             bodyFrame = frame;
             newBodyFrame = true;
@@ -575,18 +522,19 @@ bool CreateTimeline(Body* body,
     }
 
     // If no orbit or body frame was specified, use the default ones
-    if (orbitFrame == nullptr)
+    if (!orbitFrame.has_value())
         orbitFrame = defaultOrbitFrame;
-    if (bodyFrame == nullptr)
+    if (!bodyFrame.has_value())
         bodyFrame = defaultBodyFrame;
 
     // If the center of the is a star, orbital element units are
     // in AU; otherwise, use kilometers.
-    orbitsPlanet = orbitFrame->getCenter().star() == nullptr;
+    bool orbitsPlanet = parentObject.star() == nullptr;
 
-    auto newOrbit = CreateOrbit(orbitFrame->getCenter(), planetData, path, !orbitsPlanet);
+    auto newOrbit = CreateOrbit(parentObject, planetData, path, !orbitsPlanet);
     if (!newOrbit)
-        newOrbit = CreateLongLat(*planetData, orbitFrame);
+        newOrbit = CreateLongLat(*planetData, parentObject.body(), *orbitFrame);
+
     if (newOrbit == nullptr && orbit == nullptr)
     {
         if (body->getTimeline() && disposition == DataDisposition::Modify)
@@ -654,11 +602,11 @@ bool CreateTimeline(Body* body,
         // We finally have an orbit, rotation model, frames, and time range. Create
         // the object timeline.
         auto phase = TimelinePhase::CreateTimelinePhase(universe,
-                                                        body,
+                                                        body, parentObject,
                                                         beginning, ending,
-                                                        orbitFrame,
+                                                        frameCache->getFrame(*orbitFrame),
                                                         orbit,
-                                                        bodyFrame,
+                                                        frameCache->getFrame(*bodyFrame),
                                                         rotationModel);
 
         // We've already checked that beginning < ending; nothing else should go
@@ -693,6 +641,75 @@ bool CreateTimeline(Body* body,
     }
 
     return true;
+}
+
+
+bool CreateTimeline(Body* body,
+                    PlanetarySystem* system,
+                    Universe& universe,
+                    const AssociativeArray* planetData,
+                    const std::filesystem::path& path,
+                    DataDisposition disposition,
+                    BodyType bodyType)
+{
+    FrameTree* parentFrameTree = nullptr;
+    Selection parentObject = GetParentObject(system);
+    bool orbitsPlanet = false;
+    if (parentObject.body())
+    {
+        parentFrameTree = parentObject.body()->getOrCreateFrameTree();
+        //orbitsPlanet = true;
+    }
+    else if (parentObject.star())
+    {
+        const SolarSystem* solarSystem = universe.getOrCreateSolarSystem(parentObject.star());
+        parentFrameTree = solarSystem->getFrameTree();
+    }
+    else
+    {
+        // Bad orbit barycenter specified
+        return false;
+    }
+
+    FrameId defaultOrbitFrame;
+    FrameId defaultBodyFrame;
+    if (bodyType == SurfaceObject)
+    {
+        defaultOrbitFrame = GetFrameCache()->getFrameId(BodyFixedFrameKey(parentObject));
+        defaultBodyFrame = CreateTopocentricFrame(parentObject, body);
+    }
+    else
+    {
+        defaultOrbitFrame = parentObject.getType() == SelectionType::Body
+            ? GetFrameCache()->getFrameId(BodyMeanEquatorFrameKey(parentObject))
+            : GetFrameCache()->getFrameId(SimpleFrameKey::J2000Ecliptic);
+        defaultBodyFrame = defaultOrbitFrame;
+    }
+
+    if (const Value* value = planetData->getValue("Timeline"); value)
+    {
+        // If there's an explicit timeline definition, parse that.
+        const ValueArray* timelineArray = value->getArray();
+        if (timelineArray == nullptr)
+        {
+            GetLogger()->error("Error: Timeline must be an array\n");
+            return false;
+        }
+
+        std::unique_ptr<Timeline> timeline = CreateTimelineFromArray(body, parentObject, universe,
+                                                                     timelineArray, path,
+                                                                     defaultOrbitFrame, defaultBodyFrame);
+
+        if (!timeline)
+            return false;
+
+        body->setTimeline(std::move(timeline));
+        return true;
+    }
+
+    return CreateLegacyTimeline(body, parentObject, universe,
+                                planetData, path, disposition,
+                                defaultOrbitFrame, defaultBodyFrame);
 }
 
 void

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -136,6 +136,14 @@ BodyClassification GetClassificationId(std::string_view className)
 //! Maximum depth permitted for nested frames.
 unsigned int MaxFrameDepth = 50;
 
+// Check frames for circular references. For position frames, check both the
+// frametree hierarchy and the reference frame. For body frames, only the
+// reference frame is checked. For now, we consider any phase of the frame
+// center that is reachable from the current phase as a parent, and for
+// frames we consider all possible body phases. This may lead to some false
+// positive circular reference detections with certain tricky frame
+// configurations, but handling that would require tracking time windows
+// across the entire frame graph and the associated complexity of doing that.
 class TimelineValidator
 {
 public:

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -143,7 +143,7 @@ public:
         m_testBody(body), m_testTimeline(timeline)
     {}
 
-    bool validate();
+    bool validate(bool validateOrbit = true, bool validateBody = true);
 
 private:
     enum class FrameUsage
@@ -247,8 +247,11 @@ private:
 };
 
 bool
-TimelineValidator::validate()
+TimelineValidator::validate(bool validateOrbit, bool validateBody)
 {
+    if (!validateOrbit && !validateBody)
+        return true;
+
     // Validate that the timeline does not lead to circular references
     // NOTE: the check for maximum depth can be circumvented by using
     // Modify directives - to fix this we would need to keep track of
@@ -257,8 +260,10 @@ TimelineValidator::validate()
     for (unsigned int i = 0, nPhases = m_testTimeline.phaseCount(); i < nPhases; ++i)
     {
         const TimelinePhase* phase = &m_testTimeline.getPhase(i);
-        m_commands.emplace_back(ProcessPhase{ phase, FrameUsage::Body });
-        m_commands.emplace_back(ProcessPhase{ phase, FrameUsage::Position });
+        if (validateBody)
+            m_commands.emplace_back(ProcessPhase{ phase, FrameUsage::Body });
+        if (validateOrbit)
+            m_commands.emplace_back(ProcessPhase{ phase, FrameUsage::Position });
     }
 
     CommandProcessor processor(*this);
@@ -553,7 +558,6 @@ TimelineValidator::FrameFinishVisitor::visitBodyFrame(const Body* body, std::opt
     if (m_maxDepth < 0)
         return;
 
-    int frameDepth;
     const Timeline* timeline = m_validator.getTimeline(body);
     if (t.has_value())
     {
@@ -1085,7 +1089,7 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     auto timeline = std::make_unique<Timeline>();
     timeline->appendPhase(std::move(phase));
 
-    if (!TimelineValidator(body, *timeline).validate())
+    if (!TimelineValidator(body, *timeline).validate(newOrbitFrame, newBodyFrame))
     {
         GetLogger()->error("Frame depth limit exceeded for '{}'.\n", body->getName());
         return false;

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -160,8 +160,9 @@ private:
         explicit PhaseStatus(const TimelinePhase* p) : phase(p) {}
 
         const TimelinePhase* phase;
+
         int positionDepth{ NotStarted };
-        int bodyDepth{ NotStarted };
+        int bodyDepth{ NotStarted }; // cppcheck-suppress unusedStructMember
     };
 
     struct ProcessPhase
@@ -191,7 +192,7 @@ private:
     class CommandProcessor
     {
     public:
-        CommandProcessor(TimelineValidator& validator) : m_validator(validator) {}
+        explicit CommandProcessor(TimelineValidator& validator) : m_validator(validator) {}
 
         bool operator()(const ProcessPhase&) const;
         bool operator()(const FinishPhase&) const;
@@ -205,7 +206,7 @@ private:
     class FrameProcessVisitor final : public FrameVisitor
     {
     public:
-        FrameProcessVisitor(TimelineValidator& validator) : m_validator(validator) {}
+        explicit FrameProcessVisitor(TimelineValidator& validator) : m_validator(validator) {}
 
         void visitPosition(const Selection& sel) override;
         void visitBodyFrame(const Body* body, std::optional<double> epoch = std::nullopt) override;
@@ -220,7 +221,7 @@ private:
     class FrameFinishVisitor final : public FrameVisitor
     {
     public:
-        FrameFinishVisitor(TimelineValidator& validator) : m_validator(validator) {}
+        explicit FrameFinishVisitor(TimelineValidator& validator) : m_validator(validator) {}
 
         void visitPosition(const Selection& sel) override;
         void visitBodyFrame(const Body* body, std::optional<double> epoch = std::nullopt) override;

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -939,8 +939,9 @@ CreateLegacyTimeline(Body* body, //NOSONAR
                      FrameCache& frameCache)
 {
     // Information required for the object timeline.
-    std::optional<FrameId> orbitFrame;
-    std::optional<FrameId> bodyFrame;
+    using FrameDetails = std::variant<FrameId, ReferenceFrame::SharedConstPtr>;
+    FrameDetails orbitFrame = defaultOrbitFrame;
+    FrameDetails bodyFrame = defaultBodyFrame;
     std::shared_ptr<const ephem::Orbit> orbit = nullptr;
     std::shared_ptr<const ephem::RotationModel> rotationModel = nullptr;
     double beginning  = -std::numeric_limits<double>::infinity();
@@ -962,10 +963,8 @@ CreateLegacyTimeline(Body* body, //NOSONAR
         if (timeline->phaseCount() == 1)
         {
             const auto& phase = timeline->getPhase(0);
-            if (FrameId frame; frameCache.getFrameId(frame, phase.orbitFrame().get()))
-                orbitFrame = frame;
-            if (FrameId frame; frameCache.getFrameId(frame, phase.bodyFrame().get()))
-                bodyFrame = frame;
+            orbitFrame = phase.orbitFrame();
+            bodyFrame = phase.bodyFrame();
             parentObject      = phase.getFrameTree()->getOwner();
             orbit             = phase.orbit();
             rotationModel     = phase.rotationModel();
@@ -980,7 +979,7 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     {
         if (auto frame = CreateOrbitFrame(universe, frameValue, parentObject, body, frameCache); frame.has_value())
         {
-            orbitFrame = frame;
+            orbitFrame = *frame;
             newOrbitFrame = true;
             overrideOldTimeline = true;
         }
@@ -992,17 +991,11 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     {
         if (auto frame = CreateReferenceFrame(universe, bodyFrameValue, body, frameCache); frame.has_value())
         {
-            bodyFrame = frame;
+            bodyFrame = *frame;
             newBodyFrame = true;
             overrideOldTimeline = true;
         }
     }
-
-    // If no orbit or body frame was specified, use the default ones
-    if (!orbitFrame.has_value())
-        orbitFrame = defaultOrbitFrame;
-    if (!bodyFrame.has_value())
-        bodyFrame = defaultBodyFrame;
 
     // If the center of the is a star, orbital element units are
     // in AU; otherwise, use kilometers.
@@ -1010,7 +1003,12 @@ CreateLegacyTimeline(Body* body, //NOSONAR
 
     auto newOrbit = CreateOrbit(parentObject, planetData, path, !orbitsPlanet);
     if (!newOrbit)
-        newOrbit = CreateLongLat(*planetData, parentObject.body(), *orbitFrame, frameCache);
+    {
+        FrameId longLatFrame;
+        newOrbit = CreateLongLat(*planetData, parentObject.body(), longLatFrame, frameCache);
+        if (newOrbit)
+            orbitFrame = longLatFrame;
+    }
 
     if (!newOrbit && !orbit)
     {
@@ -1018,10 +1016,10 @@ CreateLegacyTimeline(Body* body, //NOSONAR
         {
             // The object definition is modifying an existing object with a multiple phase
             // timeline, but no orbit definition was given. This can happen for completely
-            // sensible reasons, such a Modify definition that just changes visual properties.
-            // Or, the definition may try to change other timeline phase properties such as
-            // the orbit frame, but without providing an orbit. In both cases, we'll just
-            // leave the original timeline alone.
+            // sensible reasons, such as a Modify definition that just changes visual
+            // properties. Or, the definition may try to change other timeline phase
+            // properties such as the orbit frame, but without providing an orbit. In both
+            // cases, we'll just leave the original timeline alone.
             return true;
         }
         else
@@ -1078,12 +1076,25 @@ CreateLegacyTimeline(Body* body, //NOSONAR
 
     // We finally have an orbit, rotation model, frames, and time range. Create
     // the object timeline.
+    class FrameDetailsVisitor
+    {
+    public:
+        FrameDetailsVisitor(const FrameCache& fc) : m_frameCache(fc) {}
+
+        ReferenceFrame::SharedConstPtr operator()(FrameId id) const { return m_frameCache.getFrame(id); }
+        ReferenceFrame::SharedConstPtr operator()(const ReferenceFrame::SharedConstPtr& ptr) const { return ptr; }
+
+    private:
+        const FrameCache& m_frameCache;
+    };
+
+    FrameDetailsVisitor visitor(frameCache);
     auto phase = TimelinePhase::CreateTimelinePhase(universe,
                                                     body, parentObject,
                                                     beginning, ending,
-                                                    frameCache.getFrame(*orbitFrame),
+                                                    std::visit(visitor, orbitFrame),
                                                     orbit,
-                                                    frameCache.getFrame(*bodyFrame),
+                                                    std::visit(visitor, bodyFrame),
                                                     rotationModel);
 
     // We've already checked that beginning < ending; nothing else should go

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -1079,7 +1079,7 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     class FrameDetailsVisitor
     {
     public:
-        FrameDetailsVisitor(const FrameCache& fc) : m_frameCache(fc) {}
+        explicit FrameDetailsVisitor(const FrameCache& fc) : m_frameCache(fc) {}
 
         ReferenceFrame::SharedConstPtr operator()(FrameId id) const { return m_frameCache.getFrame(id); }
         ReferenceFrame::SharedConstPtr operator()(const ReferenceFrame::SharedConstPtr& ptr) const { return ptr; }

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -868,7 +868,7 @@ CreateTimelinePhase(Body* body,
 
 
 std::unique_ptr<Timeline>
-CreateTimelineFromArray(Body* body,
+CreateTimelineFromArray(Body* body, //NOSONAR
                         Selection parent,
                         Universe& universe,
                         const ValueArray* timelineArray,
@@ -1109,7 +1109,7 @@ CreateLegacyTimeline(Body* body, //NOSONAR
 }
 
 
-bool CreateTimeline(Body* body,
+bool CreateTimeline(Body* body, //NOSONAR
                     PlanetarySystem* system,
                     Universe& universe,
                     const AssociativeArray* planetData,
@@ -1570,7 +1570,7 @@ Body* CreateBody(const std::string& name,
 
 
 // Create a barycenter object using the values from a hash
-Body* CreateReferencePoint(const std::string& name,
+Body* CreateReferencePoint(const std::string& name, //NOSONAR
                            PlanetarySystem* system,
                            Universe& universe,
                            Body* existingBody,

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -450,7 +450,7 @@ CreateTimelineFromArray(Body* body,
 }
 
 bool
-CreateLegacyTimeline(Body* body,
+CreateLegacyTimeline(Body* body, //NOSONAR
                      Selection parentObject,
                      Universe& universe,
                      const AssociativeArray* planetData,
@@ -652,20 +652,9 @@ bool CreateTimeline(Body* body,
                     DataDisposition disposition,
                     BodyType bodyType)
 {
-    FrameTree* parentFrameTree = nullptr;
     Selection parentObject = GetParentObject(system);
-    bool orbitsPlanet = false;
-    if (parentObject.body())
-    {
-        parentFrameTree = parentObject.body()->getOrCreateFrameTree();
-        //orbitsPlanet = true;
-    }
-    else if (parentObject.star())
-    {
-        const SolarSystem* solarSystem = universe.getOrCreateSolarSystem(parentObject.star());
-        parentFrameTree = solarSystem->getFrameTree();
-    }
-    else
+    if (SelectionType selType = parentObject.getType();
+        selType != SelectionType::Body && selType != SelectionType::Star)
     {
         // Bad orbit barycenter specified
         return false;

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -136,13 +136,470 @@ BodyClassification GetClassificationId(std::string_view className)
 //! Maximum depth permitted for nested frames.
 unsigned int MaxFrameDepth = 50;
 
-bool isFrameCircular(const ReferenceFrame& frame)
+class TimelineValidator
 {
-    // TODO
-    return false;
+public:
+    TimelineValidator(const Body* body, const Timeline& timeline) :
+        m_testBody(body), m_testTimeline(timeline)
+    {}
+
+    bool validate();
+
+private:
+    enum class FrameUsage
+    {
+        Position,
+        Body,
+    };
+
+    static constexpr int Invalid = -1;
+    static constexpr int NotStarted = -2;
+
+    struct PhaseStatus
+    {
+        explicit PhaseStatus(const TimelinePhase* p) : phase(p) {}
+
+        const TimelinePhase* phase;
+        int positionDepth{ NotStarted };
+        int bodyDepth{ NotStarted };
+    };
+
+    struct ProcessPhase
+    {
+        const TimelinePhase* phase;
+        FrameUsage usage;
+    };
+
+    struct FinishPhase
+    {
+        const TimelinePhase* phase;
+        FrameUsage usage;
+    };
+
+    struct ProcessFrame
+    {
+        const ReferenceFrame* frame;
+    };
+
+    struct FinishFrame
+    {
+        const ReferenceFrame* frame;
+    };
+
+    using Command = std::variant<ProcessPhase, FinishPhase, ProcessFrame, FinishFrame>;
+
+    class CommandProcessor
+    {
+    public:
+        CommandProcessor(TimelineValidator& validator) : m_validator(validator) {}
+
+        bool operator()(const ProcessPhase&) const;
+        bool operator()(const FinishPhase&) const;
+        bool operator()(const ProcessFrame&) const;
+        bool operator()(const FinishFrame&) const;
+
+    private:
+        TimelineValidator& m_validator;
+    };
+
+    class FrameProcessVisitor final : public FrameVisitor
+    {
+    public:
+        FrameProcessVisitor(TimelineValidator& validator) : m_validator(validator) {}
+
+        void visitPosition(const Selection& sel) override;
+        void visitBodyFrame(const Body* body, std::optional<double> epoch = std::nullopt) override;
+        void visitReferenceFrame(const ReferenceFrame*) override;
+
+        bool status() const noexcept { return m_status; }
+    private:
+        TimelineValidator& m_validator;
+        bool m_status{ true };
+    };
+
+    class FrameFinishVisitor final : public FrameVisitor
+    {
+    public:
+        FrameFinishVisitor(TimelineValidator& validator) : m_validator(validator) {}
+
+        void visitPosition(const Selection& sel) override;
+        void visitBodyFrame(const Body* body, std::optional<double> epoch = std::nullopt) override;
+        void visitReferenceFrame(const ReferenceFrame*) override;
+
+        int maxDepth() const noexcept { return m_maxDepth; }
+
+    private:
+        TimelineValidator& m_validator;
+        int m_maxDepth{ 0 };
+    };
+
+    static const Body* getBody(const Selection&);
+    const Timeline* getTimeline(const Body*) const;
+    int phaseDepth(const TimelinePhase*) const;
+    int frameDepth(const ReferenceFrame*) const;
+
+    const Body* m_testBody;
+    const Timeline& m_testTimeline;
+    std::vector<PhaseStatus> m_phases;
+    std::vector<std::pair<const ReferenceFrame*, int>> m_frames;
+    std::vector<Command> m_commands;
+};
+
+bool
+TimelineValidator::validate()
+{
+    // Validate that the timeline does not lead to circular references
+    // NOTE: the check for maximum depth can be circumvented by using
+    // Modify directives - to fix this we would need to keep track of
+    // all active reference frames that reference the current body and
+    // track those as well.
+    for (unsigned int i = 0, nPhases = m_testTimeline.phaseCount(); i < nPhases; ++i)
+    {
+        const TimelinePhase* phase = &m_testTimeline.getPhase(i);
+        m_commands.emplace_back(ProcessPhase{ phase, FrameUsage::Body });
+        m_commands.emplace_back(ProcessPhase{ phase, FrameUsage::Position });
+    }
+
+    CommandProcessor processor(*this);
+    while (!m_commands.empty())
+    {
+        auto command = m_commands.back();
+        m_commands.pop_back();
+        if (!std::visit(processor, command))
+            return false;
+    }
+
+    return true;
 }
 
+const Body*
+TimelineValidator::getBody(const Selection& sel)
+{
+    if (const Body* body = sel.body(); body)
+        return body;
+    if (const Location* location = sel.location(); location)
+        return sel.location()->getParentBody();
+    return nullptr;
+}
 
+const Timeline*
+TimelineValidator::getTimeline(const Body* body) const
+{
+    return body == m_testBody
+        ? &m_testTimeline
+        : body->getTimeline();
+}
+
+int
+TimelineValidator::phaseDepth(const TimelinePhase* phase) const
+{
+    const auto phaseBegin = m_phases.begin();
+    const auto phaseEnd = m_phases.end();
+    int maxTreeDepth = 0;
+    if (const Body* parentBody = phase->getFrameTree()->getOwner().body(); parentBody)
+    {
+        const Timeline* parentTimeline = getTimeline(parentBody);
+        for (unsigned int i = 0, nPhases = parentTimeline->phaseCount(); i < nPhases; ++i)
+        {
+            const TimelinePhase& parentPhase = parentTimeline->getPhase(i);
+            if (parentPhase.startTime() >= phase->endTime() || parentPhase.endTime() <= phase->startTime())
+                continue;
+
+            auto phaseIt = std::find_if(phaseBegin, phaseEnd,
+                                        [&parentPhase](const auto& p) { return p.phase == &parentPhase; });
+            if (phaseIt == phaseEnd || phaseIt->positionDepth < 0)
+                return -1;
+
+            if (phaseIt->positionDepth > maxTreeDepth)
+                maxTreeDepth = phaseIt->positionDepth;
+        }
+    }
+
+    return maxTreeDepth;
+}
+
+int
+TimelineValidator::frameDepth(const ReferenceFrame* frame) const
+{
+    const auto end = m_frames.end();
+    auto it = std::find_if(m_frames.begin(), end,
+                           [frame](const auto& f) { return f.first == frame; });
+    if (it == end)
+        return -1;
+
+    return it->second;
+}
+
+bool
+TimelineValidator::CommandProcessor::operator()(const ProcessPhase& command) const
+{
+    const TimelinePhase* phase = command.phase;
+    const auto end = m_validator.m_phases.end();
+    auto it = std::find_if(m_validator.m_phases.begin(), end,
+                           [phase](const auto& p) { return p.phase == phase; });
+
+    int PhaseStatus::*depthField;
+    const ReferenceFrame::SharedConstPtr& (TimelinePhase::*getFrame)() const;
+    switch (command.usage)
+    {
+    case FrameUsage::Position:
+        depthField = &PhaseStatus::positionDepth;
+        getFrame = &TimelinePhase::orbitFrame;
+        break;
+
+    case FrameUsage::Body:
+        depthField = &PhaseStatus::bodyDepth;
+        getFrame = &TimelinePhase::bodyFrame;
+        break;
+
+    default:
+        assert(0);
+        return false;
+    }
+
+    if (it == end)
+        m_validator.m_phases.emplace_back(phase).*depthField = TimelineValidator::Invalid;
+    else if (int& depth = (*it).*depthField; depth >= 0)
+        return true;
+    else if (depth == TimelineValidator::Invalid)
+        return false;
+    else
+        depth = TimelineValidator::Invalid;
+
+    m_validator.m_commands.emplace_back(FinishPhase { phase, command.usage });
+    m_validator.m_commands.emplace_back(ProcessFrame { (phase->*getFrame)().get() });
+
+    if (command.usage == FrameUsage::Position)
+    {
+        const Body* parentBody = phase->getFrameTree()->getOwner().body();
+        if (!parentBody)
+            return true;
+
+        const Timeline* parentTimeline = m_validator.getTimeline(parentBody);
+        for (unsigned int i = 0, nPhases = parentTimeline->phaseCount(); i < nPhases; ++i)
+        {
+            const TimelinePhase& parentPhase = parentTimeline->getPhase(i);
+            if (parentPhase.startTime() < phase->endTime() && parentPhase.endTime() > phase->startTime())
+                m_validator.m_commands.emplace_back(ProcessPhase { &parentPhase });
+        }
+    }
+
+    return true;
+}
+
+bool
+TimelineValidator::CommandProcessor::operator()(const FinishPhase& command) const
+{
+    const TimelinePhase* phase = command.phase;
+    const auto end = m_validator.m_phases.end();
+    auto it = std::find_if(m_validator.m_phases.begin(), end,
+                           [phase](const auto& p) { return p.phase == phase; });
+    if (it == end)
+    {
+        assert(0);
+        return false;
+    }
+
+    int PhaseStatus::*depthField;
+    const ReferenceFrame::SharedConstPtr& (TimelinePhase::*getFrame)() const;
+    switch (command.usage)
+    {
+    case FrameUsage::Position:
+        depthField = &PhaseStatus::positionDepth;
+        getFrame = &TimelinePhase::orbitFrame;
+        break;
+
+    case FrameUsage::Body:
+        depthField = &PhaseStatus::bodyDepth;
+        getFrame = &TimelinePhase::bodyFrame;
+        break;
+
+    default:
+        assert(0);
+        return false;
+    }
+
+    int maxDepth = m_validator.frameDepth((phase->*getFrame)().get());
+    if (maxDepth < 0)
+    {
+        assert(0);
+        return false;
+    }
+
+    if (command.usage == FrameUsage::Position)
+    {
+        if (int orbitDepth = m_validator.phaseDepth(phase); orbitDepth >= 0)
+        {
+            maxDepth += orbitDepth;
+        }
+        else
+        {
+            assert(0);
+            return false;
+        }
+    }
+
+    (*it).*depthField = maxDepth + 1;
+    return maxDepth < MaxFrameDepth;
+}
+
+bool
+TimelineValidator::CommandProcessor::operator()(const ProcessFrame& command) const
+{
+    const ReferenceFrame* frame = command.frame;
+    if (const auto end = m_validator.m_frames.cend(),
+        it = std::find_if(m_validator.m_frames.cbegin(), end,
+                          [frame](const auto& f) { return f.first == frame; });
+        it != end)
+    {
+        return it->second >= 0;
+    }
+
+    m_validator.m_frames.emplace_back(frame, -1);
+    m_validator.m_commands.emplace_back(FinishFrame { frame });
+    FrameProcessVisitor visitor(m_validator);
+    frame->visitChildren(visitor);
+    return visitor.status();
+}
+
+bool
+TimelineValidator::CommandProcessor::operator()(const FinishFrame& command) const
+{
+    const ReferenceFrame* frame = command.frame;
+    const auto end = m_validator.m_frames.end();
+    auto it = std::find_if(m_validator.m_frames.begin(), end,
+                           [frame](const auto& f) { return f.first == frame; });
+    if (it == end)
+    {
+        assert(0);
+        return false;
+    }
+
+    FrameFinishVisitor visitor(m_validator);
+    frame->visitChildren(visitor);
+    int depth = visitor.maxDepth();
+    if (depth < 0)
+    {
+        assert(0);
+        return false;
+    }
+
+    it->second = depth + 1;
+    return true;
+}
+
+void
+TimelineValidator::FrameProcessVisitor::visitPosition(const Selection& sel)
+{
+    const Body* body = TimelineValidator::getBody(sel);
+    if (!body)
+        return;
+
+    const Timeline* timeline = m_validator.getTimeline(body);
+    for (unsigned int i = 0, nPhases = timeline->phaseCount(); i < nPhases; ++i)
+        m_validator.m_commands.emplace_back(ProcessPhase { &timeline->getPhase(i), FrameUsage::Position });
+}
+
+void
+TimelineValidator::FrameProcessVisitor::visitBodyFrame(const Body* body, std::optional<double> t)
+{
+    const Timeline* timeline = m_validator.getTimeline(body);
+    if (t.has_value())
+    {
+        m_validator.m_commands.emplace_back(ProcessFrame { timeline->findPhase(*t).bodyFrame().get() });
+        return;
+    }
+
+    for (unsigned int i = 0, nPhases = timeline->phaseCount(); i < nPhases; ++i)
+        m_validator.m_commands.emplace_back(ProcessFrame { timeline->getPhase(i).bodyFrame().get() });
+}
+
+void
+TimelineValidator::FrameProcessVisitor::visitReferenceFrame(const ReferenceFrame* frame)
+{
+    m_validator.m_commands.emplace_back(ProcessFrame { frame });
+}
+
+void
+TimelineValidator::FrameFinishVisitor::visitPosition(const Selection& sel)
+{
+    if (m_maxDepth < 0)
+        return;
+
+    const Body* body = TimelineValidator::getBody(sel);
+    if (!body)
+        return;
+
+    const Timeline* timeline = m_validator.getTimeline(body);
+    for (unsigned int i = 0, nPhases = timeline->phaseCount(); i < nPhases; ++i)
+    {
+        int phaseDepth = m_validator.phaseDepth(&timeline->getPhase(i));
+        if (phaseDepth < 0)
+        {
+            assert(0);
+            m_maxDepth = -1;
+            return;
+        }
+
+        if (phaseDepth > m_maxDepth)
+            m_maxDepth = phaseDepth;
+    }
+}
+
+void
+TimelineValidator::FrameFinishVisitor::visitBodyFrame(const Body* body, std::optional<double> t)
+{
+    if (m_maxDepth < 0)
+        return;
+
+    int frameDepth;
+    const Timeline* timeline = m_validator.getTimeline(body);
+    if (t.has_value())
+    {
+        int frameDepth = m_validator.frameDepth(timeline->findPhase(*t).bodyFrame().get());
+        if (frameDepth < 0)
+        {
+            assert(0);
+            m_maxDepth = -1;
+            return;
+        }
+
+        if (frameDepth > m_maxDepth)
+            m_maxDepth = frameDepth;
+        return;
+    }
+
+    for (unsigned int i = 0, nPhases = timeline->phaseCount(); i < nPhases; ++i)
+    {
+        int frameDepth = m_validator.frameDepth(timeline->getPhase(i).bodyFrame().get());
+        if (frameDepth < 0)
+        {
+            assert(0);
+            m_maxDepth = -1;
+            return;
+        }
+
+        if (frameDepth > m_maxDepth)
+            m_maxDepth = frameDepth;
+    }
+}
+
+void
+TimelineValidator::FrameFinishVisitor::visitReferenceFrame(const ReferenceFrame* frame)
+{
+    if (m_maxDepth < 0)
+        return;
+
+    int depth = m_validator.frameDepth(frame);
+    if (depth < 0)
+    {
+        assert(0);
+        m_maxDepth = -1;
+    }
+
+    if (depth > m_maxDepth)
+        m_maxDepth = depth;
+}
 
 std::unique_ptr<Location>
 CreateLocation(const AssociativeArray* locationData,
@@ -446,6 +903,12 @@ CreateTimelineFromArray(Body* body,
         timeline->appendPhase(std::move(phase));
     }
 
+    if (!TimelineValidator(body, *timeline).validate())
+    {
+        GetLogger()->error("Frame depth limit exceeded for '{}'.\n", body->getName());
+        return nullptr;
+    }
+
     return timeline;
 }
 
@@ -535,7 +998,7 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     if (!newOrbit)
         newOrbit = CreateLongLat(*planetData, parentObject.body(), *orbitFrame);
 
-    if (newOrbit == nullptr && orbit == nullptr)
+    if (!newOrbit && !orbit)
     {
         if (body->getTimeline() && disposition == DataDisposition::Modify)
         {
@@ -555,7 +1018,7 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     }
 
     // If a new orbit was given, override any old orbit
-    if (newOrbit != nullptr)
+    if (newOrbit)
     {
         orbit = newOrbit;
         overrideOldTimeline = true;
@@ -590,56 +1053,44 @@ CreateLegacyTimeline(Body* body, //NOSONAR
     // Something went wrong if the disposition isn't modify and no timeline
     // is to be created.
     assert(disposition == DataDisposition::Modify || overrideOldTimeline);
+    if (!overrideOldTimeline)
+        return true;
 
-    if (overrideOldTimeline)
+    if (beginning >= ending)
     {
-        if (beginning >= ending)
-        {
-            GetLogger()->error("Beginning time must be before Ending time.\n");
-            return false;
-        }
-
-        // We finally have an orbit, rotation model, frames, and time range. Create
-        // the object timeline.
-        auto phase = TimelinePhase::CreateTimelinePhase(universe,
-                                                        body, parentObject,
-                                                        beginning, ending,
-                                                        frameCache->getFrame(*orbitFrame),
-                                                        orbit,
-                                                        frameCache->getFrame(*bodyFrame),
-                                                        rotationModel);
-
-        // We've already checked that beginning < ending; nothing else should go
-        // wrong during the creation of a TimelinePhase.
-        assert(phase != nullptr);
-        if (phase == nullptr)
-        {
-            GetLogger()->error("Internal error creating TimelinePhase.\n");
-            return false;
-        }
-
-        auto timeline = std::make_unique<Timeline>();
-        timeline->appendPhase(std::move(phase));
-
-        body->setTimeline(std::move(timeline));
-
-        // Check for circular references in frames; this can only be done once the timeline
-        // has actually been set.
-        // TIMELINE-TODO: This check is not comprehensive; it won't find recursion in
-        // multiphase timelines.
-        if (newOrbitFrame && isFrameCircular(*body->getOrbitFrame(0.0)))
-        {
-            GetLogger()->error("Orbit frame for '{}' is nested too deep (probably circular)\n", body->getName());
-            return false;
-        }
-
-        if (newBodyFrame && isFrameCircular(*body->getBodyFrame(0.0)))
-        {
-            GetLogger()->error("Body frame for '{}' is nested too deep (probably circular)\n", body->getName());
-            return false;
-        }
+        GetLogger()->error("Beginning time must be before Ending time.\n");
+        return false;
     }
 
+    // We finally have an orbit, rotation model, frames, and time range. Create
+    // the object timeline.
+    auto phase = TimelinePhase::CreateTimelinePhase(universe,
+                                                    body, parentObject,
+                                                    beginning, ending,
+                                                    frameCache->getFrame(*orbitFrame),
+                                                    orbit,
+                                                    frameCache->getFrame(*bodyFrame),
+                                                    rotationModel);
+
+    // We've already checked that beginning < ending; nothing else should go
+    // wrong during the creation of a TimelinePhase.
+    assert(phase != nullptr);
+    if (phase == nullptr)
+    {
+        GetLogger()->error("Internal error creating TimelinePhase.\n");
+        return false;
+    }
+
+    auto timeline = std::make_unique<Timeline>();
+    timeline->appendPhase(std::move(phase));
+
+    if (!TimelineValidator(body, *timeline).validate())
+    {
+        GetLogger()->error("Frame depth limit exceeded for '{}'.\n", body->getName());
+        return false;
+    }
+
+    body->setTimeline(std::move(timeline));
     return true;
 }
 

--- a/src/celengine/solarsys.h
+++ b/src/celengine/solarsys.h
@@ -17,6 +17,7 @@
 
 #include <Eigen/Core>
 
+class FrameCache;
 class FrameTree;
 class PlanetarySystem;
 class Star;
@@ -51,4 +52,5 @@ bool LoadSolarSystemObjects(std::istream& in,
                             Universe& universe,
                             const std::filesystem::path& dir,
                             celestia::engine::GeometryPaths& geometryPaths,
-                            celestia::engine::TexturePaths& texturePaths);
+                            celestia::engine::TexturePaths& texturePaths,
+                            FrameCache& frameCache);

--- a/src/celengine/timeline.cpp
+++ b/src/celengine/timeline.cpp
@@ -39,20 +39,16 @@ Timeline::findPhase(double t) const
     // nPhases = 1, so we special case that. Otherwise, we do a simple linear search,
     // as the number of phases in a timeline should always be quite small.
     if (phases.size() == 1)
-    {
         return *phases[0];
-    }
-    else
-    {
-        for (const auto& phase : phases)
-        {
-            if (t < phase->endTime())
-                return *phase;
-        }
 
-        // Time is greater than the end time of the final phase. Just return the final phase.
-        return *phases.back();
+    for (const auto& phase : phases)
+    {
+        if (t < phase->endTime())
+            return *phase;
     }
+
+    // Time is greater than the end time of the final phase. Just return the final phase.
+    return *phases.back();
 }
 
 /*! Get the phase at the specified index.

--- a/src/celengine/timelinephase.cpp
+++ b/src/celengine/timelinephase.cpp
@@ -54,7 +54,7 @@ TimelinePhase::~TimelinePhase()
 std::unique_ptr<TimelinePhase>
 TimelinePhase::CreateTimelinePhase(Universe& universe,
                                    Body* body,
-                                   Selection parent,
+                                   const Selection& parent,
                                    double startTime,
                                    double endTime,
                                    const ReferenceFrame::SharedConstPtr& orbitFrame,

--- a/src/celengine/timelinephase.cpp
+++ b/src/celengine/timelinephase.cpp
@@ -54,6 +54,7 @@ TimelinePhase::~TimelinePhase()
 std::unique_ptr<TimelinePhase>
 TimelinePhase::CreateTimelinePhase(Universe& universe,
                                    Body* body,
+                                   Selection parent,
                                    double startTime,
                                    double endTime,
                                    const ReferenceFrame::SharedConstPtr& orbitFrame,
@@ -68,14 +69,13 @@ TimelinePhase::CreateTimelinePhase(Universe& universe,
     // Get the frame tree to add the new phase to. Verify that the reference frame
     // center is either a star or solar system body.
     FrameTree* frameTree = nullptr;
-    Selection center = orbitFrame->getCenter();
-    if (center.body() != nullptr)
+    if (Body* parentBody = parent.body(); parentBody)
     {
-        frameTree = center.body()->getOrCreateFrameTree();
+        frameTree = parentBody->getOrCreateFrameTree();
     }
-    else if (center.star() != nullptr)
+    else if (Star* star = parent.star(); star)
     {
-        const SolarSystem* solarSystem = universe.getOrCreateSolarSystem(center.star());
+        const SolarSystem* solarSystem = universe.getOrCreateSolarSystem(star);
         frameTree = solarSystem->getFrameTree();
     }
     else

--- a/src/celengine/timelinephase.h
+++ b/src/celengine/timelinephase.h
@@ -13,7 +13,9 @@
 #pragma once
 
 #include <memory>
+
 #include "frame.h"
+#include "selection.h"
 
 class FrameTree;
 class Universe;
@@ -101,6 +103,7 @@ public:
     static std::unique_ptr<TimelinePhase>
     CreateTimelinePhase(Universe& universe,
                         Body* body,
+                        Selection parent,
                         double startTime,
                         double endTime,
                         const ReferenceFrame::SharedConstPtr& orbitFrame,

--- a/src/celengine/timelinephase.h
+++ b/src/celengine/timelinephase.h
@@ -103,7 +103,7 @@ public:
     static std::unique_ptr<TimelinePhase>
     CreateTimelinePhase(Universe& universe,
                         Body* body,
-                        Selection parent,
+                        const Selection& parent,
                         double startTime,
                         double endTime,
                         const ReferenceFrame::SharedConstPtr& orbitFrame,

--- a/src/celestia/CMakeLists.txt
+++ b/src/celestia/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CELESTIA_SOURCES
+  catalogloader.cpp
   catalogloader.h
   celestiacore.cpp
   celestiacore.h

--- a/src/celestia/catalogloader.cpp
+++ b/src/celestia/catalogloader.cpp
@@ -21,12 +21,8 @@
 namespace celestia
 {
 
-CatalogLoader::CatalogLoader(const std::string& typeDesc,
-                             const ContentType& contentType,
-                             ProgressNotifier* notifier,
+CatalogLoader::CatalogLoader(ProgressNotifier* notifier,
                              util::array_view<std::filesystem::path> skipPaths) :
-    m_typeDesc(typeDesc),
-    m_contentType(contentType),
     m_notifier(notifier),
     m_skipPaths(skipPaths)
 {
@@ -35,16 +31,16 @@ CatalogLoader::CatalogLoader(const std::string& typeDesc,
 void
 CatalogLoader::process(const std::filesystem::path &filePath, const std::filesystem::path &parentPath)
 {
-    if (DetermineFileType(filePath) != m_contentType)
+    if (DetermineFileType(filePath) != contentType())
         return;
 
     if (std::find(m_skipPaths.begin(), m_skipPaths.end(), filePath) != m_skipPaths.end())
     {
-        util::GetLogger()->info(_("Skipping {} catalog: {}\n"), m_typeDesc, filePath);
+        util::GetLogger()->info(_("Skipping {} catalog: {}\n"), typeDesc(), filePath);
         return;
     }
 
-    util::GetLogger()->info(_("Loading {} catalog: {}\n"), m_typeDesc, filePath);
+    util::GetLogger()->info(_("Loading {} catalog: {}\n"), typeDesc(), filePath);
     if (m_notifier)
         m_notifier->update(filePath.filename().string());
 
@@ -52,7 +48,7 @@ CatalogLoader::process(const std::filesystem::path &filePath, const std::filesys
         !catalogFile.good() || !load(catalogFile, parentPath))
     {
         util::GetLogger()->error(_("Error reading {} catalog file: {}\n"),
-                                    m_typeDesc,
+                                    typeDesc(),
                                     filePath);
     }
 }

--- a/src/celestia/catalogloader.cpp
+++ b/src/celestia/catalogloader.cpp
@@ -1,0 +1,88 @@
+// catalogloader.cpp
+//
+// Copyright (C) 2001-2026, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "catalogloader.h"
+
+#include <algorithm>
+#include <fstream>
+#include <system_error>
+
+#include <celutil/fsutils.h>
+#include <celutil/gettext.h>
+#include <celutil/logger.h>
+#include "progressnotifier.h"
+
+namespace celestia
+{
+
+CatalogLoader::CatalogLoader(const std::string& typeDesc,
+                             const ContentType& contentType,
+                             ProgressNotifier* notifier,
+                             util::array_view<std::filesystem::path> skipPaths) :
+    m_typeDesc(typeDesc),
+    m_contentType(contentType),
+    m_notifier(notifier),
+    m_skipPaths(skipPaths)
+{
+}
+
+void
+CatalogLoader::process(const std::filesystem::path &filePath, const std::filesystem::path &parentPath)
+{
+    if (DetermineFileType(filePath) != m_contentType)
+        return;
+
+    if (std::find(m_skipPaths.begin(), m_skipPaths.end(), filePath) != m_skipPaths.end())
+    {
+        util::GetLogger()->info(_("Skipping {} catalog: {}\n"), m_typeDesc, filePath);
+        return;
+    }
+
+    util::GetLogger()->info(_("Loading {} catalog: {}\n"), m_typeDesc, filePath);
+    if (m_notifier)
+        m_notifier->update(filePath.filename().string());
+
+    if (std::ifstream catalogFile(filePath);
+        !catalogFile.good() || !load(catalogFile, parentPath))
+    {
+        util::GetLogger()->error(_("Error reading {} catalog file: {}\n"),
+                                    m_typeDesc,
+                                    filePath);
+    }
+}
+
+void
+CatalogLoader::loadExtras(util::array_view<std::filesystem::path> dirs)
+{
+    std::vector<std::filesystem::path> entries;
+    std::error_code ec;
+    for (const auto &dir : dirs)
+    {
+        if (!util::IsValidDirectory(dir))
+            continue;
+
+        entries.clear();
+
+        for (auto iter = std::filesystem::recursive_directory_iterator(dir, ec); iter != std::filesystem::end(iter);
+             iter.increment(ec))
+        {
+            if (ec)
+                continue;
+            if (!std::filesystem::is_directory(iter->path(), ec))
+                entries.push_back(iter->path());
+        }
+
+        std::sort(std::begin(entries), std::end(entries));
+
+        for (const auto &fn : entries)
+            process(fn, fn.parent_path());
+    }
+}
+
+} // end namespace celestia

--- a/src/celestia/catalogloader.h
+++ b/src/celestia/catalogloader.h
@@ -11,7 +11,7 @@
 
 #include <iosfwd>
 #include <filesystem>
-#include <string>
+#include <string_view>
 
 #include <celutil/array_view.h>
 #include <celutil/filetype.h>
@@ -37,18 +37,15 @@ public:
     void loadExtras(util::array_view<std::filesystem::path> dirs);
 
 protected:
-    CatalogLoader(const std::string& typeDesc,
-                  const ContentType& contentType,
-                  ProgressNotifier* notifier,
+    CatalogLoader(ProgressNotifier* notifier,
                   util::array_view<std::filesystem::path> skipPaths);
 
+    virtual ContentType contentType() const = 0;
+    virtual std::string_view typeDesc() const = 0;
+
 private:
-    std::string m_typeDesc;
-    ContentType m_contentType;
     ProgressNotifier* m_notifier;
     util::array_view<std::filesystem::path> m_skipPaths;
-    engine::GeometryPaths* m_geometryPaths;
-    engine::TexturePaths* m_texturePaths;
 };
 
 } // namespace celestia

--- a/src/celestia/catalogloader.h
+++ b/src/celestia/catalogloader.h
@@ -1,4 +1,4 @@
-// catalogloader.h
+// catalogloader.cpp
 //
 // Copyright (C) 2001-2023, the Celestia Development Team
 //
@@ -9,16 +9,14 @@
 
 #pragma once
 
-#include <algorithm>
-#include <fstream>
+#include <iosfwd>
+#include <filesystem>
 #include <string>
 
-#include <celestia/progressnotifier.h>
 #include <celutil/array_view.h>
 #include <celutil/filetype.h>
-#include <celutil/fsutils.h>
-#include <celutil/gettext.h>
-#include <celutil/logger.h>
+
+class ProgressNotifier;
 
 namespace celestia
 {
@@ -28,84 +26,23 @@ class GeometryPaths;
 class TexturePaths;
 }
 
-template<class OBJDB> class CatalogLoader
+class CatalogLoader
 {
 public:
-    CatalogLoader(OBJDB* db,
-                  const std::string& typeDesc,
+    virtual ~CatalogLoader() = default;
+
+    virtual bool load(std::istream &in, const std::filesystem::path &dir) = 0;
+
+    void process(const std::filesystem::path &filePath, const std::filesystem::path &parentPath);
+    void loadExtras(util::array_view<std::filesystem::path> dirs);
+
+protected:
+    CatalogLoader(const std::string& typeDesc,
                   const ContentType& contentType,
                   ProgressNotifier* notifier,
-                  util::array_view<std::filesystem::path> skipPaths,
-                  engine::GeometryPaths& geometryPaths,
-                  engine::TexturePaths& texturePaths) :
-        m_objDB(db),
-        m_typeDesc(typeDesc),
-        m_contentType(contentType),
-        m_notifier(notifier),
-        m_skipPaths(skipPaths),
-        m_geometryPaths(&geometryPaths),
-        m_texturePaths(&texturePaths)
-    {
-    }
-
-    bool load(std::istream &in, const std::filesystem::path &dir)
-    {
-        return m_objDB->load(in, dir);
-    }
-
-    void process(const std::filesystem::path &filePath, const std::filesystem::path &parentPath)
-    {
-        if (DetermineFileType(filePath) != m_contentType)
-            return;
-
-        if (std::find(std::begin(m_skipPaths), std::end(m_skipPaths), filePath)
-            != std::end(m_skipPaths))
-        {
-            util::GetLogger()->info(_("Skipping {} catalog: {}\n"), m_typeDesc, filePath);
-            return;
-        }
-        util::GetLogger()->info(_("Loading {} catalog: {}\n"), m_typeDesc, filePath);
-        if (m_notifier != nullptr)
-            m_notifier->update(filePath.filename().string());
-
-        if (std::ifstream catalogFile(filePath);
-            !catalogFile.good() || !load(catalogFile, parentPath))
-        {
-            util::GetLogger()->error(_("Error reading {} catalog file: {}\n"),
-                                     m_typeDesc,
-                                     filePath);
-        }
-    }
-
-    void loadExtras(util::array_view<std::filesystem::path> dirs)
-    {
-        std::vector<std::filesystem::path> entries;
-        std::error_code       ec;
-        for (const auto &dir : dirs)
-        {
-            if (!util::IsValidDirectory(dir))
-                continue;
-
-            entries.clear();
-
-            for (auto iter = std::filesystem::recursive_directory_iterator(dir, ec); iter != end(iter);
-                 iter.increment(ec))
-            {
-                if (ec)
-                    continue;
-                if (!std::filesystem::is_directory(iter->path(), ec))
-                    entries.push_back(iter->path());
-            }
-
-            std::sort(std::begin(entries), std::end(entries));
-
-            for (const auto &fn : entries)
-                process(fn, fn.parent_path());
-        }
-    }
+                  util::array_view<std::filesystem::path> skipPaths);
 
 private:
-    OBJDB* m_objDB;
     std::string m_typeDesc;
     ContentType m_contentType;
     ProgressNotifier* m_notifier;

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -961,7 +961,7 @@ void CelestiaCore::charEntered(const char *c_p, int modifiers)
         break;
 
     case '\b':
-        sim->setSelection(sim->getSelection().parent());
+        sim->setSelection(sim->getSelection().nameParent());
         break;
 
     case '\014': // Ctrl+L

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -48,12 +48,15 @@
 #include <celengine/console.h>
 #include <celengine/framebuffer.h>
 #include <celengine/fisheyeprojectionmode.h>
+#include <celengine/frametree.h>
 #include <celengine/location.h>
 #include <celengine/overlay.h>
 #include <celengine/perspectiveprojectionmode.h>
 #include <celengine/planetgrid.h>
 #include <celengine/starname.h>
 #include <celengine/textlayout.h>
+#include <celengine/timeline.h>
+#include <celengine/timelinephase.h>
 #include <celengine/rectangle.h>
 #include <celengine/visibleregion.h>
 #include <celengine/warpmesh.h>
@@ -3164,7 +3167,7 @@ void CelestiaCore::toggleReferenceMark(const string& refMark, Selection sel)
     else if (refMark == "frame center direction")
     {
         double now = getSimulation()->getTime();
-        auto arrow = std::make_unique<BodyToBodyDirectionArrow>(*body, body->getOrbitFrame(now)->getCenter());
+        auto arrow = std::make_unique<BodyToBodyDirectionArrow>(*body, body->getTimeline()->findPhase(now).getFrameTree()->getOwner());
         arrow->setTag(refMark);
         bodyFeaturesManager->addReferenceMark(body, std::move(arrow));
     }
@@ -3179,7 +3182,7 @@ void CelestiaCore::toggleReferenceMark(const string& refMark, Selection sel)
         Body* b = body;
         while (b != nullptr)
         {
-            Selection center = b->getOrbitFrame(now)->getCenter();
+            Selection center = b->getTimeline()->findPhase(now).getFrameTree()->getOwner();
             if (center.star() != nullptr)
                 sun = center.star();
             b = center.body();

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2474,7 +2474,7 @@ bool CelestiaCore::initSimulation(const std::filesystem::path& configFileName,
 
     /***** Load the deep sky catalogs *****/
 
-    std::unique_ptr<DSODatabase> dsoCatalog = loadDSO(*config, progressNotifier, *geometryPaths, *texturePaths);
+    std::unique_ptr<DSODatabase> dsoCatalog = loadDSO(*config, progressNotifier, *geometryPaths);
     if (dsoCatalog == nullptr)
     {
         fatalError(_("Cannot read DSO database."), false);

--- a/src/celestia/eclipsefinder.cpp
+++ b/src/celestia/eclipsefinder.cpp
@@ -20,6 +20,7 @@
 #include <celengine/body.h>
 #include <celengine/frametree.h>
 #include <celengine/star.h>
+#include <celengine/timeline.h>
 #include <celengine/timelinephase.h>
 #include <celmath/distance.h>
 
@@ -46,57 +47,56 @@ testEclipse(const Body& receiver, const Body& caster, double now)
     // the receiver, as these shadows aren't likely to be relevant.  Also,
     // ignore eclipses where the caster is not an ellipsoid, since we can't
     // generate correct shadows in this case.
-    if (caster.getRadius() >= receiver.getRadius() * MinRelativeOccluderRadius &&
-        caster.isEllipsoid())
+    if (caster.getRadius() < receiver.getRadius() * MinRelativeOccluderRadius ||
+        !caster.isEllipsoid())
     {
-        // All of the eclipse related code assumes that both the caster
-        // and receiver are spherical.  Irregular receivers will work more
-        // or less correctly, but casters that are sufficiently non-spherical
-        // will produce obviously incorrect shadows.  Another assumption we
-        // make is that the distance between the caster and receiver is much
-        // less than the distance between the sun and the receiver.  This
-        // approximation works everywhere in the solar system, and likely
-        // works for any orbitally stable pair of objects orbiting a star.
-        Eigen::Vector3d posReceiver = receiver.getAstrocentricPosition(now);
-        Eigen::Vector3d posCaster = caster.getAstrocentricPosition(now);
-
-        const Star* sun = receiver.getSystem()->getStar();
-        assert(sun != nullptr);
-        double distToSun = posReceiver.norm();
-        float appSunRadius = (float) (sun->getRadius() / distToSun);
-
-        Eigen::Vector3d dir = posCaster - posReceiver;
-        double distToCaster = dir.norm() - receiver.getRadius();
-        float appOccluderRadius = (float) (caster.getRadius() / distToCaster);
-
-        // The shadow radius is the radius of the occluder plus some additional
-        // amount that depends upon the apparent radius of the sun.  For
-        // a sun that's distant/small and effectively a point, the shadow
-        // radius will be the same as the radius of the occluder.
-        float shadowRadius = (1 + appSunRadius / appOccluderRadius) *
-            caster.getRadius();
-
-        // Test whether a shadow is cast on the receiver.  We want to know
-        // if the receiver lies within the shadow volume of the caster.  Since
-        // we're assuming that everything is a sphere and the sun is far
-        // away relative to the caster, the shadow volume is a
-        // cylinder capped at one end.  Testing for the intersection of a
-        // singly capped cylinder is as simple as checking the distance
-        // from the center of the receiver to the axis of the shadow cylinder.
-        // If the distance is less than the sum of the caster's and receiver's
-        // radii, then we have an eclipse.
-        float R = receiver.getRadius() + shadowRadius;
-        double dist = math::distance(posReceiver, Eigen::ParametrizedLine<double, 3>(posCaster, posCaster));
-        if (dist < R)
-        {
-            // Ignore "eclipses" where the caster and receiver have
-            // intersecting bounding spheres.
-            if (distToCaster > caster.getRadius())
-                return true;
-        }
+        return false;
     }
 
-    return false;
+    // All of the eclipse related code assumes that both the caster
+    // and receiver are spherical.  Irregular receivers will work more
+    // or less correctly, but casters that are sufficiently non-spherical
+    // will produce obviously incorrect shadows.  Another assumption we
+    // make is that the distance between the caster and receiver is much
+    // less than the distance between the sun and the receiver.  This
+    // approximation works everywhere in the solar system, and likely
+    // works for any orbitally stable pair of objects orbiting a star.
+    Eigen::Vector3d posReceiver = receiver.getAstrocentricPosition(now);
+    Eigen::Vector3d posCaster = caster.getAstrocentricPosition(now);
+
+    const Star* sun = receiver.getTimeline()->findPhase(now).getFrameTree()->getRoot(now);
+    if (!sun)
+        return false;
+
+    double distToSun = posReceiver.norm();
+    float appSunRadius = (float) (sun->getRadius() / distToSun);
+
+    Eigen::Vector3d dir = posCaster - posReceiver;
+    double distToCaster = dir.norm() - receiver.getRadius();
+    float appOccluderRadius = (float) (caster.getRadius() / distToCaster);
+
+    // The shadow radius is the radius of the occluder plus some additional
+    // amount that depends upon the apparent radius of the sun.  For
+    // a sun that's distant/small and effectively a point, the shadow
+    // radius will be the same as the radius of the occluder.
+    float shadowRadius = (1 + appSunRadius / appOccluderRadius) *
+                         caster.getRadius();
+
+    // Test whether a shadow is cast on the receiver.  We want to know
+    // if the receiver lies within the shadow volume of the caster.  Since
+    // we're assuming that everything is a sphere and the sun is far
+    // away relative to the caster, the shadow volume is a
+    // cylinder capped at one end.  Testing for the intersection of a
+    // singly capped cylinder is as simple as checking the distance
+    // from the center of the receiver to the axis of the shadow cylinder.
+    // If the distance is less than the sum of the caster's and receiver's
+    // radii, then we have an eclipse.
+    float R = receiver.getRadius() + shadowRadius;
+    double dist = math::distance(posReceiver, Eigen::ParametrizedLine<double, 3>(posCaster, posCaster));
+
+    // Ignore "eclipses" where the caster and receiver have
+    // intersecting bounding spheres.
+    return dist < R && distToCaster > caster.getRadius();
 }
 
 double

--- a/src/celestia/eclipsefinder.cpp
+++ b/src/celestia/eclipsefinder.cpp
@@ -18,7 +18,9 @@
 #include <Eigen/Geometry>
 
 #include <celengine/body.h>
+#include <celengine/frametree.h>
 #include <celengine/star.h>
+#include <celengine/timelinephase.h>
 #include <celmath/distance.h>
 
 namespace math = celestia::math;
@@ -133,6 +135,17 @@ addEclipse(const Body& receiver, const Body& occulter,
     }
 }
 
+struct BodyInfo
+{
+    BodyInfo(const Body* _body, double _startTime, double _endTime) :
+        body(_body), startTime(_startTime), endTime(_endTime)
+    {}
+
+    const Body* body;
+    double startTime;
+    double endTime;
+};
+
 } // end unnamed namespace
 
 EclipseFinder::EclipseFinder(const Body* _body,
@@ -147,38 +160,54 @@ void EclipseFinder::findEclipses(double startDate,
                                  int eclipseTypeMask,
                                  std::vector<Eclipse>& eclipses)
 {
-    PlanetarySystem* satellites = body->getSatellites();
-
-    // See if there's anything that could test
-    if (satellites == nullptr)
-        return;
-
-    // For each body, we'll need to store the time when the last eclipse ended
-    std::vector<double> previousEclipseEndTimes;
-
-    // Make a list of satellites that we'll actually test for eclipses; ignore
-    // spacecraft and very small objects.
-    std::vector<Body*> testBodies;
-    for (int i = 0; i < satellites->getSystemSize(); i++)
+    const FrameTree* frameTree = body->getFrameTree();
+    if (!frameTree)
     {
-        Body* obj = satellites->getBody(i);
-        if (util::is_set(obj->getClassification(), EclipseObjectMask) &&
-            obj->getRadius() >= body->getRadius() * MinRelativeOccluderRadius)
+        // no satellites, bail out
+        return;
+    }
+
+    // For each body, store the start and end time of the unprocessed window
+    std::vector<BodyInfo> testBodies;
+    for (unsigned int i = 0, nPhases = frameTree->childCount(); i < nPhases; ++i)
+    {
+        const auto* phase = frameTree->getChild(i);
+        if (phase->startTime() > endDate || phase->endTime() <= startDate)
+            continue;
+
+        double phaseStart = std::max(startDate, phase->startTime());
+        double phaseEnd = std::min(endDate, phase->endTime());
+
+        if (phaseEnd <= phaseStart)
+            continue;
+
+        const Body* body = phase->body();
+        auto it = std::find_if(testBodies.begin(), testBodies.end(),
+                               [body](const BodyInfo& info) { return info.body == body; });
+        if (it == testBodies.end())
         {
-            testBodies.push_back(obj);
-            previousEclipseEndTimes.push_back(startDate - 1.0);
+            testBodies.emplace_back(body, phaseStart, phaseEnd);
+        }
+        else
+        {
+            it->startTime = std::min(it->startTime, phaseStart);
+            it->endTime = std::max(it->endTime, phaseEnd);
         }
     }
 
     if (testBodies.empty())
         return;
 
+    std::vector<double> previousEclipseEndTimes(testBodies.size());
+    std::transform(testBodies.cbegin(), testBodies.cend(), previousEclipseEndTimes.begin(),
+                   [](const BodyInfo& info) { return info.startTime - 1.0; });
+
     // TODO: Use a fixed step of one hour for now; we should use a binary
     // search instead.
-    double searchStep = 1.0 / 24.0; // one hour
+    constexpr double searchStep = 1.0 / 24.0; // one hour
 
     // Precision of eclipse duration calculation
-    double durationPrecision = 1.0 / (24.0 * 360.0); // ten seconds
+    constexpr double durationPrecision = 1.0 / (24.0 * 360.0); // ten seconds
 
     for (double t = startDate; t <= endDate; t += searchStep)
     {
@@ -188,18 +217,20 @@ void EclipseFinder::findEclipses(double startDate,
                 return;
         }
 
-        for (unsigned int i = 0; i < testBodies.size(); i++)
+        for (unsigned int i = 0; i < testBodies.size(); ++i)
         {
+            const BodyInfo& info = testBodies[i];
+
             // Only test for an eclipse if we're not in the middle of
             // of previous one.
-            if (t <= previousEclipseEndTimes[i])
+            if (t < info.startTime || t >= info.endTime || t <= previousEclipseEndTimes[i])
                 continue;
 
             if (eclipseTypeMask & Eclipse::Solar)
-                addEclipse(*body, *testBodies[i], t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
+                addEclipse(*body, *testBodies[i].body, t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
 
             if (eclipseTypeMask & Eclipse::Lunar)
-                addEclipse(*testBodies[i], *body, t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
+                addEclipse(*testBodies[i].body, *body, t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
         }
     }
 }

--- a/src/celestia/eclipsefinder.cpp
+++ b/src/celestia/eclipsefinder.cpp
@@ -155,7 +155,7 @@ EclipseFinder::EclipseFinder(const Body* _body,
 {
 }
 
-void EclipseFinder::findEclipses(double startDate,
+void EclipseFinder::findEclipses(double startDate, //NOSONAR
                                  double endDate,
                                  int eclipseTypeMask,
                                  std::vector<Eclipse>& eclipses)
@@ -181,12 +181,12 @@ void EclipseFinder::findEclipses(double startDate,
         if (phaseEnd <= phaseStart)
             continue;
 
-        const Body* body = phase->body();
+        const Body* testBody = phase->body();
         auto it = std::find_if(testBodies.begin(), testBodies.end(),
-                               [body](const BodyInfo& info) { return info.body == body; });
+                               [testBody](const BodyInfo& info) { return info.body == testBody; });
         if (it == testBodies.end())
         {
-            testBodies.emplace_back(body, phaseStart, phaseEnd);
+            testBodies.emplace_back(testBody, phaseStart, phaseEnd);
         }
         else
         {
@@ -227,10 +227,10 @@ void EclipseFinder::findEclipses(double startDate,
                 continue;
 
             if (eclipseTypeMask & Eclipse::Solar)
-                addEclipse(*body, *testBodies[i].body, t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
+                addEclipse(*body, *info.body, t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
 
             if (eclipseTypeMask & Eclipse::Lunar)
-                addEclipse(*testBodies[i].body, *body, t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
+                addEclipse(*info.body, *body, t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
         }
     }
 }

--- a/src/celestia/loaddso.cpp
+++ b/src/celestia/loaddso.cpp
@@ -29,13 +29,9 @@ class DeepSkyLoader final : public CatalogLoader
 public:
     DeepSkyLoader(DSODatabaseBuilder& db,
                   ProgressNotifier* notifier,
-                  util::array_view<std::filesystem::path> skipPaths,
-                  engine::GeometryPaths& geometryPaths,
-                  engine::TexturePaths& texturePaths) :
+                  util::array_view<std::filesystem::path> skipPaths) :
         CatalogLoader(notifier, skipPaths),
-        m_db(&db),
-        m_geometryPaths(&geometryPaths),
-        m_texturePaths(&texturePaths)
+        m_db(&db)
     {
     }
 
@@ -56,8 +52,6 @@ protected:
 
 private:
     DSODatabaseBuilder* m_db;
-    engine::GeometryPaths* m_geometryPaths;
-    engine::TexturePaths* m_texturePaths;
 };
 
 }
@@ -65,16 +59,13 @@ private:
 std::unique_ptr<DSODatabase>
 loadDSO(const CelestiaConfig& config,
         ProgressNotifier* progressNotifier,
-        engine::GeometryPaths& geometryPaths,
-        engine::TexturePaths& texturePaths)
+        engine::GeometryPaths& geometryPaths)
 {
     auto dsoDB = std::make_unique<DSODatabaseBuilder>(geometryPaths);
 
     DeepSkyLoader loader(*dsoDB,
                          progressNotifier,
-                         config.paths.skipExtras,
-                         geometryPaths,
-                         texturePaths);
+                         config.paths.skipExtras);
 
     // Load first the vector of dsoCatalogFiles in the data directory (deepsky.dsc,
     // globulars.dsc, ...):

--- a/src/celestia/loaddso.cpp
+++ b/src/celestia/loaddso.cpp
@@ -24,17 +24,15 @@ namespace celestia
 namespace
 {
 
-class DeepSkyLoader : public CatalogLoader
+class DeepSkyLoader final : public CatalogLoader
 {
 public:
     DeepSkyLoader(DSODatabaseBuilder& db,
-                  const std::string& typeDesc,
-                  const ContentType& contentType,
                   ProgressNotifier* notifier,
                   util::array_view<std::filesystem::path> skipPaths,
                   engine::GeometryPaths& geometryPaths,
                   engine::TexturePaths& texturePaths) :
-        CatalogLoader(typeDesc, contentType, notifier, skipPaths),
+        CatalogLoader(notifier, skipPaths),
         m_db(&db),
         m_geometryPaths(&geometryPaths),
         m_texturePaths(&texturePaths)
@@ -44,6 +42,16 @@ public:
     bool load(std::istream &in, const std::filesystem::path &dir) override
     {
         return m_db->load(in, dir);
+    }
+
+protected:
+    ContentType contentType() const override { return ContentType::CelestiaDeepSkyCatalog; }
+
+    std::string_view typeDesc() const override
+    {
+        // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
+        const char *typeDesc = C_("catalog", "deep sky");
+        return typeDesc;
     }
 
 private:
@@ -62,12 +70,7 @@ loadDSO(const CelestiaConfig& config,
 {
     auto dsoDB = std::make_unique<DSODatabaseBuilder>(geometryPaths);
 
-    // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
-    const char *typeDesc = C_("catalog", "deep sky");
-
     DeepSkyLoader loader(*dsoDB,
-                         typeDesc,
-                         ContentType::CelestiaDeepSkyCatalog,
                          progressNotifier,
                          config.paths.skipExtras,
                          geometryPaths,

--- a/src/celestia/loaddso.cpp
+++ b/src/celestia/loaddso.cpp
@@ -21,7 +21,38 @@
 
 namespace celestia
 {
-using DeepSkyLoader = CatalogLoader<DSODatabaseBuilder>;
+namespace
+{
+
+class DeepSkyLoader : public CatalogLoader
+{
+public:
+    DeepSkyLoader(DSODatabaseBuilder& db,
+                  const std::string& typeDesc,
+                  const ContentType& contentType,
+                  ProgressNotifier* notifier,
+                  util::array_view<std::filesystem::path> skipPaths,
+                  engine::GeometryPaths& geometryPaths,
+                  engine::TexturePaths& texturePaths) :
+        CatalogLoader(typeDesc, contentType, notifier, skipPaths),
+        m_db(&db),
+        m_geometryPaths(&geometryPaths),
+        m_texturePaths(&texturePaths)
+    {
+    }
+
+    bool load(std::istream &in, const std::filesystem::path &dir) override
+    {
+        return m_db->load(in, dir);
+    }
+
+private:
+    DSODatabaseBuilder* m_db;
+    engine::GeometryPaths* m_geometryPaths;
+    engine::TexturePaths* m_texturePaths;
+};
+
+}
 
 std::unique_ptr<DSODatabase>
 loadDSO(const CelestiaConfig& config,
@@ -34,7 +65,7 @@ loadDSO(const CelestiaConfig& config,
     // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
     const char *typeDesc = C_("catalog", "deep sky");
 
-    DeepSkyLoader loader(dsoDB.get(),
+    DeepSkyLoader loader(*dsoDB,
                          typeDesc,
                          ContentType::CelestiaDeepSkyCatalog,
                          progressNotifier,

--- a/src/celestia/loaddso.h
+++ b/src/celestia/loaddso.h
@@ -25,7 +25,6 @@ class TexturePaths;
 
 std::unique_ptr<DSODatabase> loadDSO(const CelestiaConfig& config,
                                      ProgressNotifier* progressNotifier,
-                                     engine::GeometryPaths& geometryPaths,
-                                     engine::TexturePaths& texturePaths);
+                                     engine::GeometryPaths& geometryPaths);
 
 } // namespace celestia

--- a/src/celestia/loadsso.cpp
+++ b/src/celestia/loadsso.cpp
@@ -25,18 +25,16 @@ namespace celestia
 namespace
 {
 
-class SolarSystemLoader : public CatalogLoader
+class SolarSystemLoader final : public CatalogLoader
 {
 public:
     SolarSystemLoader(Universe* universe,
-                      const std::string& typeDesc,
-                      const ContentType& contentType,
                       ProgressNotifier* notifier,
                       util::array_view<std::filesystem::path> skipPaths,
                       engine::GeometryPaths& geometryPaths,
                       engine::TexturePaths& texturePaths,
                       FrameCache& frameCache) :
-        CatalogLoader(typeDesc, contentType, notifier, skipPaths),
+        CatalogLoader(notifier, skipPaths),
         m_universe(universe),
         m_geometryPaths(&geometryPaths),
         m_texturePaths(&texturePaths),
@@ -47,6 +45,16 @@ public:
     bool load(std::istream &in, const std::filesystem::path &dir) override
     {
         return LoadSolarSystemObjects(in, *m_universe, dir, *m_geometryPaths, *m_texturePaths, *m_frameCache);
+    }
+
+protected:
+    ContentType contentType() const override { return ContentType::CelestiaCatalog; }
+
+    std::string_view typeDesc() const override
+    {
+        // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
+        const char *typeDesc = C_("catalog", "solar system");
+        return typeDesc;
     }
 
 private:
@@ -68,14 +76,9 @@ loadSSO(const CelestiaConfig &config,
     auto solarSystem = std::make_unique<SolarSystemCatalog>();
     universe->setSolarSystemCatalog(std::move(solarSystem));
 
-    // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
-    const char *typeDesc = C_("catalog", "solar system");
-
     FrameCache frameCache;
 
     SolarSystemLoader loader(universe,
-                             typeDesc,
-                             ContentType::CelestiaCatalog,
                              progressNotifier,
                              config.paths.skipExtras,
                              geometryPaths,

--- a/src/celestia/loadsso.cpp
+++ b/src/celestia/loadsso.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <memory>
 
+#include <celengine/frame.h>
 #include <celengine/universe.h>
 #include <celestia/configfile.h>
 #include <celestia/progressnotifier.h>
@@ -21,13 +22,41 @@
 namespace celestia
 {
 
-using SolarSystemLoader = CatalogLoader<Universe>;
-
-template<> bool
-CatalogLoader<Universe>::load(std::istream &in, const std::filesystem::path &dir)
+namespace
 {
-    return LoadSolarSystemObjects(in, *m_objDB, dir, *m_geometryPaths, *m_texturePaths);
-}
+
+class SolarSystemLoader : public CatalogLoader
+{
+public:
+    SolarSystemLoader(Universe* universe,
+                      const std::string& typeDesc,
+                      const ContentType& contentType,
+                      ProgressNotifier* notifier,
+                      util::array_view<std::filesystem::path> skipPaths,
+                      engine::GeometryPaths& geometryPaths,
+                      engine::TexturePaths& texturePaths,
+                      FrameCache& frameCache) :
+        CatalogLoader(typeDesc, contentType, notifier, skipPaths),
+        m_universe(universe),
+        m_geometryPaths(&geometryPaths),
+        m_texturePaths(&texturePaths),
+        m_frameCache(&frameCache)
+    {
+    }
+
+    bool load(std::istream &in, const std::filesystem::path &dir) override
+    {
+        return LoadSolarSystemObjects(in, *m_universe, dir, *m_geometryPaths, *m_texturePaths, *m_frameCache);
+    }
+
+private:
+    Universe* m_universe;
+    engine::GeometryPaths* m_geometryPaths;
+    engine::TexturePaths* m_texturePaths;
+    FrameCache* m_frameCache;
+};
+
+} // end unnamed namespace
 
 void
 loadSSO(const CelestiaConfig &config,
@@ -42,13 +71,16 @@ loadSSO(const CelestiaConfig &config,
     // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
     const char *typeDesc = C_("catalog", "solar system");
 
+    FrameCache frameCache;
+
     SolarSystemLoader loader(universe,
                              typeDesc,
                              ContentType::CelestiaCatalog,
                              progressNotifier,
                              config.paths.skipExtras,
                              geometryPaths,
-                             texturePaths);
+                             texturePaths,
+                             frameCache);
 
     // First read the solar system files listed individually in the config file.
     std::filesystem::path empty;

--- a/src/celestia/loadstars.cpp
+++ b/src/celestia/loadstars.cpp
@@ -31,13 +31,9 @@ class StarLoader final : public CatalogLoader
 public:
     StarLoader(StarDatabaseBuilder& db,
                ProgressNotifier* notifier,
-               util::array_view<std::filesystem::path> skipPaths,
-               engine::GeometryPaths& geometryPaths,
-               engine::TexturePaths& texturePaths) :
+               util::array_view<std::filesystem::path> skipPaths) :
         CatalogLoader(notifier, skipPaths),
-        m_db(&db),
-        m_geometryPaths(&geometryPaths),
-        m_texturePaths(&texturePaths)
+        m_db(&db)
     {
     }
 
@@ -58,8 +54,6 @@ protected:
 
 private:
     StarDatabaseBuilder* m_db;
-    engine::GeometryPaths* m_geometryPaths;
-    engine::TexturePaths* m_texturePaths;
 };
 
 void
@@ -132,9 +126,7 @@ loadStars(const CelestiaConfig &config,
 
     StarLoader loader(starDBBuilder,
                       progressNotifier,
-                      config.paths.skipExtras,
-                      geometryPaths,
-                      texturePaths);
+                      config.paths.skipExtras);
 
     // Next, read any ASCII star catalog files specified in the StarCatalogs list.
     std::filesystem::path empty;

--- a/src/celestia/loadstars.cpp
+++ b/src/celestia/loadstars.cpp
@@ -23,10 +23,36 @@
 namespace celestia
 {
 
-using StarLoader = CatalogLoader<StarDatabaseBuilder>;
-
 namespace
 {
+
+class StarLoader : public CatalogLoader
+{
+public:
+    StarLoader(StarDatabaseBuilder& db,
+               const std::string& typeDesc,
+               const ContentType& contentType,
+               ProgressNotifier* notifier,
+               util::array_view<std::filesystem::path> skipPaths,
+               engine::GeometryPaths& geometryPaths,
+               engine::TexturePaths& texturePaths) :
+        CatalogLoader(typeDesc, contentType, notifier, skipPaths),
+        m_db(&db),
+        m_geometryPaths(&geometryPaths),
+        m_texturePaths(&texturePaths)
+    {
+    }
+
+    bool load(std::istream &in, const std::filesystem::path &dir) override
+    {
+        return m_db->load(in, dir);
+    }
+
+private:
+    StarDatabaseBuilder* m_db;
+    engine::GeometryPaths* m_geometryPaths;
+    engine::TexturePaths* m_texturePaths;
+};
 
 void
 loadCrossIndex(StarNameDatabase& starNamesDB, StarCatalog catalog, const std::filesystem::path &filename)
@@ -99,7 +125,7 @@ loadStars(const CelestiaConfig &config,
     // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
     const char *typeDesc = C_("catalog", "star");
 
-    StarLoader loader(&starDBBuilder,
+    StarLoader loader(starDBBuilder,
                       typeDesc,
                       ContentType::CelestiaStarCatalog,
                       progressNotifier,

--- a/src/celestia/loadstars.cpp
+++ b/src/celestia/loadstars.cpp
@@ -26,17 +26,15 @@ namespace celestia
 namespace
 {
 
-class StarLoader : public CatalogLoader
+class StarLoader final : public CatalogLoader
 {
 public:
     StarLoader(StarDatabaseBuilder& db,
-               const std::string& typeDesc,
-               const ContentType& contentType,
                ProgressNotifier* notifier,
                util::array_view<std::filesystem::path> skipPaths,
                engine::GeometryPaths& geometryPaths,
                engine::TexturePaths& texturePaths) :
-        CatalogLoader(typeDesc, contentType, notifier, skipPaths),
+        CatalogLoader(notifier, skipPaths),
         m_db(&db),
         m_geometryPaths(&geometryPaths),
         m_texturePaths(&texturePaths)
@@ -46,6 +44,16 @@ public:
     bool load(std::istream &in, const std::filesystem::path &dir) override
     {
         return m_db->load(in, dir);
+    }
+
+protected:
+    ContentType contentType() const override { return ContentType::CelestiaStarCatalog; }
+
+    std::string_view typeDesc() const override
+    {
+        // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
+        const char *typeDesc = C_("catalog", "star");
+        return typeDesc;
     }
 
 private:
@@ -122,12 +130,7 @@ loadStars(const CelestiaConfig &config,
 
     starDBBuilder.setNameDatabase(std::move(starNameDB));
 
-    // TRANSLATORS: this is a part of phrases "Loading {} catalog", "Skipping {} catalog"
-    const char *typeDesc = C_("catalog", "star");
-
     StarLoader loader(starDBBuilder,
-                      typeDesc,
-                      ContentType::CelestiaStarCatalog,
                       progressNotifier,
                       config.paths.skipExtras,
                       geometryPaths,

--- a/src/celestia/qt/qtselectionpopup.cpp
+++ b/src/celestia/qt/qtselectionpopup.cpp
@@ -28,11 +28,14 @@
 #include <QString>
 
 #include <celengine/body.h>
+#include <celengine/frametree.h>
 #include <celengine/marker.h>
 #include <celengine/render.h>
 #include <celengine/selection.h>
 #include <celengine/simulation.h>
 #include <celengine/solarsys.h>
+#include <celengine/timeline.h>
+#include <celengine/timelinephase.h>
 #include <celestia/celestiacore.h>
 #include <celestia/helper.h>
 #include <celutil/gettext.h>
@@ -320,7 +323,7 @@ SelectionPopup::createReferenceVectorMenu()
     connect(spinVectorAction, SIGNAL(triggered()), this, SLOT(slotToggleSpinVector()));
     refVecMenu->addAction(spinVectorAction);
 
-    Selection center = body->getOrbitFrame(appCore->getSimulation()->getTime())->getCenter();
+    Selection center = body->getTimeline()->findPhase(appCore->getSimulation()->getTime()).getFrameTree()->getOwner();
     if (center.body() != nullptr)
     {
         // Only show the frame center menu item if the selection orbits another

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -16,6 +16,7 @@
 #include <celengine/atmosphere.h>
 #include <celengine/axisarrow.h>
 #include <celengine/body.h>
+#include <celengine/frametree.h>
 #include <celengine/location.h>
 #include <celengine/planetgrid.h>
 #include <celengine/timeline.h>
@@ -1138,8 +1139,8 @@ static int object_orbitframe(lua_State* l)
     }
     else
     {
-        const auto& f = sel->body()->getOrbitFrame(t);
-        celx.newFrame(ObserverFrame(f));
+        const auto& phase = sel->body()->getTimeline()->findPhase(t);
+        celx.newFrame(ObserverFrame(phase.getFrameTree()->getOwner(), phase.orbitFrame()));
     }
 
     return 1;
@@ -1180,7 +1181,7 @@ static int object_bodyframe(lua_State* l)
     else
     {
         const auto& f = sel->body()->getBodyFrame(t);
-        celx.newFrame(ObserverFrame(f));
+        celx.newFrame(ObserverFrame(sel->body(), f));
     }
 
     return 1;

--- a/src/celscript/lua/celx_phase.cpp
+++ b/src/celscript/lua/celx_phase.cpp
@@ -13,6 +13,7 @@
 #include "celx.h"
 #include "celx_internal.h"
 #include "celx_phase.h"
+#include <celengine/frametree.h>
 #include <celengine/timelinephase.h>
 #include <celephem/orbit.h>
 #include <celephem/rotation.h>
@@ -95,8 +96,7 @@ static int phase_orbitframe(lua_State* l)
     celx.checkArgs(1, 1, "No arguments allowed for to phase:orbitframe");
 
     auto phase = this_phase(l);
-    auto f = phase->orbitFrame();
-    celx.newFrame(ObserverFrame(f));
+    celx.newFrame(ObserverFrame(phase->getFrameTree()->getOwner(), phase->orbitFrame()));
 
     return 1;
 }
@@ -113,8 +113,7 @@ static int phase_bodyframe(lua_State* l)
     celx.checkArgs(1, 1, "No arguments allowed for to phase:bodyframe");
 
     auto phase = this_phase(l);
-    const auto& f = phase->bodyFrame();
-    celx.newFrame(ObserverFrame(f));
+    celx.newFrame(ObserverFrame(phase->body(), phase->bodyFrame()));
 
     return 1;
 }


### PR DESCRIPTION
Removes the center property from the `ReferenceFrame` object. This property was only used for orbit frames, removing it allows us to more aggressively share the reference frames. E.g. there is only one instance of the `J2000EclipticFrame`.

This enables a new syntax where the `Center` of a reference frame can be specified in the `OrbitFrame` block itself. Non-OrbitFrame uses of ReferenceFrames (`BodyFrame`, `ConstVector` frames in `TwoVector` frames) will ignore the Center and should now allow specifying without the `Center`.

For future optimization, i.e. not for this PR: convert reference frames to constant vector frames at startup.

While fixing this, I ran into the issue that several places in the code are using the name tree hierarchy instead of the frame tree hierarchy to determine object parents.

Annoyingly celx treats all frames as ObserverFrame (which allows for doing stuff like setting the observer frame to an object's orbit frame), too late to fix that now. For the purposes of celx, the center of a body frame is always taken to be the body itself.

- [x] Reimplement the circular references check, ensuring it works for timelines
- [x] Fix remaining places where name hierarchy parents (via `PlanetarySystem`) are used
- [x] More tests to verify the syntax still works (done locally by editing cassini.ssc, automation is somewhat tricky at the moment)
- [x] Earth works
- [x] Pluto-Charon barycenter works
- [x] Gamma Cephei Ab works