### PR TITLE
Update Qt Wayland drag handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
               -DENABLE_SDL=ON                                \
               -DENABLE_QT5=${{matrix.config.qt5}}            \
               -DENABLE_QT6=${{matrix.config.qt6}}            \
-              -DUSE_WAYLAND=${{matrix.config.wayland}}       \
+              -DUSE_WAYLAND_DRAG=${{matrix.config.wayland}}  \
               -DENABLE_FFMPEG=ON                             \
               -DENABLE_LIBAVIF=${{matrix.config.avif}}       \
               -DENABLE_MINIAUDIO=${{matrix.config.minaudio}} \
@@ -343,7 +343,7 @@ jobs:
               -DENABLE_SDL=ON                \
               -DENABLE_QT5=OFF               \
               -DENABLE_QT6=ON                \
-              -DUSE_WAYLAND=OFF              \
+              -DUSE_WAYLAND_DRAG=OFF         \
               -DENABLE_FFMPEG=ON             \
               -DENABLE_LIBAVIF=ON            \
               -DENABLE_MINIAUDIO=ON          \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ option(ENABLE_FAST_MATH   "Build with unsafe fast-math compiller option (Default
 option(ENABLE_TESTS       "Enable unit tests? (Default: off)" OFF)
 option(ENABLE_GLES        "Build for OpenGL ES 2.0 instead of OpenGL 2.1 (Default: off)" OFF)
 option(ENABLE_LTO         "Enable link time optimizations (Default: off)" OFF)
-option(USE_WAYLAND        "Use Wayland in Qt frontend (Default: off)" OFF)
+option(USE_WAYLAND_DRAG   "Use Wayland in Qt frontend (Default: off)" OFF)
 option(USE_ICU            "Use ICU for UTF8 decoding for text rendering (Default: off)" OFF)
 option(USE_WIN_ICU        "Use Windows SDK's ICU implementation (Default: off)" OFF)
 option(USE_MESHOPTIMIZER  "Use meshoptimizer (Default: off)" OFF)
@@ -308,20 +308,47 @@ if(USE_MESHOPTIMIZER)
   set(HAVE_MESHOPTIMIZER 1)
 endif()
 
-if(USE_WAYLAND)
+if(USE_WAYLAND_DRAG)
   message(STATUS "Creating Wayland protocol helpers")
 
   find_package(Wayland COMPONENTS protocols scanner REQUIRED)
 
   include(WaylandAddProtocolClient)
-  wayland_add_protocol_client(PROTOCOL_SOURCES
-    "unstable/pointer-constraints/pointer-constraints-unstable-v1.xml")
-  wayland_add_protocol_client(PROTOCOL_SOURCES
-    "unstable/relative-pointer/relative-pointer-unstable-v1.xml")
 
-  set_source_files_properties(${PROTOCOL_SOURCES} PROPERTIES GENERATED ON)
-  add_library(wayland-protocols-helper STATIC ${PROTOCOL_SOURCES})
-  target_include_directories(wayland-protocols-helper PUBLIC ${Wayland_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+  wayland_find_protocol_definition(
+    PROTOCOL_POINTER_CONSTRAINTS
+    NAME pointer-constraints-unstable-v1.xml
+    PATHS "unstable/pointer-constraints")
+
+  wayland_find_protocol_definition(
+    PROTOCOL_RELATIVE_POINTER
+    NAME relative-pointer-unstable-v1.xml
+    PATHS "unstable/relative-pointer"
+  )
+
+  wayland_find_protocol_definition(
+    PROTOCOL_POINTER_WARP
+    NAME pointer-warp-v1.xml
+    PATHS "staging/pointer-warp"
+  )
+
+  if(PROTOCOL_POINTER_CONSTRAINTS AND PROTOCOL_RELATIVE_POINTER)
+    wayland_add_protocol_client(PROTOCOL_SOURCES "${PROTOCOL_POINTER_CONSTRAINTS}")
+    wayland_add_protocol_client(PROTOCOL_SOURCES "${PROTOCOL_RELATIVE_POINTER}")
+    list(APPEND CEL_WAYLAND_DEFINES HAS_WAYLAND_POINTER_CONSTRAINTS)
+    set(HAS_WAYLAND_DRAG ON)
+  endif()
+  if(PROTOCOL_POINTER_WARP)
+    wayland_add_protocol_client(PROTOCOL_SOURCES "${PROTOCOL_POINTER_WARP}")
+    list(APPEND CEL_WAYLAND_DEFINES HAS_WAYLAND_POINTER_WARP)
+    set(HAS_WAYLAND_DRAG ON)
+  endif()
+
+  if(HAS_WAYLAND_DRAG)
+    set_source_files_properties(${PROTOCOL_SOURCES} PROPERTIES GENERATED ON)
+    add_library(wayland-protocols-helper STATIC ${PROTOCOL_SOURCES})
+    target_include_directories(wayland-protocols-helper PUBLIC ${Wayland_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+  endif()
 endif()
 
 find_package(gperf REQUIRED)

--- a/cmake/WaylandAddProtocolClient.cmake
+++ b/cmake/WaylandAddProtocolClient.cmake
@@ -1,26 +1,48 @@
+function(wayland_find_protocol_definition)
+  cmake_parse_arguments(PARSE_ARGV 1 arg "" "NAME" "PATHS")
+  foreach(rel_path IN LISTS arg_PATHS)
+    list(APPEND abs_paths "${Wayland_PROTOCOLS_DATADIR}/${rel_path}")
+  endforeach()
+
+  find_file(
+    _PROTOCOL_FILE
+    ${arg_NAME}
+    PATHS ${abs_paths}
+  )
+  if(_PROTOCOL_FILE STREQUAL "PROTOCOL_FILE-NOTFOUND")
+    message(STATUS "Wayland protocol file ${arg_NAME} not found")
+  else()
+    message(STATUS "Wayland protocol file ${arg_NAME} found")
+    set(${ARGV0} "${_PROTOCOL_FILE}" PARENT_SCOPE)
+  endif()
+
+  unset(_PROTOCOL_FILE CACHE)
+endfunction()
+
 function(wayland_add_protocol_client _sources _protocol)
-    if (NOT TARGET Wayland::Scanner)
-        message(FATAL_ERROR "The wayland-scanner executable has not been found on your system.")
-    endif()
+  if (NOT TARGET Wayland::Scanner)
+    message(FATAL_ERROR "The wayland-scanner executable has not been found on your system.")
+  endif()
 
-    if (NOT Wayland_PROTOCOLS_DATADIR)
-        message(FATAL_ERROR "The wayland-protocols data directory has not been found on your system.")
-    endif()
+  if (NOT Wayland_PROTOCOLS_DATADIR)
+    message(FATAL_ERROR "The wayland-protocols data directory has not been found on your system.")
+  endif()
 
-    get_filename_component(_basename "${_protocol}" NAME_WLE)
+  get_filename_component(_basename "${_protocol}" NAME_WLE)
 
-    set(_source_file "${Wayland_PROTOCOLS_DATADIR}/${_protocol}")
-    set(_client_header "${CMAKE_CURRENT_BINARY_DIR}/${_basename}-client-protocol.h")
-    set(_private_code "${CMAKE_CURRENT_BINARY_DIR}/${_basename}-protocol.c")
+  set(_client_header "${CMAKE_CURRENT_BINARY_DIR}/${_basename}-client-protocol.h")
+  set(_private_code "${CMAKE_CURRENT_BINARY_DIR}/${_basename}-protocol.c")
 
-    add_custom_command(OUTPUT "${_client_header}"
-        COMMAND Wayland::Scanner client-header < ${_source_file} > ${_client_header}
-        DEPENDS ${_source_file} VERBATIM)
+  add_custom_command(OUTPUT "${_client_header}"
+    COMMAND Wayland::Scanner client-header < ${_protocol} > ${_client_header}
+    DEPENDS ${_protocol} VERBATIM
+  )
 
-    add_custom_command(OUTPUT "${_private_code}"
-        COMMAND Wayland::Scanner private-code < ${_source_file} > ${_private_code}
-        DEPENDS ${_source_file} VERBATIM)
+  add_custom_command(OUTPUT "${_private_code}"
+    COMMAND Wayland::Scanner private-code < ${_protocol} > ${_private_code}
+    DEPENDS ${_protocol} VERBATIM
+  )
 
-    list(APPEND ${_sources} "${_private_code}" "${_client_header}")
-    set(${_sources} ${${_sources}} PARENT_SCOPE)
+  list(APPEND ${_sources} "${_private_code}" "${_client_header}")
+  set(${_sources} ${${_sources}} PARENT_SCOPE)
 endfunction()

--- a/src/celestia/qt/CelestiaQtCommon.cmake
+++ b/src/celestia/qt/CelestiaQtCommon.cmake
@@ -1,80 +1,64 @@
 set(QT_NO_CREATE_VERSIONLESS_FUNCTIONS ON)
 set(QT_NO_CREATE_VERSIONLESS_TARGETS ON)
 
-function(GetQtSources UseWayland)
+function(GetQtSources VARNAME)
   set(REL_QT_SOURCES
     qtappwin.cpp
-    qtbookmark.cpp
-    qtcelestialbrowser.cpp
-    qtcelestiaactions.cpp
-    qtcolorswatchwidget.cpp
-    qtcommandline.cpp
-    qtdateutil.cpp
-    qtdeepskybrowser.cpp
-    qtdraghandler.cpp
-    qteventfinder.cpp
-    qtglwidget.cpp
-    qtgotoobjectdialog.cpp
-    qtinfopanel.cpp
-    qtmain.cpp
-    qtpreferencesdialog.cpp
-    qtselectionpopup.cpp
-    qtsettimedialog.cpp
-    qtsolarsystembrowser.cpp
-    qttimetoolbar.cpp
-    qttourguide.cpp
-    xbel.cpp
-  )
-
-  set(REL_QT_HEADERS
     qtappwin.h
+    qtbookmark.cpp
     qtbookmark.h
+    qtcelestialbrowser.cpp
     qtcelestialbrowser.h
+    qtcelestiaactions.cpp
     qtcelestiaactions.h
+    qtcolorswatchwidget.cpp
     qtcolorswatchwidget.h
+    qtcommandline.cpp
     qtcommandline.h
+    qtdateutil.cpp
     qtdateutil.h
+    qtdeepskybrowser.cpp
     qtdeepskybrowser.h
+    qtdraghandler.cpp
     qtdraghandler.h
+    qteventfinder.cpp
     qteventfinder.h
     qtgettext.h
-    qtgotoobjectdialog.h
+    qtglwidget.cpp
     qtglwidget.h
+    qtgotoobjectdialog.cpp
+    qtgotoobjectdialog.h
+    qtinfopanel.cpp
     qtinfopanel.h
+    qtmain.cpp
     qtpathutil.h
+    qtpreferencesdialog.cpp
     qtpreferencesdialog.h
+    qtselectionpopup.cpp
     qtselectionpopup.h
+    qtsettimedialog.cpp
     qtsettimedialog.h
+    qtsolarsystembrowser.cpp
     qtsolarsystembrowser.h
+    qttimetoolbar.cpp
     qttimetoolbar.h
+    qttourguide.cpp
     qttourguide.h
+    xbel.cpp
     xbel.h
   )
 
-  if(UseWayland)
-    list(APPEND REL_QT_SOURCES qtwaylanddraghandler.cpp)
-    list(APPEND REL_QT_HEADERS qtwaylanddraghandler.h)
+  if(HAS_WAYLAND_DRAG)
+    list(APPEND REL_QT_SOURCES qtwaylanddraghandler.cpp qtwaylanddraghandler.h)
   endif()
 
   if(WIN32)
-    set(REL_RES celestia.rc)
+    set(APPEND REL_QT_SOURCES celestia.rc)
   endif()
 
   foreach(SRC_FILE IN LISTS REL_QT_SOURCES)
     list(APPEND OutputSources "../qt/${SRC_FILE}")
   endforeach()
 
-  set(QT_SOURCES ${OutputSources} PARENT_SCOPE)
-
-  foreach(SRC_FILE IN LISTS REL_QT_HEADERS)
-    list(APPEND OutputHeaders "../qt/${SRC_FILE}")
-  endforeach()
-
-  set(QT_HEADERS ${OutputHeaders} PARENT_SCOPE)
-
-  foreach(SRC_FILE IN LISTS REL_RES)
-    list(APPEND OutputRes "../qt/${SRC_FILE}")
-  endforeach()
-
-  set(RES ${OutputRes} PARENT_SCOPE)
+  set(${VARNAME} "${OutputSources}" PARENT_SCOPE)
 endfunction()

--- a/src/celestia/qt/qtdraghandler.cpp
+++ b/src/celestia/qt/qtdraghandler.cpp
@@ -7,7 +7,7 @@
 
 #include <celestia/celestiacore.h>
 
-#ifdef USE_WAYLAND
+#ifdef HAS_WAYLAND_DRAG
 #include "qtwaylanddraghandler.h"
 #endif
 
@@ -17,7 +17,7 @@ namespace celestia::qt
 namespace
 {
 inline auto
-mouseEventPos(const QMouseEvent &m)
+mouseEventPos(const QMouseEvent& m)
 {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     return m.globalPos();
@@ -28,36 +28,35 @@ mouseEventPos(const QMouseEvent &m)
 }
 
 void
-DragHandler::begin(const QMouseEvent &m, qreal s, int b)
+DragHandler::begin(const QMouseEvent& m, qreal s, int b)
 {
-    saveCursorPos = mouseEventPos(m);
-    scale         = s;
-    buttons       = b;
+    m_saveCursorPos = mouseEventPos(m);
+    m_scale         = s;
+    m_buttons       = b;
 }
 
 void
 DragHandler::move(const QMouseEvent &m, qreal s)
 {
-    if (scale != s)
-        begin(m, s, buttons);
-    auto relativeMovement = mouseEventPos(m) - saveCursorPos;
-    appCore->mouseMove(
-        static_cast<float>(relativeMovement.x() * scale),
-        static_cast<float>(relativeMovement.y() * scale),
-        effectiveButtons());
-    saveCursorPos = mouseEventPos(m);
+    if (m_scale != s)
+        begin(m, s, m_buttons);
+    auto relativeMovement = mouseEventPos(m) - m_saveCursorPos;
+    m_appCore->mouseMove(static_cast<float>(relativeMovement.x() * m_scale),
+                         static_cast<float>(relativeMovement.y() * m_scale),
+                         effectiveButtons());
+    m_saveCursorPos = mouseEventPos(m);
 }
 
 void
 DragHandler::setButton(int button)
 {
-    buttons |= button;
+    m_buttons |= button;
 }
 
 void
 DragHandler::clearButton(int button)
 {
-    buttons &= ~button;
+    m_buttons &= ~button;
 }
 
 int
@@ -67,10 +66,10 @@ DragHandler::effectiveButtons() const
     // On the Mac, right dragging is be simulated with Option+left drag.
     // We may want to enable this on other platforms, though it's mostly only helpful
     // for users with single button mice.
-    if (buttons & CelestiaCore::AltKey)
-        return (buttons | CelestiaCore::RightButton) & (~CelestiaCore::LeftButton);
+    if (m_buttons & CelestiaCore::AltKey)
+        return (m_buttons | CelestiaCore::RightButton) & (~CelestiaCore::LeftButton);
 #endif
-    return buttons;
+    return m_buttons;
 }
 
 // Warping drag handler
@@ -79,23 +78,16 @@ void
 WarpingDragHandler::restoreCursorPosition() const
 {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QCursor::setPos(saveCursorPos);
+    QCursor::setPos(saveCursorPos());
 #else
-    QCursor::setPos(saveCursorPos.toPoint());
+    QCursor::setPos(saveCursorPos().toPoint());
 #endif
 }
 
 void
 WarpingDragHandler::move(const QMouseEvent &m, qreal s)
 {
-    if (scale != s)
-        begin(m, s, buttons);
-    auto relativeMovement = mouseEventPos(m) - saveCursorPos;
-    appCore->mouseMove(
-        static_cast<float>(relativeMovement.x() * scale),
-        static_cast<float>(relativeMovement.y() * scale),
-        effectiveButtons());
-
+    DragHandler::move(m, s);
     restoreCursorPosition();
 }
 
@@ -113,9 +105,14 @@ createDragHandler([[maybe_unused]] QWidget *widget, CelestiaCore *appCore)
     if (platformName == "cocoa" || platformName == "windows" || platformName == "xcb")
         return std::make_unique<WarpingDragHandler>(appCore);
 
-#ifdef USE_WAYLAND
+#ifdef HAS_WAYLAND_DRAG
     if (platformName == "wayland")
-        return std::make_unique<WaylandDragHandler>(widget, appCore);
+        return wayland::createWaylandDragHandler(widget, appCore);
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    // Qt 6.10+ has built-in support for the Wayland pointer warp protocol
+    // so try to use that
+    if (platformName == "wayland")
+        return std::make_unique<WarpingDragHandler>(appCore);
 #endif
 
     return std::make_unique<DragHandler>(appCore);

--- a/src/celestia/qt/qtdraghandler.h
+++ b/src/celestia/qt/qtdraghandler.h
@@ -20,6 +20,8 @@
 #include <QPointF>
 #endif
 
+#include <celutil/classops.h>
+
 class QMouseEvent;
 class QWidget;
 
@@ -30,21 +32,14 @@ namespace celestia::qt
 
 // The base version of DragHandler is the fallback implementation for
 // platforms which do not support pointer warping
-class DragHandler
+class DragHandler : private util::NoCopy
 {
 public:
-    explicit DragHandler(CelestiaCore *core) : appCore(core)
-    {
-    }
+    explicit DragHandler(CelestiaCore* appCore) : m_appCore(appCore) {}
     virtual ~DragHandler() = default;
 
-    DragHandler(const DragHandler &)            = delete;
-    DragHandler &operator=(const DragHandler &) = delete;
-    DragHandler(DragHandler &&)                 = delete;
-    DragHandler &operator=(DragHandler &&)      = delete;
-
-    virtual void begin(const QMouseEvent &, qreal, int);
-    virtual void move(const QMouseEvent &, qreal);
+    virtual void begin(const QMouseEvent&, qreal, int);
+    virtual void move(const QMouseEvent&, qreal);
     virtual void finish(){ /* nothing to do */ };
 
     void setButton(int);
@@ -57,28 +52,33 @@ protected:
     using PointType = QPointF;
 #endif
 
-    CelestiaCore *appCore;
-    PointType     saveCursorPos{};
-    qreal         scale{};
-    int           buttons{ 0 };
-
     int effectiveButtons() const;
+
+    CelestiaCore* appCore() const noexcept { return m_appCore; }
+    const PointType& saveCursorPos() const noexcept { return m_saveCursorPos; }
+    qreal scale() const noexcept { return m_scale; }
+
+private:
+    CelestiaCore* m_appCore;
+    PointType m_saveCursorPos;
+    qreal m_scale{ 1 };
+    int m_buttons{ 0 };
 };
 
 // Implementation of DragHandler which uses pointer warping to enable infinite
 // movement
-class WarpingDragHandler : public DragHandler
+class WarpingDragHandler final : public DragHandler
 {
 public:
     using DragHandler::DragHandler;
 
-    void move(const QMouseEvent &, qreal) override;
+    void move(const QMouseEvent&, qreal) override;
     void finish() override;
 
 private:
     void restoreCursorPosition() const;
 };
 
-std::unique_ptr<DragHandler> createDragHandler(QWidget *, CelestiaCore *);
+std::unique_ptr<DragHandler> createDragHandler(QWidget*, CelestiaCore*);
 
 } // end namespace celestia::qt

--- a/src/celestia/qt/qtwaylanddraghandler.cpp
+++ b/src/celestia/qt/qtwaylanddraghandler.cpp
@@ -4,27 +4,33 @@
 
 #include <QGuiApplication>
 #include <QWidget>
+#include <QWindow>
 #include <qpa/qplatformnativeinterface.h>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0) && defined(HAS_WAYLAND_POINTER_WARP)
+#include <pointer-warp-v1-client-protocol.h>
+#endif
 
 #include <celestia/celestiacore.h>
 
-namespace celestia::qt
+namespace celestia::qt::wayland
 {
 
 namespace
 {
 
-QPlatformNativeInterface *
-getPlatformNativeInterface()
+struct Interfaces
 {
-    static QPlatformNativeInterface *pni = nullptr;
-    if (!pni)
-    {
-        pni = QGuiApplication::platformNativeInterface();
-    }
-
-    return pni;
-}
+    wl_pointer* pointer{ nullptr };
+#ifdef HAS_WAYLAND_POINTER_CONSTRAINTS
+    zwp_pointer_constraints_v1* pointerConstraints{ nullptr };
+    zwp_relative_pointer_manager_v1* relativePointerManager{ nullptr };
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0) && defined(HAS_WAYLAND_POINTER_WARP)
+    bool hasPointerWarp{ false };
+#endif
+    bool initialized{ false };
+};
 
 void
 addRegistryItem(
@@ -34,20 +40,36 @@ addRegistryItem(
     const char   *interface,
     std::uint32_t version)
 {
-    auto pointerInterfaces = static_cast<WaylandDragHandler::PointerInterfaces *>(data);
-    if (std::strcmp(interface, zwp_pointer_constraints_v1_interface.name) == 0
-        && version == static_cast<std::uint32_t>(zwp_pointer_constraints_v1_interface.version))
+    [[maybe_unused]] auto interfaces = static_cast<Interfaces*>(data);
+#ifdef HAS_WAYLAND_POINTER_CONSTRAINTS
+    if (std::strcmp(interface, zwp_pointer_constraints_v1_interface.name) == 0)
     {
-        pointerInterfaces->pointerConstraints = static_cast<zwp_pointer_constraints_v1 *>(
-            wl_registry_bind(registry, name, &zwp_pointer_constraints_v1_interface, version));
+        if (version == static_cast<std::uint32_t>(zwp_pointer_constraints_v1_interface.version))
+        {
+            interfaces->pointerConstraints = static_cast<zwp_pointer_constraints_v1*>(
+                wl_registry_bind(registry, name, &zwp_pointer_constraints_v1_interface, version));
+        }
+        return;
     }
-    else if (
-        std::strcmp(interface, zwp_relative_pointer_manager_v1_interface.name) == 0
-        && version == static_cast<std::uint32_t>(zwp_relative_pointer_manager_v1_interface.version))
+
+    if (std::strcmp(interface, zwp_relative_pointer_manager_v1_interface.name) == 0)
     {
-        pointerInterfaces->relativePointerManager = static_cast<zwp_relative_pointer_manager_v1 *>(
-            wl_registry_bind(registry, name, &zwp_relative_pointer_manager_v1_interface, version));
+        if (version == static_cast<std::uint32_t>(zwp_relative_pointer_manager_v1_interface.version))
+        {
+            interfaces->relativePointerManager = static_cast<zwp_relative_pointer_manager_v1*>(
+                wl_registry_bind(registry, name, &zwp_relative_pointer_manager_v1_interface, version));
+        }
+        return;
     }
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0) && defined(HAS_WAYLAND_POINTER_WARP)
+    if (std::strcmp(interface, wp_pointer_warp_v1_interface.name) == 0)
+    {
+        if (version == static_cast<std::uint32_t>(wp_pointer_warp_v1_interface.version))
+            interfaces->hasPointerWarp = true;
+        return;
+    }
+#endif
 }
 
 void
@@ -56,131 +78,134 @@ removeRegistryItem(void *data, wl_registry *registry, std::uint32_t name)
     // not handled
 }
 
-std::shared_ptr<WaylandDragHandler::PointerInterfaces>
-getPointerInterfaces()
+wl_registry_listener
+createListener()
 {
-    static std::weak_ptr<WaylandDragHandler::PointerInterfaces> cachedPointerInterfaces{};
-    auto pointerInterfaces = cachedPointerInterfaces.lock();
-    if (pointerInterfaces)
-        return pointerInterfaces;
+    wl_registry_listener listener;
+    listener.global = &addRegistryItem;
+    listener.global_remove = &removeRegistryItem;
+    return listener;
+}
 
-    QPlatformNativeInterface *pni = getPlatformNativeInterface();
+const Interfaces*
+getInterfaces()
+{
+    static Interfaces interfaces;
+    if (interfaces.initialized)
+        return &interfaces;
+
+    interfaces.initialized = true;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    auto instance = static_cast<const QGuiApplication*>(QGuiApplication::instance());
+    if (!instance)
+        return &interfaces;
+
+    const auto* waylandApp = instance->nativeInterface<QNativeInterface::QWaylandApplication>();
+    if (!waylandApp)
+        return &interfaces;
+
+    auto display = waylandApp->display();
+    interfaces.pointer = waylandApp->pointer();
+#else
+    QPlatformNativeInterface* pni = QGuiApplication::platformNativeInterface();
     if (!pni)
-        return nullptr;
+        return &interfaces;
 
-    auto display = static_cast<wl_display *>(pni->nativeResourceForIntegration("wl_display"));
+    auto display = static_cast<wl_display*>(pni->nativeResourceForIntegration("wl_display"));
+    interfaces.pointer = static_cast<wl_pointer*>(pni->nativeResourceForIntegration("wl_pointer"));
+#endif
+
     if (!display)
-        return nullptr;
+        return &interfaces;
 
-    wl_registry *registry = wl_display_get_registry(display);
+    wl_registry* registry = wl_display_get_registry(display);
     if (!registry)
-        return nullptr;
+        return &interfaces;
 
-    pointerInterfaces = std::make_shared<WaylandDragHandler::PointerInterfaces>(registry);
-    static const wl_registry_listener registryListener{ &addRegistryItem, &removeRegistryItem };
-
-    wl_registry_add_listener(registry, &registryListener, pointerInterfaces.get());
+    static const wl_registry_listener listener = createListener();
+    wl_registry_add_listener(registry, &listener, &interfaces);
     wl_display_roundtrip(display);
 
-    cachedPointerInterfaces = pointerInterfaces;
-    return pointerInterfaces;
+    return &interfaces;
 }
 
 } // end unnamed namespace
 
-const zwp_relative_pointer_v1_listener WaylandDragHandler::listener{ processRelativePointer };
+#ifdef HAS_WAYLAND_POINTER_CONSTRAINTS
+const zwp_relative_pointer_v1_listener PointerConstraintsDragHandler::s_listener{ &processRelativePointer };
 
-WaylandDragHandler::WaylandDragHandler(QWidget *_widget, CelestiaCore *_appCore) :
-    DragHandler(_appCore), widget(_widget)
+PointerConstraintsDragHandler::PointerConstraintsDragHandler(CelestiaCore* appCore,
+                                                             QWidget* widget,
+                                                             wl_pointer* pointer) :
+    DragHandler(appCore), m_widget(widget), m_pointer(pointer)
 {
-}
-
-WaylandDragHandler::~WaylandDragHandler()
-{
-    if (lockedPointer)
-        zwp_locked_pointer_v1_destroy(lockedPointer);
-    if (relativePointer)
-        zwp_relative_pointer_v1_destroy(relativePointer);
 }
 
 void
-WaylandDragHandler::begin(const QMouseEvent &m, qreal s, int b)
+PointerConstraintsDragHandler::begin(const QMouseEvent &m, qreal s, int b)
 {
-    buttons  = b;
-    scale    = s;
-    auto pni = getPlatformNativeInterface();
+    DragHandler::begin(m, s, b);
+
+    auto pni = QGuiApplication::platformNativeInterface();
     if (!pni)
     {
-        fallback = true;
-        DragHandler::begin(m, s, b);
+        m_fallback = true;
         return;
     }
 
-    surface = static_cast<wl_surface *>(
-        pni->nativeResourceForWindow("surface", widget->window()->windowHandle()));
-    pointer = static_cast<wl_pointer *>(pni->nativeResourceForIntegration("wl_pointer"));
-    if (!surface || !pointer)
+    auto surface = static_cast<wl_surface*>(pni->nativeResourceForWindow("surface", m_widget->window()->windowHandle()));
+    if (!surface)
     {
-        fallback = true;
-        DragHandler::begin(m, s, b);
+        m_fallback = true;
         return;
     }
 
-    pointerInterfaces = getPointerInterfaces();
+    auto interfaces = getInterfaces();
+    m_relativePointer = UniqueRelativePointer(zwp_relative_pointer_manager_v1_get_relative_pointer(interfaces->relativePointerManager,
+                                                                                                   m_pointer));
 
-    relativePointer = zwp_relative_pointer_manager_v1_get_relative_pointer(
-        pointerInterfaces->relativePointerManager,
-        pointer);
-    if (!relativePointer)
+    if (!m_relativePointer)
     {
-        fallback = true;
-        DragHandler::begin(m, s, b);
+        m_fallback = true;
         return;
     }
 
-    zwp_relative_pointer_v1_add_listener(relativePointer, &listener, this);
+    zwp_relative_pointer_v1_add_listener(m_relativePointer.get(), &s_listener, this);
 
-    lockedPointer = zwp_pointer_constraints_v1_lock_pointer(
-        pointerInterfaces->pointerConstraints,
-        surface,
-        pointer,
-        nullptr,
-        ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT);
-    if (!lockedPointer)
+    m_lockedPointer = UniqueLockedPointer(zwp_pointer_constraints_v1_lock_pointer(interfaces->pointerConstraints,
+                                                                                  surface,
+                                                                                  m_pointer,
+                                                                                  nullptr,
+                                                                                  ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT));
+    if (!m_lockedPointer)
     {
-        zwp_relative_pointer_v1_destroy(relativePointer);
-        fallback = true;
-        DragHandler::begin(m, s, b);
-        return;
+        m_relativePointer.reset();
+        m_fallback = true;
     }
 }
 
 void
-WaylandDragHandler::move(const QMouseEvent &m, qreal s)
+PointerConstraintsDragHandler::move(const QMouseEvent &m, qreal s)
 {
-    if (fallback)
-    {
+    if (m_fallback)
         DragHandler::move(m, s);
-    }
 }
 
 void
-WaylandDragHandler::finish()
+PointerConstraintsDragHandler::finish()
 {
-    if (fallback)
+    if (m_fallback)
     {
         DragHandler::finish();
         return;
     }
-    zwp_locked_pointer_v1_destroy(lockedPointer);
-    lockedPointer = nullptr;
 
-    zwp_relative_pointer_v1_destroy(relativePointer);
-    relativePointer = nullptr;
+    m_lockedPointer.reset();
+    m_relativePointer.reset();
 }
 
 void
-WaylandDragHandler::processRelativePointer(
+PointerConstraintsDragHandler::processRelativePointer(
     void *data,
     zwp_relative_pointer_v1 * /* pointer */,
     std::uint32_t /* utime_hi */,
@@ -190,26 +215,27 @@ WaylandDragHandler::processRelativePointer(
     wl_fixed_t /* dx_unaccel */,
     wl_fixed_t /* dy_unaccel */)
 {
-    auto dragHandler = static_cast<WaylandDragHandler *>(data);
-    dragHandler->appCore->mouseMove(
-        static_cast<float>(wl_fixed_to_double(dx) * dragHandler->scale),
-        static_cast<float>(wl_fixed_to_double(dy) * dragHandler->scale),
-        dragHandler->effectiveButtons());
+    auto dragHandler = static_cast<PointerConstraintsDragHandler*>(data);
+    dragHandler->appCore()->mouseMove(static_cast<float>(wl_fixed_to_double(dx) * dragHandler->scale()),
+                                      static_cast<float>(wl_fixed_to_double(dy) * dragHandler->scale()),
+                                      dragHandler->effectiveButtons());
 }
+#endif
 
-WaylandDragHandler::PointerInterfaces::PointerInterfaces(wl_registry *_registry) :
-    registry{ _registry }
+std::unique_ptr<DragHandler> createWaylandDragHandler([[maybe_unused]] QWidget* widget, CelestiaCore* appCore)
 {
+    [[maybe_unused]] auto interfaces = getInterfaces();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0) && defined(HAS_WAYLAND_POINTER_WARP)
+    // use built-in Qt pointer warp functionality
+    if (interfaces->hasPointerWarp)
+        return std::make_unique<WarpingDragHandler>(appCore);
+#endif
+#ifdef HAS_WAYLAND_POINTER_CONSTRAINTS
+    if (interfaces->pointer && interfaces->pointerConstraints && interfaces->relativePointerManager)
+        return std::make_unique<PointerConstraintsDragHandler>(appCore, widget, interfaces->pointer);
+#endif
+
+    return std::make_unique<DragHandler>(appCore);
 }
 
-WaylandDragHandler::PointerInterfaces::~PointerInterfaces()
-{
-    if (pointerConstraints)
-        zwp_pointer_constraints_v1_destroy(pointerConstraints);
-    if (relativePointerManager)
-        zwp_relative_pointer_manager_v1_destroy(relativePointerManager);
-    if (registry)
-        wl_registry_destroy(registry);
-}
-
-} // end namespace celestia::qt
+} // end namespace celestia::qt::wayland

--- a/src/celestia/qt/qtwaylanddraghandler.h
+++ b/src/celestia/qt/qtwaylanddraghandler.h
@@ -5,10 +5,13 @@
 
 #include <QtGlobal>
 
+#include <wayland-client.h>
+#ifdef HAS_WAYLAND_POINTER_CONSTRAINTS
 #include <pointer-constraints-unstable-v1-client-protocol.h>
 #include <relative-pointer-unstable-v1-client-protocol.h>
-#include <wayland-client.h>
+#endif
 
+#include <celutil/uniquedel.h>
 #include "qtdraghandler.h"
 
 class QMouseEvent;
@@ -16,40 +19,29 @@ class QWidget;
 
 class CelestiaCore;
 
-namespace celestia::qt
+namespace celestia::qt::wayland
 {
+#ifdef HAS_WAYLAND_POINTER_CONSTRAINTS
+using UniqueRelativePointer = util::UniquePtrDel<zwp_relative_pointer_v1, &zwp_relative_pointer_v1_destroy>;
+using UniqueLockedPointer = util::UniquePtrDel<zwp_locked_pointer_v1, &zwp_locked_pointer_v1_destroy>;
 
-class WaylandDragHandler : public DragHandler
+class PointerConstraintsDragHandler final : public DragHandler
 {
 public:
-    struct PointerInterfaces
-    {
-        wl_registry                     *registry;
-        zwp_pointer_constraints_v1      *pointerConstraints{ nullptr };
-        zwp_relative_pointer_manager_v1 *relativePointerManager{ nullptr };
+    PointerConstraintsDragHandler(CelestiaCore*, QWidget*, wl_pointer*);
 
-        PointerInterfaces(wl_registry *);
-        ~PointerInterfaces();
-    };
-
-    WaylandDragHandler(QWidget *, CelestiaCore *);
-    ~WaylandDragHandler();
-
-    void begin(const QMouseEvent &, qreal, int) override;
-    void move(const QMouseEvent &, qreal) override;
+    void begin(const QMouseEvent&, qreal, int) override;
+    void move(const QMouseEvent&, qreal) override;
     void finish() override;
 
 private:
-    QWidget                           *widget{ nullptr };
-    std::shared_ptr<PointerInterfaces> pointerInterfaces{ nullptr };
-    int                                buttons{ 0 };
-    wl_surface                        *surface{ nullptr };
-    wl_pointer                        *pointer{ nullptr };
-    zwp_relative_pointer_v1           *relativePointer{ nullptr };
-    zwp_locked_pointer_v1             *lockedPointer{ nullptr };
-    bool                               fallback{ false };
+    static const zwp_relative_pointer_v1_listener s_listener;
 
-    static const zwp_relative_pointer_v1_listener listener;
+    QWidget* m_widget;
+    wl_pointer* m_pointer;
+    UniqueRelativePointer m_relativePointer;
+    UniqueLockedPointer m_lockedPointer;
+    bool m_fallback{ false };
 
     static void processRelativePointer(
         void *data,
@@ -61,5 +53,8 @@ private:
         wl_fixed_t,
         wl_fixed_t);
 };
+#endif
 
-} // end namespace celestia::qt
+std::unique_ptr<DragHandler> createWaylandDragHandler(QWidget*, CelestiaCore*);
+
+} // end namespace celestia::qt::wayland

