### PR TITLE
Quick fix for limb darkening

### DIFF
--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -1760,9 +1760,10 @@ buildFragmentShader(const ShaderProperties& props)
         source += "fragColor.rgb = fragColor.rgb * scatterEx + scatterColor;\n";
     }
 
+    // Limb darkening
     if (props.lightModel == LightingModel::StarModel)
     {
-        source += "fragColor.rgb = fragColor.rgb - vec3(1.0 - NV) * vec3(0.56, 0.61, 0.72);\n";
+        source += "fragColor.rgb = fragColor.rgb * (1.0 - vec3(1.0 - NV) * vec3(0.56, 0.61, 0.72));\n";
     }
 
     if (emitLineAA)


### PR DESCRIPTION
Limb darkening used subtraction instead of division.
Spots in the center are ok, but even at 45° angle they start to have color (0, 0, 0)
<img width="1348" height="740" alt="изображение" src="https://github.com/user-attachments/assets/084cda5f-5511-4bc9-a9fb-7d15c94b08cf" />

Implemented a quick fix that also fixes the brightness normalization:
<img width="1270" height="784" alt="изображение" src="https://github.com/user-attachments/assets/8cd9ac69-eff0-4752-82fa-bd054beced4b" />