### PR TITLE
Make default font paths localizable

### DIFF
--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -238,9 +238,9 @@ StarTextures
 # TitleFont: Used to display object names, messages, and script text.
 #            Default "DejaVuSans-Bold.ttf,15"
 #------------------------------------------------------------------------
-  Font       "DejaVuSans.ttf,9"
-  LabelFont  "DejaVuSans.ttf,9"
-  TitleFont  "DejaVuSans-Bold.ttf,15"
+#  Font       "DejaVuSans.ttf,9"
+#  LabelFont  "DejaVuSans.ttf,9"
+#  TitleFont  "DejaVuSans-Bold.ttf,15"
 
 
 #------------------------------------------------------------------------

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2617,13 +2617,20 @@ LoadFontHelper(const Renderer* renderer,
                const char* defaultKey,
                const std::filesystem::path& defaultPath)
 {
-    std::filesystem::path fontPath = configPath;
-    if (fontPath.empty())
+    if (!configPath.empty())
     {
-        const char* translated = _(defaultKey);
-        fontPath = translated == defaultKey ? defaultPath : translated;
+        if (auto font = LoadTextureFont(
+                renderer,
+                configPath.is_absolute() ? configPath : std::filesystem::path("fonts") / configPath);
+            font != nullptr)
+        {
+            return font;
+        }
     }
 
+    // Reading default font as fallback
+    const char* translated = _(defaultKey);
+    std::filesystem::path fontPath = translated == defaultKey ? defaultPath : translated;
     return LoadTextureFont(renderer, fontPath.is_absolute() ? fontPath : std::filesystem::path("fonts") / fontPath);
 }
 

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2612,16 +2612,19 @@ bool CelestiaCore::initSimulation(const std::filesystem::path& configFileName,
 }
 
 static std::shared_ptr<TextureFont>
-LoadFontHelper(const Renderer *renderer, const std::filesystem::path &p)
+LoadFontHelper(const Renderer* renderer,
+               const std::filesystem::path& configPath,
+               const char* defaultKey,
+               const std::filesystem::path& defaultPath)
 {
-    if (p.is_absolute())
-        return LoadTextureFont(renderer, p);
+    std::filesystem::path fontPath = configPath;
+    if (fontPath.empty())
+    {
+        const char* translated = _(defaultKey);
+        fontPath = translated == defaultKey ? defaultPath : translated;
+    }
 
-    int index = 0;
-    int size = TextureFont::kDefaultSize;
-    std::filesystem::path path = LocaleFilename(ParseFontName(std::filesystem::path("fonts") / p, index, size));
-
-    return LoadTextureFont(renderer, path, index, size);
+    return LoadTextureFont(renderer, fontPath.is_absolute() ? fontPath : std::filesystem::path("fonts") / fontPath);
 }
 
 bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
@@ -2689,15 +2692,13 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
         setFaintestAutoMag();
     }
 
-    auto mainFont = config->fonts.mainFont.empty()
-                ? LoadFontHelper(renderer, "DejaVuSans.ttf,12")
-                : LoadFontHelper(renderer, config->fonts.mainFont);
+    auto mainFont = LoadFontHelper(renderer, config->fonts.mainFont, N_("DEFAULT_MAIN_FONT"), "DejaVuSans.ttf,9");
     if (mainFont != nullptr)
         hud->font(mainFont);
     else
         std::cout << _("Error loading font; text will not be visible.\n");
 
