### PR TITLE
Use looser nearZ floor for non-convex bodies

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -5181,11 +5181,20 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
             float nearZcoeff = std::cos(math::degToRad(fov / 2.0f)) * (static_cast<float>(viewportHeight) / maxSpan);
             nearZ = -nearZ * nearZcoeff;
 
-            // Floor at 2 ULPs of `radius`: below that, float32 noise in `d`
-            // makes nearZ jump between discrete values and the atmosphere
-            // shell flickers.
-            float ulp = std::nextafter(radius, radius * 2.0f) - radius;
-            float bodyMinNearZ = std::max(MinNearPlaneDistance, ulp * 2.0f);
+            // Floor the near plane: tight 2-ULP for convex bodies, looser
+            // radius/2000 for non-convex ones whose bounding sphere is
+            // conservative and may approach the camera even when the
+            // geometry doesn't.
+            float bodyMinNearZ;
+            if (convex)
+            {
+                float ulp = std::nextafter(radius, radius * 2.0f) - radius;
+                bodyMinNearZ = std::max(MinNearPlaneDistance, ulp * 2.0f);
+            }
+            else
+            {
+                bodyMinNearZ = std::max(MinNearPlaneDistance, radius / 2000.0f);
+            }
             ri.nearZ = std::min(nearZ, -bodyMinNearZ);
 
             if (!convex)

--- a/src/celengine/texture.cpp
+++ b/src/celengine/texture.cpp
@@ -149,6 +149,8 @@ getInternalFormat(PixelFormat format, bool needsMipmap)
     case PixelFormat::DXT1_sRGBA:
     case PixelFormat::DXT3_sRGBA:
     case PixelFormat::DXT5_sRGBA:
+    case PixelFormat::BC7:
+    case PixelFormat::BC7_sRGBA:
         return static_cast<GLenum>(format);
     case PixelFormat::sRGB:
         if (!needsRGBAExpansion(format, needsMipmap))

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2062,19 +2062,27 @@ void CelestiaCore::draw(View* view)
     else
         sim->render(*renderer, *view->observer);
 
-    // Viewport need to be reset to start from (x,y) instead of point zero
-    if (process && (x != 0 || y != 0))
-        renderer->setRenderRegion(x, y, viewWidth, viewHeight);
-
     if (process)
     {
         bool ok = true;
         for (int i = 0; i < nEffects; i++)
         {
+            FramebufferObject* dst;
+            if (i == nEffects - 1)
+            {
+                // The last effect renders to the screen FBO, needs to be reset
+                // to start from (x,y) instead of point zero
+                dst = &screenFbo.value();
+                if (x != 0 || y != 0)
+                    renderer->setRenderRegion(x, y, viewWidth, viewHeight);
+            }
+            else
+            {
+                dst = view->getFBO(i + 1);
+            }
+
             FramebufferObject* src = view->getFBO(i);
-            // Last effect renders to the screen FBO; intermediate effects render to the next FBO.
-            if (FramebufferObject* dst = (i + 1 < nEffects) ? view->getFBO(i + 1) : &screenFbo.value();
-                !viewportEffects[i]->prerender(renderer, src, dst) ||
+            if (!viewportEffects[i]->prerender(renderer, src, dst) ||
                 !viewportEffects[i]->render(renderer, src, viewWidth, viewHeight))
             {
                 GetLogger()->error("Unable to render viewport effect.\n");

--- a/src/celestia/view.cpp
+++ b/src/celestia/view.cpp
@@ -281,16 +281,19 @@ View::updateFBOs(const std::vector<std::unique_ptr<ViewportEffect>>& effects, in
     if (static_cast<int>(fbos.size()) != count)
         fbos.resize(count);
 
-    for (int i = 0; i < count; i++)
+    // Walk backwards through the chain: this lets us propagate float-source
+    // requirements towards index 0 in a single pass (if any later effect
+    // needs a float source, all earlier FBOs must also be float so
+    // linear-light precision is preserved end-to-end — a half-float
+    // tonemap fed by an unorm8 intermediate would still band).
+    bool useFloat = false;
+    for (int i = count - 1; i >= 0; i--)
     {
+        useFloat = useFloat || effects[i]->needsFloatSource();
+
         // Only the first FBO needs MSAA to match the output framebuffer.
         // Subsequent FBOs receive already-resolved blits so samples=1 suffices.
         int samples = (i == 0) ? samplesToRequest : 1;
-
-        // Use a float color buffer only when the consuming effect requires it
-        // (e.g. the sRGB tonemap needs linear-light precision). Half-float
-        // texture formats are core in GLES 3.0+ and desktop GL 3.0+.
-        bool useFloat = effects[i]->needsFloatSource();
 
         auto& fbo = fbos[i];
 


### PR DESCRIPTION
The 2-ULP floor introduced in #2561 is too tight when the bounding sphere is conservative (e.g. radius*sqrt(3) for mesh bodies), which can collapse the partition near plane and trigger MaxFarNearRatio clamping. This caused z-fight slivers on Earth with the Earth Auroras add-on installed. Restore the radius/2000 floor for non-convex bodies.

Also fixes
1. BC7 textures are not handled correctly on ES
2. Viewport effects before sRGB viewport effect don't have float color frame buffer and cause loss