### PR TITLE
Discard annotations behind the camera

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -767,6 +767,13 @@ void Renderer::addAnnotation(vector<Annotation>& annotations,
                       pos.y() * m_modelMatrix(2, 1) +
                       pos.z() * m_modelMatrix(2, 2);
         win.z() = -depth;
+
+        // Discard annotations behind the camera (negative win.z);
+        // they are never rendered and would corrupt the near plane
+        // in buildDepthPartitions.
+        if (win.z() <= 0.0f)
+            return;
+
         // use round to remove precision error (+/- 0.0000x)
         // which causes label jittering
         float x = round(win.x());
@@ -5497,14 +5504,15 @@ Renderer::buildDepthPartitions()
     }
 
     // Adjust the nearest interval to include the closest marker (if it's
-    // closer to the observer than anything else
+    // closer to the observer than anything else).
     if (!depthSortedAnnotations.empty())
     {
-        // Factor of 0.999 makes sure ensures that the near plane does not fall
+        // Factor of 0.999 ensures that the near plane does not fall
         // exactly at the marker's z coordinate (in which case the marker
         // would be susceptible to getting clipped.)
-        if (-depthSortedAnnotations[0].position.z() > zNearest)
-            zNearest = -depthSortedAnnotations[0].position.z() * 0.999f;
+        float closestZ = depthSortedAnnotations.back().position.z();
+        if (-closestZ > zNearest)
+            zNearest = -closestZ * 0.999f;
     }
 
 #if DEBUG_COALESCE


### PR DESCRIPTION
In this URL, planet rendering is enabled, star label enabled, planet label disabled, but actually earth (object) is not visible. As soon as you enable Planet labels, it becomes visible.

cel://Follow/Sol:Earth/2026-06-14T17:07:27.02813Z?x=AFDkc1R6Sfs&y=gKxFkfsi4vv//////////w&z=AIAqZ3p8/kD5/////////w&ow=0.07218444&ox=-0.0019799145&oy=-0.9973888&oz=0.0010392186&select=Sol:Earth&fov=28.503483&ts=1&ltd=0&p=1&rf=69244307&nrf=192&lm=2049&tsrc=0&ver=3