### PR TITLE
Add support for HDR tone mapping

### DIFF
--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -533,4 +533,14 @@ StarTextures
 #------------------------------------------------------------------------
 # SRGBRendering true
 
+#------------------------------------------------------------------------
+# Exposure controls the exponential tone-mapping operator
+# (1 - exp(-Exposure * L)) applied to the linear HDR scene during the
+# sRGB output post-process.  It softly rolls off highlights above 1.0
+# instead of hard-clipping them.  Only takes effect when SRGBRendering
+# is enabled.
+# The default value is 1.0.
+#------------------------------------------------------------------------
+# Exposure 1.0
+
 }

--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -530,17 +530,20 @@ StarTextures
 # On OpenGL ES, the GL_EXT_sRGB extension is required; if it is not
 # available the setting is ignored.
 # The default value is false.
-#------------------------------------------------------------------------
-# SRGBRendering true
-
-#------------------------------------------------------------------------
+#
 # Exposure controls the exponential tone-mapping operator
 # (1 - exp(-Exposure * L)) applied to the linear HDR scene during the
 # sRGB output post-process.  It softly rolls off highlights above 1.0
 # instead of hard-clipping them.  Only takes effect when SRGBRendering
 # is enabled.
 # The default value is 1.0.
+#
+# ToneMapping toggles the exponential tone-map in the sRGB post-process.
+# When false, HDR highlights hard-clip to white instead of rolling off.
+# Only takes effect when SRGBRendering is enabled. The default is false.
 #------------------------------------------------------------------------
-# Exposure 1.0
+# SRGBRendering true
+# Exposure      1.0
+# ToneMapping   true
 
 }

--- a/shaders/psfstarglow_frag.glsl
+++ b/shaders/psfstarglow_frag.glsl
@@ -23,6 +23,8 @@ in float v_alpha;
 in float v_peakRadiance;
 in float v_psfRadius;
 in float v_p04;
+in float v_limbRadius;   // resolved-body limb radius in unscaled px, 0 if none
+in float v_fadeExp;      // interior-fade crush exponent (per sprite)
 
 void main(void)
 {
@@ -46,11 +48,26 @@ void main(void)
     float val = pow(base * psfB, 2.5);
     val = min(val, v_peakRadiance);
 
-    // Clamp each channel of v_color * val to 1 BEFORE applying the
-    // fade alpha so the bleached-white centre of a colored (e.g.
-    // blue) star stays white through the fade, instead of reverting
-    // to its underlying tint once v_alpha drops the per-channel value
-    // back below saturation.
-    vec3 clampedColor = min(vec3(1.0), v_color * val);
-    fragColor = vec4(clampedColor * v_alpha, 1.0);
+    // Fade the glow toward the resolving disc.  Outside the geometric limb the
+    // halo fades linearly with v_alpha.  Inside the limb reshape the interior
+    // into a plateau (kPsfCoreSharpness) so it reads as a flat-topped face, then
+    // crush it and floor at the limb brightness (valLimb * v_alpha).  The crush
+    // exponent v_fadeExp = 1 + log2(peak/valLimb) is evaluated per sprite so the
+    // disc core meets the limb floor at v_alpha == 0.5 while preserving the full
+    // plateau at v_alpha == 1.  Point sources (v_limbRadius == 0) keep the plain
+    // linear fade.
+    const float kPsfCoreSharpness = 8.0;
+    float brightness = val * v_alpha;
+    if (v_limbRadius > 0.0 && px < v_limbRadius && v_peakRadiance > 1.0)
+    {
+        float baseL   = v_p04 / v_limbRadius - psfA;
+        float valLimb = min(pow(max(baseL, 0.0) * psfB, 2.5), v_peakRadiance);
+        float t = 1.0 - px / v_limbRadius;
+        t = pow(t, 1.0 / kPsfCoreSharpness);
+        float valPlateau = mix(valLimb, v_peakRadiance, t);
+        brightness = max(valPlateau * pow(v_alpha, v_fadeExp),
+                         valLimb * v_alpha);
+    }
+
+    fragColor = vec4(v_color * brightness, 1.0);
 }

--- a/shaders/psfstarglow_vert.glsl
+++ b/shaders/psfstarglow_vert.glsl
@@ -15,6 +15,7 @@ layout(location = 0) in vec4 in_Position;
 layout(location = 8) in vec3 in_Color;
 layout(location = 9) in float in_Intensity;
 layout(location = 13) in float in_Alpha;      // glow fade
+layout(location = 14) in float in_LimbRadius; // resolved-body limb radius (px)
 
 uniform float pointRadius;
 uniform float psfA;        // = optimization / pointRadius
