### PR TITLE
Fix empty view in multi-view with viewport effect enabled

### DIFF
--- a/src/celengine/framebuffer.cpp
+++ b/src/celengine/framebuffer.cpp
@@ -423,6 +423,15 @@ FramebufferObject::resolve() const
     if (m_msaaFboId == 0)
         return true;
 
+    // glBlitFramebuffer is affected by the scissor test, but the caller's scissor
+    // is in window coordinates while the blit destination is FBO-local. For views
+    // that don't start at (0,0) the scissor box wouldn't overlap the destination
+    // and the resolve would silently produce nothing. Disable scissor around the
+    // blit and restore the GL state afterwards.
+    GLboolean scissorEnabled = glIsEnabled(GL_SCISSOR_TEST);
+    if (scissorEnabled)
+        glDisable(GL_SCISSOR_TEST);
+
     // Desktop GL / GLES3: blit the MSAA color renderbuffer into the resolve texture FBO.
     // GL_READ_FRAMEBUFFER / GL_DRAW_FRAMEBUFFER and glBlitFramebuffer are available on
     // desktop GL (via ARB_framebuffer_object, which is required) and GLES 3.0+.
@@ -431,5 +440,8 @@ FramebufferObject::resolve() const
     glBlitFramebuffer(0, 0, static_cast<GLint>(m_width), static_cast<GLint>(m_height),
                       0, 0, static_cast<GLint>(m_width), static_cast<GLint>(m_height),
                       GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+    if (scissorEnabled)
+        glEnable(GL_SCISSOR_TEST);
     return true;
 }

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1463,6 +1463,13 @@ void Renderer::render(const Observer& observer,
 
     ambientColor = Color(ambientLightLevel, ambientLightLevel, ambientLightLevel).linearize(gl::sRGBRendering);
 
+    // glClear(GL_DEPTH_BUFFER_BIT) is masked by glDepthMask. A previous pass
+    // (e.g. a post-process quad from a prior view) may have left depthMask=false,
+    // which would silently skip clearing the depth buffer for this view.
+    PipelineState clearPs;
+    clearPs.depthMask = true;
+    setPipelineState(clearPs);
+
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 


### PR DESCRIPTION
Two independent issues caused the newly added view to render as empty when splitting horizontally/vertically while a viewport effect was active:

1. FramebufferObject::resolve() runs glBlitFramebuffer to copy MSAA samples to the resolve texture, but glBlitFramebuffer is affected by the scissor test. The caller's scissor is in window coordinates (set by setRenderRegion), while the blit destination uses FBO-local coordinates. For non-root views these regions do not overlap, so the resolve silently produced nothing. Temporarily disable the scissor test around the blit.

2. PassthroughViewportEffect::render leaves the pipeline cache with depthMask=false. The next view's Renderer::render then issues glClear(GL_DEPTH_BUFFER_BIT), which is masked by glDepthMask and becomes a no-op, so the new view's freshly created FBO keeps its uninitialized depth values and depth test produces garbage. Set a known pipeline state with depthMask enabled before the clear.
