### PR TITLE
Default values for atmosphere rendering

### DIFF
--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -394,8 +394,8 @@ StarTextures
 #     planet textures.
 #------------------------------------------------------------------------
   OrbitPathSamplePoints  100
-  AtmosphereSegmentCount 3
-  AtmosphereExtinctionThreshold 0.05
+  AtmosphereSegmentCount 6
+  AtmosphereExtinctionThreshold 0.000125
   RingSystemSections     100
 
   ShadowTextureSize      256

--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -372,14 +372,11 @@ StarTextures
 #
 #   AtmosphereSegmentCount defines how many segments to use when
 #   integrating atmospheric scattering. The valid range is 1 to 16,
-#   and the default value is 3.
+#   and the default value is 6.
 #
 #   AtmosphereExtinctionThreshold defines the relative density at the
 #   outer edge of an atmosphere. It must be between 0 and 1. The default
-#   value is 0.05.
-#
-#   RingSystemSections defines the number of segments in which ring
-#   systems are rendered. The default value is 100.
+#   value is 0.000125.
 #
 #   ShadowTextureSize defines the size* of shadow texture to be used.
 #   The default value is 256. Maximum useful value is 2048.
@@ -396,7 +393,6 @@ StarTextures
   OrbitPathSamplePoints  100
   AtmosphereSegmentCount 6
   AtmosphereExtinctionThreshold 0.000125
-  RingSystemSections     100
 
   ShadowTextureSize      256
   EclipseTextureSize     128

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -124,8 +124,8 @@ class Renderer
     struct DetailOptions
     {
         unsigned int orbitPathSamplePoints{ 100 };
-        unsigned int atmosphereSegmentCount{ 3 };
-        float atmosphereExtinctionThreshold{ 0.05f };
+        unsigned int atmosphereSegmentCount{ 6 };
+        float atmosphereExtinctionThreshold{ 0.000125f };
         unsigned int shadowTextureSize{ 256 };
         unsigned int eclipseTextureSize{ 128 };
         double orbitWindowEnd{ 0.5 };

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -204,7 +204,7 @@ applyRenderDetails(CelestiaConfig::RenderDetails& renderDetails, const Associati
         renderDetails.atmosphere.extinctionThreshold >= 1.0f)
     {
         GetLogger()->error("AtmosphereExtinctionThreshold must be between 0 and 1.\n");
-        renderDetails.atmosphere.extinctionThreshold = 0.05f;
+        renderDetails.atmosphere.extinctionThreshold = 0.000125f;
     }
     applyNumber(renderDetails.aaSamples, hash, "AntialiasingSamples"sv);
     applyNumber(renderDetails.SolarSystemMaxDistance, hash, "SolarSystemMaxDistance"sv);


### PR DESCRIPTION
**AtmosphereSegmentCount** = 6
-> 6-segment atmosphere enables decent-looking cloudless Venus and Titan atmospheres (and "deep" Rayleigh scattering atmospheres in general) without tanking FPS too severely.

Cloudless Venus with 5, 6, and 16 segments:
<img width="751" height="669" alt="2026-07-20 Venus 5-segments" src="https://github.com/user-attachments/assets/b877d650-1ce0-4c12-90b3-790382061bbd" />
<img width="940" height="906" alt="2026-07-19 Venus 6-segments" src="https://github.com/user-attachments/assets/fe81a6a1-b568-4054-a3d4-bd2afb2c533d" />
<img width="990" height="990" alt="2026-07-20 Venus 16-segments" src="https://github.com/user-attachments/assets/e2d37fbc-d1f2-4e2f-84db-e8a7bed85109" />


**AtmosphereExtinctionThreshold** = 0.000125
-> Earth's atmosphere is not visibly truncated, and while Titan's and especially Venus's atmospheres are truncated, Titan's is not too prominent, and Venus's atmosphere is presumably not frequently closely observed regardless.

<img width="1920" height="735" alt="2026-07-19 Earth 9H" src="https://github.com/user-attachments/assets/b7f4a429-c9cf-4c99-9f1f-4ee7cc2fcdfc" />
<img width="1920" height="723" alt="2026-07-19 Titan 9H" src="https://github.com/user-attachments/assets/8fcbfb7c-1963-43bb-aeee-196c2718f3a8" />
<img width="1920" height="701" alt="2026-07-19 Venus 9H" src="https://github.com/user-attachments/assets/1b30c7ea-2235-4a1f-976d-1d1af3e27dfe" />

Additionally, this PR also removes the obsolete **RingSystemSections**, at Pedro's request.