### PR TITLE
Fix some GCC/Clang warnings

### DIFF
--- a/src/celengine/completion.cpp
+++ b/src/celengine/completion.cpp
@@ -19,7 +19,7 @@ std::string Completion::getName() const
 
 Selection Completion::getSelection() const
 {
-    return std::visit([this](auto& arg)
+    return std::visit([](auto& arg)
     {
         using T = std::decay_t<decltype(arg)>;
         if constexpr (std::is_same_v<T, Selection>)

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -134,7 +134,7 @@ BodyClassification GetClassificationId(std::string_view className)
 
 
 //! Maximum depth permitted for nested frames.
-unsigned int MaxFrameDepth = 50;
+constexpr int MaxFrameDepth = 50;
 
 // Check frames for circular references. For position frames, check both the
 // frametree hierarchy and the reference frame. For body frames, only the

--- a/src/celestia/eclipsefinder.cpp
+++ b/src/celestia/eclipsefinder.cpp
@@ -146,29 +146,16 @@ struct BodyInfo
     double endTime;
 };
 
-} // end unnamed namespace
-
-EclipseFinder::EclipseFinder(const Body* _body,
-                             EclipseFinderWatcher* _watcher) :
-    body(_body),
-    watcher(_watcher)
+std::vector<BodyInfo>
+getTestBodies(const Body* body, double startDate, double endDate)
 {
-}
-
-void EclipseFinder::findEclipses(double startDate, //NOSONAR
-                                 double endDate,
-                                 int eclipseTypeMask,
-                                 std::vector<Eclipse>& eclipses)
-{
+    std::vector<BodyInfo> testBodies;
     const FrameTree* frameTree = body->getFrameTree();
     if (!frameTree)
-    {
-        // no satellites, bail out
-        return;
-    }
+        return testBodies;
 
+    const float minRadius = body->getRadius() * MinRelativeOccluderRadius;
     // For each body, store the start and end time of the unprocessed window
-    std::vector<BodyInfo> testBodies;
     for (unsigned int i = 0, nPhases = frameTree->childCount(); i < nPhases; ++i)
     {
         const auto* phase = frameTree->getChild(i);
@@ -182,6 +169,12 @@ void EclipseFinder::findEclipses(double startDate, //NOSONAR
             continue;
 
         const Body* testBody = phase->body();
+        if (!util::is_set(testBody->getClassification(), EclipseObjectMask) ||
+            testBody->getRadius() < minRadius)
+        {
+            continue;
+        }
+
         auto it = std::find_if(testBodies.begin(), testBodies.end(),
                                [testBody](const BodyInfo& info) { return info.body == testBody; });
         if (it == testBodies.end())
@@ -195,6 +188,24 @@ void EclipseFinder::findEclipses(double startDate, //NOSONAR
         }
     }
 
+    return testBodies;
+}
+
+} // end unnamed namespace
+
+EclipseFinder::EclipseFinder(const Body* _body,
+                             EclipseFinderWatcher* _watcher) :
+    body(_body),
+    watcher(_watcher)
+{
+}
+
+void EclipseFinder::findEclipses(double startDate,
+                                 double endDate,
+                                 Eclipse::Type eclipseTypeMask,
+                                 std::vector<Eclipse>& eclipses)
+{
+    std::vector<BodyInfo> testBodies = getTestBodies(body, startDate, endDate);
     if (testBodies.empty())
         return;
 
@@ -211,11 +222,8 @@ void EclipseFinder::findEclipses(double startDate, //NOSONAR
 
     for (double t = startDate; t <= endDate; t += searchStep)
     {
-        if (watcher != nullptr)
-        {
-            if (watcher->eclipseFinderProgressUpdate(t) == EclipseFinderWatcher::AbortOperation)
-                return;
-        }
+        if (watcher && watcher->eclipseFinderProgressUpdate(t) == EclipseFinderWatcher::Status::AbortOperation)
+            return;
 
         for (unsigned int i = 0; i < testBodies.size(); ++i)
         {
@@ -226,10 +234,10 @@ void EclipseFinder::findEclipses(double startDate, //NOSONAR
             if (t < info.startTime || t >= info.endTime || t <= previousEclipseEndTimes[i])
                 continue;
 
-            if (eclipseTypeMask & Eclipse::Solar)
+            if (util::is_set(eclipseTypeMask, Eclipse::Type::Solar))
                 addEclipse(*body, *info.body, t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
 
-            if (eclipseTypeMask & Eclipse::Lunar)
+            if (util::is_set(eclipseTypeMask, Eclipse::Type::Lunar))
                 addEclipse(*info.body, *body, t, searchStep, durationPrecision, eclipses, previousEclipseEndTimes, i);
         }
     }

--- a/src/celestia/eclipsefinder.h
+++ b/src/celestia/eclipsefinder.h
@@ -14,13 +14,15 @@
 
 #include <vector>
 
+#include <celutil/flag.h>
+
 class Body;
 
 
 struct Eclipse
 {
     // values must be 2^n
-    enum Type {
+    enum class Type {
         Solar = 0x01,
         Lunar = 0x02
     };
@@ -32,11 +34,12 @@ struct Eclipse
     double endTime{ 0.0 };
 };
 
+ENUM_CLASS_BITWISE_OPS(Eclipse::Type)
 
 class EclipseFinderWatcher
 {
- public:
-    enum Status
+public:
+    enum class Status
     {
         ContinueOperation = 0,
         AbortOperation = 1,
@@ -49,14 +52,14 @@ class EclipseFinderWatcher
 
 class EclipseFinder
 {
- public:
-    EclipseFinder(const Body*, EclipseFinderWatcher* = nullptr);
+public:
+    explicit EclipseFinder(const Body*, EclipseFinderWatcher* = nullptr);
 
     void findEclipses(double startDate,
                       double endDate,
-                      int eclipseTypeMask,
+                      Eclipse::Type eclipseTypeMask,
                       std::vector<Eclipse>& eclipses);
- private:
+private:
     const Body* body;
     EclipseFinderWatcher* watcher;
 };

--- a/src/celestia/qt/qteventfinder.cpp
+++ b/src/celestia/qt/qteventfinder.cpp
@@ -343,32 +343,31 @@ EventFinder::EventFinder(CelestiaCore* _appCore,
 EclipseFinderWatcher::Status
 EventFinder::eclipseFinderProgressUpdate(double t)
 {
-    if (progress != nullptr)
-    {
-        // Avoid processing events at every update, otherwise finding eclipse
-        // can take a very long time.
-        //if (t - lastProgressUpdate > searchSpan * 0.01)
-        if (searchTimer.elapsed() >= 100)
-        {
-            searchTimer.start();
-            progress->setValue((int) t);
-            QApplication::processEvents();
-            lastProgressUpdate = t;
-        }
+    if (!progress)
+        return Status::ContinueOperation;
 
-        return progress->wasCanceled() ? AbortOperation : ContinueOperation;
+    // Avoid processing events at every update, otherwise finding eclipse
+    // can take a very long time.
+    //if (t - lastProgressUpdate > searchSpan * 0.01)
+    if (searchTimer.elapsed() >= 100)
+    {
+        searchTimer.start();
+        progress->setValue((int) t);
+        QApplication::processEvents();
+        lastProgressUpdate = t;
     }
-    return EclipseFinderWatcher::ContinueOperation;
+
+    return progress->wasCanceled() ? Status::AbortOperation : Status::ContinueOperation;
 }
 
 void
 EventFinder::slotFindEclipses()
 {
-    int eclipseTypeMask = Eclipse::Solar;
+    Eclipse::Type eclipseTypeMask = Eclipse::Type::Solar;
     if (lunarOnlyButton->isChecked())
-        eclipseTypeMask = Eclipse::Lunar;
+        eclipseTypeMask = Eclipse::Type::Lunar;
     else if (allEclipsesButton->isChecked())
-        eclipseTypeMask = Eclipse::Solar | Eclipse::Lunar;
+        eclipseTypeMask = Eclipse::Type::Solar | Eclipse::Type::Lunar;
 
     std::string bodyName = fmt::format("Sol/{}", planets[planetSelect->currentIndex()]);
     Selection obj = appCore->getSimulation()->findObjectFromPath(bodyName);

--- a/src/celestia/textinput.cpp
+++ b/src/celestia/textinput.cpp
@@ -50,7 +50,7 @@ TextInput::getCompletion() const
 std::optional<Selection>
 TextInput::getSelectedCompletion()
 {
-    if (m_completionIdx >= 0 && m_completionIdx < m_completion.size())
+    if (m_completionIdx >= 0 && m_completionIdx < static_cast<int>(m_completion.size()))
         return m_completion[m_completionIdx].getSelection();
     return std::nullopt;
 }
@@ -122,9 +122,9 @@ TextInput::doBackspace(const Simulation* sim, bool withLocations)
 void
 TextInput::doTab()
 {
-    if (m_completionIdx + 1 < (int) m_completion.size())
+    if (m_completionIdx + 1 < static_cast<int>(m_completion.size()))
         m_completionIdx++;
-    else if ((int) m_completion.size() > 0 && m_completionIdx + 1 == (int) m_completion.size())
+    else if (!m_completion.empty() && m_completionIdx + 1 == static_cast<int>(m_completion.size()))
         m_completionIdx = 0;
 
     if (m_completionIdx >= 0)

--- a/src/celestia/win32/wineclipses.cpp
+++ b/src/celestia/win32/wineclipses.cpp
@@ -305,7 +305,7 @@ EclipseFinderProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
         SendDlgItemMessage(hDlg, IDC_ECLIPSES_LIST, LVM_SETEXTENDEDLISTVIEWSTYLE, 0, LVS_EX_FULLROWSELECT);
 
         CheckRadioButton(hDlg, IDC_SOLARECLIPSE, IDC_LUNARECLIPSE, IDC_SOLARECLIPSE);
-        efd->type = Eclipse::Solar;
+        efd->type = Eclipse::Type::Solar;
 
         constexpr std::size_t numItems = 6;
         std::array<std::wstring, numItems> items
@@ -415,10 +415,10 @@ EclipseFinderProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
             }
             break;
         case IDC_SOLARECLIPSE:
-                eclipseFinderDlg->type = Eclipse::Solar;
+                eclipseFinderDlg->type = Eclipse::Type::Solar;
             break;
         case IDC_LUNARECLIPSE:
-                eclipseFinderDlg->type = Eclipse::Lunar;
+                eclipseFinderDlg->type = Eclipse::Type::Lunar;
             break;
         case IDC_ECLIPSETARGET:
             if(HIWORD(wParam) == CBN_SELCHANGE)
@@ -450,7 +450,7 @@ EclipseFinderProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
                         {
                             eclipseFinderDlg->TimetoSet_ =
                                 (eclipse->startTime + eclipse->endTime) / 2.0f;
-                            eclipseFinderDlg->BodytoSet_ = eclipseFinderDlg->type == Eclipse::Solar
+                            eclipseFinderDlg->BodytoSet_ = eclipseFinderDlg->type == Eclipse::Type::Solar
                                                          ? eclipse->receiver
                                                          : eclipse->occulter;
                         }

--- a/src/celrender/globularrenderer.h
+++ b/src/celrender/globularrenderer.h
@@ -37,7 +37,7 @@ public:
     void render();
 
 private:
-    struct FormManager;
+    class FormManager;
     struct Object;
 
     void renderForm(CelestiaGLProgram *tidalProg, CelestiaGLProgram *globProg, const Object &obj) const;

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -79,7 +79,7 @@ struct FontDescriptor
 
 struct FontMetrics
 {
-    int maxAscent;;
+    int maxAscent;
     int maxDescent;
 };
 

--- a/src/celutil/tokenizer.cpp
+++ b/src/celutil/tokenizer.cpp
@@ -97,8 +97,6 @@ private:
     void processExponentSign(int);
     void processExponent(int);
 
-    bool isInvalidEndState() const noexcept;
-
     BufferedFile* m_file;
     std::size_t m_expPos{ 0 };
     State m_state{ State::Start };
@@ -380,16 +378,6 @@ NumberStateMachine::processExponent(int next)
         m_file->advance(false);
     else
         m_state = State::End;
-}
-
-bool
-NumberStateMachine::isInvalidEndState() const noexcept
-{
-    return m_state == State::Start ||
-           m_state == State::IntegerSign ||
-           (m_state == State::FractionalPoint && !m_hasDigits) ||
-           m_state == State::ExponentSymbol ||
-           m_state == State::ExponentSign;
 }
 
 class StringStateMachine

--- a/src/tools/cmod/cmodview/modelviewwidget.cpp
+++ b/src/tools/cmod/cmodview/modelviewwidget.cpp
@@ -55,7 +55,6 @@ constexpr int ShadowBufferSize = 1024;
 constexpr int ShadowSampleKernelWidth = 2;
 
 constexpr GLuint TangentAttributeIndex = 6;
-constexpr GLuint PointSizeAttributeIndex = 7;
 
 // Calculate the matrix used to render the model from the
 // perspective of the light.


### PR DESCRIPTION
Fixes for warnings identified with Clang 21/GCC 16 using options `-Wall -pedantic`
(Annoyingly, Ubuntu 26.04 supplies a version of Eigen that triggers a bunch of unused variable warnings in GCC 15/16, I am not fixing those!)

Includes a bugfix for the eclipse finder object mask not being applied.