### PR TITLE
Fix some issues around DDS

### DIFF
--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -9,19 +9,20 @@ namespace celestia::gl
 {
 
 #ifdef GL_ES
-CELAPI bool OES_texture_border_clamp             = false; //NOSONAR
-CELAPI bool OES_geometry_shader                  = false; //NOSONAR
+CELAPI bool OES_texture_border_clamp          = false; //NOSONAR
+CELAPI bool OES_geometry_shader               = false; //NOSONAR
 #endif
-CELAPI bool ARB_texture_compression_bptc   = false; //NOSONAR
-CELAPI bool EXT_texture_compression_s3tc   = false; //NOSONAR
-CELAPI bool EXT_texture_filter_anisotropic = false; //NOSONAR
-CELAPI bool EXT_texture_sRGB_R8            = false; //NOSONAR
-CELAPI bool MESA_pack_invert               = false; //NOSONAR
-CELAPI GLint maxPointSize                  = 0; //NOSONAR
-CELAPI GLint maxTextureSize                = 0; //NOSONAR
-CELAPI GLfloat maxLineWidth                = 0.0f; //NOSONAR
-CELAPI GLint maxTextureAnisotropy          = 0; //NOSONAR
-CELAPI bool sRGBRendering                  = false; //NOSONAR
+CELAPI bool ARB_texture_compression_bptc      = false; //NOSONAR
+CELAPI bool EXT_texture_compression_s3tc      = false; //NOSONAR
+CELAPI bool EXT_texture_compression_s3tc_srgb = false; //NOSONAR
+CELAPI bool EXT_texture_filter_anisotropic    = false; //NOSONAR
+CELAPI bool EXT_texture_sRGB_R8               = false; //NOSONAR
+CELAPI bool MESA_pack_invert                  = false; //NOSONAR
+CELAPI GLint maxPointSize                     = 0; //NOSONAR
+CELAPI GLint maxTextureSize                   = 0; //NOSONAR
+CELAPI GLfloat maxLineWidth                   = 0.0f; //NOSONAR
+CELAPI GLint maxTextureAnisotropy             = 0; //NOSONAR
+CELAPI bool sRGBRendering                     = false; //NOSONAR
 
 namespace
 {
@@ -88,6 +89,13 @@ bool init(util::array_view<std::string> ignore) noexcept
     ARB_texture_compression_bptc   = check_extension(ignore, "GL_ARB_texture_compression_bptc");
 #endif
     EXT_texture_compression_s3tc   = check_extension(ignore, "GL_EXT_texture_compression_s3tc");
+#ifdef GL_ES
+    // On GLES, sRGB S3TC requires a separate extension.
+    EXT_texture_compression_s3tc_srgb = EXT_texture_compression_s3tc
+                                        && check_extension(ignore, "GL_EXT_texture_compression_s3tc_srgb");
+#else
+    EXT_texture_compression_s3tc_srgb = EXT_texture_compression_s3tc;
+#endif
     EXT_texture_filter_anisotropic = check_extension(ignore, "GL_EXT_texture_filter_anisotropic") || check_extension(ignore, "GL_ARB_texture_filter_anisotropic");
     EXT_texture_sRGB_R8            = check_extension(ignore, "GL_EXT_texture_sRGB_R8");
     MESA_pack_invert               = check_extension(ignore, "GL_MESA_pack_invert");

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -38,6 +38,7 @@ enum Version
 
 extern CELAPI bool ARB_texture_compression_bptc; //NOSONAR
 extern CELAPI bool EXT_texture_compression_s3tc; //NOSONAR
+extern CELAPI bool EXT_texture_compression_s3tc_srgb; //NOSONAR
 extern CELAPI bool EXT_texture_filter_anisotropic; //NOSONAR
 extern CELAPI bool EXT_texture_sRGB_R8; //NOSONAR
 extern CELAPI bool MESA_pack_invert; //NOSONAR

--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -147,7 +147,7 @@ GetUncompressedFormat(const DDSurfaceDesc& ddsd)
             ddsd.format.greenMask == 0x0000ff00 &&
             ddsd.format.blueMask  == 0x00ff0000)
         {
-            return PixelFormat::RGB8;
+            return PixelFormat::sRGB;
         }
 
 #ifndef GL_ES
@@ -155,7 +155,8 @@ GetUncompressedFormat(const DDSurfaceDesc& ddsd)
                     ddsd.format.greenMask == 0x0000ff00 &&
                     ddsd.format.blueMask  == 0x000000ff)
         {
-            return PixelFormat::BGR8;
+            util::GetLogger()->warn("Uncompressed BGR DDS texture loaded as linear; GL has no sBGR internal format.\n");
+            return PixelFormat::BGR;
         }
 #endif
 
