### PR TITLE
Draw PSF glow in front of resolved bodies on overflow

### DIFF
--- a/shaders/psfstarglow_frag.glsl
+++ b/shaders/psfstarglow_frag.glsl
@@ -19,6 +19,7 @@ uniform float psfB;
 uniform float pointScale;
 
 in vec3  v_color;
+in float v_alpha;
 in float v_peakRadiance;
 in float v_psfRadius;
 in float v_pointSize;
@@ -39,6 +40,15 @@ void main(void)
 
     float val = pow(base * psfB, 2.5);
     val = clamp(val, 0.0, v_peakRadiance);
+
+    // Cap per-fragment output radiance at v_alpha (hue-preserving): the
+    // PSF center can otherwise dump arbitrarily large values into the
+    // additive accumulation, oversaturating any single pixel.  Scaling
+    // by v_alpha is what actually makes the C++-side alpha fade visible
+    // — without it, premultiplied v_color and the inverse-max clamp
+    // cancel out, defeating the fade.
+    float maxCh = max(max(v_color.r, v_color.g), v_color.b);
+    val = min(val, v_alpha / max(maxCh, 1e-6));
 
     fragColor = vec4(v_color * val, 1.0);
 }

--- a/shaders/psfstarglow_vert.glsl
+++ b/shaders/psfstarglow_vert.glsl
@@ -27,7 +27,7 @@ out float v_pointSize;
 
 void main(void)
 {
-    v_color = in_Color.rgb;
+    v_color = in_Color.rgb * in_Color.a;
     v_peakRadiance = in_Intensity;
 
     // Glow mode: PSF support radius depends on peak radiance.

--- a/shaders/psfstarglow_vert.glsl
+++ b/shaders/psfstarglow_vert.glsl
@@ -21,6 +21,7 @@ uniform float psfB;        // = 1 / (pi/pointRadius - a)
 uniform float pointScale;  // DPI scale
 
 out vec3  v_color;
+out float v_alpha;
 out float v_peakRadiance;
 out float v_psfRadius;  // PSF cutoff radius in px (>0)
 out float v_pointSize;
@@ -28,6 +29,7 @@ out float v_pointSize;
 void main(void)
 {
     v_color = in_Color.rgb * in_Color.a;
+    v_alpha = in_Color.a;
     v_peakRadiance = in_Intensity;
 
     // Glow mode: PSF support radius depends on peak radiance.

--- a/shaders/psfstarglowlarge_frag.glsl
+++ b/shaders/psfstarglowlarge_frag.glsl
@@ -37,5 +37,11 @@ void main(void)
     float val = pow(base * psfB, 2.5);
     val = clamp(val, 0.0, v_peakRadiance);
 
+    // Cap per-fragment output radiance at v_color.a (hue-preserving):
+    // see psfstarglow_frag.glsl for the rationale — scaling by alpha
+    // is what makes the C++-side alpha fade visible.
+    float maxCh = max(max(v_color.r, v_color.g), v_color.b);
+    val = min(val, v_color.a / max(maxCh, 1e-6));
+
     fragColor = vec4(v_color.rgb * val, 1.0);
 }

--- a/shaders/psfstarglowlarge_vert.glsl
+++ b/shaders/psfstarglowlarge_vert.glsl
@@ -30,7 +30,7 @@ out float v_peakRadiance;
 void main(void)
 {
     v_uv           = in_TexCoord0;
-    v_color        = in_Color;
+    v_color        = vec4(in_Color.rgb * in_Color.a, in_Color.a);
     v_peakRadiance = in_Intensity;
 
     set_vp(vec4(in_Normal, 1.0));

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1619,6 +1619,7 @@ Renderer::calculatePointSize(float appMag,
 // object to smooth things out, making it dimmer as the disc size exceeds the
 // max disc size.
 void Renderer::renderObjectAsPoint(const Vector3f& position,
+                                   float distance,
                                    float radius,
                                    float appMag,
                                    float discSizeInPixels,
@@ -1637,7 +1638,7 @@ void Renderer::renderObjectAsPoint(const Vector3f& position,
     if (starStyle == StarStyle::PointSpreadFunction)
     {
         float pointScale = static_cast<float>(screenDpi) / 96.0f;
-        addStarAsPsfPoint(position, color, appMag, pointScale, radius, discSizeInPixels, emissive);
+        addStarAsPsfPoint(position, color, appMag, pointScale, distance, radius, discSizeInPixels, emissive);
         return;
     }
 
@@ -1704,6 +1705,7 @@ void Renderer::addStarAsPsfPoint(const Vector3f &position,
                                  const Color    &color,
                                  float           appMag,
                                  float           pointScale,
+                                 float           distance,
                                  float           radius,
                                  float           discSizeInPixels,
                                  bool            emissive)
@@ -1749,7 +1751,7 @@ void Renderer::addStarAsPsfPoint(const Vector3f &position,
     // Peak radiance whose bloom radius (per the shader's PSF formula)
     // equals the body's angular disc.  kLimbFudge < 1 pulls the bright
     // edge inside the limb (Askaniy's overexposure mitigation).
-    constexpr float kLimbFudge = 0.9f;
+    constexpr float kLimbFudge = 0.7f;
     float a    = starOptimization / r;
     float invB = celestia::numbers::pi_v<float> / r - a;
     float angR = kLimbFudge * discSizeInPixels / pointScale;
@@ -1777,6 +1779,26 @@ void Renderer::addStarAsPsfPoint(const Vector3f &position,
             : spritePos;
         float glowPeakToUse = overflow ? glowPeak : linkedGlowPeak;
 
+        // Fade the glow between two anchors: alpha = 1 at the
+        // distance where glowPeak == linkedGlowPeak (bloom just
+        // reaches the limb), alpha = 0 at the body's surface.  In the
+        // saturated regime glowPeak ≈ starMaxIrradiance (~constant in
+        // d) while linkedGlowPeak ∝ 1/d^2.5, so the match distance is
+        //   d_match = d_now * (linkedGlowPeak_now / glowPeak)^(1/2.5)
+        float alpha = 1.0f;
+        if (!overflow && radius > 0.0f)
+        {
+            float distToSurface = distance - radius;
+            float distMatch     = distance * std::pow(linkedGlowPeak / glowPeak, 0.4f);
+            float distToMatch   = distMatch - radius;
+            alpha = (distToMatch > 0.0f)
+                ? std::clamp(distToSurface / distToMatch, 0.0f, 1.0f)
+                : 0.0f;
+            if (alpha <= 0.0f)
+                return;
+        }
+        Color glowColor(linearStarColor, alpha);
+
         // Fast oversize check: avoid computing pow unless we actually
         // need sizePhys.  sizePhys > maxPointSize is equivalent to
         // glowPeak > (maxPointSize * a / (2 * pointScale))^2.5.
@@ -1788,11 +1810,11 @@ void Renderer::addStarAsPsfPoint(const Vector3f &position,
         {
             // Oversize glow (typical for Sol at ~1 AU): hand it to the
             // batched billboard renderer.
-            m_psfGlowLargeRenderer->addStar(glowPos, linearStarColor, glowPeakToUse);
+            m_psfGlowLargeRenderer->addStar(glowPos, glowColor, glowPeakToUse);
         }
         else
         {
-            psfGlowBuffer->addStar(glowPos, linearStarColor, glowPeakToUse);
+            psfGlowBuffer->addStar(glowPos, glowColor, glowPeakToUse);
         }
     }
 }
@@ -2962,6 +2984,7 @@ void Renderer::renderPlanet(Body& body,
         if (float maxCoeff = surfaceColor.toVector3().maxCoeff(); maxCoeff > 0.0f) // ignore [ 0 0 0 ]; used by old addons to make objects not get rendered as point
         {
             renderObjectAsPoint(pos,
+                                distance,
                                 body.getRadius(),
                                 appMag,
                                 discSizeInPixels,
@@ -3039,6 +3062,7 @@ void Renderer::renderStar(const Star& star,
     }
 
     renderObjectAsPoint(pos,
+                        distance,
                         star.getRadius(),
                         appMag,
                         discSizeInPixels,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1626,28 +1626,26 @@ void Renderer::renderObjectAsPoint(const Vector3f& position,
                                    bool useHalos,
                                    bool emissive)
 {
+    // In PSF mode, route through the PSF path when the body is a
+    // genuine light source (stars), or when it's still unresolved
+    // (any body — the point representation works regardless of
+    // whether it emits).  A resolved reflective body is excluded
+    // because the PSF's radial falloff inevitably paints a bright
+    // saturated core inside the mesh and a dim tail extending many
+    // disc radii past the limb, both of which are visible artifacts
+    // on a planet whose true visual is just the sharp-edged disc.
+    if (starStyle == StarStyle::PointSpreadFunction)
+    {
+        float pointScale = static_cast<float>(screenDpi) / 96.0f;
+        addStarAsPsfPoint(position, color, appMag, pointScale, radius, discSizeInPixels, emissive);
+        return;
+    }
+
     const bool useScaledDiscs = starStyle == StarStyle::ScaledDiscStars;
     float maxDiscSize = useScaledDiscs ? MaxScaledDiscStarSize : 1.0f;
     float maxBlendDiscSize = maxDiscSize + 3.0f;
 
     if (discSizeInPixels >= maxBlendDiscSize && !useHalos) return;
-
-    // In PSF mode, render any light source as a PSF point-sprite when
-    // the PSF blob still dominates its true angular disc.  This is the
-    // close-object counterpart to the far-star PSF path in
-    // PointStarRenderer: the per-interval projection (km-scale) used
-    // here is what allows e.g. Sol at 1 AU to escape the ly-scale near
-    // plane of renderPointStars.
-    if (starStyle == StarStyle::PointSpreadFunction)
-    {
-        float pointScale = static_cast<float>(screenDpi) / 96.0f;
-        float psfDiscPx  = 2.0f * std::max(starPointRadius, 1.0e-3f) * pointScale;
-        if (psfDiscPx > discSizeInPixels)
-        {
-            addStarAsPsfPoint(position, color, appMag, pointScale);
-            return;
-        }
-    }
 
     float fade = 1.0f;
     if (discSizeInPixels > maxDiscSize)
@@ -1705,7 +1703,10 @@ void Renderer::renderObjectAsPoint(const Vector3f& position,
 void Renderer::addStarAsPsfPoint(const Vector3f &position,
                                  const Color    &color,
                                  float           appMag,
-                                 float           pointScale)
+                                 float           pointScale,
+                                 float           radius,
+                                 float           discSizeInPixels,
+                                 bool            emissive)
 {
     // Mirrors the PSF math in PointStarRenderer::process for far stars,
     // but submits to the same psfPointBuffer / psfGlowBuffer with KM-scale
@@ -1721,6 +1722,8 @@ void Renderer::addStarAsPsfPoint(const Vector3f &position,
     ps.blendFunc = {GL_ONE, GL_ONE};
     ps.depthTest = true;
     setPipelineState(ps);
+
+    const Vector3f &spritePos = position;
 
     float exposureFactor = std::max(starExposure, 1.0e-6f);
     float r              = std::max(starPointRadius, 1.0e-3f);
@@ -1738,9 +1741,23 @@ void Renderer::addStarAsPsfPoint(const Vector3f &position,
     Color linearStarColor = psfGreenNormalization(color, 0.1f, greenScale);
     float peakRadCol = peakRad * greenScale;
 
-    if (peakRadCol > minPeak)
-        psfPointBuffer->addStar(position, linearStarColor, peakRadCol);
+    // Suppress the cone-cap sprite once the body is resolved as a
+    // mesh; the linked glow below handles the bloom around the disc.
+    if (peakRadCol > minPeak && discSizeInPixels <= 1.0f)
+        psfPointBuffer->addStar(spritePos, linearStarColor, peakRadCol);
 
+    // Peak radiance whose bloom radius (per the shader's PSF formula)
+    // equals the body's angular disc.  kLimbFudge < 1 pulls the bright
+    // edge inside the limb (Askaniy's overexposure mitigation).
+    constexpr float kLimbFudge = 0.9f;
+    float a    = starOptimization / r;
+    float invB = celestia::numbers::pi_v<float> / r - a;
+    float angR = kLimbFudge * discSizeInPixels / pointScale;
+    float linkedGlowPeak = std::pow(angR * (a + invB), 2.5f);
+
+    // Gate on the irradiance-based peak so the linked term only
+    // enhances an already-firing glow, never starts one (keeps
+    // reflective bodies with large angular radius from blooming).
     if (peakRadCol > 1.0f && starOptimization > 0.0f)
     {
         float glowPeak = peakRadCol;
@@ -1749,24 +1766,33 @@ void Renderer::addStarAsPsfPoint(const Vector3f &position,
             glowPeak = (1.0f - 1.0f / (peakRadCol / starMaxIrradiance + 1.0f))
                        * starMaxIrradiance;
         }
+        // Place glow in front when the bloom overflows the disc;
+        // otherwise pin it to the limb (emissive only).
+        bool overflow = glowPeak > linkedGlowPeak;
+        if (!overflow && !emissive)
+            return;
+
+        Vector3f glowPos = overflow && radius > 0.0f
+            ? calculateQuadCenter(getCameraOrientationf(), spritePos, radius)
+            : spritePos;
+        float glowPeakToUse = overflow ? glowPeak : linkedGlowPeak;
 
         // Fast oversize check: avoid computing pow unless we actually
         // need sizePhys.  sizePhys > maxPointSize is equivalent to
         // glowPeak > (maxPointSize * a / (2 * pointScale))^2.5.
-        float a = starOptimization / r;
         float glowPeakLargeThreshold = std::pow(static_cast<float>(celestia::gl::maxPointSize)
                                                 * a / (2.0f * pointScale),
                                                 2.5f);
 
-        if (glowPeak > glowPeakLargeThreshold)
+        if (glowPeakToUse > glowPeakLargeThreshold)
         {
             // Oversize glow (typical for Sol at ~1 AU): hand it to the
             // batched billboard renderer.
-            m_psfGlowLargeRenderer->addStar(position, linearStarColor, glowPeak);
+            m_psfGlowLargeRenderer->addStar(glowPos, linearStarColor, glowPeakToUse);
         }
         else
         {
-            psfGlowBuffer->addStar(position, linearStarColor, glowPeak);
+            psfGlowBuffer->addStar(glowPos, linearStarColor, glowPeakToUse);
         }
     }
 }
@@ -2987,7 +3013,7 @@ void Renderer::renderStar(const Star& star,
         Atmosphere atmosphere;
 
         // Use atmosphere effect to give stars a fuzzy fringe
-        if (star.hasCorona() && rp.geometry == engine::GeometryHandle::Invalid)
+        if (starStyle != StarStyle::PointSpreadFunction && star.hasCorona() && rp.geometry == engine::GeometryHandle::Invalid)
         {
             Color atmColor(color.red() * 0.5f, color.green() * 0.5f, color.blue() * 0.5f);
             atmosphere.height = radius * 0.2f /* CoronaHeight */;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1770,12 +1770,11 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
         psfPointBuffer->addStar(spritePos, linearStarColor, peakRadCol);
 
     // Peak radiance whose bloom radius (per the shader's PSF formula)
-    // equals the body's angular disc.  kLimbFudge < 1 pulls the bright
-    // edge inside the limb (Askaniy's overexposure mitigation).
-    constexpr float kLimbFudge = 0.7f;
+    // equals the body's angular disc.
+    constexpr float kLimbFudge = 1.0f;
     float a    = starOptimization / r;
     float invB = celestia::numbers::pi_v<float> / r - a;
-    float angR = kLimbFudge * discSizeInPixels / pointScale;
+    float angR = discSizeInPixels / pointScale;
     float linkedGlowPeak = std::pow(angR * (a + invB), 2.5f);
 
     // Gate on the irradiance-based peak so the linked term only
@@ -1789,23 +1788,22 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
             glowPeak = (1.0f - 1.0f / (peakRadCol / starMaxIrradiance + 1.0f))
                        * starMaxIrradiance;
         }
-        // Place glow in front when the bloom overflows the disc;
-        // otherwise pin it to the limb (emissive only).
+        // Always render the glow in front of the body (calculateQuadCenter
+        // puts it on the near-side tangent plane).  Skip entirely for
+        // resolved reflective bodies that aren't bright enough to overflow.
         bool overflow = glowPeak > linkedGlowPeak;
         if (!overflow && !emissive)
             return;
 
-        Vector3f glowPos = overflow && radius > 0.0f
-            ? calculateQuadCenter(getCameraOrientationf(), spritePos, radius)
-            : spritePos;
-        float glowPeakToUse = overflow ? glowPeak : linkedGlowPeak;
+        Vector3f glowPos = calculateQuadCenter(getCameraOrientationf(), spritePos, radius);
+        // Size tracks whichever peak is larger: glowPeak in the far/overflow
+        // regime, linkedGlowPeak once the disc resolves so the sprite keeps
+        // pace with the growing disc instead of capping at starMaxIrradiance.
+        float glowPeakToUse = std::max(glowPeak, linkedGlowPeak);
 
-        // Fade the glow as the camera approaches the surface so the
-        // disc-pinned bloom doesn't double-render over the resolved
-        // body.  See computePsfGlowAlpha for the derivation.
-        float alpha = overflow
-            ? 1.0f
-            : computePsfGlowAlpha(distance, radius, linkedGlowPeak, glowPeak);
+        // Fade alpha 1 → 0 between d_match and the body surface so the
+        // sprite vanishes smoothly as the disc takes over.
+        float alpha = computePsfGlowAlpha(distance, radius, linkedGlowPeak, glowPeak);
         if (alpha <= 0.0f)
             return;
         Color glowColor(linearStarColor, alpha);

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1771,7 +1771,6 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
 
     // Peak radiance whose bloom radius (per the shader's PSF formula)
     // equals the body's angular disc.
-    constexpr float kLimbFudge = 1.0f;
     float a    = starOptimization / r;
     float invB = celestia::numbers::pi_v<float> / r - a;
     float angR = discSizeInPixels / pointScale;
@@ -1791,8 +1790,7 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
         // Always render the glow in front of the body (calculateQuadCenter
         // puts it on the near-side tangent plane).  Skip entirely for
         // resolved reflective bodies that aren't bright enough to overflow.
-        bool overflow = glowPeak > linkedGlowPeak;
-        if (!overflow && !emissive)
+        if (glowPeak <= linkedGlowPeak && !emissive)
             return;
 
         Vector3f glowPos = calculateQuadCenter(getCameraOrientationf(), spritePos, radius);

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1618,15 +1618,15 @@ Renderer::calculatePointSize(float appMag,
 // jarring, however . . . so we'll blend in the particle view of the
 // object to smooth things out, making it dimmer as the disc size exceeds the
 // max disc size.
-void Renderer::renderObjectAsPoint(const Vector3f& position,
-                                   float distance,
-                                   float radius,
+void Renderer::renderObjectAsPoint(const PointObjectInfo& info,
                                    float appMag,
                                    float discSizeInPixels,
                                    const Color &color,
                                    bool useHalos,
                                    bool emissive)
 {
+    const Vector3f& position = info.position;
+    float radius = info.radius;
     // In PSF mode, route through the PSF path when the body is a
     // genuine light source (stars), or when it's still unresolved
     // (any body — the point representation works regardless of
@@ -1638,7 +1638,7 @@ void Renderer::renderObjectAsPoint(const Vector3f& position,
     if (starStyle == StarStyle::PointSpreadFunction)
     {
         float pointScale = static_cast<float>(screenDpi) / 96.0f;
-        addStarAsPsfPoint(position, color, appMag, pointScale, distance, radius, discSizeInPixels, emissive);
+        addStarAsPsfPoint(info, color, appMag, pointScale, discSizeInPixels, emissive);
         return;
     }
 
@@ -1701,15 +1701,36 @@ void Renderer::renderObjectAsPoint(const Vector3f& position,
 }
 
 
-void Renderer::addStarAsPsfPoint(const Vector3f &position,
+// Alpha for the disc-pinned PSF glow: 1 at the distance where
+// glowPeak == linkedGlowPeak (bloom just reaches the limb), 0 at
+// the body's surface.  In the saturated regime glowPeak is roughly
+// constant in d while linkedGlowPeak ∝ 1/d^2.5, so the match
+// distance is d_match = d_now * (linkedGlowPeak / glowPeak)^(1/2.5).
+static float
+computePsfGlowAlpha(float distance, float radius,
+                    float linkedGlowPeak, float glowPeak)
+{
+    if (radius <= 0.0f)
+        return 1.0f;
+    float distToSurface = distance - radius;
+    float distMatch     = distance * std::pow(linkedGlowPeak / glowPeak, 0.4f);
+    float distToMatch   = distMatch - radius;
+    if (distToMatch <= 0.0f)
+        return 0.0f;
+    return std::clamp(distToSurface / distToMatch, 0.0f, 1.0f);
+}
+
+
+void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
                                  const Color    &color,
                                  float           appMag,
                                  float           pointScale,
-                                 float           distance,
-                                 float           radius,
                                  float           discSizeInPixels,
                                  bool            emissive)
 {
+    const Vector3f& position = info.position;
+    float distance = info.distance;
+    float radius   = info.radius;
     // Mirrors the PSF math in PointStarRenderer::process for far stars,
     // but submits to the same psfPointBuffer / psfGlowBuffer with KM-scale
     // positions.  The buffers are drained per-interval inside
@@ -1779,24 +1800,14 @@ void Renderer::addStarAsPsfPoint(const Vector3f &position,
             : spritePos;
         float glowPeakToUse = overflow ? glowPeak : linkedGlowPeak;
 
-        // Fade the glow between two anchors: alpha = 1 at the
-        // distance where glowPeak == linkedGlowPeak (bloom just
-        // reaches the limb), alpha = 0 at the body's surface.  In the
-        // saturated regime glowPeak ≈ starMaxIrradiance (~constant in
-        // d) while linkedGlowPeak ∝ 1/d^2.5, so the match distance is
-        //   d_match = d_now * (linkedGlowPeak_now / glowPeak)^(1/2.5)
-        float alpha = 1.0f;
-        if (!overflow && radius > 0.0f)
-        {
-            float distToSurface = distance - radius;
-            float distMatch     = distance * std::pow(linkedGlowPeak / glowPeak, 0.4f);
-            float distToMatch   = distMatch - radius;
-            alpha = (distToMatch > 0.0f)
-                ? std::clamp(distToSurface / distToMatch, 0.0f, 1.0f)
-                : 0.0f;
-            if (alpha <= 0.0f)
-                return;
-        }
+        // Fade the glow as the camera approaches the surface so the
+        // disc-pinned bloom doesn't double-render over the resolved
+        // body.  See computePsfGlowAlpha for the derivation.
+        float alpha = overflow
+            ? 1.0f
+            : computePsfGlowAlpha(distance, radius, linkedGlowPeak, glowPeak);
+        if (alpha <= 0.0f)
+            return;
         Color glowColor(linearStarColor, alpha);
 
         // Fast oversize check: avoid computing pow unless we actually
@@ -2983,9 +2994,7 @@ void Renderer::renderPlanet(Body& body,
         const auto surfaceColor = body.getSurface().color.linearize(gl::sRGBRendering);
         if (float maxCoeff = surfaceColor.toVector3().maxCoeff(); maxCoeff > 0.0f) // ignore [ 0 0 0 ]; used by old addons to make objects not get rendered as point
         {
-            renderObjectAsPoint(pos,
-                                distance,
-                                body.getRadius(),
+            renderObjectAsPoint(PointObjectInfo{pos, distance, body.getRadius()},
                                 appMag,
                                 discSizeInPixels,
                                 surfaceColor * (1.0f / maxCoeff), // normalize point color; 'darkness' is handled by size of point determined by GeomAlbedo.
@@ -3061,9 +3070,7 @@ void Renderer::renderStar(const Star& star,
                      rp, LightingState(), m);
     }
 
-    renderObjectAsPoint(pos,
-                        distance,
-                        star.getRadius(),
+    renderObjectAsPoint(PointObjectInfo{pos, distance, star.getRadius()},
                         appMag,
                         discSizeInPixels,
                         color,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -528,6 +528,7 @@ class Renderer
                             float &glareAlpha) const;
 
     void renderObjectAsPoint(const Eigen::Vector3f& center,
+                             float distance,
                              float radius,
                              float appMag,
                              float discSizeInPixels,
@@ -544,6 +545,7 @@ class Renderer
                            const Color           &color,
                            float                  appMag,
                            float                  pointScale,
+                           float                  distance,
                            float                  radius,
                            float                  discSizeInPixels,
                            bool                   emissive);

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -543,7 +543,10 @@ class Renderer
     void addStarAsPsfPoint(const Eigen::Vector3f &position,
                            const Color           &color,
                            float                  appMag,
-                           float                  pointScale);
+                           float                  pointScale,
+                           float                  radius,
+                           float                  discSizeInPixels,
+                           bool                   emissive);
 
     void locationsToAnnotations(const Body& body,
                                 const Eigen::Vector3d& bodyPosition,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -527,9 +527,17 @@ class Renderer
                             float &glareSize,
                             float &glareAlpha) const;
 
-    void renderObjectAsPoint(const Eigen::Vector3f& center,
-                             float distance,
-                             float radius,
+    // Geometric description of a renderable point-like body shared by
+    // renderObjectAsPoint / addStarAsPsfPoint, so we can thread the
+    // precomputed camera distance without exceeding parameter limits.
+    struct PointObjectInfo
+    {
+        Eigen::Vector3f position;
+        float           distance;
+        float           radius;
+    };
+
+    void renderObjectAsPoint(const PointObjectInfo& info,
                              float appMag,
                              float discSizeInPixels,
                              const Color& color,
@@ -541,12 +549,10 @@ class Renderer
     // true angular disc.  Adds to psfPointBuffer / psfGlowBuffer (drained
     // per-interval inside renderSolarSystemObjects), or falls back to the
     // m_psfGlowLargeRenderer billboard path for oversize glows.
-    void addStarAsPsfPoint(const Eigen::Vector3f &position,
+    void addStarAsPsfPoint(const PointObjectInfo &info,
                            const Color           &color,
                            float                  appMag,
                            float                  pointScale,
-                           float                  distance,
-                           float                  radius,
                            float                  discSizeInPixels,
                            bool                   emissive);
 


### PR DESCRIPTION
   | body         | overflow (glowPeak > linkedGlowPeak) | result                                  |
   | ------------ | ------------------------------------ | --------------------------------------- |
   | emissive     | yes                                  | front of body, peak = `glowPeak`        |
   | emissive     | no (with fade out)                                   | body center, peak = `linkedGlowPeak`    |
   | non-emissive | yes                                  | front of body, peak = `glowPeak`        |
   | non-emissive | no                                   | **skipped**                             |
