### PR TITLE
Pass PSF glow fade alpha as a float instead of packing it into color

### DIFF
--- a/shaders/psfstarglow_vert.glsl
+++ b/shaders/psfstarglow_vert.glsl
@@ -12,7 +12,8 @@
 // Point Spread Function (PSF) star renderer - glow (eye-PSF) pass.
 
 layout(location = 0) in vec4 in_Position;
-layout(location = 8) in vec4 in_Color;
+layout(location = 3) in float in_Alpha;      // glow fade
+layout(location = 8) in vec3 in_Color;
 layout(location = 9) in float in_Intensity;
 
 uniform float pointRadius;
@@ -32,8 +33,8 @@ out float v_p04;        // pow(peakRadiance, 0.4); needed because v_psfRadius
 
 void main(void)
 {
-    v_color = in_Color.rgb;
-    v_alpha = in_Color.a;
+    v_color = in_Color;
+    v_alpha = in_Alpha;
     v_peakRadiance = in_Intensity;
 
     // Glow mode: PSF support radius depends on peak radiance.

--- a/shaders/psfstarglow_vert.glsl
+++ b/shaders/psfstarglow_vert.glsl
@@ -12,9 +12,9 @@
 // Point Spread Function (PSF) star renderer - glow (eye-PSF) pass.
 
 layout(location = 0) in vec4 in_Position;
-layout(location = 3) in float in_Alpha;      // glow fade
 layout(location = 8) in vec3 in_Color;
 layout(location = 9) in float in_Intensity;
+layout(location = 13) in float in_Alpha;      // glow fade
 
 uniform float pointRadius;
 uniform float psfA;        // = optimization / pointRadius

--- a/shaders/psfstarglowlarge_frag.glsl
+++ b/shaders/psfstarglowlarge_frag.glsl
@@ -15,7 +15,8 @@ uniform float psfA;
 uniform float psfB;
 
 in vec2  v_uv;
-in vec4  v_color;
+in vec3  v_color;
+in float v_alpha;
 in float v_peakRadiance;
 in float v_psfRadius;
 in float v_p04;
@@ -37,11 +38,11 @@ void main(void)
     val = min(val, v_peakRadiance);
 
     // Clamp each channel of v_color * val to 1 BEFORE applying the
-    // fade alpha (v_color.a) so the bleached-white centre of a
+    // fade alpha (v_alpha) so the bleached-white centre of a
     // coloured star stays white through the fade, instead of
     // reverting to its underlying tint once alpha drops the
     // per-channel value back below saturation.  See
     // psfstarglow_frag.glsl for the full rationale.
     vec3 clampedColor = min(vec3(1.0), v_color.rgb * val);
-    fragColor = vec4(clampedColor * v_color.a, 1.0);
+    fragColor = vec4(clampedColor * v_alpha, 1.0);
 }

--- a/shaders/psfstarglowlarge_vert.glsl
+++ b/shaders/psfstarglowlarge_vert.glsl
@@ -16,7 +16,8 @@
 layout(location = 0) in vec2  in_Position;    // quad corner in [-1, 1]
 layout(location = 1) in vec3  in_Normal;      // star world position
 layout(location = 2) in vec2  in_TexCoord0;   // quad UV in [0, 1]
-layout(location = 8) in vec4  in_Color;       // linear RGB
+layout(location = 3) in float in_Alpha;       // glow fade
+layout(location = 8) in vec3  in_Color;       // linear RGB
 layout(location = 9) in float in_Intensity;   // peak radiance
 
 uniform float psfA;             // optimization / pointRadius
@@ -27,7 +28,8 @@ uniform float psfPointScale;    // DPI scale
 uniform vec2  psfViewportRcp;   // (1/width, 1/height)
 
 out vec2  v_uv;
-out vec4  v_color;
+out vec3  v_color;
+out float v_alpha;
 out float v_peakRadiance;
 out float v_psfRadius;
 out float v_p04;
