### PR TITLE
Size PSF glow core to the exact projected limb radius

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1806,7 +1806,11 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
     // equals the body's angular disc.
     float a    = starOptimization / r;
     float invB = celestia::numbers::pi_v<float> / r - a;
-    float angR = discSizeInPixels / pointScale;
+    // Exact projected limb radius; discSizeInPixels undershoots up close.
+    float limbDiscPixels = discSizeInPixels;
+    if (distance > radius)
+        limbDiscPixels = radius / (std::sqrt(distance * distance - radius * radius) * pixelSize);
+    float angR = limbDiscPixels / pointScale;
     float linkedGlowPeak = std::pow(angR * (a + invB), 2.5f);
 
     // Gate on the irradiance-based peak so the linked term only


### PR DESCRIPTION
Sizes the PSF glow core with the exact projected limb radius  radius / sqrt(distance² − radius²)  instead of the small-angle  radius / distance , which undershoots up close and leaves a ring of bare mesh outside the glow (not very noticeable right now due to the fade out).