### PR TITLE
Fix two crashes

### DIFF
--- a/src/celengine/dsodbbuilder.cpp
+++ b/src/celengine/dsodbbuilder.cpp
@@ -22,6 +22,7 @@
 #include <celastro/astro.h>
 #include <celcompat/numbers.h>
 #include <celutil/associativearray.h>
+#include <celutil/fsutils.h>
 #include <celutil/logger.h>
 #include <celutil/gettext.h>
 #include <celutil/parser.h>
@@ -214,7 +215,7 @@ DSODatabaseBuilder::load(std::istream& in,
     util::Parser    parser(&tokenizer);
 
 #ifdef ENABLE_NLS
-    std::string s = resourcePath.string();
+    std::string s = util::PathToString(resourcePath);
     const char *d = s.c_str();
     bindtextdomain(d, d); // domain name is the same as resource path
 #endif
@@ -260,7 +261,7 @@ DSODatabaseBuilder::load(std::istream& in,
             continue;
         }
 
-        UserCategory::loadCategories(obj.get(), *objParams, DataDisposition::Add, resourcePath.string());
+        UserCategory::loadCategories(obj.get(), *objParams, DataDisposition::Add, util::PathToString(resourcePath));
 
         if (nextAutoCatalogNumber == AstroCatalog::InvalidIndex)
         {

--- a/src/celengine/solarsys.cpp
+++ b/src/celengine/solarsys.cpp
@@ -842,7 +842,7 @@ SolarSystemsBuilder::parseSsc(std::istream& in, //NOSONAR
     util::Parser parser(&tokenizer);
 
 #ifdef ENABLE_NLS
-    std::string s = directory.string();
+    std::string s = util::PathToString(directory);
     const char* d = s.c_str();
     bindtextdomain(d, d); // domain name is the same as resource path
 #endif
@@ -990,7 +990,7 @@ SolarSystemsBuilder::parseSsc(std::istream& in, //NOSONAR
 
                 if (body)
                 {
-                    UserCategory::loadCategories(body, *objectData, disposition, directory.string());
+                    UserCategory::loadCategories(body, *objectData, disposition, util::PathToString(directory));
                     if (disposition == DataDisposition::Add)
                         for (const auto& name : names)
                             body->addAlias(name);
@@ -1022,7 +1022,7 @@ SolarSystemsBuilder::parseSsc(std::istream& in, //NOSONAR
             {
                 if (std::unique_ptr<Location> location = createLocation(*objectData); location)
                 {
-                    UserCategory::loadCategories(location.get(), *objectData, disposition, directory.string());
+                    UserCategory::loadCategories(location.get(), *objectData, disposition, util::PathToString(directory));
                     location->setName(primaryName);
                     GetBodyFeaturesManager()->addLocation(parent.body(), std::move(location));
                 }

--- a/src/celengine/stardbbuilder.cpp
+++ b/src/celengine/stardbbuilder.cpp
@@ -722,7 +722,7 @@ StarDatabaseBuilder::load(std::istream& in, //NOSONAR
     util::Parser parser(&tokenizer);
 
 #ifdef ENABLE_NLS
-    std::string domain = resourcePath.string();
+    std::string domain = util::PathToString(resourcePath);
     const char *d = domain.c_str();
     bindtextdomain(d, d); // domain name is the same as resource path
 #else
@@ -859,9 +859,13 @@ StarDatabaseBuilder::createOrUpdateStar(const StcHeader& header,
     {
         distance = position->norm();
     }
+    else if (star == nullptr)
+    {
+        stcError(header, _("Star has no position and no existing record to update."));
+        return false;
+    }
     else
     {
-        assert(star != nullptr);
         distance = star->getPosition().norm();
     }
 

--- a/src/celengine/videooverlay.cpp
+++ b/src/celengine/videooverlay.cpp
@@ -28,6 +28,7 @@ extern "C"
 #include <libswscale/swscale.h>
 }
 
+#include <celutil/fsutils.h>
 #include <celutil/logger.h>
 #include "glsupport.h"
 #include "rectangle.h"
@@ -216,22 +217,22 @@ VideoOverlay::Impl::~Impl()
 
 bool VideoOverlay::Impl::open(const std::filesystem::path& path)
 {
-    if (avformat_open_input(&ff.fmtCtx, path.string().c_str(), nullptr, nullptr) < 0)
+    if (avformat_open_input(&ff.fmtCtx, celestia::util::PathToString(path).c_str(), nullptr, nullptr) < 0)
     {
-        GetLogger()->error("VideoOverlay: failed to open '{}'\n", path.string());
+        GetLogger()->error("VideoOverlay: failed to open '{}'\n", path);
         return false;
     }
 
     if (avformat_find_stream_info(ff.fmtCtx, nullptr) < 0)
     {
-        GetLogger()->error("VideoOverlay: no stream info in '{}'\n", path.string());
+        GetLogger()->error("VideoOverlay: no stream info in '{}'\n", path);
         return false;
     }
 
     ff.videoStream = av_find_best_stream(ff.fmtCtx, AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0);
     if (ff.videoStream < 0)
     {
-        GetLogger()->error("VideoOverlay: no video stream in '{}'\n", path.string());
+        GetLogger()->error("VideoOverlay: no video stream in '{}'\n", path);
         return false;
     }
 

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -20,6 +20,7 @@
 #include <fmt/format.h>
 
 #include <celutil/filetype.h>
+#include <celutil/fsutils.h>
 #include <celutil/logger.h>
 #include <celutil/parser.h>
 #include <celutil/tokenizer.h>
@@ -338,7 +339,7 @@ void VirtualTexture::populateTileTree()
 
             int u = -1;
             int v = -1;
-            if (auto filename = d.path().filename().string();
+            if (auto filename = celestia::util::PathToString(d.path().filename());
                 filename.size() < tilePrefix.size()
                 || std::string_view{filename.data(), tilePrefix.size()} != tilePrefix
                 || std::sscanf(filename.c_str() + tilePrefix.size(), "%d_%d.", &u, &v) != 2

--- a/src/celephem/scriptorbit.cpp
+++ b/src/celephem/scriptorbit.cpp
@@ -14,6 +14,7 @@
 #include <Eigen/Core>
 #include <lua.hpp>
 
+#include <celutil/fsutils.h>
 #include <celutil/logger.h>
 #include "orbit.h"
 #include "scriptobject.h"
@@ -222,7 +223,7 @@ CreateScriptedOrbit(const std::string* moduleName,
     SetLuaVariables(luaState, parameters);
     // set the addon path
     {
-        std::string pathStr = path.string();
+        std::string pathStr = celestia::util::PathToString(path);
         lua_pushstring(luaState, "AddonPath");
         lua_pushstring(luaState, pathStr.c_str());
         lua_settable(luaState, -3);

--- a/src/celephem/scriptrotation.cpp
+++ b/src/celephem/scriptrotation.cpp
@@ -16,6 +16,7 @@
 #include <Eigen/Geometry>
 #include <lua.hpp>
 
+#include <celutil/fsutils.h>
 #include <celutil/logger.h>
 #include "rotation.h"
 #include "scriptobject.h"
@@ -221,7 +222,7 @@ CreateScriptedRotation(const std::string* moduleName,
     SetLuaVariables(luaState, parameters);
     // set the addon path
     {
-        std::string pathStr = path.string();
+        std::string pathStr = celestia::util::PathToString(path);
         lua_pushstring(luaState, "AddonPath");
         lua_pushstring(luaState, pathStr.c_str());
         lua_settable(luaState, -3);

--- a/src/celephem/spiceinterface.cpp
+++ b/src/celephem/spiceinterface.cpp
@@ -15,6 +15,7 @@
 
 #include <SpiceUsr.h>
 
+#include <celutil/fsutils.h>
 #include <celutil/logger.h>
 
 using celestia::util::GetLogger;
@@ -97,7 +98,7 @@ bool LoadSpiceKernel(const std::filesystem::path& filepath)
     if (!getResidentKernelsSet()->insert(filepath).second)
         return true;
 
-    furnsh_c(filepath.string().c_str());
+    furnsh_c(celestia::util::PathToString(filepath).c_str());
 
     // If there was an error loading the kernel, dump the error message.
     if (failed_c())

--- a/src/celestia/catalogloader.cpp
+++ b/src/celestia/catalogloader.cpp
@@ -42,7 +42,7 @@ CatalogLoader::process(const std::filesystem::path &filePath, const std::filesys
 
     util::GetLogger()->info(_("Loading {} catalog: {}\n"), typeDesc(), filePath);
     if (m_notifier)
-        m_notifier->update(filePath.filename().string());
+        m_notifier->update(util::PathToString(filePath.filename()));
 
     if (std::ifstream catalogFile(filePath);
         !catalogFile.good() || !load(catalogFile, parentPath))

--- a/src/celestia/ffmpegcapture.cpp
+++ b/src/celestia/ffmpegcapture.cpp
@@ -18,6 +18,7 @@ extern "C"
 
 #include <celengine/render.h>
 #include <celimage/pixelformat.h>
+#include <celutil/fsutils.h>
 
 using namespace std;
 using namespace celestia;
@@ -89,9 +90,7 @@ bool FFMPEGCapturePrivate::init(const std::filesystem::path& filename)
 #endif
 
     // always use matroska (*.mkv) as a container
-    // don't change filename.string().c_str() -> filename.c_str()!
-    // on windows c_str() return wchar_t*
-    avformat_alloc_output_context2(&oc, nullptr, "matroska", filename.string().c_str());
+    avformat_alloc_output_context2(&oc, nullptr, "matroska", util::PathToString(filename).c_str());
 
     return oc != nullptr;
 }
@@ -294,13 +293,11 @@ bool FFMPEGCapturePrivate::addStream(int width, int height, float fps)
 bool FFMPEGCapturePrivate::start()
 {
     // open the output file, if needed
-    if ((oc->oformat->flags & AVFMT_NOFILE) == 0)
+    if ((oc->oformat->flags & AVFMT_NOFILE) == 0
+        && avio_open(&oc->pb, util::PathToString(filename).c_str(), AVIO_FLAG_WRITE) < 0)
     {
-        if (avio_open(&oc->pb, filename.string().c_str(), AVIO_FLAG_WRITE) < 0)
-        {
-            cout << "Failed to open video file\n";
-            return false;
-        }
+        cout << "Failed to open video file\n";
+        return false;
     }
 
     // Write the stream header, if any.
@@ -310,7 +307,7 @@ bool FFMPEGCapturePrivate::start()
         return false;
     }
 
-    av_dump_format(oc, 0, filename.string().c_str(), 1);
+    av_dump_format(oc, 0, util::PathToString(filename).c_str(), 1);
 
     if ((pkt = av_packet_alloc()) == nullptr)
     {

--- a/src/celestia/loadstars.cpp
+++ b/src/celestia/loadstars.cpp
@@ -18,6 +18,7 @@
 #include <celestia/configfile.h>
 #include <celestia/progressnotifier.h>
 #include <celutil/gettext.h>
+#include <celutil/fsutils.h>
 #include <celutil/logger.h>
 
 namespace celestia
@@ -86,7 +87,7 @@ loadStars(const CelestiaConfig &config,
     if (auto &path = config.paths.starDatabaseFile; !path.empty())
     {
         if (progressNotifier)
-            progressNotifier->update(path.string());
+            progressNotifier->update(util::PathToString(path));
 
         if (std::ifstream starFile(path, std::ios::binary); starFile.good())
         {

--- a/src/celestia/miniaudiosession.cpp
+++ b/src/celestia/miniaudiosession.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include <celutil/fsutils.h>
 #include <celutil/logger.h>
 
 #define MINIAUDIO_IMPLEMENTATION
@@ -158,7 +159,7 @@ bool MiniAudioSession::play(double startTime)
     case MiniAudioSessionPrivate::State::EngineStarted:
         // load sound file from disk into our own ma_sound, but bound to
         // the shared engine
-        result = ma_sound_init_from_file(&p->backend->engine, path().string().c_str(), MA_SOUND_FLAG_ASYNC, nullptr, nullptr, &p->sound);
+        result = ma_sound_init_from_file(&p->backend->engine, celestia::util::PathToString(path()).c_str(), MA_SOUND_FLAG_ASYNC, nullptr, nullptr, &p->sound);
         if (result != MA_SUCCESS)
         {
             GetLogger()->error("Failed to load sound file {}", path());

--- a/src/celestia/scriptmenu.cpp
+++ b/src/celestia/scriptmenu.cpp
@@ -17,6 +17,7 @@
 #include <string_view>
 
 #include <celutil/filetype.h>
+#include <celutil/fsutils.h>
 #include <celutil/gettext.h>
 #include <celutil/logger.h>
 
@@ -49,7 +50,7 @@ void process(const std::filesystem::path& p, std::vector<ScriptMenuItem>& menuIt
         return;
 
     ScriptMenuItem& item = menuItems.emplace_back();
-    item.title = p.filename().string();
+    item.title = celestia::util::PathToString(p.filename());
     item.filename = p;
 
     // Read the first line, handling various newline conventions

--- a/src/celestia/sdl/gui.cpp
+++ b/src/celestia/sdl/gui.cpp
@@ -29,9 +29,7 @@
 #include "renderdialog.h"
 #include "timedialog.h"
 
-#ifdef _WIN32
-#include <celutil/winutil.h>
-#endif
+#include <celutil/fsutils.h>
 
 namespace celestia::sdl
 {
@@ -74,11 +72,7 @@ Gui::create(SDL_Window* window, SDL_GLContext context, CelestiaCore* appCore, co
     io.IniFilename = nullptr;
 
     std::filesystem::path iniPath = environment.getImguiSettingsPath();
-#ifdef _WIN32
-    std::string iniFilename = util::WideToUTF8(iniPath.native());
-#else
-    std::string iniFilename = iniPath.string();
-#endif
+    std::string iniFilename = util::PathToString(iniPath);
 
     if (!iniFilename.empty())
         ImGui::LoadIniSettingsFromDisk(iniFilename.c_str());

--- a/src/celmodel/modelfile.cpp
+++ b/src/celmodel/modelfile.cpp
@@ -1323,16 +1323,16 @@ ModelWriter::TextWriter::writeMaterial(const Material& material) //NOSONAR
             switch (static_cast<TextureSemantic>(i))
             {
             case TextureSemantic::DiffuseMap:
-                fmt::print(*out, "texture0 \"{}\"\n", texSource.string());
+                fmt::print(*out, "texture0 \"{}\"\n", celestia::util::PathToString(texSource));
                 break;
             case TextureSemantic::NormalMap:
-                fmt::print(*out, "normalmap \"{}\"\n", texSource.string());
+                fmt::print(*out, "normalmap \"{}\"\n", celestia::util::PathToString(texSource));
                 break;
             case TextureSemantic::SpecularMap:
-                fmt::print(*out, "specularmap \"{}\"\n", texSource.string());
+                fmt::print(*out, "specularmap \"{}\"\n", celestia::util::PathToString(texSource));
                 break;
             case TextureSemantic::EmissiveMap:
-                fmt::print(*out, "emissivemap \"{}\"\n", texSource.string());
+                fmt::print(*out, "emissivemap \"{}\"\n", celestia::util::PathToString(texSource));
                 break;
             default:
                 return false;

--- a/src/celscript/lua/celx.cpp
+++ b/src/celscript/lua/celx.cpp
@@ -27,6 +27,7 @@
 #include <celengine/timeline.h>
 #include <celengine/timelinephase.h>
 #include <celutil/associativearray.h>
+#include <celutil/fsutils.h>
 #include <celutil/gettext.h>
 #include <celutil/logger.h>
 #include <celutil/stringutils.h>
@@ -656,19 +657,21 @@ int LuaState::loadScript(istream& in, const std::filesystem::path& streamname)
     info.bufSize = sizeof(buf);
     info.in = &in;
 
+    const std::string streamNameUTF8 = celestia::util::PathToString(streamname);
+
     if (streamname != "string")
     {
         lua_pushstring(state, "celestia-scriptpath");
-        lua_pushstring(state, streamname.string().c_str());
+        lua_pushstring(state, streamNameUTF8.c_str());
         lua_settable(state, LUA_REGISTRYINDEX);
     }
 
 #if LUA_VERSION_NUM >= 502
     int status = lua_load(state, readStreamChunk, &info,
-                          streamname.string().c_str(), nullptr);
+                          streamNameUTF8.c_str(), nullptr);
 #else
     int status = lua_load(state, readStreamChunk, &info,
-                          streamname.string().c_str());
+                          streamNameUTF8.c_str());
 #endif
     if (status != 0)
         cout << "Error loading script: " << lua_tostring(state, -1) << '\n';

--- a/src/celscript/lua/luascript.cpp
+++ b/src/celscript/lua/luascript.cpp
@@ -18,6 +18,7 @@
 #include <celestia/configfile.h>
 #include <celestia/celestiacore.h>
 #include <celestia/progressnotifier.h>
+#include <celutil/fsutils.h>
 #include <celutil/gettext.h>
 #include <celutil/logger.h>
 #include "celx_internal.h"
@@ -148,7 +149,7 @@ class LuaPathFinder
     {
         string out;
         for (const auto& dir : dirs)
-            out += (dir / "?.lua;").string();
+            out += util::PathToString(dir / "?.lua;");
         return out;
     }
 
@@ -217,7 +218,7 @@ bool CreateLuaEnvironment(CelestiaCore *appCore, const CelestiaConfig *config, P
             appCore->fatalError(fmt::format(fmt::runtime(_("Error opening LuaHook {}")), config->paths.luaHook));
 
         if (progressNotifier != nullptr)
-            progressNotifier->update(config->paths.luaHook.string());
+            progressNotifier->update(util::PathToString(config->paths.luaHook));
 
         status = luaHook->loadScript(scriptfile, config->paths.luaHook);
     }

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -18,6 +18,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <boost/container_hash/hash.hpp>
+
 #include <celcompat/charconv.h>
 #include <celengine/glsupport.h>
 #include <celengine/render.h>
@@ -773,7 +775,11 @@ template<> struct std::hash<FontCacheKey>
 {
     std::size_t operator()(const FontCacheKey &k) const
     {
-        return std::hash<std::string>()(celestia::util::PathToString(k.filename)) ^ std::hash<int>()(k.index) ^ std::hash<int>()(k.size);
+        std::size_t seed = 0;
+        boost::hash_combine(seed, std::filesystem::hash_value(k.filename));
+        boost::hash_combine(seed, k.index);
+        boost::hash_combine(seed, k.size);
+        return seed;
     }
 };
 

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -25,6 +25,7 @@
 #include <celimage/image.h>
 #include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
+#include <celutil/fsutils.h>
 #include <celutil/logger.h>
 #include <celutil/utf8.h>
 #include <ft2build.h>
@@ -710,7 +711,7 @@ LoadFontFace(FT_Library ft, const std::filesystem::path &path, int index, int si
 {
     FT_Face face;
 
-    if (FT_New_Face(ft, path.string().c_str(), index, &face) != 0)
+    if (FT_New_Face(ft, celestia::util::PathToString(path).c_str(), index, &face) != 0)
     {
         GetLogger()->error("Could not open font {}\n", path);
         return nullptr;
@@ -740,7 +741,7 @@ std::filesystem::path
 ParseFontName(const std::filesystem::path &filename, int &index, int &size)
 {
     // Format with font path/collection index(if any)/font size(if any)
-    auto fn = filename.string();
+    auto fn = celestia::util::PathToString(filename);
     if (auto ps = fn.rfind(','); ps != std::string::npos)
     {
         if (from_chars(&fn[ps + 1], &fn[fn.size()], size).ec == std::errc())
@@ -748,9 +749,9 @@ ParseFontName(const std::filesystem::path &filename, int &index, int &size)
             if (auto pi = fn.rfind(',', ps - 1); pi != std::string::npos)
             {
                 if (from_chars(&fn[pi + 1], &fn[pi], index).ec == std::errc())
-                    return fn.substr(0, pi);
+                    return std::filesystem::u8path(fn.substr(0, pi));
             }
-            return fn.substr(0, ps);
+            return std::filesystem::u8path(fn.substr(0, ps));
         }
     }
     return filename;
@@ -772,7 +773,7 @@ template<> struct std::hash<FontCacheKey>
 {
     std::size_t operator()(const FontCacheKey &k) const
     {
-        return std::hash<std::string>()(k.filename.string()) ^ std::hash<int>()(k.index) ^ std::hash<int>()(k.size);
+        return std::hash<std::string>()(celestia::util::PathToString(k.filename)) ^ std::hash<int>()(k.index) ^ std::hash<int>()(k.size);
     }
 };
 

--- a/src/celutil/filetype.cpp
+++ b/src/celutil/filetype.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <string_view>
 
+#include "fsutils.h"
 #include "stringutils.h"
 
 using namespace std::string_view_literals;
@@ -51,8 +52,8 @@ constexpr std::string_view ContentWarpMeshExt = ".map"sv;
 ContentType DetermineFileType(const std::filesystem::path& filename, bool isExtension)
 {
     const std::string ext = isExtension
-        ? filename.string()
-        : filename.extension().string();
+        ? celestia::util::PathToString(filename)
+        : celestia::util::PathToString(filename.extension());
 
     if (compareIgnoringCase(JPEGExt, ext) == 0 ||
         compareIgnoringCase(JPGExt, ext) == 0 ||

--- a/src/celutil/fsutils.cpp
+++ b/src/celutil/fsutils.cpp
@@ -98,6 +98,16 @@ U8FileName(std::string_view source, bool allowWildcardExtension)
     return std::filesystem::u8path(source);
 }
 
+std::string
+PathToString(const std::filesystem::path &path)
+{
+#ifdef _WIN32
+    return WideToUTF8(path.native());
+#else
+    return path.native();
+#endif
+}
+
 std::filesystem::path LocaleFilename(const std::filesystem::path &p)
 {
     const char *orig = N_("LANGUAGE");

--- a/src/celutil/fsutils.h
+++ b/src/celutil/fsutils.h
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <optional>
+#include <string>
 #include <string_view>
 
 #include <celutil/array_view.h>
@@ -34,6 +35,7 @@ struct PathHasher
 
 std::optional<std::filesystem::path> U8FileName(std::string_view source,
                                    bool allowWildcardExtension = true);
+std::string PathToString(const std::filesystem::path& path);
 std::filesystem::path LocaleFilename(const std::filesystem::path& filename);
 std::filesystem::path PathExp(std::filesystem::path&& filename);
 std::filesystem::path ResolveWildcard(const std::filesystem::path& wildcard,


### PR DESCRIPTION
Add a non-throwing celestia::util::PathToString() helper and use it everywhere a path was converted to a narrow string, since path::string() throws on Windows for paths not representable in the active code page.

Replace the assert(star != nullptr) in StarDatabaseBuilder::createOrUpdateStar with an stcError and return false, so a star with no position and no existing record logs an error instead of crashing.