### PR TITLE
Refactor overlay management into OverlayManager

### DIFF
--- a/src/celengine/CMakeLists.txt
+++ b/src/celengine/CMakeLists.txt
@@ -76,8 +76,8 @@ set(CELENGINE_SOURCES
   orbitsampler.h
   overlay.cpp
   overlay.h
-  overlayimage.cpp
-  overlayimage.h
+  imageoverlay.cpp
+  imageoverlay.h
   parseobject.cpp
   parseobject.h
   perspectiveprojectionmode.cpp

--- a/src/celengine/imageoverlay.cpp
+++ b/src/celengine/imageoverlay.cpp
@@ -48,7 +48,7 @@ void ImageOverlay::render(float curr_time, int width, int height)
         ySize /= coeffy;                // new overlay picture height to fit viewport
 
         left = (fwidth - xSize) / 2.0f; // to be sure overlay pict is centered in viewport
-        bottom = 0;                     // overlay pict locked at bottom of screen
+        bottom = 0.0f;                  // overlay pict locked at bottom of screen
     }
 
     float alpha = 1.0f;

--- a/src/celengine/imageoverlay.cpp
+++ b/src/celengine/imageoverlay.cpp
@@ -1,10 +1,10 @@
 #include <algorithm>
 #include <celmath/mathlib.h>
-#include "overlayimage.h"
+#include "imageoverlay.h"
 #include "rectangle.h"
 #include "render.h"
 
-OverlayImage::OverlayImage(const std::filesystem::path& f, Renderer *r) :
+ImageOverlay::ImageOverlay(const std::filesystem::path& f, Renderer *r) :
     texture(LoadTextureFromFile(f.is_relative() ? "images" / f : f,
                                 Texture::EdgeClamp,
                                 Texture::NoMipMaps)),
@@ -12,17 +12,17 @@ OverlayImage::OverlayImage(const std::filesystem::path& f, Renderer *r) :
 {
 }
 
-void OverlayImage::setColor(const Color& c)
+void ImageOverlay::setColor(const Color& c)
 {
     colors.fill(c);
 }
 
-void OverlayImage::setColor(std::array<Color, 4>& c)
+void ImageOverlay::setColor(std::array<Color, 4>& c)
 {
     std::copy(c.begin(), c.end(), colors.begin());
 }
 