--- a/src/celestia/qt5/CMakeLists.txt
+++ b/src/celestia/qt5/CMakeLists.txt
@@ -18,21 +18,17 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
 find_package(Qt5 COMPONENTS Widgets CONFIG REQUIRED)
-qt5_add_resources(RC_SRC "../qt/icons.qrc")
+qt5_add_resources(CEL_QT5_RC_SRC "../qt/icons.qrc")
 
-if(USE_WAYLAND)
-  GetQtSources(ON)
-else()
-  GetQtSources(OFF)
-endif()
+GetQtSources(CEL_QT5_SOURCES)
 
-add_executable(celestia-qt5 WIN32 ${QT_SOURCES} ${RES} ${RC_SRC})
+add_executable(celestia-qt5 WIN32 ${CEL_QT5_SOURCES} ${CEL_QT5_RC_SRC})
 add_dependencies(celestia-qt5 celestia)
 target_link_libraries(celestia-qt5 Qt5::Widgets celestia)
 
-if(USE_WAYLAND)
+if(HAS_WAYLAND_DRAG)
   target_link_libraries(celestia-qt5 Wayland::Client wayland-protocols-helper)
-  target_compile_definitions(celestia-qt5 PRIVATE USE_WAYLAND)
+  target_compile_definitions(celestia-qt5 PRIVATE HAS_WAYLAND_DRAG ${CEL_WAYLAND_DEFINES})
   target_include_directories(celestia-qt5 PRIVATE ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 

--- a/src/celestia/qt6/CMakeLists.txt
+++ b/src/celestia/qt6/CMakeLists.txt
@@ -11,23 +11,19 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 COMPONENTS Core Widgets OpenGLWidgets CONFIG REQUIRED)
-if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
-    find_package(Qt6GuiPrivate REQUIRED NO_MODULE)
-endif()
-qt6_add_resources(RC_SRC "../qt/icons.qrc")
+qt6_add_resources(CEL_QT6_RC_SRC "../qt/icons.qrc")
 
