### PR TITLE
Switch celestia-gaia-stardb submodule to CelestiaProject mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/tools/celestia-gaia-stardb"]
 	path = src/tools/celestia-gaia-stardb
-	url = https://codeberg.org/pelagornithid/celestia-gaia-stardb.git
+	url = https://github.com/CelestiaProject/celestia-gaia-stardb.git
 [submodule "thirdparty/miniaudio"]
 	path = thirdparty/miniaudio
 	url = https://github.com/mackron/miniaudio.git


### PR DESCRIPTION
Seems there can be reliability issues checking this module out from codeberg, so switch to the mirror repo in the CelestiaProject organisation