### PR TITLE
Apply location positions as a post-processing step

### DIFF
--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -1071,8 +1071,7 @@ SolarSystemsBuilder::parseSsc(std::istream& in, //NOSONAR
         {
             if (parent.body())
             {
-                std::unique_ptr<Location> location = createLocation(*objectData, parent.body());
-                if (location != nullptr)
+                if (std::unique_ptr<Location> location = createLocation(*objectData); location)
                 {
                     UserCategory::loadCategories(location.get(), *objectData, disposition, directory.string());
                     location->setName(primaryName);
@@ -1801,14 +1800,12 @@ SolarSystemsBuilder::createTimelinePhase(Body* body, //NOSONAR
 }
 
 std::unique_ptr<Location>
-SolarSystemsBuilder::createLocation(const AssociativeArray& locationData,
-                                    const Body* body) const
+SolarSystemsBuilder::createLocation(const AssociativeArray& locationData)
 {
     auto location = std::make_unique<Location>();
 
     auto longlat = locationData.getSphericalTuple("LongLat").value_or(Eigen::Vector3d::Zero());
-    Eigen::Vector3f position = body->geodeticToCartesian(longlat).cast<float>();
-    location->setPosition(position);
+    m_locationPositions.emplace_back(location.get(), longlat);
 
     auto size = locationData.getLength<float>("Size").value_or(1.0f);
     location->setSize(size);
@@ -1856,6 +1853,16 @@ SolarSystemsBuilder::getFrameTree(const Selection& selection)
 
     // Frame center is not a star or body.
     return nullptr;
+}
+
+void
+SolarSystemsBuilder::finish() const
+{
+    // Set location positions here, after all modify operations have been processed
+    for (const auto& [location, longLat] : m_locationPositions)
+    {
+        location->setPosition(location->getParentBody()->geodeticToCartesian(longLat).cast<float>());
+    }
 }
 
 SolarSystem::SolarSystem(Star* _star) :

--- a/src/celengine/solarsys.h
+++ b/src/celengine/solarsys.h
@@ -13,9 +13,13 @@
 #include <filesystem>
 #include <iosfwd>
 #include <memory>
+#include <tuple>
 #include <unordered_map>
 
+#include <Eigen/Core>
+
 #include <celutil/associativearray.h>
+#include <celutil/blockarray.h>
 #include "astroobj.h"
 #include "parseobject.h"
 
@@ -64,6 +68,8 @@ public:
 
     bool parseSsc(std::istream& in, const std::filesystem::path& resDir);
 
+    void finish() const;
+
 private:
     enum class BodyType
     {
@@ -88,8 +94,7 @@ private:
                                const std::filesystem::path& path,
                                DataDisposition disposition);
 
-    std::unique_ptr<Location> createLocation(const celestia::util::AssociativeArray& locationData,
-                                             const Body* body) const;
+    std::unique_ptr<Location> createLocation(const celestia::util::AssociativeArray& locationData);
 
     bool createTimeline(Body* body,
                         PlanetarySystem* system,
@@ -131,4 +136,6 @@ private:
     celestia::engine::TexturePaths* m_texturePaths;
     celestia::engine::UrlManager* m_urlManager;
     FrameCache m_frameCache;
+
+    BlockArray<std::tuple<Location*, Eigen::Vector3d>> m_locationPositions;
 };

--- a/src/celestia/loadsso.cpp
+++ b/src/celestia/loadsso.cpp
@@ -78,6 +78,9 @@ loadSSO(const CelestiaConfig& config,
 
     // Next, read all the solar system files in the extras directories
     loader.loadExtras(config.paths.extrasDirs);
+
+    // Final processing now all files (and Modify operations) have been processed
+    builder.finish();
 }
 
 } // namespace celestia


### PR DESCRIPTION
Calling geodeticToCartesian on the body to apply the position should be done after all .ssc files are processed, otherwise Modify operations may result in the locations ending up at an unexpected place relative to the surface.

Fixes #1832