-if(USE_WAYLAND)
-  GetQtSources(ON)
-else()
-  GetQtSources(OFF)
-endif()
+GetQtSources(CEL_QT6_SOURCES)
 
-add_executable(celestia-qt6 WIN32 ${QT_SOURCES} ${RES} ${RC_SRC})
+add_executable(celestia-qt6 WIN32 ${CEL_QT6_SOURCES} ${CEL_QT6_RC_SRC})
 add_dependencies(celestia-qt6 celestia)
 target_link_libraries(celestia-qt6 PUBLIC Qt6::Widgets Qt6::OpenGLWidgets celestia)
 
-if(USE_WAYLAND)
-  target_compile_definitions(celestia-qt6 PRIVATE USE_WAYLAND)
+if(HAS_WAYLAND_DRAG)
+  if (Qt6Core_VERSION VERSION_GREATER_EQUAL "6.10.0")
+    find_package(Qt6 COMPONENTS GuiPrivate REQUIRED NO_MODULE)
+  endif()
+  target_compile_definitions(celestia-qt6 PRIVATE HAS_WAYLAND_DRAG ${CEL_WAYLAND_DEFINES})
   target_link_libraries(celestia-qt6
       PUBLIC
           Wayland::Client


### PR DESCRIPTION
- Attempt to use warping in Qt 6.10 if wp_pointer_warp is detected
- Provide fallback if Wayland protocol files are not supplied
- Don't attempt to destroy global Wayland objects

Supersedes #2525
Fixes #2393