@@ -30,6 +31,8 @@ out float v_peakRadiance;
 out float v_psfRadius;  // PSF cutoff radius in px (>0)
 out float v_p04;        // pow(peakRadiance, 0.4); needed because v_psfRadius
                         // is now the shrunken visibility radius, not p04/a.
+out float v_limbRadius; // resolved-body limb radius in unscaled px, 0 if none
+out float v_fadeExp;    // interior-fade crush exponent (per sprite)
 
 void main(void)
 {
@@ -57,6 +60,19 @@ void main(void)
 
     v_psfRadius = rEff;
     v_p04       = p04;
+    v_limbRadius = in_LimbRadius;
+
+    // Interior-fade exponent, evaluated once per sprite so the crushed disc
+    // core meets the limb floor at v_alpha == 0.5: N = 1 + log2(peak/valLimb).
+    float fadeExp = 10.0;
+    if (in_LimbRadius > 0.0)
+    {
+        float baseL   = p04 / in_LimbRadius - psfA;
+        float valLimb = min(pow(max(baseL, 0.0) * psfB, 2.5), in_Intensity);
+        if (valLimb > 0.0)
+            fadeExp = 1.0 + log2(in_Intensity / valLimb);
+    }
+    v_fadeExp = fadeExp;
 
     gl_PointSize = 2.0 * rEff * pointScale;
     set_vp(in_Position);

--- a/shaders/psfstarglowlarge_frag.glsl
+++ b/shaders/psfstarglowlarge_frag.glsl
@@ -20,6 +20,8 @@ in float v_alpha;
 in float v_peakRadiance;
 in float v_psfRadius;
 in float v_p04;
+in float v_limbRadius;   // resolved-body limb radius in unscaled px, 0 if none
+in float v_fadeExp;      // interior-fade crush exponent (per sprite)
 
 void main(void)
 {
@@ -37,12 +39,25 @@ void main(void)
     float val = pow(base * psfB, 2.5);
     val = min(val, v_peakRadiance);
 
-    // Clamp each channel of v_color * val to 1 BEFORE applying the
-    // fade alpha (v_alpha) so the bleached-white centre of a
-    // coloured star stays white through the fade, instead of
-    // reverting to its underlying tint once alpha drops the
-    // per-channel value back below saturation.  See
-    // psfstarglow_frag.glsl for the full rationale.
-    vec3 clampedColor = min(vec3(1.0), v_color.rgb * val);
-    fragColor = vec4(clampedColor * v_alpha, 1.0);
+    // See psfstarglow_frag.glsl: outside the geometric limb the halo fades
+    // linearly with v_alpha.  Inside the limb reshape the interior into a
+    // plateau (kPsfCoreSharpness) so it reads as a flat-topped face, then crush
+    // it and floor at the limb brightness (valLimb * v_alpha).  The per-sprite
+    // exponent v_fadeExp = 1 + log2(peak/valLimb) makes the disc core meet the
+    // limb floor at v_alpha == 0.5 while preserving the full plateau at
+    // v_alpha == 1.  0 limb (point sources) => plain linear fade.
+    const float kPsfCoreSharpness = 8.0;
+    float brightness = val * v_alpha;
+    if (v_limbRadius > 0.0 && px < v_limbRadius && v_peakRadiance > 1.0)
+    {
+        float baseL   = v_p04 / v_limbRadius - psfA;
+        float valLimb = min(pow(max(baseL, 0.0) * psfB, 2.5), v_peakRadiance);
+        float t = 1.0 - px / v_limbRadius;
+        t = pow(t, 1.0 / kPsfCoreSharpness);
+        float valPlateau = mix(valLimb, v_peakRadiance, t);
+        brightness = max(valPlateau * pow(v_alpha, v_fadeExp),
+                         valLimb * v_alpha);
+    }
+
+    fragColor = vec4(v_color.rgb * brightness, 1.0);
 }

--- a/shaders/psfstarglowlarge_vert.glsl
+++ b/shaders/psfstarglowlarge_vert.glsl
@@ -19,6 +19,7 @@ layout(location = 2) in vec2  in_TexCoord0;   // quad UV in [0, 1]
 layout(location = 8) in vec3  in_Color;       // linear RGB
 layout(location = 9) in float in_Intensity;   // peak radiance
 layout(location = 13) in float in_Alpha;       // glow fade
+layout(location = 14) in float in_LimbRadius;  // resolved-body limb radius (px)
 
 uniform float psfA;             // optimization / pointRadius
 uniform float psfB;             // 1 / (pi/pointRadius - a)
@@ -33,6 +34,8 @@ out float v_alpha;
 out float v_peakRadiance;
 out float v_psfRadius;
 out float v_p04;
+out float v_limbRadius;   // resolved-body limb radius in unscaled px, 0 if none
+out float v_fadeExp;      // interior-fade crush exponent (per sprite)
 
 void main(void)
 {
@@ -40,6 +43,7 @@ void main(void)
     v_color        = in_Color;
     v_alpha        = in_Alpha;
     v_peakRadiance = in_Intensity;
+    v_limbRadius   = in_LimbRadius;
 
     float p04   = pow(in_Intensity, 0.4);
     float rFull = p04 / psfA;
@@ -53,6 +57,18 @@ void main(void)
 
     v_psfRadius = rEff;
     v_p04       = p04;
+
+    // Interior-fade exponent, evaluated once per sprite so the crushed disc
+    // core meets the limb floor at v_alpha == 0.5: N = 1 + log2(peak/valLimb).
+    float fadeExp = 10.0;
+    if (in_LimbRadius > 0.0)
+    {
+        float baseL   = p04 / in_LimbRadius - psfA;
+        float valLimb = min(pow(max(baseL, 0.0) * psfB, 2.5), in_Intensity);
+        if (valLimb > 0.0)
+            fadeExp = 1.0 + log2(in_Intensity / valLimb);
+    }
+    v_fadeExp = fadeExp;
 
     set_vp(vec4(in_Normal, 1.0));
 

--- a/shaders/psfstarpoint_frag.glsl
+++ b/shaders/psfstarpoint_frag.glsl
@@ -25,9 +25,8 @@ void main(void)
     vec2  d  = (gl_PointCoord.xy - vec2(0.5)) * v_pointSize;
     float px = length(d) / pointScale;
 
-    // Linear cone of radius `pointRadius`, height min(peakRadiance, 1).
     float falloff = clamp(1.0 - px / pointRadius, 0.0, 1.0);
-    float height  = min(v_peakRadiance, 1.0);
+    float height  = v_peakRadiance;
     vec3  radiance = v_color * (falloff * height);
 
     fragColor = vec4(radiance, 1.0);

--- a/shaders/srgb_frag.glsl
+++ b/shaders/srgb_frag.glsl
@@ -5,6 +5,9 @@ uniform sampler2D tex;
 // Exposure for tone mapping.
 uniform float exposure;
 
+// 0 skips tone mapping (linear light hard-clips on output); non-zero applies it.
+uniform float toneMapping;
+
 // Apply the sRGB electro-optical transfer function (IEC 61966-2-1).
 // Input is assumed to be linear light; output is gamma-encoded for display.
 vec3 linearToSRGB(vec3 c)
@@ -20,7 +23,8 @@ vec3 linearToSRGB(vec3 c)
 void main(void)
 {
     vec4 color = texture(tex, texCoord);
-    // Exponential tone mapping to roll off HDR highlights.
-    vec3 mapped = vec3(1.0) - exp(-exposure * max(color.rgb, vec3(0.0)));
+    // Exponential tone mapping to roll off HDR highlights, unless disabled.
+    vec3 tonemapped = vec3(1.0) - exp(-exposure * color.rgb);
+    vec3 mapped = mix(color.rgb, tonemapped, toneMapping);
     fragColor = vec4(linearToSRGB(mapped), color.a);
 }

--- a/shaders/srgb_frag.glsl
+++ b/shaders/srgb_frag.glsl
@@ -2,6 +2,9 @@ in vec2 texCoord;
 
 uniform sampler2D tex;
 
+// Exposure for tone mapping.
+uniform float exposure;
+
 // Apply the sRGB electro-optical transfer function (IEC 61966-2-1).
 // Input is assumed to be linear light; output is gamma-encoded for display.
 vec3 linearToSRGB(vec3 c)
@@ -17,8 +20,7 @@ vec3 linearToSRGB(vec3 c)
 void main(void)
 {
     vec4 color = texture(tex, texCoord);
-    // Clamp to [0,1] before conversion — the half-float FBO can accumulate
-    // values above 1.0 from additive blending (e.g. star glow), which must
-    // be saturated before the sRGB transfer function is applied.
-    fragColor = vec4(linearToSRGB(min(color.rgb, vec3(1.0))), color.a);
+    // Exponential tone mapping to roll off HDR highlights.
+    vec3 mapped = vec3(1.0) - exp(-exposure * max(color.rgb, vec3(0.0)));
+    fragColor = vec4(linearToSRGB(mapped), color.a);
 }

--- a/shaders/srgb_frag.glsl
+++ b/shaders/srgb_frag.glsl
@@ -24,7 +24,8 @@ void main(void)
 {
     vec4 color = texture(tex, texCoord);
     // Exponential tone mapping to roll off HDR highlights, unless disabled.
-    vec3 tonemapped = vec3(1.0) - exp(-exposure * color.rgb);
-    vec3 mapped = mix(color.rgb, tonemapped, toneMapping);
+    vec3 mapped = color.rgb;
+    if (toneMapping != 0.0)
+        mapped = vec3(1.0) - exp(-exposure * color.rgb);
     fragColor = vec4(linearToSRGB(mapped), color.a);
 }

--- a/src/celengine/psfstarvertexbuffer.cpp
+++ b/src/celengine/psfstarvertexbuffer.cpp
@@ -166,6 +166,15 @@ PsfStarVertexBuffer::setupVertexArrayObject()
 
     m_vo->addVertexBuffer(
         *m_bo,
+        CelestiaGLProgram::LimbRadiusAttributeIndex,
+        1,
+        gl::VertexObject::DataType::Float,
+        false,
+        sizeof(StarVertex),
+        offsetof(StarVertex, limbRadius));
+
+    m_vo->addVertexBuffer(
+        *m_bo,
         CelestiaGLProgram::ColorAttributeIndex,
         3,
         gl::VertexObject::DataType::UnsignedByte,
@@ -201,12 +210,14 @@ void
 PsfStarVertexBuffer::addStar(const Eigen::Vector3f &pos,
                              const Color &color,
                              float peakRadiance,
+                             float limbRadius,
                              float alpha)
 {
     if (m_nStars < m_capacity)
     {
         m_vertices[m_nStars].position = pos;
         m_vertices[m_nStars].peakRadiance = peakRadiance;
+        m_vertices[m_nStars].limbRadius = limbRadius;
         m_vertices[m_nStars].alpha = alpha;
         color.get(m_vertices[m_nStars].color.data());
         m_nStars++;

--- a/src/celengine/psfstarvertexbuffer.h
+++ b/src/celengine/psfstarvertexbuffer.h
@@ -58,7 +58,7 @@ public:
     void finish() override;
 
     void addStar(const Eigen::Vector3f &pos, const Color &color, float peakRadiance,
-                 float alpha = 1.0f);
+                 float limbRadius = 0.0f, float alpha = 1.0f);
 
     void setPointRadius(float r)      { m_pointRadius = r; }
     void setOptimization(float opt)   { m_optimization = opt; }
@@ -72,8 +72,9 @@ private:
     {
         Eigen::Vector3f            position;
         float                      peakRadiance;
-        float                      alpha;   // glow fade
-        std::array<unsigned char, 4> color; // rgb only; alpha byte unused
+        float                      limbRadius;   // resolved-body limb (px), 0 if none
+        float                      alpha;        // glow fade, full float precision
+        std::array<unsigned char, 4> color;      // rgb only; alpha byte unused
     };
 
     const Renderer                 &m_renderer;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1775,9 +1775,6 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
     ps.depthTest = true;
     setPipelineState(ps);
 
-    const Vector3f &spritePos = position;
-    Vector3f frontPos = calculateQuadCenter(getCameraOrientationf(), spritePos, radius);
-
     float exposureFactor = std::max(starExposure, 1.0e-6f);
     float r              = std::max(starPointRadius, 1.0e-3f);
     float peakRadScale   = exposureFactor * 3.0f
@@ -1800,6 +1797,8 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
     float greenScale = 1.0f;
     Color linearStarColor = psfGreenNormalization(color, 0.1f, greenScale);
     float peakRadCol = peakRad * greenScale;
+
+    Eigen::Vector3f frontPos = calculateQuadCenter(getCameraOrientationf(), position, radius);
 
     // Suppress the cone-cap sprite once the body is resolved as a
     // mesh; the linked glow below handles the bloom around the disc.
@@ -1859,11 +1858,11 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
         {
             // Oversize glow (typical for Sol at ~1 AU): hand it to the
             // batched billboard renderer.
-            m_psfGlowLargeRenderer->addStar(glowPos, linearStarColor, glowPeakToUse, alpha);
+            m_psfGlowLargeRenderer->addStar(glowPos, linearStarColor, glowPeakToUse, angR, alpha);
         }
         else
         {
-            psfGlowBuffer->addStar(glowPos, linearStarColor, glowPeakToUse, alpha);
+            psfGlowBuffer->addStar(glowPos, linearStarColor, glowPeakToUse, angR, alpha);
         }
     }
 }
@@ -4662,6 +4661,19 @@ void Renderer::setExposure(float e)
 float Renderer::getExposure() const
 {
     return exposure;
+}
+
+
+void Renderer::setToneMapping(bool enabled)
+{
+    toneMapping = enabled;
+    markSettingsChanged();
+}
+
+
+bool Renderer::getToneMapping() const
+{
+    return toneMapping;
 }
 
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4652,6 +4652,19 @@ float Renderer::getStarExposure() const
 }
 
 
+void Renderer::setExposure(float e)
+{
+    exposure = std::clamp(e, 1.0e-3f, 1.0e6f);
+    markSettingsChanged();
+}
+
+
+float Renderer::getExposure() const
+{
+    return exposure;
+}
+
+
 void Renderer::loadTextures(Body* body)
 {
     const Surface& surface = body->getSurface();

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1805,22 +1805,33 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
     if (discSizeInPixels <= 1.0f)
         psfPointBuffer->addStar(frontPos, linearStarColor, peakRadCol);
 
-    // Peak radiance whose bloom radius (per the shader's PSF formula)
-    // equals the body's angular disc.
-    float a    = starOptimization / r;
-    float invB = celestia::numbers::pi_v<float> / r - a;
-    // Exact projected limb radius; discSizeInPixels undershoots up close.
-    float limbDiscPixels = discSizeInPixels;
-    if (distance > radius)
-        limbDiscPixels = radius / (std::sqrt(distance * distance - radius * radius) * pixelSize);
-    float angR = limbDiscPixels / pointScale;
-    float linkedGlowPeak = std::pow(angR * (a + invB), 2.5f);
-
     // Gate on the irradiance-based peak so the linked term only
     // enhances an already-firing glow, never starts one (keeps
     // reflective bodies with large angular radius from blooming).
     if (peakRadCol > 1.0f && starOptimization > 0.0f)
     {
+        // Peak radiance whose bloom radius (per the shader's PSF formula)
+        // equals the body's angular disc.
+        float a    = starOptimization / r;
+        float invB = celestia::numbers::pi_v<float> / r - a;
+        // Exact projected limb radius; discSizeInPixels undershoots up close.
+        float limbDiscPixels = discSizeInPixels;
+        float fadeLimbDiscPixels = limbDiscPixels;
+        if (distance > radius)
+        {
+            float limbAngularRadius = radius / std::sqrt(distance * distance - radius * radius);
+            limbDiscPixels = limbAngularRadius / pixelSize;
+
+            // The distance-fade derivation assumes that a growing projected limb
+            // means the observer moved closer. Camera zoom also grows the limb, so
+            // evaluate the fade at the projection's unit zoom instead.
+            fadeLimbDiscPixels = limbAngularRadius / projectionMode->getPixelSize(1.0f);
+        }
+        float angR = limbDiscPixels / pointScale;
+        float linkedGlowPeak = std::pow(angR * (a + invB), 2.5f);
+        float fadeAngR = fadeLimbDiscPixels / pointScale;
+        float fadeLinkedGlowPeak = std::pow(fadeAngR * (a + invB), 2.5f);
+
         float glowPeak = peakRadCol;
         if (starMaxIrradiance > 0.0f)
         {
@@ -1843,7 +1854,7 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
         // sprite vanishes smoothly as the disc takes over.  This is a
         // continuous distance-derived value, so pass it as a float to keep
         // the transition smooth.
-        float alpha = computePsfGlowAlpha(distance, radius, linkedGlowPeak, glowPeak);
+        float alpha = computePsfGlowAlpha(distance, radius, fadeLinkedGlowPeak, glowPeak);
         if (alpha <= 0.0f)
             return;
 

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -306,6 +306,8 @@ class Renderer
     float getStarExposure() const;
     void  setExposure(float e);
     float getExposure() const;
+    void  setToneMapping(bool enabled);
+    bool  getToneMapping() const;
     void setResolution(celestia::engine::TextureResolution resolution);
     celestia::engine::TextureResolution getResolution() const;
     void enableSelectionPointer();
@@ -695,6 +697,7 @@ class Renderer
     float starDimClipFactor{ 10.0f };
     float starExposure{ 10.0f };
     float exposure{ 1.0f };
+    bool  toneMapping{ false };
 
     Color ambientColor;
     std::string displayedSurface;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -304,6 +304,8 @@ class Renderer
     float getStarDimClipFactor() const;
     void  setStarExposure(float e);
     float getStarExposure() const;
+    void  setExposure(float e);
+    float getExposure() const;
     void setResolution(celestia::engine::TextureResolution resolution);
     celestia::engine::TextureResolution getResolution() const;
     void enableSelectionPointer();
@@ -692,6 +694,7 @@ class Renderer
     float starMaxIrradiance{ 100.0f };
     float starDimClipFactor{ 10.0f };
     float starExposure{ 10.0f };
+    float exposure{ 1.0f };
 
     Color ambientColor;
     std::string displayedSurface;

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -248,6 +248,7 @@ public:
         ScaleFactorAttributeIndex   = 11,
         LineSideAttributeIndex      = 12,
         AlphaAttributeIndex         = 13,
+        LimbRadiusAttributeIndex    = 14,
     };
 
     CelestiaGLProgramLight lights[MaxShaderLights];

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -72,6 +72,7 @@ bool PassthroughViewportEffect::render(Renderer* renderer, FramebufferObject* fb
 
     prog->use();
     prog->samplerParam("tex") = 0;
+    prog->floatParam("exposure") = renderer->getExposure();
     glBindTexture(GL_TEXTURE_2D, fbo->colorTexture());
     renderer->setPipelineState(ps);
     vo.draw();

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -73,6 +73,7 @@ bool PassthroughViewportEffect::render(Renderer* renderer, FramebufferObject* fb
     prog->use();
     prog->samplerParam("tex") = 0;
     prog->floatParam("exposure") = renderer->getExposure();
+    prog->floatParam("toneMapping") = renderer->getToneMapping() ? 1.0f : 0.0f;
     glBindTexture(GL_TEXTURE_2D, fbo->colorTexture());
     renderer->setPipelineState(ps);
     vo.draw();

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2773,7 +2773,7 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
                                 std::optional<bool> sRGBRendering,
                                 [[maybe_unused]] bool useMesaPackInvert)
 {
-    gl::sRGBRendering = sRGBRendering.value_or(config->renderDetails.sRGBRendering);
+    gl::sRGBRendering = sRGBRendering.value_or(config->renderDetails.output.sRGB);
 
     if (gl::sRGBRendering)
     {

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2819,6 +2819,7 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
 
     renderer->colors = renderer->colors.linearize(gl::sRGBRendering);
     m_scriptMaps.initColorMaps(renderer->colors);
+    renderer->setToneMapping(config->renderDetails.output.toneMapping);
 
     if (util::is_set(renderer->getRenderFlags(), RenderFlags::ShowAutoMag))
     {

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -211,7 +211,9 @@ applyRenderDetails(CelestiaConfig::RenderDetails& renderDetails, const Associati
     renderDetails.SolarSystemMaxDistance = std::clamp(renderDetails.SolarSystemMaxDistance, 1.0f, 10.0f);
     applyNumber(renderDetails.ShadowMapSize, hash, "ShadowMapSize"sv);
     applyStringArray(renderDetails.ignoreGLExtensions, hash, "IgnoreGLExtensions"sv);
-    applyBoolean(renderDetails.sRGBRendering, hash, "SRGBRendering"sv);
+    applyBoolean(renderDetails.output.sRGB, hash, "SRGBRendering"sv);
+    applyNumber(renderDetails.output.exposure, hash, "Exposure"sv);
+    renderDetails.output.exposure = std::clamp(renderDetails.output.exposure, 1.0e-3f, 1.0e6f);
     applyNumber(renderDetails.stars.pointRadius, hash, "StarPointRadius"sv);
     renderDetails.stars.pointRadius = std::clamp(renderDetails.stars.pointRadius, 1.0f, 10.0f);
     applyNumber(renderDetails.stars.optimization, hash, "StarOptimization"sv);

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -214,6 +214,7 @@ applyRenderDetails(CelestiaConfig::RenderDetails& renderDetails, const Associati
     applyBoolean(renderDetails.output.sRGB, hash, "SRGBRendering"sv);
     applyNumber(renderDetails.output.exposure, hash, "Exposure"sv);
     renderDetails.output.exposure = std::clamp(renderDetails.output.exposure, 1.0e-3f, 1.0e6f);
+    applyBoolean(renderDetails.output.toneMapping, hash, "ToneMapping"sv);
     applyNumber(renderDetails.stars.pointRadius, hash, "StarPointRadius"sv);
     renderDetails.stars.pointRadius = std::clamp(renderDetails.stars.pointRadius, 1.0f, 10.0f);
     applyNumber(renderDetails.stars.optimization, hash, "StarOptimization"sv);

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -93,7 +93,12 @@ struct CelestiaConfig
         float SolarSystemMaxDistance{ 1.0f };
         unsigned int ShadowMapSize{ 0 };
         std::vector<std::string> ignoreGLExtensions{ };
-        bool sRGBRendering{ false };
+        struct OutputRendering
+        {
+            bool sRGB{ false };
+            float exposure{ 1.0f };
+        };
+        OutputRendering output{ };
         struct AtmosphereRendering
         {
             unsigned int segmentCount{ 3 };

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -97,6 +97,7 @@ struct CelestiaConfig
         {
             bool sRGB{ false };
             float exposure{ 1.0f };
+            bool toneMapping{ false };
         };
         OutputRendering output{ };
         struct AtmosphereRendering

--- a/src/celestia/qt/preferences.ui
+++ b/src/celestia/qt/preferences.ui
@@ -1020,6 +1020,49 @@
              </layout>
             </item>
             <item>
+             <widget class="QCheckBox" name="toneMappingCheck">
+              <property name="toolTip">
+               <string>Softly roll off HDR highlights instead of clipping them to white. Only affects sRGB rendering.</string>
+              </property>
+              <property name="text">
+               <string>Tone mapping</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_exposure">
+              <item>
+               <widget class="QLabel" name="exposureLabel">
+                <property name="text">
+                 <string>Exposure:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QDoubleSpinBox" name="exposureSpinBox">
+                <property name="toolTip">
+                 <string>Exposure of the HDR tone mapper. Only affects sRGB rendering when tone mapping is enabled.</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="minimum">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>100.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
              <spacer name="verticalSpacer_13">
               <property name="orientation">
                <enum>Qt::Vertical</enum>

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -604,6 +604,8 @@ CelestiaAppWindow::writeSettings()
     settings.setValue("StarMaxIrradiance", renderer->getStarMaxIrradiance());
     settings.setValue("StarDimClipFactor", renderer->getStarDimClipFactor());
     settings.setValue("StarExposure", renderer->getStarExposure());
+    settings.setValue("Exposure", renderer->getExposure());
+    settings.setValue("ToneMapping", renderer->getToneMapping());
     settings.setValue("TextureResolution", static_cast<unsigned int>(renderer->getResolution()));
     settings.setValue("StarsColor", static_cast<int>(renderer->getStarColorTable()));
 

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -182,6 +182,9 @@ CelestiaGlWidget::initializeGL()
     appRenderer->setExposure(
         static_cast<float>(settings.value("Exposure",
                                           appCore->getConfig()->renderDetails.output.exposure).toDouble()));
+    appRenderer->setToneMapping(
+        settings.value("ToneMapping",
+                       appCore->getConfig()->renderDetails.output.toneMapping).toBool());
 }
 
 void

--- a/src/celestia/qt/qtglwidget.cpp
+++ b/src/celestia/qt/qtglwidget.cpp
@@ -179,6 +179,9 @@ CelestiaGlWidget::initializeGL()
     appRenderer->setStarExposure(
         (float) settings.value("StarExposure",
                                appCore->getConfig()->renderDetails.stars.exposure).toDouble());
+    appRenderer->setExposure(
+        static_cast<float>(settings.value("Exposure",
+                                          appCore->getConfig()->renderDetails.output.exposure).toDouble()));
 }
 
 void

--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -233,6 +233,8 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
         else
             ui.sRGBRenderingCombo->setCurrentIndex(settings.value("sRGBRendering").toBool() ? 1 : 2);
     }
+    ui.toneMappingCheck->setChecked(renderer->getToneMapping());
+    ui.exposureSpinBox->setValue(renderer->getExposure());
 
     switch (renderer->getResolution())
     {
@@ -768,6 +770,18 @@ PreferencesDialog::on_sRGBRenderingCombo_currentIndexChanged(int index)
         settings.remove("sRGBRendering");
     else
         settings.setValue("sRGBRendering", index == 1);
+}
+
+void
+PreferencesDialog::on_toneMappingCheck_toggled(bool checked) const
+{
+    appCore->getRenderer()->setToneMapping(checked);
+}
+
+void
+PreferencesDialog::on_exposureSpinBox_valueChanged(double value) const
+{
+    appCore->getRenderer()->setExposure(static_cast<float>(value));
 }
 
 // Texture resolution

--- a/src/celestia/qt/qtpreferencesdialog.h
+++ b/src/celestia/qt/qtpreferencesdialog.h
@@ -108,6 +108,8 @@ private slots:
     void on_renderPathBox_currentIndexChanged(int index) const;
     void on_antialiasLinesCheck_stateChanged(int state);
     void on_sRGBRenderingCombo_currentIndexChanged(int index);
+    void on_toneMappingCheck_toggled(bool checked) const;
+    void on_exposureSpinBox_valueChanged(double value) const;
 
     void on_lowResolutionButton_clicked() const;
     void on_mediumResolutionButton_clicked() const;

--- a/src/celestia/sdl/appwindow.cpp
+++ b/src/celestia/sdl/appwindow.cpp
@@ -190,6 +190,7 @@ AppWindow::run(const Settings& settings)
     renderer->setStarOptimization(config->renderDetails.stars.optimization);
     renderer->setStarMaxIrradiance(config->renderDetails.stars.maxIrradiance);
     renderer->setStarExposure(config->renderDetails.stars.exposure);
+    renderer->setExposure(config->renderDetails.output.exposure);
 
     settings.apply(m_appCore.get());
 

--- a/src/celestia/win32/winmain.cpp
+++ b/src/celestia/win32/winmain.cpp
@@ -707,6 +707,7 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     appCore->getRenderer()->setStarOptimization(appCore->getConfig()->renderDetails.stars.optimization);
     appCore->getRenderer()->setStarMaxIrradiance(appCore->getConfig()->renderDetails.stars.maxIrradiance);
     appCore->getRenderer()->setStarExposure(appCore->getConfig()->renderDetails.stars.exposure);
+    appCore->getRenderer()->setExposure(appCore->getConfig()->renderDetails.output.exposure);
 
     auto cursorHandler = std::make_unique<WinCursorHandler>(hDefaultCursor);
     appCore->setCursorHandler(cursorHandler.get());

--- a/src/celrender/largestarrenderer.cpp
+++ b/src/celrender/largestarrenderer.cpp
@@ -196,12 +196,22 @@ LargeStarRenderer::setupVertexArrayObject()
         false,
         sizeof(StarVertex),
         offsetof(StarVertex, alpha));
+
+    m_vo->addVertexBuffer(
+        *m_bo,
+        CelestiaGLProgram::LimbRadiusAttributeIndex,
+        1,
+        gl::VertexObject::DataType::Float,
+        false,
+        sizeof(StarVertex),
+        offsetof(StarVertex, limbRadius));
 }
 
 void
 LargeStarRenderer::addStar(const Eigen::Vector3f &center,
                            const Color           &color,
                            float                  scalar,
+                           float                  limbRadius,
                            float                  alpha)
 {
     if (m_nStars < m_capacity)
@@ -212,12 +222,13 @@ LargeStarRenderer::addStar(const Eigen::Vector3f &center,
         StarVertex *out = &m_vertices[static_cast<std::size_t>(m_nStars) * kVerticesPerStar];
         for (std::size_t i = 0; i < kVerticesPerStar; ++i)
         {
-            out[i].center = center;
-            out[i].scalar = scalar;
-            out[i].alpha  = alpha;
-            out[i].color  = packedColor;
-            out[i].corner = { kQuadCorners[i].x, kQuadCorners[i].y };
-            out[i].uv     = { kQuadCorners[i].u, kQuadCorners[i].v };
+            out[i].center     = center;
+            out[i].scalar     = scalar;
+            out[i].limbRadius = limbRadius;
+            out[i].alpha      = alpha;
+            out[i].color      = packedColor;
+            out[i].corner     = { kQuadCorners[i].x, kQuadCorners[i].y };
+            out[i].uv         = { kQuadCorners[i].u, kQuadCorners[i].v };
         }
         m_nStars++;
     }

--- a/src/celrender/largestarrenderer.h
+++ b/src/celrender/largestarrenderer.h
@@ -54,7 +54,7 @@ public:
     void finish() override;
 
     void addStar(const Eigen::Vector3f &center, const Color &color, float scalar,
-                 float alpha = 1.0f);
+                 float limbRadius = 0.0f, float alpha = 1.0f);
 
 protected:
     explicit LargeStarRenderer(Renderer &renderer, StaticShader shaderId, capacity_t capacity);
@@ -72,7 +72,8 @@ private:
     {
         Eigen::Vector3f              center;
         float                        scalar;  // peak radiance or pixel size
-        float                        alpha;   // PSF glow fade
+        float                        limbRadius; // resolved-body limb (px), 0 if none
+        float                        alpha;   // PSF glow fade, full float precision
         std::array<unsigned char, 4> color;   // legacy shader also reads .a
         std::array<signed char, 2>   corner;  // ±127 -> ±1.0 (signed byte normalized)
         std::array<unsigned char, 2> uv;      // 0/255 -> 0/1 (unsigned byte normalized)


### PR DESCRIPTION
Took the simple shader from https://learnopengl.com/Advanced-Lighting/HDR . Tonemapping is needed for proper atmosphere rendering.

PSF is also changed accordingly

- Removed the per-fragment brightness clamp so star radiance stays uncapped (HDR).
- Reshaped the glow interior into a flat-topped plateau instead of a center peak.
- Faded the interior exponentially and floored it at the limb brightness so the disc collapses to the limb as it resolves (when alpha = 0.5, the two values are equal).

<img width="1454" height="1085" alt="psf_real_fadeexp" src="https://github.com/user-attachments/assets/ef7c2938-0ba1-45d7-9ab6-9f37480fd1ee" />

