### PR TITLE
Remove fmt submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "thirdparty/fmt"]
-	path = thirdparty/fmt
-	url = https://github.com/fmtlib/fmt.git
 [submodule "src/tools/celestia-gaia-stardb"]
 	path = src/tools/celestia-gaia-stardb
 	url = https://codeberg.org/pelagornithid/celestia-gaia-stardb.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,11 +261,7 @@ endif()
 
 link_libraries(Eigen3::Eigen)
 
-find_package(fmt 8.1.0 CONFIG QUIET)
-if(NOT fmt_FOUND)
-  message(STATUS "Using fmt submodule")
-  add_subdirectory("${CMAKE_SOURCE_DIR}/thirdparty/fmt")
-endif()
+find_package(fmt 8.1.0 CONFIG QUIET REQUIRED)
 link_libraries(fmt::fmt)
 
 find_package(PNG REQUIRED)


### PR DESCRIPTION
We require 8.1.0 for roundtrippable floating point output. From quick package search:

| Distro | fmt version |
| --------- | ---------------- |
| Debian 11 | 7.1.3 |
| Debian 12 | 9.1.0 |
| Debian 13 | 10.1.1 |
| Ubuntu 22.04 | 8.1.1 |
| Ubuntu 24.04 | 9.1.0 |
| Ubuntu 25.10 | 10.1.1 |
| Ubuntu 26.04 | 10.1.1 |

This would be annoying for Debian 11 but that distribution is going to be unsupported at the end of August.