@@ -167,7 +168,8 @@ GetUncompressedFormat(const DDSurfaceDesc& ddsd)
             ddsd.format.blueMask  == 0x000000ff &&
             ddsd.format.alphaMask == 0xff000000)
         {
-            return PixelFormat::BGRA8;
+            util::GetLogger()->warn("Uncompressed BGRA DDS texture loaded as linear; GL has no sBGRA internal format.\n");
+            return PixelFormat::BGRA;
         }
 
         if (ddsd.format.redMask           == 0x000000ff &&
@@ -175,7 +177,7 @@ GetUncompressedFormat(const DDSurfaceDesc& ddsd)
                     ddsd.format.blueMask  == 0x00ff0000 &&
                     ddsd.format.alphaMask == 0xff000000)
         {
-            return PixelFormat::RGBA8;
+            return PixelFormat::sRGBA;
         }
 
         break;

--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -215,13 +215,13 @@ GetFormat(const DDSurfaceDesc& ddsd)
         return GetUncompressedFormat(ddsd);
 
     case FourCC("DXT1"):
-        return PixelFormat::DXT1;
+        return PixelFormat::DXT1_sRGBA;
 
     case FourCC("DXT3"):
-        return PixelFormat::DXT3;
+        return PixelFormat::DXT3_sRGBA;
 
     case FourCC("DXT5"):
-        return PixelFormat::DXT5;
+        return PixelFormat::DXT5_sRGBA;
 
     // DX10 extended header is handled by the caller before reaching here.
 

--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -324,7 +324,16 @@ CreateDecompressedImage(const DDSurfaceDesc& ddsd, PixelFormat format, std::istr
         }
     }
 
-    auto img = std::make_unique<Image>(transparent0 ? PixelFormat::RGB : PixelFormat::RGBA, ddsd.width, ddsd.height);
+    const bool isSRGB = format == PixelFormat::DXT1_sRGBA ||
+                        format == PixelFormat::DXT3_sRGBA ||
+                        format == PixelFormat::DXT5_sRGBA ||
+                        format == PixelFormat::BC7_sRGBA;
+    PixelFormat outFormat;
+    if (transparent0)
+        outFormat = isSRGB ? PixelFormat::sRGB : PixelFormat::RGB;
+    else
+        outFormat = isSRGB ? PixelFormat::sRGBA : PixelFormat::RGBA;
+    auto img = std::make_unique<Image>(outFormat, ddsd.width, ddsd.height);
     std::memcpy(img->getPixels(), pixels.get(), (transparent0 ? 3 : 4) * ddsd.width * ddsd.height);
     return img;
 }
@@ -408,7 +417,7 @@ Image* LoadDDSImage(const std::filesystem::path& filename)
     }
 
     // Check if the platform supports compressed DTXc textures
-    if (IsCompressedFormat(format) && !IsBPTCFormat(format) && !gl::EXT_texture_compression_s3tc)
+    if (IsCompressedFormat(format) && !IsBPTCFormat(format)/* && !gl::EXT_texture_compression_s3tc*/)
         return CreateDecompressedImage(ddsd, format, in, filename).release();
 
     // TODO: Verify that the reported texture size matches the amount of

--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -128,6 +128,14 @@ IsBPTCFormat(PixelFormat format)
     return format == PixelFormat::BC7 || format == PixelFormat::BC7_sRGBA;
 }
 
+constexpr bool
+IsSRGBS3TCFormat(PixelFormat format)
+{
+    return format == PixelFormat::DXT1_sRGBA ||
+           format == PixelFormat::DXT3_sRGBA ||
+           format == PixelFormat::DXT5_sRGBA;
+}
+
 PixelFormat
 GetUncompressedFormat(const DDSurfaceDesc& ddsd)
 {
@@ -416,8 +424,10 @@ Image* LoadDDSImage(const std::filesystem::path& filename)
         return nullptr;
     }
 
-    // Check if the platform supports compressed DTXc textures
-    if (IsCompressedFormat(format) && !IsBPTCFormat(format)/* && !gl::EXT_texture_compression_s3tc*/)
+    // Decompress in software when the platform doesn't support the compressed format.
+    if (IsCompressedFormat(format) && !IsBPTCFormat(format)
+        && (!gl::EXT_texture_compression_s3tc
+            || (IsSRGBS3TCFormat(format) && !gl::EXT_texture_compression_s3tc_srgb)))
         return CreateDecompressedImage(ddsd, format, in, filename).release();
 
     // TODO: Verify that the reported texture size matches the amount of


### PR DESCRIPTION
1. sRGB DDS texture support on ES requires another extension "GL_EXT_texture_compression_s3tc_srgb"
2. sRGB format is treated as linear when decompress in software mode
3. Non-DX10 DDS textures are treated as sRGB by default