### PR TITLE
Rename Reflectivity to SphAlbedo; rework albedo substitutions

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -109,7 +109,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/be.po
+++ b/po/be.po
@@ -115,8 +115,8 @@ msgstr "Няправільнае значэньне GeomAlbedo: {}\n"
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
-msgstr "Няправільнае значэньне Reflectivity: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
+msgstr "Няправільнае значэньне SphAlbedo: {}\n"
 
 #: ../src/celengine/solarsys.cpp:999
 #, c++-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -111,7 +111,7 @@ msgstr "Неправилна стойност на геометричното а
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr "Неправилна стойност на отражателната способност: {}\n"
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/celestia.pot
+++ b/po/celestia.pot
@@ -106,7 +106,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/de.po
+++ b/po/de.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/el.po
+++ b/po/el.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/es.po
+++ b/po/es.po
@@ -108,7 +108,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/fr.po
+++ b/po/fr.po
@@ -111,7 +111,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/gl.po
+++ b/po/gl.po
@@ -110,8 +110,8 @@ msgstr "Valor do albedo xeométrico (GeomAlbedo) incorrecto: {}\n"
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
-msgstr "Valor da reflectividade (Reflectivity) incorrecto: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
+msgstr "Valor da reflectividade (SphAlbedo) incorrecto: {}\n"
 
 #: ../src/celengine/solarsys.cpp:999
 #, c++-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/it.po
+++ b/po/it.po
@@ -112,8 +112,8 @@ msgstr "GeomAlbedo valore non valido: {}\n"
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
-msgstr "Reflectivity valore non valido: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
+msgstr "SphAlbedo valore non valido: {}\n"
 
 #: ../src/celengine/solarsys.cpp:999
 #, c++-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/ka.po
+++ b/po/ka.po
@@ -111,8 +111,8 @@ msgstr "არასწორი GeomAlbedo მნიშვნელობა: {
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
-msgstr "არასწორი Reflectivity მნიშვნელობა: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
+msgstr "არასწორი SphAlbedo მნიშვნელობა: {}\n"
 
 #: ../src/celengine/solarsys.cpp:999
 #, c++-format

--- a/po/ko.po
+++ b/po/ko.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/lt.po
+++ b/po/lt.po
@@ -102,7 +102,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/lv.po
+++ b/po/lv.po
@@ -108,7 +108,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/nb.po
+++ b/po/nb.po
@@ -109,7 +109,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/nl.po
+++ b/po/nl.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/pl.po
+++ b/po/pl.po
@@ -113,7 +113,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/pt.po
+++ b/po/pt.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -113,8 +113,8 @@ msgstr "Valor incorreto de GeomAlbedo: {}\n"
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
-msgstr "Valor incorreto de Reflectivity: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
+msgstr "Valor incorreto de SphAlbedo: {}\n"
 
 #: ../src/celengine/solarsys.cpp:999
 #, c++-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -109,7 +109,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/ru.po
+++ b/po/ru.po
@@ -116,8 +116,8 @@ msgstr "Недопустимое значение GeomAlbedo: {}\n"
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
-msgstr "Недопустимое значение Reflectivity: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
+msgstr "Недопустимое значение SphAlbedo: {}\n"
 
 #: ../src/celengine/solarsys.cpp:999
 #, c++-format

--- a/po/sk.po
+++ b/po/sk.po
@@ -108,7 +108,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/sv.po
+++ b/po/sv.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/tr.po
+++ b/po/tr.po
@@ -110,7 +110,7 @@ msgstr "Yanlış GeomAlbedo değeri: {}\n"
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr "Yanlış Yansıma değeri: {}\n"
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/uk.po
+++ b/po/uk.po
@@ -108,7 +108,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -113,8 +113,8 @@ msgstr "错误的 GeomAlbedo 值：{}\n"
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
-msgstr "错误的 Reflectivity 值：{}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
+msgstr "错误的 SphAlbedo 值：{}\n"
 
 #: ../src/celengine/solarsys.cpp:999
 #, c++-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -107,7 +107,7 @@ msgstr ""
 
 #: ../src/celengine/solarsys.cpp:991
 #, c++-format
-msgid "Incorrect Reflectivity value: {}\n"
+msgid "Incorrect SphAlbedo value: {}\n"
 msgstr ""
 
 #: ../src/celengine/solarsys.cpp:999

--- a/src/celengine/body.cpp
+++ b/src/celengine/body.cpp
@@ -87,7 +87,7 @@ Body::setDefaultProperties()
     density = 0.0f;
     bondAlbedo = 0.5f;
     geomAlbedo = 0.5f;
-    reflectivity = 0.5f;
+    sphAlbedo = 0.5f;
     temperature = 0.0f;
     emissivity = 1.0f;
     internalHeatFlux = 0.0f;
@@ -367,15 +367,15 @@ Body::setBondAlbedo(float _bondAlbedo)
 }
 
 float
-Body::getReflectivity() const
+Body::getSphAlbedo() const
 {
-    return reflectivity;
+    return sphAlbedo;
 }
 
 void
-Body::setReflectivity(float _reflectivity)
+Body::setSphAlbedo(float _sphAlbedo)
 {
-    reflectivity = _reflectivity;
+    sphAlbedo = _sphAlbedo;
 }
 
 float
