### PR TITLE
Fix some shader issues

### DIFF
--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -104,7 +104,6 @@ void main(void)
 )glsl"sv;
 
 constexpr std::string_view errorFragmentShaderSource = R"glsl(
-out vec4 fragColor;
 void main(void)
 {
    fragColor = vec4(1.0, 0.0, 0.0, 1.0);
@@ -1197,7 +1196,7 @@ R"glsl(
 
     source += DeclareLights(props);
     source += TextureCoordDeclarations(props, Shader_Out);
-    source += DeclareUniform("textureOffset", Shader_Float);
+    source += DeclareUniform("texCoordOffset", Shader_Float);
 
     if (props.usePointSize())
         source += PointSizeDeclaration();
@@ -1282,20 +1281,20 @@ R"glsl(
                                          TexUsage::OverlayTexture))
         {
             source += "diffTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + ";\n";
-            source += "diffTexCoord.x += textureOffset;\n";
+            source += "diffTexCoord.x += texCoordOffset;\n";
         }
     }
     else
     {
         if (util::is_set(props.texUsage, TexUsage::DiffuseTexture))
         {
-            source += "diffTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + " + vec2(textureOffset, 0.0);\n";
+            source += "diffTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + " + vec2(texCoordOffset, 0.0);\n";
             nTexCoords++;
         }
 
         if (util::is_set(props.texUsage, TexUsage::NormalTexture))
         {
-            source += "normTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + " + vec2(textureOffset, 0.0);\n";
+            source += "normTexCoord = " + TexCoord2D(nTexCoords, hasTexCoordTransform) + " + vec2(texCoordOffset, 0.0);\n";
             nTexCoords++;
         }
 
@@ -2840,7 +2839,7 @@ CelestiaGLProgram::initParameters()
         ringRadius           = floatParam("ringRadius");
     }
 
-    textureOffset = floatParam("textureOffset");
+    textureOffset = floatParam("texCoordOffset");
 
     if (util::is_set(props.texUsage, TexUsage::CloudShadowTexture))
     {

--- a/src/celrender/linerenderer.cpp
+++ b/src/celrender/linerenderer.cpp
@@ -498,6 +498,9 @@ LineRenderer::render(const Matrices &mvp, int count, int offset)
     if (!m_inUse)
         prerender();
 
+    if (m_prog == nullptr)
+        return;
+
     m_prog->setMVPMatrices(*mvp.projection, *mvp.modelview);
 
     if (m_useTriangles)


### PR DESCRIPTION
1. textureOffset is a GLSL built-in (since 1.30 / ES 3.00), so using it as a uniform name fails on stricter drivers. Rename the uniform to texCoordOffset. (Weird that it actually runs perfectly fine on ANGLE or iOS and only fails on Android devices)
2. The error fragment shader also redeclared fragColor, which is already declared by FragmentHeader. Drop the duplicate so the fallback shader compiles.
3. Guard against a null program in LineRenderer::render so we don't crash if shader setup failed.