### PR TITLE
Perform premultiply alpha at last

### DIFF
--- a/shaders/psfstarglow_frag.glsl
+++ b/shaders/psfstarglow_frag.glsl
@@ -22,21 +22,27 @@ in vec3  v_color;
 in float v_alpha;
 in float v_peakRadiance;
 in float v_psfRadius;
-in float v_pointSize;
 
 void main(void)
 {
     // Pixel offset from the centre of the point sprite (in screen pixels).
-    vec2  d  = (gl_PointCoord.xy - vec2(0.5)) * v_pointSize;
-    float px = length(d) / pointScale;
+    // gl_PointSize was set to 2 * v_psfRadius * pointScale in the vertex
+    // shader, so length(gl_PointCoord - 0.5) * 2 * v_psfRadius equals the
+    // distance from the sprite centre in unscaled pixels (pointScale
+    // cancels out).
+    float px = length(gl_PointCoord.xy - vec2(0.5)) * 2.0 * v_psfRadius;
 
     // intensity = clamp(((peak^0.4 / px - a) * b)^2.5, 0, peak)
     if (px >= v_psfRadius)
         discard;
 
-    float base = pow(v_peakRadiance, 0.4) / px - psfA;
+    // p04 = pow(v_peakRadiance, 0.4) was already computed in the vertex
+    // shader as v_psfRadius * psfA -- recover it with a multiply instead
+    // of paying for a pow per fragment.
+    float p04 = v_psfRadius * psfA;
+    float base = p04 / px - psfA;
     float val = pow(base * psfB, 2.5);
-    val = clamp(val, 0.0, v_peakRadiance);
+    val = min(val, v_peakRadiance);
 
     // Clamp each channel of v_color * val to 1 BEFORE applying the
     // fade alpha so the bleached-white centre of a colored (e.g.

--- a/shaders/psfstarglow_frag.glsl
+++ b/shaders/psfstarglow_frag.glsl
@@ -28,27 +28,21 @@ void main(void)
 {
     // Pixel offset from the centre of the point sprite (in screen pixels).
     vec2  d  = (gl_PointCoord.xy - vec2(0.5)) * v_pointSize;
-    float px = length(d) / max(pointScale, 1e-6);
+    float px = length(d) / pointScale;
 
     // intensity = clamp(((peak^0.4 / px - a) * b)^2.5, 0, peak)
-    if (px <= 0.0 || px >= v_psfRadius)
+    if (px >= v_psfRadius)
         discard;
 
-    float base = pow(max(v_peakRadiance, 1e-6), 0.4) / px - psfA;
-    if (base <= 0.0)
-        discard;
-
+    float base = pow(v_peakRadiance, 0.4) / px - psfA;
     float val = pow(base * psfB, 2.5);
     val = clamp(val, 0.0, v_peakRadiance);
 
-    // Cap per-fragment output radiance at v_alpha (hue-preserving): the
-    // PSF center can otherwise dump arbitrarily large values into the
-    // additive accumulation, oversaturating any single pixel.  Scaling
-    // by v_alpha is what actually makes the C++-side alpha fade visible
-    // — without it, premultiplied v_color and the inverse-max clamp
-    // cancel out, defeating the fade.
-    float maxCh = max(max(v_color.r, v_color.g), v_color.b);
-    val = min(val, v_alpha / max(maxCh, 1e-6));
-
-    fragColor = vec4(v_color * val, 1.0);
+    // Clamp each channel of v_color * val to 1 BEFORE applying the
+    // fade alpha so the bleached-white centre of a colored (e.g.
+    // blue) star stays white through the fade, instead of reverting
+    // to its underlying tint once v_alpha drops the per-channel value
+    // back below saturation.
+    vec3 clampedColor = min(vec3(1.0), v_color * val);
+    fragColor = vec4(clampedColor * v_alpha, 1.0);
 }

--- a/shaders/psfstarglow_vert.glsl
+++ b/shaders/psfstarglow_vert.glsl
@@ -24,7 +24,6 @@ out vec3  v_color;
 out float v_alpha;
 out float v_peakRadiance;
 out float v_psfRadius;  // PSF cutoff radius in px (>0)
-out float v_pointSize;
 
 void main(void)
 {
@@ -36,9 +35,7 @@ void main(void)
     // psf_radius = peakRadiance^0.4 / a  (px, in unscaled coordinates)
     float r = pow(in_Intensity, 0.4) / psfA;
     v_psfRadius = r;
-    float size = 2.0 * r * pointScale;
 
-    v_pointSize = size;
-    gl_PointSize = size;
+    gl_PointSize = 2.0 * r * pointScale;
     set_vp(in_Position);
 }

--- a/shaders/psfstarglow_vert.glsl
+++ b/shaders/psfstarglow_vert.glsl
@@ -28,16 +28,15 @@ out float v_pointSize;
 
 void main(void)
 {
-    v_color = in_Color.rgb * in_Color.a;
+    v_color = in_Color.rgb;
     v_alpha = in_Color.a;
     v_peakRadiance = in_Intensity;
 
     // Glow mode: PSF support radius depends on peak radiance.
     // psf_radius = peakRadiance^0.4 / a  (px, in unscaled coordinates)
-    float intensity = max(in_Intensity, 1e-6);
-    float r = (psfA > 0.0) ? (pow(intensity, 0.4) / psfA) : 1.0;
+    float r = pow(in_Intensity, 0.4) / psfA;
     v_psfRadius = r;
-    float size = max(2.0 * r * pointScale, 1.0);
+    float size = 2.0 * r * pointScale;
 
     v_pointSize = size;
     gl_PointSize = size;

--- a/shaders/psfstarglowlarge_frag.glsl
+++ b/shaders/psfstarglowlarge_frag.glsl
@@ -22,26 +22,24 @@ void main(void)
 {
     // r = peak^0.4 / a is the PSF support radius in logical pixels; the
     // quad spans [-r, +r] so px = length(uv - 0.5) * 2 * r.
-    float p04 = pow(max(v_peakRadiance, 1e-6), 0.4);
-    float r   = (psfA > 0.0) ? (p04 / psfA) : 1.0;
+    float p04 = pow(v_peakRadiance, 0.4);
+    float r   = p04 / psfA;
 
     vec2  d  = (v_uv - vec2(0.5)) * 2.0 * r;
     float px = length(d);
-    if (px <= 0.0 || px >= r)
+    if (px >= r)
         discard;
 
     float base = p04 / px - psfA;
-    if (base <= 0.0)
-        discard;
-
     float val = pow(base * psfB, 2.5);
     val = clamp(val, 0.0, v_peakRadiance);
 
-    // Cap per-fragment output radiance at v_color.a (hue-preserving):
-    // see psfstarglow_frag.glsl for the rationale — scaling by alpha
-    // is what makes the C++-side alpha fade visible.
-    float maxCh = max(max(v_color.r, v_color.g), v_color.b);
-    val = min(val, v_color.a / max(maxCh, 1e-6));
-
-    fragColor = vec4(v_color.rgb * val, 1.0);
+    // Clamp each channel of v_color * val to 1 BEFORE applying the
+    // fade alpha (v_color.a) so the bleached-white centre of a
+    // coloured star stays white through the fade, instead of
+    // reverting to its underlying tint once alpha drops the
+    // per-channel value back below saturation.  See
+    // psfstarglow_frag.glsl for the full rationale.
+    vec3 clampedColor = min(vec3(1.0), v_color.rgb * val);
+    fragColor = vec4(clampedColor * v_color.a, 1.0);
 }

--- a/shaders/psfstarglowlarge_frag.glsl
+++ b/shaders/psfstarglowlarge_frag.glsl
@@ -17,22 +17,24 @@ uniform float psfB;
 in vec2  v_uv;
 in vec4  v_color;
 in float v_peakRadiance;
+in float v_psfRadius;
 
 void main(void)
 {
     // r = peak^0.4 / a is the PSF support radius in logical pixels; the
     // quad spans [-r, +r] so px = length(uv - 0.5) * 2 * r.
-    float p04 = pow(v_peakRadiance, 0.4);
-    float r   = p04 / psfA;
-
+    float r  = v_psfRadius;
     vec2  d  = (v_uv - vec2(0.5)) * 2.0 * r;
     float px = length(d);
     if (px >= r)
         discard;
 
+    // p04 = pow(v_peakRadiance, 0.4) = r * psfA -- recover with a multiply
+    // instead of paying for a pow per fragment.
+    float p04  = r * psfA;
     float base = p04 / px - psfA;
     float val = pow(base * psfB, 2.5);
-    val = clamp(val, 0.0, v_peakRadiance);
+    val = min(val, v_peakRadiance);
 
     // Clamp each channel of v_color * val to 1 BEFORE applying the
     // fade alpha (v_color.a) so the bleached-white centre of a

--- a/shaders/psfstarglowlarge_vert.glsl
+++ b/shaders/psfstarglowlarge_vert.glsl
@@ -30,7 +30,7 @@ out float v_peakRadiance;
 void main(void)
 {
     v_uv           = in_TexCoord0;
-    v_color        = vec4(in_Color.rgb * in_Color.a, in_Color.a);
+    v_color        = in_Color;
     v_peakRadiance = in_Intensity;
 
     set_vp(vec4(in_Normal, 1.0));

--- a/shaders/psfstarglowlarge_vert.glsl
+++ b/shaders/psfstarglowlarge_vert.glsl
@@ -26,6 +26,7 @@ uniform vec2  psfViewportRcp;   // (1/width, 1/height)
 out vec2  v_uv;
 out vec4  v_color;
 out float v_peakRadiance;
+out float v_psfRadius;
 
 void main(void)
 {
@@ -33,9 +34,12 @@ void main(void)
     v_color        = in_Color;
     v_peakRadiance = in_Intensity;
 
+    float r        = pow(in_Intensity, 0.4) / psfA;
+    v_psfRadius    = r;
+
     set_vp(vec4(in_Normal, 1.0));
 
-    float sizePhys = 2.0 * pow(in_Intensity, 0.4) / psfA * psfPointScale;
+    float sizePhys = 2.0 * r * psfPointScale;
     vec2  extent   = sizePhys * psfViewportRcp;
     gl_Position.xy += in_Position * extent * gl_Position.w;
 }

--- a/shaders/psfstarpoint_frag.glsl
+++ b/shaders/psfstarpoint_frag.glsl
@@ -23,11 +23,10 @@ void main(void)
 {
     // Pixel offset from the centre of the point sprite (in screen pixels).
     vec2  d  = (gl_PointCoord.xy - vec2(0.5)) * v_pointSize;
-    float px = length(d) / max(pointScale, 1e-6);
+    float px = length(d) / pointScale;
 
     // Linear cone of radius `pointRadius`, height min(peakRadiance, 1).
-    float r = max(pointRadius, 1e-6);
-    float falloff = clamp(1.0 - px / r, 0.0, 1.0);
+    float falloff = clamp(1.0 - px / pointRadius, 0.0, 1.0);
     float height  = min(v_peakRadiance, 1.0);
     vec3  radiance = v_color * (falloff * height);
 


### PR DESCRIPTION
#2567 introduced a bug that non-white stars becomes partially transparent due to because we are using rgb / max(r,g,b) as the color. This PR performs color clamping first before premultiplying alpha for fade out.

Also removed a bunch of max/if checks.