@@ -847,7 +847,7 @@ Body::getLuminosity(float sunLuminosity,
     // Compute the total energy hitting the planet
     double incidentEnergy = satIrradiance * math::circleArea(radius * 1000);
 
-    double reflectedEnergy = incidentEnergy * getReflectivity();
+    double reflectedEnergy = incidentEnergy * getGeomAlbedo();
 
     // Compute the luminosity (i.e. power relative to solar power)
     return static_cast<float>(reflectedEnergy / astro::SOLAR_POWER);

--- a/src/celengine/body.h
+++ b/src/celengine/body.h
@@ -242,8 +242,8 @@ public:
     void setGeomAlbedo(float);
     float getBondAlbedo() const;
     void setBondAlbedo(float);
-    float getReflectivity() const;
-    void setReflectivity(float);
+    float getSphAlbedo() const;
+    void setSphAlbedo(float);
     float getTemperature(double t = 0) const;
     void setTemperature(float);
     float getEmissivity() const;
@@ -367,7 +367,7 @@ private:
     float density{ 0.0f };
     float geomAlbedo{ 0.5f };
     float bondAlbedo{ 0.5f };
-    float reflectivity{ 0.5f };
+    float sphAlbedo{ 0.5f };
     float temperature{ 0.0f };
     float emissivity{ 1.0f };
     float internalHeatFlux{ 0.0f };

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1297,7 +1297,7 @@ setupSecondaryLightSources(vector<SecondaryIlluminator>& secondaryIlluminators,
             i.reflectedIrradiance += j.luminosity / ((float) (i.position_v - j.position).squaredNorm() * au2);
         }
 
-        i.reflectedIrradiance *= i.body->getReflectivity();
+        i.reflectedIrradiance *= i.body->getGeomAlbedo();
     }
 }
 

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -1480,6 +1480,7 @@ Body* CreateBody(const std::string& name,
         // TODO: make this warn
         GetLogger()->verbose("Deprecated parameter Albedo used in {} definition.\nUse GeomAlbedo & BondAlbedo instead.\n", name);
         body->setGeomAlbedo(*albedo);
+        body->setBondAlbedo(std::min(*albedo, 1.0f));
     }
 
     if (auto albedo = planetData->getNumber<float>("GeomAlbedo"); albedo.has_value())
@@ -1487,11 +1488,11 @@ Body* CreateBody(const std::string& name,
         if (*albedo > 0.0)
         {
             body->setGeomAlbedo(*albedo);
-            // Set the BondAlbedo and Reflectivity values if it is <1, otherwise as 1.
+            // Set the BondAlbedo and SphAlbedo values if it is <1, otherwise as 1.
             if (*albedo > 1.0f)
                 albedo = 1.0f;
             body->setBondAlbedo(*albedo);
-            body->setReflectivity(*albedo);
+            body->setSphAlbedo(*albedo);
         }
         else
         {
@@ -1499,12 +1500,18 @@ Body* CreateBody(const std::string& name,
         }
     }
 
-    if (auto reflectivity = planetData->getNumber<float>("Reflectivity"); reflectivity.has_value())
+    if (auto albedo = planetData->getNumber<float>("SphAlbedo"); albedo.has_value())
     {
-        if (*reflectivity >= 0.0f && *reflectivity <= 1.0f)
-            body->setReflectivity(*reflectivity);
+        if (*albedo >= 0.0f && *albedo <= 1.0f)
+        {
+            body->setSphAlbedo(*albedo);
+            // Take spherical albedo (AKA visual Bond albedo) as bolometric
+            body->setBondAlbedo(*albedo);
+        }
         else
-            GetLogger()->error(_("Incorrect Reflectivity value: {}\n"), *reflectivity);
+        {
+            GetLogger()->error(_("Incorrect SphAlbedo value: {}\n"), *albedo);
+        }
     }
 
     if (auto albedo = planetData->getNumber<float>("BondAlbedo"); albedo.has_value())

--- a/src/celscript/lua/celx_object.cpp
+++ b/src/celscript/lua/celx_object.cpp
@@ -648,7 +648,7 @@ static int object_getinfo(lua_State* l)
         celx.setTable("albedo", (lua_Number)body->getGeomAlbedo());
         celx.setTable("geomAlbedo", (lua_Number)body->getGeomAlbedo());
         celx.setTable("bondAlbedo", (lua_Number)body->getBondAlbedo());
-        celx.setTable("reflectivity", (lua_Number)body->getReflectivity());
+        celx.setTable("sphAlbedo", (lua_Number)body->getSphAlbedo());
         celx.setTable("infoURL", body->getInfoURL().c_str());
         celx.setTable("radius", (lua_Number)body->getRadius());
 


### PR DESCRIPTION
The addition of the `Reflectivity` parameter was proposed in #833, but the quantity it refers to is more often called "spherical albedo" (see [Robinson, 2025](https://arxiv.org/abs/2507.22258) as an example), being one of the suggested names in that issue. Here a shortened form is used, for consistency with `GeomAlbedo` and `BondAlbedo`.

A couple of additional assumptions for input albedo values are made:
- `SphAlbedo` is used as an stand-in for `BondAlbedo` if the latter isn't provided; the first is an wavelength-specific form of the latter (being frequently named _visual Bond albedo_), which is bolometric.
- `Albedo` (deprecated) is used for both `GeomAlbedo` and `BondAlbedo`, thus covering both possible use cases for it (setting the object brightness and temperature).

In a couple of instances, the `getReflectivity` method is replaced with `getGeomAlbedo`, as it's used to get the _maximum_ rather than average brightness, considering phase functions.