### PR TITLE
Shrink PSF glow billboard to its visible radius

### DIFF
--- a/shaders/psfstarglow_frag.glsl
+++ b/shaders/psfstarglow_frag.glsl
@@ -22,6 +22,7 @@ in vec3  v_color;
 in float v_alpha;
 in float v_peakRadiance;
 in float v_psfRadius;
+in float v_p04;
 
 void main(void)
 {
@@ -33,14 +34,15 @@ void main(void)
     float px = length(gl_PointCoord.xy - vec2(0.5)) * 2.0 * v_psfRadius;
 
     // intensity = clamp(((peak^0.4 / px - a) * b)^2.5, 0, peak)
+    // v_psfRadius now bounds the visible disc (where val*alpha >= 1 sRGB
+    // code); the discard mostly fires for the corners of the point quad.
     if (px >= v_psfRadius)
         discard;
 
-    // p04 = pow(v_peakRadiance, 0.4) was already computed in the vertex
-    // shader as v_psfRadius * psfA -- recover it with a multiply instead
-    // of paying for a pow per fragment.
-    float p04 = v_psfRadius * psfA;
-    float base = p04 / px - psfA;
+    // p04 comes through the varying; it isn't recoverable from
+    // v_psfRadius anymore because v_psfRadius is the visibility-clipped
+    // radius rather than p04/psfA.
+    float base = v_p04 / px - psfA;
     float val = pow(base * psfB, 2.5);
     val = min(val, v_peakRadiance);
 

--- a/shaders/psfstarglow_vert.glsl
+++ b/shaders/psfstarglow_vert.glsl
@@ -18,12 +18,17 @@ layout(location = 9) in float in_Intensity;
 uniform float pointRadius;
 uniform float psfA;        // = optimization / pointRadius
 uniform float psfB;        // = 1 / (pi/pointRadius - a)
+uniform float psfMinVisRad; // smallest linear radiance value that the
+                            // framebuffer can still encode as non-zero
+                            // (1/255 for linear, 1/(255*12.92) for sRGB)
 uniform float pointScale;  // DPI scale
 
 out vec3  v_color;
 out float v_alpha;
 out float v_peakRadiance;
 out float v_psfRadius;  // PSF cutoff radius in px (>0)
+out float v_p04;        // pow(peakRadiance, 0.4); needed because v_psfRadius
+                        // is now the shrunken visibility radius, not p04/a.
 
 void main(void)
 {
@@ -33,9 +38,25 @@ void main(void)
 
     // Glow mode: PSF support radius depends on peak radiance.
     // psf_radius = peakRadiance^0.4 / a  (px, in unscaled coordinates)
-    float r = pow(in_Intensity, 0.4) / psfA;
-    v_psfRadius = r;
+    float p04   = pow(in_Intensity, 0.4);
+    float rFull = p04 / psfA;
 
-    gl_PointSize = 2.0 * r * pointScale;
+    // Tighten the rasterised radius to where the post-alpha brightest
+    // channel falls below one framebuffer code (psfMinVisRad linear).
+    // The shape of the PSF inside is unchanged; we just discard the
+    // invisible rim up-front instead of running the fragment shader
+    // to discard it.
+    //
+    //   val(px) = ((p04/px - a) * b)^2.5
+    //   visible: val * alpha >= psfMinVisRad
+    //   => px <= p04 / (a + (psfMinVisRad/alpha)^0.4 / b)
+    float tVal  = psfMinVisRad / max(v_alpha, 1.0e-3);
+    float rEff  = p04 / (psfA + pow(tVal, 0.4) / psfB);
+    rEff        = min(rEff, rFull);
+
+    v_psfRadius = rEff;
+    v_p04       = p04;
+
+    gl_PointSize = 2.0 * rEff * pointScale;
     set_vp(in_Position);
 }

--- a/shaders/psfstarglowlarge_frag.glsl
+++ b/shaders/psfstarglowlarge_frag.glsl
@@ -18,21 +18,21 @@ in vec2  v_uv;
 in vec4  v_color;
 in float v_peakRadiance;
 in float v_psfRadius;
+in float v_p04;
 
 void main(void)
 {
-    // r = peak^0.4 / a is the PSF support radius in logical pixels; the
-    // quad spans [-r, +r] so px = length(uv - 0.5) * 2 * r.
+    // r is now the visibility-clipped radius (see vert shader).
     float r  = v_psfRadius;
     vec2  d  = (v_uv - vec2(0.5)) * 2.0 * r;
     float px = length(d);
     if (px >= r)
         discard;
 
-    // p04 = pow(v_peakRadiance, 0.4) = r * psfA -- recover with a multiply
-    // instead of paying for a pow per fragment.
-    float p04  = r * psfA;
-    float base = p04 / px - psfA;
+    // p04 comes through the varying; it isn't recoverable from r
+    // anymore because r is the visibility-clipped radius rather than
+    // p04/psfA.
+    float base = v_p04 / px - psfA;
     float val = pow(base * psfB, 2.5);
     val = min(val, v_peakRadiance);
 

--- a/shaders/psfstarglowlarge_vert.glsl
+++ b/shaders/psfstarglowlarge_vert.glsl
@@ -20,6 +20,9 @@ layout(location = 8) in vec4  in_Color;       // linear RGB
 layout(location = 9) in float in_Intensity;   // peak radiance
 
 uniform float psfA;             // optimization / pointRadius
+uniform float psfB;             // 1 / (pi/pointRadius - a)
+uniform float psfMinVisRad;     // smallest linear radiance the framebuffer
+                                // encodes non-zero (see psfstarglow_vert).
 uniform float psfPointScale;    // DPI scale
 uniform vec2  psfViewportRcp;   // (1/width, 1/height)
 
@@ -27,6 +30,7 @@ out vec2  v_uv;
 out vec4  v_color;
 out float v_peakRadiance;
 out float v_psfRadius;
+out float v_p04;
 
 void main(void)
 {
@@ -34,12 +38,22 @@ void main(void)
     v_color        = in_Color;
     v_peakRadiance = in_Intensity;
 
-    float r        = pow(in_Intensity, 0.4) / psfA;
-    v_psfRadius    = r;
+    float p04   = pow(in_Intensity, 0.4);
+    float rFull = p04 / psfA;
+
+    // Match psfstarglow_vert.glsl: tighten the rasterised radius to
+    // where the post-alpha brightest channel falls below one
+    // framebuffer code (psfMinVisRad linear).
+    float tVal  = psfMinVisRad / max(in_Color.a, 1.0e-3);
+    float rEff  = p04 / (psfA + pow(tVal, 0.4) / psfB);
+    rEff        = min(rEff, rFull);
+
+    v_psfRadius = rEff;
+    v_p04       = p04;
 
     set_vp(vec4(in_Normal, 1.0));
 
-    float sizePhys = 2.0 * r * psfPointScale;
+    float sizePhys = 2.0 * rEff * psfPointScale;
     vec2  extent   = sizePhys * psfViewportRcp;
     gl_Position.xy += in_Position * extent * gl_Position.w;
 }

--- a/src/celengine/psfstarvertexbuffer.cpp
+++ b/src/celengine/psfstarvertexbuffer.cpp
@@ -13,6 +13,7 @@
 
 #include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
+#include <celastro/astro.h>
 #include <celcompat/numbers.h>
 #include <celutil/color.h>
 
@@ -117,6 +118,9 @@ PsfStarVertexBuffer::makeCurrent()
         float b = (denom != 0.0f) ? (1.0f / denom) : 0.0f;
         m_prog->floatParam("psfA") = a;
         m_prog->floatParam("psfB") = b;
+        m_prog->floatParam("psfMinVisRad") = celestia::gl::sRGBRendering
+                                                 ? celestia::astro::LOWEST_IRRADIATION_SRGB
+                                                 : celestia::astro::LOWEST_IRRADIATION;
     }
 }
 

--- a/src/celrender/psfglowlargerenderer.cpp
+++ b/src/celrender/psfglowlargerenderer.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 
+#include <celastro/astro.h>
 #include <celcompat/numbers.h>
 #include <celengine/glsupport.h>
 #include <celengine/shadermanager.h>
@@ -34,6 +35,9 @@ PsfGlowLargeRenderer::onMakeCurrent(const Eigen::Vector2f &viewportRcp)
 
     program()->floatParam("psfA")           = a;
     program()->floatParam("psfB")           = b;
+    program()->floatParam("psfMinVisRad")   = celestia::gl::sRGBRendering
+                                                  ? celestia::astro::LOWEST_IRRADIATION_SRGB
+                                                  : celestia::astro::LOWEST_IRRADIATION;
     program()->floatParam("psfPointScale")  = m_pointScale;
     program()->vec2Param ("psfViewportRcp") = viewportRcp;
 }


### PR DESCRIPTION
This should greatly improve performance of PSF because the fragment size has been reduced when GPU bound.

with my testing, with 10k max irradiance + 100k exposure. The FPS increased from 33 to 68.