### PR TITLE
Block QComboBox signals while populating preferences dialog

### DIFF
--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -222,10 +222,11 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
 
     ui.antialiasLinesCheck->setChecked(util::is_set(renderFlags, ::RenderFlags::ShowSmoothLines));
 
-    ui.sRGBRenderingCombo->addItem(_("Use config default"));
-    ui.sRGBRenderingCombo->addItem(_("Enabled"));
-    ui.sRGBRenderingCombo->addItem(_("Disabled"));
     {
+        QSignalBlocker blocker(ui.sRGBRenderingCombo);
+        ui.sRGBRenderingCombo->addItem(_("Use config default"));
+        ui.sRGBRenderingCombo->addItem(_("Enabled"));
+        ui.sRGBRenderingCombo->addItem(_("Disabled"));
         QSettings settings;
         if (!settings.contains("sRGBRendering"))
             ui.sRGBRenderingCombo->setCurrentIndex(0);
@@ -275,22 +276,28 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
             break;
     }
 
-    ui.starColorBox->addItem(_("Blackbody D65"), static_cast<int>(ColorTableType::Blackbody_D65));
-    ui.starColorBox->addItem(_("Blackbody (Solar Whitepoint)"), static_cast<int>(ColorTableType::SunWhite));
-    ui.starColorBox->addItem(_("Blackbody (Vega Whitepoint)"), static_cast<int>(ColorTableType::VegaWhite));
-    ui.starColorBox->addItem(_("Classic colors"), static_cast<int>(ColorTableType::Enhanced));
-    SetComboBoxValue(ui.starColorBox, static_cast<int>(colors));
+    {
+        QSignalBlocker blocker(ui.starColorBox);
+        ui.starColorBox->addItem(_("Blackbody D65"), static_cast<int>(ColorTableType::Blackbody_D65));
+        ui.starColorBox->addItem(_("Blackbody (Solar Whitepoint)"), static_cast<int>(ColorTableType::SunWhite));
+        ui.starColorBox->addItem(_("Blackbody (Vega Whitepoint)"), static_cast<int>(ColorTableType::VegaWhite));
+        ui.starColorBox->addItem(_("Classic colors"), static_cast<int>(ColorTableType::Enhanced));
+        SetComboBoxValue(ui.starColorBox, static_cast<int>(colors));
+    }
 
     ui.autoMagnitudeCheck->setChecked(util::is_set(renderFlags, ::RenderFlags::ShowAutoMag));
 
+    {
+        QSignalBlocker blocker(ui.dateFormatBox);
 #ifndef _WIN32
-    ui.dateFormatBox->addItem(_("Local format"), astro::Date::Locale);
+        ui.dateFormatBox->addItem(_("Local format"), astro::Date::Locale);
 #endif
-    ui.dateFormatBox->addItem(_("Time zone name"), astro::Date::TZName);
-    ui.dateFormatBox->addItem(_("UTC offset"), astro::Date::UTCOffset);
+        ui.dateFormatBox->addItem(_("Time zone name"), astro::Date::TZName);
+        ui.dateFormatBox->addItem(_("UTC offset"), astro::Date::UTCOffset);
 
-    astro::Date::Format dateFormat = appCore->getDateFormat();
-    SetComboBoxValue(ui.dateFormatBox, dateFormat);
+        astro::Date::Format dateFormat = appCore->getDateFormat();
+        SetComboBoxValue(ui.dateFormatBox, dateFormat);
+    }
 }
 
 // Objects


### PR DESCRIPTION
Auto-connected slots on sRGBRenderingCombo, starColorBox, and dateFormatBox fire during the initial addItem() calls in the dialog constructor (the combo's current index transitions from -1 to 0). For sRGBRenderingCombo this is destructive: the slot calls settings.remove("sRGBRendering"), wiping any previously saved preference before it can be read. The other two combos transiently apply the wrong value to the renderer/appCore before SetComboBoxValue corrects it.

Wrap each populate-and-select block in a QSignalBlocker so the slots only run in response to actual user actions.