### PR TITLE
Rename windowWidth/Height to viewportWidth/Height

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -488,12 +488,12 @@ float Renderer::getScaleFactor() const
 
 float Renderer::getPointWidth() const
 {
-    return 2.0f / viewportWidth * getScaleFactor();
+    return 2.0f / static_cast<float>(viewportWidth) * getScaleFactor();
 }
 
 float Renderer::getPointHeight() const
 {
-    return 2.0f / viewportHeight * getScaleFactor();
+    return 2.0f / static_cast<float>(viewportHeight) * getScaleFactor();
 }
 
 void Renderer::setFaintestAM45deg(float _faintestAutoMag45deg)

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -448,11 +448,10 @@ bool Renderer::init(int winWidth, int winHeight,
 
 void Renderer::resize(int width, int height)
 {
-    windowWidth = width;
-    windowHeight = height;
-    projectionMode->setSize(static_cast<float>(windowWidth), static_cast<float>(windowHeight));
-    // glViewport(windowWidth, windowHeight);
-    m_orthoProjMatrix = math::Ortho2D(0.0f, (float)windowWidth, 0.0f, (float)windowHeight);
+    viewportWidth = width;
+    viewportHeight = height;
+    projectionMode->setSize(static_cast<float>(viewportWidth), static_cast<float>(viewportHeight));
+    m_orthoProjMatrix = math::Ortho2D(0.0f, static_cast<float>(viewportWidth), 0.0f, static_cast<float>(viewportHeight));
 }
 
 void Renderer::setFieldOfView(float _fov)
@@ -464,16 +463,6 @@ void Renderer::setFieldOfView(float _fov)
 int Renderer::getScreenDpi() const
 {
     return screenDpi;
-}
-
-int Renderer::getWindowWidth() const
-{
-    return windowWidth;
-}
-
-int Renderer::getWindowHeight() const
-{
-    return windowHeight;
 }
 
 void Renderer::setScreenDpi(int _dpi)
@@ -499,12 +488,12 @@ float Renderer::getScaleFactor() const
 
 float Renderer::getPointWidth() const
 {
-    return 2.0f / windowWidth * getScaleFactor();
+    return 2.0f / viewportWidth * getScaleFactor();
 }
 
 float Renderer::getPointHeight() const
 {
-    return 2.0f / windowHeight * getScaleFactor();
+    return 2.0f / viewportHeight * getScaleFactor();
 }
 
 void Renderer::setFaintestAM45deg(float _faintestAutoMag45deg)
@@ -767,7 +756,7 @@ void Renderer::addAnnotation(vector<Annotation>& annotations,
                              float size,
                              bool special)
 {
-    std::array<int, 4> view{ 0, 0, windowWidth, windowHeight };
+    std::array<int, 4> view{ 0, 0, viewportWidth, viewportHeight };
     Vector3f win;
     bool success = projectionMode->project(pos, m_modelMatrix, m_projMatrix, m_MVPMatrix, view, win);
     if (success)
@@ -3963,7 +3952,7 @@ void Renderer::renderDeepSkyObjects(const Universe& universe,
     dsoRenderer.labelMode        = labelMode;
 
     dsoRenderer.frustum = projectionMode->getInfiniteFrustum(MinNearPlaneDistance, observer.getZoom());
-    // Use pixelSize * screenDpi instead of FoV, to eliminate windowHeight dependence.
+    // Use pixelSize * screenDpi instead of FoV, to eliminate viewportHeight dependence.
     // = 1.0 at startup
     float effDistanceToScreen = mmToInches((float) REF_DISTANCE_TO_SCREEN) * pixelSize * getScreenDpi();
 
@@ -4808,7 +4797,7 @@ void Renderer::setRenderRegion(int x, int y, int width, int height, bool withSci
 
 float Renderer::getAspectRatio() const
 {
-    return static_cast<float>(windowWidth) / static_cast<float>(windowHeight);
+    return static_cast<float>(viewportWidth) / static_cast<float>(viewportHeight);
 }
 
 bool Renderer::getInfo(map<string, string>& info) const
@@ -5029,8 +5018,8 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
         if (frustum.testSphere(center, cullRadius) != math::FrustumAspect::Outside)
         {
             float nearZ = center.norm() - radius;
-            float maxSpan = hypot((float) windowWidth, (float) windowHeight);
-            float nearZcoeff = cos(math::degToRad(fov / 2.0f)) * ((float) windowHeight / maxSpan);
+            float maxSpan = std::hypot(static_cast<float>(viewportWidth), static_cast<float>(viewportHeight));
+            float nearZcoeff = std::cos(math::degToRad(fov / 2.0f)) * (static_cast<float>(viewportHeight) / maxSpan);
             nearZ = -nearZ * nearZcoeff;
 
             if (nearZ > -MinNearPlaneDistance)

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -183,8 +183,6 @@ class Renderer
     void setScreenDpi(int);
     float getTextScaleFactor() const;
     void setTextScaleFactor(float);
-    int getWindowWidth() const;
-    int getWindowHeight() const;
 
     float getScaleFactor() const;
     float getPointWidth() const;
@@ -633,8 +631,8 @@ class Renderer
  private:
     std::unique_ptr<ShaderManager> shaderManager{ std::make_unique<ShaderManager>() };
 
-    int windowWidth{ 0 };
-    int windowHeight{ 0 };
+    int viewportWidth{ 0 };
+    int viewportHeight{ 0 };
     float fov{ celestia::engine::standardFOV };
     double cosViewConeAngle{ 0.0 };
     int screenDpi{ 96 };

--- a/src/celrender/skygridrenderer.cpp
+++ b/src/celrender/skygridrenderer.cpp
@@ -459,7 +459,7 @@ void
 SkyGridRenderer::render(const engine::SkyGrid& grid, float zoom)
 {
     auto vfov = static_cast<double>(m_renderer.getProjectionMode()->getFOV(zoom));
-    double viewAspectRatio = static_cast<double>(m_renderer.getWindowWidth()) / static_cast<double>(m_renderer.getWindowHeight());
+    double viewAspectRatio = static_cast<double>(m_renderer.getAspectRatio());
     Eigen::Quaterniond cameraOrientation = m_renderer.getCameraOrientation();
 
     RenderInfo renderInfo(vfov, viewAspectRatio, cameraOrientation, grid);


### PR DESCRIPTION
These were always the current render region, not the window. Drop the misleading getWindowWidth/Height accessors.