-void OverlayImage::render(float curr_time, int width, int height)
+void ImageOverlay::render(float curr_time, int width, int height)
 {
     if (renderer == nullptr || texture == nullptr || (curr_time >= start + duration))
         return;

--- a/src/celengine/imageoverlay.cpp
+++ b/src/celengine/imageoverlay.cpp
@@ -32,20 +32,23 @@ void ImageOverlay::render(float curr_time, int width, int height)
     float xSize = overrideWidth  > 0.0f ? overrideWidth  : static_cast<float>(texture->getWidth());
     float ySize = overrideHeight > 0.0f ? overrideHeight : static_cast<float>(texture->getHeight());
 
+    float fwidth  = static_cast<float>(width);
+    float fheight = static_cast<float>(height);
+
     // center overlay image horizontally if offsetX = 0
-    float left = (width * (1 + offsetX) - xSize)/2;
+    float left = (fwidth * (1.0f + offsetX) - xSize) / 2.0f;
     // center overlay image vertically if offsetY = 0
-    float bottom = (height * (1 + offsetY) - ySize)/2;
+    float bottom = (fheight * (1.0f + offsetY) - ySize) / 2.0f;
 
     if (fitscreen)
     {
-        float coeffx = xSize / width;  // overlay pict width/view window width ratio
-        float coeffy = ySize / height; // overlay pict height/view window height ratio
-        xSize /= coeffx;               // new overlay picture width size to fit viewport
-        ySize /= coeffy;               // new overlay picture height to fit viewport
+        float coeffx = xSize / fwidth;  // overlay pict width/view window width ratio
+        float coeffy = ySize / fheight; // overlay pict height/view window height ratio
+        xSize /= coeffx;                // new overlay picture width size to fit viewport
+        ySize /= coeffy;                // new overlay picture height to fit viewport
 
-        left = (width - xSize) / 2;    // to be sure overlay pict is centered in viewport
-        bottom = 0;                    // overlay pict locked at bottom of screen
+        left = (fwidth - xSize) / 2.0f; // to be sure overlay pict is centered in viewport
+        bottom = 0;                     // overlay pict locked at bottom of screen
     }
 
     float alpha = 1.0f;

--- a/src/celengine/imageoverlay.h
+++ b/src/celengine/imageoverlay.h
@@ -9,19 +9,19 @@
 
 class Renderer;
 
-class OverlayImage
+class ImageOverlay
 {
  public:
-    // Opaque handle assigned by Hud::addImage at insertion time. Returned to
+    // Opaque handle assigned by OverlayManager at insertion time. Returned to
     // celx callers so they can remove a specific image later. 0 is reserved
     // as "no id."
     using Id = std::uint64_t;
 
-    OverlayImage(const std::filesystem::path&, Renderer*);
-    OverlayImage()               = delete;
-    ~OverlayImage()              = default;
-    OverlayImage(OverlayImage&)  = delete;
-    OverlayImage(OverlayImage&&) = delete;
+    ImageOverlay(const std::filesystem::path&, Renderer*);
+    ImageOverlay()               = delete;
+    ~ImageOverlay()              = default;
+    ImageOverlay(ImageOverlay&)  = delete;
+    ImageOverlay(ImageOverlay&&) = delete;
 
     void render(float, int, int);
     // True once the image has fully faded out and no longer renders;

--- a/src/celengine/videooverlay.h
+++ b/src/celengine/videooverlay.h
@@ -36,7 +36,7 @@ public:
     VideoOverlay(VideoOverlay&&) = delete;
 
     // Advance playback to currentTime and draw the current frame. currentTime
-    // is Celestia's real-time clock (seconds), matching what OverlayImage
+    // is Celestia's real-time clock (seconds), matching what ImageOverlay
     // receives.
     void render(double currentTime, int vpWidth, int vpHeight);
 

--- a/src/celestia/CMakeLists.txt
+++ b/src/celestia/CMakeLists.txt
@@ -23,6 +23,8 @@ set(CELESTIA_SOURCES
   loadstars.cpp
   loadstars.h
   moviecapture.h
+  overlaymanager.cpp
+  overlaymanager.h
   scriptmenu.cpp
   scriptmenu.h
   textinput.cpp

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2244,50 +2244,70 @@ int CelestiaCore::getTextWidth(std::string_view s) const
 }
 
 
-OverlayImage::Id CelestiaCore::addScriptImage(std::unique_ptr<OverlayImage>&& _image)
+ImageOverlay::Id CelestiaCore::addScriptImage(std::unique_ptr<ImageOverlay>&& _image)
 {
-    return hud->addImage(std::move(_image), timeInfo.currentTime);
+    return hud->overlayManager().addImage(std::move(_image), timeInfo.currentTime);
 }
 
-bool CelestiaCore::removeScriptImage(OverlayImage::Id id)
+bool CelestiaCore::removeScriptImage(ImageOverlay::Id id)
 {
-    return hud->removeImage(id);
+    return hud->overlayManager().removeImage(id);
+}
+
+bool CelestiaCore::setImageOverlaySize(ImageOverlay::Id id, float width, float height) const
+{
+    return hud->overlayManager().setImageSize(id, width, height);
+}
+
+bool CelestiaCore::setImageOverlayOffset(ImageOverlay::Id id, float x, float y) const
+{
+    return hud->overlayManager().setImageOffset(id, x, y);
 }
 
 void CelestiaCore::clearScriptImages()
 {
-    hud->clearImages();
+    hud->overlayManager().clearImages();
 }
 
 #ifdef USE_FFMPEG
 VideoOverlay::Id CelestiaCore::addVideoOverlay(std::unique_ptr<VideoOverlay>&& overlay)
 {
-    return hud->addVideoOverlay(std::move(overlay));
+    return hud->overlayManager().addVideo(std::move(overlay));
 }
 
 bool CelestiaCore::removeVideoOverlay(VideoOverlay::Id id)
 {
-    return hud->removeVideoOverlay(id);
+    return hud->overlayManager().removeVideo(id);
 }
 
 bool CelestiaCore::seekVideoOverlay(VideoOverlay::Id id, double seconds) const
 {
-    return hud->seekVideoOverlay(id, seconds);
+    return hud->overlayManager().seekVideo(id, seconds);
 }
 
 bool CelestiaCore::pauseVideoOverlay(VideoOverlay::Id id) const
 {
-    return hud->pauseVideoOverlay(id);
+    return hud->overlayManager().pauseVideo(id);
 }
 
 bool CelestiaCore::resumeVideoOverlay(VideoOverlay::Id id) const
 {
-    return hud->resumeVideoOverlay(id);
+    return hud->overlayManager().resumeVideo(id);
+}
+
+bool CelestiaCore::setVideoOverlaySize(VideoOverlay::Id id, float width, float height) const
+{
+    return hud->overlayManager().setVideoSize(id, width, height);
+}
+
+bool CelestiaCore::setVideoOverlayOffset(VideoOverlay::Id id, float x, float y) const
+{
+    return hud->overlayManager().setVideoOffset(id, x, y);
 }
 
 void CelestiaCore::clearVideoOverlays()
 {
-    hud->clearVideoOverlays();
+    hud->overlayManager().clearVideos();
 }
 #endif
 

--- a/src/celestia/celestiacore.h
+++ b/src/celestia/celestiacore.h
@@ -27,7 +27,7 @@
 #include <celengine/universe.h>
 #include <celengine/render.h>
 #include <celengine/simulation.h>
-#include <celengine/overlayimage.h>
+#include <celengine/imageoverlay.h>
 #ifdef USE_FFMPEG
 #include <celengine/videooverlay.h>
 #endif
@@ -366,10 +366,12 @@ public:
     // Append an overlay image. Each call adds another image without
     // displacing existing ones; expired images are pruned automatically.
     // Returns the freshly-assigned image id (0 means the image was null).
-    OverlayImage::Id addScriptImage(std::unique_ptr<OverlayImage>&&);
+    ImageOverlay::Id addScriptImage(std::unique_ptr<ImageOverlay>&&);
     // Remove a specific overlay image by id. Returns true when an image
     // was actually removed.
-    bool removeScriptImage(OverlayImage::Id);
+    bool removeScriptImage(ImageOverlay::Id);
+    bool setImageOverlaySize(ImageOverlay::Id, float width, float height) const;
+    bool setImageOverlayOffset(ImageOverlay::Id, float x, float y) const;
     // Remove every currently-displayed overlay image.
     void clearScriptImages();
 
@@ -379,6 +381,8 @@ public:
     bool seekVideoOverlay(VideoOverlay::Id, double seconds) const;
     bool pauseVideoOverlay(VideoOverlay::Id) const;
     bool resumeVideoOverlay(VideoOverlay::Id) const;
+    bool setVideoOverlaySize(VideoOverlay::Id, float width, float height) const;
+    bool setVideoOverlayOffset(VideoOverlay::Id, float x, float y) const;
     void clearVideoOverlays();
 #endif
 

--- a/src/celestia/hud.cpp
+++ b/src/celestia/hud.cpp
@@ -30,10 +30,6 @@
 #include <celengine/location.h>
 #include <celengine/observer.h>
 #include <celengine/overlay.h>
-#include <celengine/overlayimage.h>
-#ifdef USE_FFMPEG
-#include <celengine/videooverlay.h>
-#endif
 #include <celengine/rectangle.h>
 #include <celengine/simulation.h>
 #include <celengine/star.h>
@@ -938,32 +934,10 @@ Hud::renderOverlay(const WindowMetrics& metrics,
 
     m_overlay->begin();
 
-    if (!m_images.empty())
-    {
-        if (!m_hudSettings.showOverlayImage || !isScriptRunning)
-        {
-            // Overlays are gated off (preference toggled or script ended).
-            // Drop the queue rather than letting it accumulate silently.
-            m_images.clear();
-        }
-        else
-        {
-            auto now = static_cast<float>(timeInfo.currentTime);
-            // Drop fully-faded images first so the loop doesn't pile up
-            // state across many short-lived overlays; render the survivors
-            // in insertion order (newest on top).
-            m_images.erase(
-                std::remove_if(m_images.begin(), m_images.end(),
-                               [now](const auto& img) { return img->isExpired(now); }),
-                m_images.end());
-            for (const auto& img : m_images)
-                img->render(now, metrics.width, metrics.height);
-        }
-    }
-
-#ifdef USE_FFMPEG
-    renderVideoOverlays(metrics, timeInfo.currentTime, isScriptRunning);
-#endif
+    m_overlayManager.render(metrics.width,
+                            metrics.height,
+                            timeInfo.currentTime,
+                            m_hudSettings.showOverlayImage && isScriptRunning);
 
     views.renderBorders(m_overlay.get(), metrics, timeInfo.currentTime);
 
@@ -1372,127 +1346,5 @@ Hud::showText(const TextPrintPosition& position,
     m_messageStart = currentTime;
     m_messageDuration = duration;
 }
-
-OverlayImage::Id
-Hud::addImage(std::unique_ptr<OverlayImage>&& _image, double currentTime)
-{
-    if (_image == nullptr) return 0;
-    _image->setStartTime(static_cast<float>(currentTime));
-    ++m_nextImageId;
-    _image->setId(m_nextImageId);
-    m_images.push_back(std::move(_image));
-    return m_nextImageId;
-}
-
-bool
-Hud::removeImage(OverlayImage::Id id)
-{
-    if (id == 0) return false;
-    auto before = m_images.size();
-    m_images.erase(
-        std::remove_if(m_images.begin(), m_images.end(),
-                       [id](const auto& img) { return img->id() == id; }),
-        m_images.end());
-    return m_images.size() != before;
-}
-
-void
-Hud::clearImages()
-{
-    m_images.clear();
-}
-
-#ifdef USE_FFMPEG
-VideoOverlay::Id
-Hud::addVideoOverlay(std::unique_ptr<VideoOverlay>&& overlay)
-{
-    if (!overlay) return 0;
-    ++m_nextVideoId;
-    overlay->setId(m_nextVideoId);
-    m_videoOverlays.push_back(std::move(overlay));
-    return m_nextVideoId;
-}
-
-bool
-Hud::removeVideoOverlay(VideoOverlay::Id id)
-{
-    if (id == 0) return false;
-    auto before = m_videoOverlays.size();
-    m_videoOverlays.erase(
-        std::remove_if(m_videoOverlays.begin(), m_videoOverlays.end(),
-                       [id](const auto& v) { return v->id() == id; }),
-        m_videoOverlays.end());
-    return m_videoOverlays.size() != before;
-}
-
-bool
-Hud::seekVideoOverlay(VideoOverlay::Id id, double seconds) const
-{
-    if (id == 0) return false;
-    for (const auto& v : m_videoOverlays)
-    {
-        if (v->id() == id)
-        {
-            v->seek(seconds);
-            return true;
-        }
-    }
-    return false;
-}
-
-bool
-Hud::pauseVideoOverlay(VideoOverlay::Id id) const
-{
-    if (id == 0) return false;
-    for (const auto& v : m_videoOverlays)
-    {
-        if (v->id() == id)
-        {
-            v->pause();
-            return true;
-        }
-    }
-    return false;
-}
-
-bool
-Hud::resumeVideoOverlay(VideoOverlay::Id id) const
-{
-    if (id == 0) return false;
-    for (const auto& v : m_videoOverlays)
-    {
-        if (v->id() == id)
-        {
-            v->resume();
-            return true;
-        }
-    }
-    return false;
-}
-
-void
-Hud::clearVideoOverlays()
-{
-    m_videoOverlays.clear();
-}
-
-void
-Hud::renderVideoOverlays(const WindowMetrics& metrics, double currentTime, bool isScriptRunning)
-{
-    if (m_videoOverlays.empty()) return;
-    if (!m_hudSettings.showOverlayImage || !isScriptRunning)
-    {
-        m_videoOverlays.clear();
-        return;
-    }
-    for (const auto& v : m_videoOverlays)
-        v->render(currentTime, metrics.width, metrics.height);
-    // Drop overlays whose non-looping playback has finished.
-    m_videoOverlays.erase(
-        std::remove_if(m_videoOverlays.begin(), m_videoOverlays.end(),
-                       [](const auto& v) { return v->isFinished(); }),
-        m_videoOverlays.end());
-}
-#endif
 
 } // end namespace celestia

--- a/src/celestia/hud.h
+++ b/src/celestia/hud.h
@@ -24,11 +24,8 @@
 #include <Eigen/Core>
 
 #include <celastro/date.h>
-#include <celengine/overlayimage.h>
-#ifdef USE_FFMPEG
-#include <celengine/videooverlay.h>
-#endif
 #include <celengine/selection.h>
+#include <celestia/overlaymanager.h>
 #include <celestia/textinput.h>
 #include <celestia/textprintposition.h>
 #include <celestia/windowmetrics.h>
@@ -160,26 +157,9 @@ public:
                        bool editMode);
 
     void showText(const TextPrintPosition&, std::string_view, double duration, double currentTime);
-    // Push an overlay image onto the stack of currently-displayed images.
-    // Each image is rendered until its own duration elapses, then dropped
-    // from the stack; calling this never replaces existing images. Returns
-    // the freshly-assigned image id so callers can pass it to removeImage
-    // later. 0 is reserved as "no id" and is never returned on success.
-    OverlayImage::Id addImage(std::unique_ptr<OverlayImage>&&, double);
-    // Remove the overlay image with the given id, if any. No-op when the id
-    // is 0 or not currently active.
-    bool removeImage(OverlayImage::Id);
-    // Drop every currently-displayed overlay image immediately.
-    void clearImages();
 
-#ifdef USE_FFMPEG
-    VideoOverlay::Id addVideoOverlay(std::unique_ptr<VideoOverlay>&&);
-    bool removeVideoOverlay(VideoOverlay::Id);
-    bool seekVideoOverlay(VideoOverlay::Id, double seconds) const;
-    bool pauseVideoOverlay(VideoOverlay::Id) const;
-    bool resumeVideoOverlay(VideoOverlay::Id) const;
-    void clearVideoOverlays();
-#endif
+    OverlayManager& overlayManager() noexcept { return m_overlayManager; }
+    const OverlayManager& overlayManager() const noexcept { return m_overlayManager; }
 
     HudSettings& hudSettings() noexcept { return m_hudSettings; }
     const HudSettings& hudSettings() const noexcept { return m_hudSettings; }
@@ -190,26 +170,13 @@ private:
     void renderSelectionInfo(const WindowMetrics&, const Simulation*, Selection, const Eigen::Vector3d&);
     void renderTextMessages(const WindowMetrics&, double);
     void renderMovieCapture(const WindowMetrics&, const MovieCapture&);
-#ifdef USE_FFMPEG
-    void renderVideoOverlays(const WindowMetrics&, double currentTime, bool isScriptRunning);
-#endif
 
     HudSettings m_hudSettings;
     HudFonts m_hudFonts;
 
     std::unique_ptr<Overlay> m_overlay;
 
-    // Active script overlays. New images are appended in `addImage`;
-    // expired ones are pruned during renderOverlay.
-    std::vector<std::unique_ptr<OverlayImage>> m_images;
-    // Counter for assigning image ids; pre-incremented so the first id is 1
-    // and the sentinel 0 is reserved for "no id."
-    OverlayImage::Id m_nextImageId { 0 };
-
-#ifdef USE_FFMPEG
-    std::vector<std::unique_ptr<VideoOverlay>> m_videoOverlays;
-    VideoOverlay::Id m_nextVideoId { 0 };
-#endif
+    OverlayManager m_overlayManager;
 
     std::locale loc;
 

--- a/src/celestia/overlaymanager.cpp
+++ b/src/celestia/overlaymanager.cpp
@@ -1,0 +1,175 @@
+// overlaymanager.cpp
+//
+// Copyright (C) 2026-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "overlaymanager.h"
+
+namespace celestia
+{
+
+ImageOverlay::Id
+OverlayManager::addImage(std::unique_ptr<ImageOverlay>&& image, double currentTime)
+{
+    if (image == nullptr) return 0;
+    image->setStartTime(static_cast<float>(currentTime));
+    return m_images.add(std::move(image));
+}
+
+bool
+OverlayManager::removeImage(ImageOverlay::Id id)
+{
+    return m_images.remove(id);
+}
+
+bool
+OverlayManager::setImageSize(ImageOverlay::Id id, float width, float height) const
+{
+    if (auto* img = m_images.find(id); img != nullptr)
+    {
+        img->setSize(width, height);
+        return true;
+    }
+    return false;
+}
+
+bool
+OverlayManager::setImageOffset(ImageOverlay::Id id, float x, float y) const
+{
+    if (auto* img = m_images.find(id); img != nullptr)
+    {
+        img->setOffset(x, y);
+        return true;
+    }
+    return false;
+}
+
+void
+OverlayManager::clearImages() noexcept
+{
+    m_images.clear();
+}
+
+#ifdef USE_FFMPEG
+
+VideoOverlay::Id
+OverlayManager::addVideo(std::unique_ptr<VideoOverlay>&& video)
+{
+    return m_videos.add(std::move(video));
+}
+
+bool
+OverlayManager::removeVideo(VideoOverlay::Id id)
+{
+    return m_videos.remove(id);
+}
+
+bool
+OverlayManager::seekVideo(VideoOverlay::Id id, double seconds) const
+{
+    if (auto* v = m_videos.find(id); v != nullptr)
+    {
+        v->seek(seconds);
+        return true;
+    }
+    return false;
+}
+
+bool
+OverlayManager::pauseVideo(VideoOverlay::Id id) const
+{
+    if (auto* v = m_videos.find(id); v != nullptr)
+    {
+        v->pause();
+        return true;
+    }
+    return false;
+}
+
+bool
+OverlayManager::resumeVideo(VideoOverlay::Id id) const
+{
+    if (auto* v = m_videos.find(id); v != nullptr)
+    {
+        v->resume();
+        return true;
+    }
+    return false;
+}
+
+bool
+OverlayManager::setVideoSize(VideoOverlay::Id id, float width, float height) const
+{
+    if (auto* v = m_videos.find(id); v != nullptr)
+    {
+        v->setSize(width, height);
+        return true;
+    }
+    return false;
+}
+
+bool
+OverlayManager::setVideoOffset(VideoOverlay::Id id, float x, float y) const
+{
+    if (auto* v = m_videos.find(id); v != nullptr)
+    {
+        v->setOffset(x, y);
+        return true;
+    }
+    return false;
+}
+
+void
+OverlayManager::clearVideos() noexcept
+{
+    m_videos.clear();
+}
+
+#endif // USE_FFMPEG
+
+void
+OverlayManager::render(int viewportWidth, int viewportHeight, double currentTime, bool enabled)
+{
+    if (!m_images.empty())
+    {
+        if (!enabled)
+        {
+            // Drop the queue rather than letting it accumulate silently
+            // while the gate is off.
+            m_images.clear();
+        }
+        else
+        {
+            auto now = static_cast<float>(currentTime);
+            // Drop fully-faded images first so the loop doesn't pile up
+            // state across many short-lived overlays; render the survivors
+            // in insertion order (newest on top).
+            m_images.eraseIf([now](const auto& img) { return img->isExpired(now); });
+            for (const auto& img : m_images)
+                img->render(now, viewportWidth, viewportHeight);
+        }
+    }
+
+#ifdef USE_FFMPEG
+    if (!m_videos.empty())
+    {
+        if (!enabled)
+        {
+            m_videos.clear();
+        }
+        else
+        {
+            for (const auto& v : m_videos)
+                v->render(currentTime, viewportWidth, viewportHeight);
+            // Drop overlays whose non-looping playback has finished.
+            m_videos.eraseIf([](const auto& v) { return v->isFinished(); });
+        }
+    }
+#endif
+}
+
+} // namespace celestia

--- a/src/celestia/overlaymanager.h
+++ b/src/celestia/overlaymanager.h
@@ -1,0 +1,130 @@
+// overlaymanager.h
+//
+// Copyright (C) 2026-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <celengine/imageoverlay.h>
+#ifdef USE_FFMPEG
+#include <celengine/videooverlay.h>
+#endif
+
+namespace celestia
+{
+
+// Small owning container for objects that carry their own Id. Hands out a
+// fresh, monotonically-increasing id on each insertion (0 is reserved as
+// "no id"); supports linear lookup, id-based removal, and predicate-based
+// pruning. Used as an implementation detail of OverlayManager.
+template <typename T>
+class IdentifiedList
+{
+public:
+    using Id = typename T::Id;
+
+    Id add(std::unique_ptr<T>&& item)
+    {
+        if (item == nullptr) return 0;
+        ++m_nextId;
+        item->setId(m_nextId);
+        m_items.push_back(std::move(item));
+        return m_nextId;
+    }
+
+    bool remove(Id id)
+    {
+        if (id == 0) return false;
+        auto before = m_items.size();
+        m_items.erase(
+            std::remove_if(m_items.begin(), m_items.end(),
+                           [id](const auto& it) { return it->id() == id; }),
+            m_items.end());
+        return m_items.size() != before;
+    }
+
+    void clear() noexcept { m_items.clear(); }
+
+    T* find(Id id) const
+    {
+        if (id == 0) return nullptr;
+        for (const auto& it : m_items)
+        {
+            if (it->id() == id)
+                return it.get();
+        }
+        return nullptr;
+    }
+
+    template <typename Pred>
+    void eraseIf(Pred&& pred)
+    {
+        m_items.erase(
+            std::remove_if(m_items.begin(), m_items.end(), std::forward<Pred>(pred)),
+            m_items.end());
+    }
+
+    bool empty() const noexcept { return m_items.empty(); }
+
+    auto begin() const noexcept { return m_items.begin(); }
+    auto end()   const noexcept { return m_items.end(); }
+
+private:
+    std::vector<std::unique_ptr<T>> m_items;
+    Id m_nextId{ 0 };
+};
+
+// Owns the per-script ImageOverlay and VideoOverlay stacks that Hud used
+// to manage inline. Hud holds one of these and forwards script-facing
+// add/remove/clear calls to it; render() drives both stacks during
+// Hud::renderOverlay.
+class OverlayManager
+{
+public:
+    OverlayManager() = default;
+    ~OverlayManager() = default;
+    OverlayManager(const OverlayManager&) = delete;
+    OverlayManager& operator=(const OverlayManager&) = delete;
+
+    // Append an image to the stack and stamp it with `currentTime` as its
+    // start. Returns the freshly-assigned id; 0 means the image was null.
+    ImageOverlay::Id addImage(std::unique_ptr<ImageOverlay>&&, double currentTime);
+    bool removeImage(ImageOverlay::Id);
+    bool setImageSize(ImageOverlay::Id, float width, float height) const;
+    bool setImageOffset(ImageOverlay::Id, float x, float y) const;
+    void clearImages() noexcept;
+
+#ifdef USE_FFMPEG
+    VideoOverlay::Id addVideo(std::unique_ptr<VideoOverlay>&&);
+    bool removeVideo(VideoOverlay::Id);
+    bool seekVideo(VideoOverlay::Id, double seconds) const;
+    bool pauseVideo(VideoOverlay::Id) const;
+    bool resumeVideo(VideoOverlay::Id) const;
+    bool setVideoSize(VideoOverlay::Id, float width, float height) const;
+    bool setVideoOffset(VideoOverlay::Id, float x, float y) const;
+    void clearVideos() noexcept;
+#endif
+
+    // Drive the image + video stacks for one frame. When `enabled` is
+    // false (the showOverlayImage preference is off, or no script is
+    // running), both stacks are cleared instead of rendered, matching
+    // the gating Hud used to do inline.
+    void render(int viewportWidth, int viewportHeight, double currentTime, bool enabled);
+
+private:
+    IdentifiedList<ImageOverlay> m_images;
+#ifdef USE_FFMPEG
+    IdentifiedList<VideoOverlay> m_videos;
+#endif
+};
+
+} // namespace celestia

--- a/src/celscript/legacy/command.cpp
+++ b/src/celscript/legacy/command.cpp
@@ -18,7 +18,7 @@
 #include <celengine/body.h>
 #include <celengine/dsodb.h>
 #include <celengine/galaxy.h>
-#include <celengine/overlayimage.h>
+#include <celengine/imageoverlay.h>
 #include <celengine/render.h>
 #include <celengine/selection.h>
 #include <celengine/simulation.h>
@@ -935,7 +935,7 @@ CommandScriptImage::CommandScriptImage(float _duration, float _fadeafter,
 
 void CommandScriptImage::processInstantaneous(ExecutionEnvironment& env)
 {
-    auto image = std::make_unique<OverlayImage>(filename, env.getRenderer());
+    auto image = std::make_unique<ImageOverlay>(filename, env.getRenderer());
     image->setDuration(duration);
     image->setFadeAfter(fadeafter);
     image->setOffset(xoffset, yoffset);

--- a/src/celscript/lua/celx_celestia.cpp
+++ b/src/celscript/lua/celx_celestia.cpp
@@ -2324,12 +2324,12 @@ parseOverlayColors(lua_State* l, int slot, std::string_view methodName)
     return colors;
 }
 
-// Build an OverlayImage from celestia:overlay / celestia:addimageoverlay args.
+// Build an ImageOverlay from celestia:overlay / celestia:addimageoverlay args.
 // Returns nullptr if the filename argument was missing or invalid.
 // `methodName` is used for argc/error messages so each method reports its
 // own name.
-static std::unique_ptr<OverlayImage>
-buildOverlayImage(lua_State* l, const CelestiaCore* appCore, std::string_view methodName)
+static std::unique_ptr<ImageOverlay>
+buildImageOverlay(lua_State* l, const CelestiaCore* appCore, std::string_view methodName)
 {
     const char* filename = Celx_SafeGetString(l, 6, AllErrors, fmt::format("Fifth argument to celestia:{} must be a string (filename)", methodName).c_str());
     if (filename == nullptr)
@@ -2383,7 +2383,7 @@ buildOverlayImage(lua_State* l, const CelestiaCore* appCore, std::string_view me
             color.alpha(alpha);
     }
 
-    auto image = std::make_unique<OverlayImage>(filename, appCore->getRenderer());
+    auto image = std::make_unique<ImageOverlay>(filename, appCore->getRenderer());
     image->setDuration(duration);
     image->setFadeAfter(fadeafter);
     image->setOffset(xoffset, yoffset);
@@ -2402,7 +2402,7 @@ static int celestia_overlay(lua_State* l)
     Celx_CheckArgs(l, 2, 11, "One to ten arguments expected to function celestia:overlay");
 
     CelestiaCore* appCore = this_celestia(l);
-    if (auto image = buildOverlayImage(l, appCore, "overlay"); image != nullptr)
+    if (auto image = buildImageOverlay(l, appCore, "overlay"); image != nullptr)
     {
         appCore->clearScriptImages();
         appCore->addScriptImage(std::move(image));
@@ -2418,7 +2418,7 @@ static int celestia_addimageoverlay(lua_State* l)
     Celx_CheckArgs(l, 2, 11, "One to ten arguments expected to function celestia:addimageoverlay");
 
     CelestiaCore* appCore = this_celestia(l);
-    auto image = buildOverlayImage(l, appCore, "addimageoverlay");
+    auto image = buildImageOverlay(l, appCore, "addimageoverlay");
     if (image == nullptr)
     {
         lua_pushnil(l);
@@ -2434,7 +2434,7 @@ static int celestia_addimageoverlay(lua_State* l)
 static int celestia_removeimageoverlay(lua_State* l)
 {
     Celx_CheckArgs(l, 2, 2, "One argument expected to function celestia:removeimageoverlay");
-    auto id = static_cast<OverlayImage::Id>(Celx_SafeGetNumber(
+    auto id = static_cast<ImageOverlay::Id>(Celx_SafeGetNumber(
         l, 2, AllErrors,
         "First argument to celestia:removeimageoverlay must be a number (overlay id)"));
     lua_pushboolean(l, this_celestia(l)->removeScriptImage(id) ? 1 : 0);
@@ -2447,6 +2447,46 @@ static int celestia_clearimageoverlays(lua_State* l)
     Celx_CheckArgs(l, 1, 1, "No arguments expected for celestia:clearimageoverlays");
     this_celestia(l)->clearScriptImages();
     return 0;
+}
+
+// celestia:setimageoverlaysize(id, width, height) -- override the rendered
+// size in pixels of an existing image overlay. A non-positive value on
+// either axis falls back to the texture's intrinsic dimension. Returns
+// true if an image with that id was found.
+static int celestia_setimageoverlaysize(lua_State* l)
+{
+    Celx_CheckArgs(l, 4, 4, "Three arguments expected for celestia:setimageoverlaysize");
+    auto id = static_cast<ImageOverlay::Id>(Celx_SafeGetNumber(
+        l, 2, AllErrors,
+        "First argument to celestia:setimageoverlaysize must be a number (overlay id)"));
+    float width  = static_cast<float>(Celx_SafeGetNumber(
+        l, 3, AllErrors,
+        "Second argument to celestia:setimageoverlaysize must be a number (width)"));
+    float height = static_cast<float>(Celx_SafeGetNumber(
+        l, 4, AllErrors,
+        "Third argument to celestia:setimageoverlaysize must be a number (height)"));
+    lua_pushboolean(l, this_celestia(l)->setImageOverlaySize(id, width, height) ? 1 : 0);
+    return 1;
+}
+
+// celestia:setimageoverlayoffset(id, xoffset, yoffset) -- reposition an
+// existing image overlay. 0 = centred on that axis, ±1 = edge of viewport;
+// matches the xoffset/yoffset convention used by addimageoverlay. Returns
+// true if an image with that id was found.
+static int celestia_setimageoverlayoffset(lua_State* l)
+{
+    Celx_CheckArgs(l, 4, 4, "Three arguments expected for celestia:setimageoverlayoffset");
+    auto id = static_cast<ImageOverlay::Id>(Celx_SafeGetNumber(
+        l, 2, AllErrors,
+        "First argument to celestia:setimageoverlayoffset must be a number (overlay id)"));
+    float x = static_cast<float>(Celx_SafeGetNumber(
+        l, 3, AllErrors,
+        "Second argument to celestia:setimageoverlayoffset must be a number (xoffset)"));
+    float y = static_cast<float>(Celx_SafeGetNumber(
+        l, 4, AllErrors,
+        "Third argument to celestia:setimageoverlayoffset must be a number (yoffset)"));
+    lua_pushboolean(l, this_celestia(l)->setImageOverlayOffset(id, x, y) ? 1 : 0);
+    return 1;
 }
 
 #ifdef USE_FFMPEG
@@ -2551,6 +2591,46 @@ static int celestia_resumevideooverlay(lua_State* l)
         l, 2, AllErrors,
         "First argument to celestia:resumevideooverlay must be a number (video id)"));
     lua_pushboolean(l, this_celestia(l)->resumeVideoOverlay(id) ? 1 : 0);
+    return 1;
+}
+
+// celestia:setvideooverlaysize(id, width, height) -- override the rendered
+// size in pixels of an existing video overlay. 0 on either axis falls back
+// to the video's native dimension for that axis. Returns true if a video
+// with that id was found.
+static int celestia_setvideooverlaysize(lua_State* l)
+{
+    Celx_CheckArgs(l, 4, 4, "Three arguments expected for celestia:setvideooverlaysize");
+    auto id = static_cast<VideoOverlay::Id>(Celx_SafeGetNumber(
+        l, 2, AllErrors,
+        "First argument to celestia:setvideooverlaysize must be a number (video id)"));
+    float width  = static_cast<float>(Celx_SafeGetNumber(
+        l, 3, AllErrors,
+        "Second argument to celestia:setvideooverlaysize must be a number (width)"));
+    float height = static_cast<float>(Celx_SafeGetNumber(
+        l, 4, AllErrors,
+        "Third argument to celestia:setvideooverlaysize must be a number (height)"));
+    lua_pushboolean(l, this_celestia(l)->setVideoOverlaySize(id, width, height) ? 1 : 0);
+    return 1;
+}
+
+// celestia:setvideooverlayoffset(id, xoffset, yoffset) -- reposition an
+// existing video overlay. 0 = centred on that axis, ±1 = edge of viewport;
+// matches the xoffset/yoffset convention used by addvideooverlay. Returns
+// true if a video with that id was found.
+static int celestia_setvideooverlayoffset(lua_State* l)
+{
+    Celx_CheckArgs(l, 4, 4, "Three arguments expected for celestia:setvideooverlayoffset");
+    auto id = static_cast<VideoOverlay::Id>(Celx_SafeGetNumber(
+        l, 2, AllErrors,
+        "First argument to celestia:setvideooverlayoffset must be a number (video id)"));
+    float x = static_cast<float>(Celx_SafeGetNumber(
+        l, 3, AllErrors,
+        "Second argument to celestia:setvideooverlayoffset must be a number (xoffset)"));
+    float y = static_cast<float>(Celx_SafeGetNumber(
+        l, 4, AllErrors,
+        "Third argument to celestia:setvideooverlayoffset must be a number (yoffset)"));
+    lua_pushboolean(l, this_celestia(l)->setVideoOverlayOffset(id, x, y) ? 1 : 0);
     return 1;
 }
 #endif // USE_FFMPEG
@@ -2938,6 +3018,8 @@ void CreateCelestiaMetaTable(lua_State* l)
     Celx_RegisterMethod(l, "addimageoverlay", celestia_addimageoverlay);
     Celx_RegisterMethod(l, "removeimageoverlay", celestia_removeimageoverlay);
     Celx_RegisterMethod(l, "clearimageoverlays", celestia_clearimageoverlays);
+    Celx_RegisterMethod(l, "setimageoverlaysize", celestia_setimageoverlaysize);
+    Celx_RegisterMethod(l, "setimageoverlayoffset", celestia_setimageoverlayoffset);
 #ifdef USE_FFMPEG
     Celx_RegisterMethod(l, "addvideooverlay", celestia_addvideooverlay);
     Celx_RegisterMethod(l, "removevideooverlay", celestia_removevideooverlay);
@@ -2945,6 +3027,8 @@ void CreateCelestiaMetaTable(lua_State* l)
     Celx_RegisterMethod(l, "seekvideooverlay", celestia_seekvideooverlay);
     Celx_RegisterMethod(l, "pausevideooverlay", celestia_pausevideooverlay);
     Celx_RegisterMethod(l, "resumevideooverlay", celestia_resumevideooverlay);
+    Celx_RegisterMethod(l, "setvideooverlaysize", celestia_setvideooverlaysize);
+    Celx_RegisterMethod(l, "setvideooverlayoffset", celestia_setvideooverlayoffset);
 #endif
     Celx_RegisterMethod(l, "verbosity", celestia_verbosity);
 


### PR DESCRIPTION
Move the ImageOverlay and VideoOverlay stacks out of Hud into a new OverlayManager class so Hud no longer carries the nine script-overlay methods and four corresponding data members. OverlayManager uses a small IdentifiedList<T> template internally for id assignment and lookup.

Rename OverlayImage to ImageOverlay so both overlay types share the *Overlay suffix and disambiguate from the existing Overlay drawing class.

Add size/offset accessors on existing overlays:
celestia:setimageoverlaysize / setimageoverlayoffset and the corresponding setvideooverlaysize / setvideooverlayoffset Lua bindings.