### PR TITLE
Change AtmosphereExtinctionThreshold

### DIFF
--- a/src/celengine/atmosphere.h
+++ b/src/celengine/atmosphere.h
@@ -50,7 +50,7 @@ struct Atmosphere
 // to render. The radius of the sphere is the height at which the
 // density of the atmosphere falls to the extinction threshold, i.e.
 // -H * ln(extinctionThreshold)
-constexpr inline float AtmosphereExtinctionThreshold = 0.0025f;
+constexpr inline float AtmosphereExtinctionThreshold = 0.00001f;
 
 #ifdef HAVE_CONSTEXPR_CMATH
 constexpr inline float LogAtmosphereExtinctionThreshold = std::log(AtmosphereExtinctionThreshold);

--- a/src/celengine/atmosphere.h
+++ b/src/celengine/atmosphere.h
@@ -50,7 +50,7 @@ struct Atmosphere
 // to render. The radius of the sphere is the height at which the
 // density of the atmosphere falls to the extinction threshold, i.e.
 // -H * ln(extinctionThreshold)
-constexpr inline float AtmosphereExtinctionThreshold = 0.05f;
+constexpr inline float AtmosphereExtinctionThreshold = 0.0025f;
 
 #ifdef HAVE_CONSTEXPR_CMATH
 constexpr inline float LogAtmosphereExtinctionThreshold = std::log(AtmosphereExtinctionThreshold);

--- a/src/celengine/atmosphere.h
+++ b/src/celengine/atmosphere.h
@@ -50,7 +50,7 @@ struct Atmosphere
 // to render. The radius of the sphere is the height at which the
 // density of the atmosphere falls to the extinction threshold, i.e.
 // -H * ln(extinctionThreshold)
-constexpr inline float AtmosphereExtinctionThreshold = 0.00001f;
+constexpr inline float AtmosphereExtinctionThreshold = 0.000125f;
 
 #ifdef HAVE_CONSTEXPR_CMATH
 constexpr inline float LogAtmosphereExtinctionThreshold = std::log(AtmosphereExtinctionThreshold);


### PR DESCRIPTION
This PR changes the value of **AtmosphereExtinctionThreshold**, which enables the upper atmosphere to be rendered. This solves abrupt clipping of atmospheres noticed on various atmospheres, such as Earth's or Titan's. However, larger atmospheres are more computationally expensive, and so setting this value too high can be laggy.

The values being experimented with so far are:
- 0.0025f = ~6 scale heights. For Earth, this corresponds to 8.5 * 6 = 51 km.
- 0.000125f = ~9 scale heights. (~77 km on Earth.)
- 0.00001f = ~11.5 scale heights. (~98 km on Earth.)

Previously this was attempted in #2200, but the buggy atmosphere code resulted in erroneous rendering and hence the attempt was abandoned. This bug was finally resolved recently by #2632, prompting this PR.