@@ -36,6 +38,7 @@ void main(void)
 {
     v_uv           = in_TexCoord0;
     v_color        = in_Color;
+    v_alpha        = in_Alpha;
     v_peakRadiance = in_Intensity;
 
     float p04   = pow(in_Intensity, 0.4);
@@ -44,7 +47,7 @@ void main(void)
     // Match psfstarglow_vert.glsl: tighten the rasterised radius to
     // where the post-alpha brightest channel falls below one
     // framebuffer code (psfMinVisRad linear).
-    float tVal  = psfMinVisRad / max(in_Color.a, 1.0e-3);
+    float tVal  = psfMinVisRad / max(in_Alpha, 1.0e-3);
     float rEff  = p04 / (psfA + pow(tVal, 0.4) / psfB);
     rEff        = min(rEff, rFull);
 

--- a/shaders/psfstarglowlarge_vert.glsl
+++ b/shaders/psfstarglowlarge_vert.glsl
@@ -16,9 +16,9 @@
 layout(location = 0) in vec2  in_Position;    // quad corner in [-1, 1]
 layout(location = 1) in vec3  in_Normal;      // star world position
 layout(location = 2) in vec2  in_TexCoord0;   // quad UV in [0, 1]
-layout(location = 3) in float in_Alpha;       // glow fade
 layout(location = 8) in vec3  in_Color;       // linear RGB
 layout(location = 9) in float in_Intensity;   // peak radiance
+layout(location = 13) in float in_Alpha;       // glow fade
 
 uniform float psfA;             // optimization / pointRadius
 uniform float psfB;             // 1 / (pi/pointRadius - a)

--- a/shaders/psfstarpoint_vert.glsl
+++ b/shaders/psfstarpoint_vert.glsl
@@ -12,7 +12,7 @@
 // Point Spread Function (PSF) star renderer - point (cone) pass.
 
 layout(location = 0) in vec4 in_Position;
-layout(location = 8) in vec4 in_Color;        // green-normalised, linear-space, 8-bit per channel
+layout(location = 8) in vec3 in_Color;        // green-normalised, linear-space, 8-bit per channel
 layout(location = 9) in float in_Intensity;   // peakRadiance = exposure * 3 * irradiance / (pi * pointRadius^2)
 
 uniform float pointRadius; // pt, user setting (1..10)
@@ -24,7 +24,7 @@ out float v_pointSize;
 
 void main(void)
 {
-    v_color = in_Color.rgb;
+    v_color = in_Color;
     v_peakRadiance = in_Intensity;
 
     float size = 2.0 * pointRadius * pointScale;

--- a/src/celengine/psfstarvertexbuffer.cpp
+++ b/src/celengine/psfstarvertexbuffer.cpp
@@ -154,10 +154,20 @@ PsfStarVertexBuffer::setupVertexArrayObject()
         sizeof(StarVertex),
         offsetof(StarVertex, peakRadiance));
 
+    // continuous distance-derived glow fade; float for a smooth transition
+    m_vo->addVertexBuffer(
+        *m_bo,
+        CelestiaGLProgram::TextureCoord1AttributeIndex,
+        1,
+        gl::VertexObject::DataType::Float,
+        false,
+        sizeof(StarVertex),
+        offsetof(StarVertex, alpha));
+
     m_vo->addVertexBuffer(
         *m_bo,
         CelestiaGLProgram::ColorAttributeIndex,
-        4,
+        3,
         gl::VertexObject::DataType::UnsignedByte,
         true,
         sizeof(StarVertex),
@@ -190,12 +200,14 @@ PsfStarVertexBuffer::disable()
 void
 PsfStarVertexBuffer::addStar(const Eigen::Vector3f &pos,
                              const Color &color,
-                             float peakRadiance)
+                             float peakRadiance,
+                             float alpha)
 {
     if (m_nStars < m_capacity)
     {
         m_vertices[m_nStars].position = pos;
         m_vertices[m_nStars].peakRadiance = peakRadiance;
+        m_vertices[m_nStars].alpha = alpha;
         color.get(m_vertices[m_nStars].color.data());
         m_nStars++;
     }

--- a/src/celengine/psfstarvertexbuffer.cpp
+++ b/src/celengine/psfstarvertexbuffer.cpp
@@ -157,7 +157,7 @@ PsfStarVertexBuffer::setupVertexArrayObject()
     // continuous distance-derived glow fade; float for a smooth transition
     m_vo->addVertexBuffer(
         *m_bo,
-        CelestiaGLProgram::TextureCoord1AttributeIndex,
+        CelestiaGLProgram::AlphaAttributeIndex,
         1,
         gl::VertexObject::DataType::Float,
         false,

--- a/src/celengine/psfstarvertexbuffer.h
+++ b/src/celengine/psfstarvertexbuffer.h
@@ -57,7 +57,8 @@ public:
     void render();
     void finish() override;
 
-    void addStar(const Eigen::Vector3f &pos, const Color &color, float peakRadiance);
+    void addStar(const Eigen::Vector3f &pos, const Color &color, float peakRadiance,
+                 float alpha = 1.0f);
 
     void setPointRadius(float r)      { m_pointRadius = r; }
     void setOptimization(float opt)   { m_optimization = opt; }
@@ -71,7 +72,8 @@ private:
     {
         Eigen::Vector3f            position;
         float                      peakRadiance;
-        std::array<unsigned char, 4> color;
+        float                      alpha;   // glow fade
+        std::array<unsigned char, 4> color; // rgb only; alpha byte unused
     };
 
     const Renderer                 &m_renderer;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1833,11 +1833,12 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
         float glowPeakToUse = std::max(glowPeak, linkedGlowPeak);
 
         // Fade alpha 1 → 0 between d_match and the body surface so the
-        // sprite vanishes smoothly as the disc takes over.
+        // sprite vanishes smoothly as the disc takes over.  This is a
+        // continuous distance-derived value, so pass it as a float to keep
+        // the transition smooth.
         float alpha = computePsfGlowAlpha(distance, radius, linkedGlowPeak, glowPeak);
         if (alpha <= 0.0f)
             return;
-        Color glowColor(linearStarColor, alpha);
 
         // Fast oversize check: avoid computing pow unless we actually
         // need sizePhys.  sizePhys > maxPointSize is equivalent to
@@ -1850,11 +1851,11 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
         {
             // Oversize glow (typical for Sol at ~1 AU): hand it to the
             // batched billboard renderer.
-            m_psfGlowLargeRenderer->addStar(glowPos, glowColor, glowPeakToUse);
+            m_psfGlowLargeRenderer->addStar(glowPos, linearStarColor, glowPeakToUse, alpha);
         }
         else
         {
-            psfGlowBuffer->addStar(glowPos, glowColor, glowPeakToUse);
+            psfGlowBuffer->addStar(glowPos, linearStarColor, glowPeakToUse, alpha);
         }
     }
 }

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -244,6 +244,7 @@ public:
         NextVCoordAttributeIndex    = 10,
         ScaleFactorAttributeIndex   = 11,
         LineSideAttributeIndex      = 12,
+        AlphaAttributeIndex         = 13,
     };
 
     CelestiaGLProgramLight lights[MaxShaderLights];