-    if (auto titleFont = config->fonts.titleFont.empty() ? nullptr : LoadFontHelper(renderer, config->fonts.titleFont);
+    if (auto titleFont = LoadFontHelper(renderer, config->fonts.titleFont, N_("DEFAULT_TITLE_FONT"), "DejaVuSans-Bold.ttf,15");
         titleFont != nullptr)
     {
         hud->titleFont(titleFont);
@@ -2723,7 +2724,7 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
     }
     else
     {
-        auto labelFont = LoadFontHelper(renderer, config->fonts.labelFont);
+        auto labelFont = LoadFontHelper(renderer, config->fonts.labelFont, N_("DEFAULT_LABEL_FONT"), "DejaVuSans.ttf,9");
         renderer->setFont(Renderer::FontStyle::Normal, labelFont == nullptr ? hud->font() : labelFont);
     }
 

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -293,7 +293,7 @@ TextureFontPrivate::loadFont(const std::filesystem::path &filename, int index, i
     int   screenDpi = m_renderer->getScreenDpi();
     auto  face      = LoadFontFace(ftlib, filename,
                                    index,
-                                   scale * static_cast<float>(size),
+                                   static_cast<int>(scale * static_cast<float>(size)),
                                    screenDpi);
     if (face == nullptr)
         return false;

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -291,12 +291,9 @@ TextureFontPrivate::loadFont(const std::filesystem::path &filename, int index, i
 
     float scale     = m_renderer->getTextScaleFactor();
     int   screenDpi = m_renderer->getScreenDpi();
-    int   psize     = TextureFont::kDefaultSize;
-    int   pindex    = 0;
-    auto  nameonly  = ParseFontName(filename, pindex, psize);
-    auto  face      = LoadFontFace(ftlib, nameonly,
-                                   index > 0 ? index : 0,
-                                   static_cast<int>(scale * static_cast<float>(size > 0 ? size : psize)),
+    auto  face      = LoadFontFace(ftlib, filename,
+                                   index,
+                                   scale * static_cast<float>(size),
                                    screenDpi);
     if (face == nullptr)
         return false;
@@ -782,22 +779,29 @@ template<> struct std::hash<FontCacheKey>
 using FontCache = std::unordered_map<FontCacheKey, std::weak_ptr<TextureFont>>;
 
 std::shared_ptr<TextureFont>
-LoadTextureFont(const Renderer *r, const std::filesystem::path &filename, int index, int size)
+LoadTextureFont(const Renderer *r, const std::filesystem::path &filename, std::optional<int> index, std::optional<int> size)
 {
     // Init FontCache
     static FontCache *fontCache = nullptr;
     if (fontCache == nullptr)
         fontCache = new FontCache;
 
+    int  parsedIndex = 0;
+    int  parsedSize  = TextureFont::kDefaultSize;
+    auto path        = ParseFontName(filename, parsedIndex, parsedSize);
+
+    parsedIndex = index.value_or(parsedIndex);
+    parsedSize  = size.value_or(parsedSize);
+
     // Lookup for an existing cached font
-    std::weak_ptr<TextureFont> &font = (*fontCache)[{ filename, index, size }];
+    std::weak_ptr<TextureFont> &font = (*fontCache)[{ path, parsedIndex, parsedSize }];
     std::shared_ptr<TextureFont> ret = font.lock();
     if (ret == nullptr)
     {
         ret = std::make_shared<TextureFont>(r);
-        if (!ret->impl->loadFont(filename, index, size))
+        if (!ret->impl->loadFont(path, parsedIndex, parsedSize))
         {
-            GetLogger()->error("Could not load font at path: {} index: {} size: {}\n", filename, index, size);
+            GetLogger()->error("Could not load font at path: {} index: {} size: {}\n", path, parsedIndex, parsedSize);
             return nullptr;
         }
 

--- a/src/celttf/truetypefont.h
+++ b/src/celttf/truetypefont.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <filesystem>
 #include <string_view>
 
@@ -20,10 +21,7 @@ class Renderer;
 class TextureFont;
 
 std::shared_ptr<TextureFont>
-LoadTextureFont(const Renderer *, const std::filesystem::path &, int index = 0, int size = 0);
-
-std::filesystem::path
-ParseFontName(const std::filesystem::path &, int &, int &);
+LoadTextureFont(const Renderer*, const std::filesystem::path&, std::optional<int> index = std::nullopt, std::optional<int> size = std::nullopt);
 
 struct TextureFontPrivate;
 class TextureFont
@@ -61,5 +59,5 @@ private:
     std::unique_ptr<TextureFontPrivate> impl;
 
     friend std::shared_ptr<TextureFont>
-    LoadTextureFont(const Renderer*, const std::filesystem::path&, int, int);
+    LoadTextureFont(const Renderer*, const std::filesystem::path&, std::optional<int>, std::optional<int>);
 };


### PR DESCRIPTION
The previous implementation that uses `LocaleFilename` cannot handle having a ttc index. It was bad for CJK fonts which usually comes in .ttc format to save space.

Move the default Font / TitleFont / LabelFont entries out of celestia.cfg.in and into LoadFontHelper, exposed as gettext keys (DEFAULT_MAIN_FONT, DEFAULT_TITLE_FONT, DEFAULT_LABEL_FONT) so translators can ship locale-appropriate defaults without users having to touch their config.

Also consolidate the "fontpath,index,size" parsing inside LoadTextureFont; index/size become std::optional so callers can either accept the parsed values or override them.