### PR TITLE
Atmosphere phase function fixes

### DIFF
--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -702,11 +702,8 @@ ScatteringPhaseFunctions(const ShaderProperties& /*unused*/)
 
     // Evaluate the Mie and Rayleigh phase functions; both are functions of the cosine
     // of the angle between the view vector and light vector
-    source += "    float phMie = (1.0 - mieK * mieK) / ((1.0 - mieK * cosTheta) * (1.0 - mieK * cosTheta));\n";
-
-    // Ignore Rayleigh phase function and treat Rayleigh scattering as isotropic
-    // source += "    float phRayleigh = (1.0 + cosTheta * cosTheta);\n";
-    source += "    float phRayleigh = 1.0;\n";
+    source += "    float phMie = (1.0 - mieK * mieK) / ((1.0 + mieK * cosTheta) * (1.0 + mieK * cosTheta));\n";
+    source += "    float phRayleigh = 0.75 * (1.0 + cosTheta * cosTheta);\n";
 
     return source;
 }
@@ -2218,7 +2215,7 @@ buildParticleVertexShader(const ShaderProperties& props, bool fisheyeEnabled)
     {
         source += "    {\n";
         fmt::format_to(std::back_inserter(source), "         float cosTheta = dot({}, eyeDir);\n", LightProperty(i, "direction"));
-        source += "         float phMie = (1.0 - mieK * mieK) / ((1.0 - mieK * cosTheta) * (1.0 - mieK * cosTheta));\n";
+        source += "         float phMie = (1.0 - mieK * mieK) / ((1.0 + mieK * cosTheta) * (1.0 + mieK * cosTheta));\n";
         source += "         brightness += phMie;\n";
         source += "    }\n";
     }

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -729,8 +729,15 @@ void ReadAtmosphere(Body* body,
         atmosphere->mieCoeff = *mieCoeff;
     if (auto mieScaleHeight = atmosData.getLength<float>("MieScaleHeight"))
         atmosphere->mieScaleHeight = *mieScaleHeight;
-    if (auto miePhaseAsymmetry = atmosData.getNumber<float>("MieAsymmetry"); miePhaseAsymmetry.has_value())
+    if (auto miePhaseAsymmetry = atmosData.getNumber<float>("MieHGAnisotropy"); miePhaseAsymmetry.has_value())
+    {
         atmosphere->miePhaseAsymmetry = *miePhaseAsymmetry;
+    }
+    else if (auto miePhaseAsymmetry = atmosData.getNumber<float>("MieAsymmetry"); miePhaseAsymmetry.has_value())
+    {
+        GetLogger()->warn("Deprecated parameter MieAsymmetry used in {} definition.\nUse MieHGAnisotropy instead.\n", body->getName());
+        atmosphere->miePhaseAsymmetry = -*miePhaseAsymmetry; // invert sign to address established usage
+    }
     if (auto rayleighCoeff = atmosData.getVector3<float>("Rayleigh"); rayleighCoeff.has_value())
         atmosphere->rayleighCoeff = *rayleighCoeff;
     //atmosData->getNumber("RayleighScaleHeight", atmosphere->rayleighScaleHeight);


### PR DESCRIPTION
The Mie phase function had an error in that the angle theta fed to it was the phase angle rather than the angle between incoming and outgoing directions (these angles aren't the same, though comlementary to each other). Here it is fixed by inverting a couple of signs in the equation. This means that the MieAsymmetry .ssc parameter will work the opposite way it did before - unfortunate, but it should now match the definition of the phase parameter g (for the Henyey-Greenstein function)/k (Schlick).

The Rayleigh function was previously commented out in favor of isotropic scattering; now it is used. It is multiplied by a factor (taken from the scattersim source code) so that the average value is close to 1, matching the isotropic approach.