--- a/src/celrender/largestarrenderer.cpp
+++ b/src/celrender/largestarrenderer.cpp
@@ -166,6 +166,8 @@ LargeStarRenderer::setupVertexArrayObject()
         sizeof(StarVertex),
         offsetof(StarVertex, uv));
 
+    // Color stays 4-component: this layout is shared with
+    // LegacyLargeStarRenderer, whose shader reads in_Color.a.
     m_vo->addVertexBuffer(
         *m_bo,
         CelestiaGLProgram::ColorAttributeIndex,
@@ -183,12 +185,24 @@ LargeStarRenderer::setupVertexArrayObject()
         false,
         sizeof(StarVertex),
         offsetof(StarVertex, scalar));
+
+    // continuous distance-derived glow fade; float for a smooth transition
+    // (unused by the legacy shader)
+    m_vo->addVertexBuffer(
+        *m_bo,
+        CelestiaGLProgram::TextureCoord1AttributeIndex,
+        1,
+        gl::VertexObject::DataType::Float,
+        false,
+        sizeof(StarVertex),
+        offsetof(StarVertex, alpha));
 }
 
 void
 LargeStarRenderer::addStar(const Eigen::Vector3f &center,
                            const Color           &color,
-                           float                  scalar)
+                           float                  scalar,
+                           float                  alpha)
 {
     if (m_nStars < m_capacity)
     {
@@ -200,6 +214,7 @@ LargeStarRenderer::addStar(const Eigen::Vector3f &center,
         {
             out[i].center = center;
             out[i].scalar = scalar;
+            out[i].alpha  = alpha;
             out[i].color  = packedColor;
             out[i].corner = { kQuadCorners[i].x, kQuadCorners[i].y };
             out[i].uv     = { kQuadCorners[i].u, kQuadCorners[i].v };

--- a/src/celrender/largestarrenderer.cpp
+++ b/src/celrender/largestarrenderer.cpp
@@ -190,7 +190,7 @@ LargeStarRenderer::setupVertexArrayObject()
     // (unused by the legacy shader)
     m_vo->addVertexBuffer(
         *m_bo,
-        CelestiaGLProgram::TextureCoord1AttributeIndex,
+        CelestiaGLProgram::AlphaAttributeIndex,
         1,
         gl::VertexObject::DataType::Float,
         false,

--- a/src/celrender/largestarrenderer.h
+++ b/src/celrender/largestarrenderer.h
@@ -53,7 +53,8 @@ public:
     void render();
     void finish() override;
 
-    void addStar(const Eigen::Vector3f &center, const Color &color, float scalar);
+    void addStar(const Eigen::Vector3f &center, const Color &color, float scalar,
+                 float alpha = 1.0f);
 
 protected:
     explicit LargeStarRenderer(Renderer &renderer, StaticShader shaderId, capacity_t capacity);
@@ -71,7 +72,8 @@ private:
     {
         Eigen::Vector3f              center;
         float                        scalar;  // peak radiance or pixel size
-        std::array<unsigned char, 4> color;
+        float                        alpha;   // PSF glow fade
+        std::array<unsigned char, 4> color;   // legacy shader also reads .a
         std::array<signed char, 2>   corner;  // ±127 -> ±1.0 (signed byte normalized)
         std::array<unsigned char, 2> uv;      // 0/255 -> 0/1 (unsigned byte normalized)
     };


### PR DESCRIPTION
The glow fade alpha was baked into the 8-bit alpha channel of the vertex color, which limits the precision. This lifts it out to be passed separately as float.