### PR TITLE
Composite atmosphere transmission per color channel

### DIFF
--- a/src/celengine/glshader.cpp
+++ b/src/celengine/glshader.cpp
@@ -391,6 +391,17 @@ GLProgramBuilder::bindAttribute(GLuint index, const GLchar* name) const
         glBindAttribLocation(id, index, name);
 }
 
+void
+GLProgramBuilder::bindFragmentOutput(GLuint colorNumber, GLuint index, const GLchar* name) const
+{
+    if (isValid())
+#ifdef GL_ES
+        glBindFragDataLocationIndexedEXT(id, colorNumber, index, name);
+#else
+        glBindFragDataLocationIndexed(id, colorNumber, index, name);
+#endif
+}
+
 GLProgram
 GLProgramBuilder::link(GLShaderStatus& status)
 {

--- a/src/celengine/glshader.h
+++ b/src/celengine/glshader.h
@@ -142,6 +142,7 @@ public:
     void attach(GLVertexShader&&);
 
     void bindAttribute(GLuint index, const GLchar* name) const;
+    void bindFragmentOutput(GLuint colorNumber, GLuint index, const GLchar* name) const;
 
     GLProgram link(GLShaderStatus&);
 

--- a/src/celengine/glsupport.cpp
+++ b/src/celengine/glsupport.cpp
@@ -14,6 +14,7 @@ CELAPI bool OES_geometry_shader               = false; //NOSONAR
 #else
 CELAPI bool ARB_invalidate_subdata             = false; //NOSONAR
 #endif
+CELAPI bool dualSourceBlending                 = false; //NOSONAR
 CELAPI bool ARB_texture_compression_bptc      = false; //NOSONAR
 CELAPI bool EXT_texture_compression_s3tc      = false; //NOSONAR
 CELAPI bool EXT_texture_compression_s3tc_srgb = false; //NOSONAR
@@ -82,6 +83,13 @@ bool init(util::array_view<std::string> ignore) noexcept
 #ifdef GL_ES
     OES_texture_border_clamp           = check_extension(ignore, "GL_OES_texture_border_clamp") || check_extension(ignore, "GL_EXT_texture_border_clamp");
     OES_geometry_shader                = check_extension(ignore, "GL_OES_geometry_shader") || check_extension(ignore, "GL_EXT_geometry_shader");
+    dualSourceBlending                 = check_extension(ignore, "GL_EXT_blend_func_extended");
+    if (dualSourceBlending)
+    {
+        GLint maxDualSourceDrawBuffers = 0;
+        glGetIntegerv(GL_MAX_DUAL_SOURCE_DRAW_BUFFERS_EXT, &maxDualSourceDrawBuffers);
+        dualSourceBlending = maxDualSourceDrawBuffers > 0;
+    }
     // BPTC on GLES is exposed via GL_EXT_texture_compression_bptc; the
     // compressed-format tokens (0x8E8C / 0x8E8D) are identical to the desktop
     // GL_ARB_texture_compression_bptc extension, so the same flag drives both
@@ -90,6 +98,7 @@ bool init(util::array_view<std::string> ignore) noexcept
 #else
     ARB_invalidate_subdata         = check_extension(ignore, "GL_ARB_invalidate_subdata");
     ARB_texture_compression_bptc   = check_extension(ignore, "GL_ARB_texture_compression_bptc");
+    dualSourceBlending             = true;
 #endif
     EXT_texture_compression_s3tc   = check_extension(ignore, "GL_EXT_texture_compression_s3tc");
 #ifdef GL_ES

--- a/src/celengine/glsupport.h
+++ b/src/celengine/glsupport.h
@@ -47,6 +47,7 @@ enum Version
 #ifndef GL_ES
 extern CELAPI bool ARB_invalidate_subdata; //NOSONAR
 #endif
+extern CELAPI bool dualSourceBlending; //NOSONAR
 extern CELAPI bool ARB_texture_compression_bptc; //NOSONAR
 extern CELAPI bool EXT_texture_compression_s3tc; //NOSONAR
 extern CELAPI bool EXT_texture_compression_s3tc_srgb; //NOSONAR

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -2017,10 +2017,18 @@ buildAtmosphereFragmentShader(const ShaderProperties& props)
 {
     bool transmissionOnly =
         props.effects == LightingEffects::AtmosphereTransmission;
+    bool dualSource =
+        props.effects == LightingEffects::AtmosphereDualSource;
 
     std::string source(VersionHeader);
+#ifdef GL_ES
+    if (dualSource)
+        source += "#extension GL_EXT_blend_func_extended : require\n";
+#endif
     source += CommonHeader;
     source += FragmentHeader;
+    if (dualSource)
+        source += DeclareOutput("atmosphereTransmission", Shader_Vector4);
 
     source += DeclareLights(props);
     source += DeclareUniform("eyePosition", Shader_Vector3);
@@ -2062,6 +2070,8 @@ buildAtmosphereFragmentShader(const ShaderProperties& props)
             source += "    color += (phRayleigh * rayleighCoeff + phMie * mieCoeff) * " + ScatteredColor(i) + ";\n";
         }
         source += "    fragColor = vec4(color, 0.0);\n";
+        if (dualSource)
+            source += "    atmosphereTransmission = vec4(scatterEx, 1.0);\n";
     }
     source += "}\n";
 
@@ -2370,6 +2380,11 @@ buildProgram(const ShaderProperties& props, bool fisheyeEnabled)
         {
             builder.attach(std::move(vs));
             builder.attach(std::move(fs));
+            if (props.effects == LightingEffects::AtmosphereDualSource)
+            {
+                builder.bindFragmentOutput(0, 0, "fragColor");
+                builder.bindFragmentOutput(0, 1, "atmosphereTransmission");
+            }
             program = builder.link(status);
         }
     }

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -852,6 +852,28 @@ AtmosphericEffects(const ShaderProperties& props)
 
 
 std::string
+AtmosphericTransmission()
+{
+    return R"glsl({
+    float rq = dot(eyePosition, eyeDir);
+    float qq = dot(eyePosition, eyePosition) - atmosphereRadius.y;
+    float d = sqrt(max(rq * rq - qq, 0.0));
+    vec3 atmEnter = eyePosition + min(0.0, -rq + d) * eyeDir;
+    vec3 viewDirection = -eyeDir;
+    float enterRadius = max(length(atmEnter), 1.0e-6);
+    float leaveRadius = max(length(nposition), 1.0e-6);
+    float enterColumn = chapmanToSpace(enterRadius,
+                                       dot(atmEnter, viewDirection) / enterRadius);
+    float leaveColumn = chapmanToSpace(leaveRadius,
+                                       dot(nposition, viewDirection) / leaveRadius);
+    float opticalDepth = max(0.0, enterColumn - leaveColumn);
+    scatterEx = exp(-extinctionCoeff * opticalDepth);
+}
+)glsl";
+}
+
+
+std::string
 ScatteringConstantDeclarations(const ShaderProperties& /*props*/)
 {
     std::string source;
@@ -1993,6 +2015,9 @@ buildAtmosphereVertexShader(const ShaderProperties& props, bool fisheyeEnabled)
 GLFragmentShader
 buildAtmosphereFragmentShader(const ShaderProperties& props)
 {
+    bool transmissionOnly =
+        props.effects == LightingEffects::AtmosphereTransmission;
+
     std::string source(VersionHeader);
     source += CommonHeader;
     source += FragmentHeader;
@@ -2004,8 +2029,11 @@ buildAtmosphereFragmentShader(const ShaderProperties& props)
     source += DeclareInput("position", Shader_Vector3);
     source += DeclareInput("normal", Shader_Vector3);
 
-    for (unsigned i = 0; i < props.nLights; i++)
-        source += DeclareLocal(ScatteredColor(i), Shader_Vector3);
+    if (!transmissionOnly)
+    {
+        for (unsigned i = 0; i < props.nLights; i++)
+            source += DeclareLocal(ScatteredColor(i), Shader_Vector3);
+    }
 
     source += "\nvoid main(void)\n{\n";
 
@@ -2014,25 +2042,27 @@ buildAtmosphereFragmentShader(const ShaderProperties& props)
     source += "vec3 eyeDir = normalize(eyePosition - nposition);\n";
     source += "float NV = dot(N, eyeDir);\n";
 
-    source += DeclareLocal("NL", Shader_Float);
     source += DeclareLocal("scatterEx", Shader_Vector3);
-    source += AtmosphericEffects(props);
-
-    // Sum the contributions from each light source
-    source += "vec3 color = vec3(0.0);\n";
-
-    // Only do scattering calculations for the primary light source
-    // TODO: Eventually handle multiple light sources, and removed the 'min'
-    // from the line below.
-    for (unsigned i = 0; i < std::min(static_cast<unsigned int>(props.nLights), 1u); i++)
+    if (transmissionOnly)
     {
-        source += "    float cosTheta = dot(eyeDir, " + LightProperty(i, "direction") + ");\n";
-        source += ScatteringPhaseFunctions(props);
-
-        source += "    color += (phRayleigh * rayleighCoeff + phMie * mieCoeff) * " + ScatteredColor(i) + ";\n";
+        source += AtmosphericTransmission();
+        source += "    fragColor = vec4(scatterEx, 1.0);\n";
     }
+    else
+    {
+        source += DeclareLocal("NL", Shader_Float);
+        source += AtmosphericEffects(props);
 
-    source += "    fragColor = vec4(color, dot(scatterEx, vec3(0.333)));\n";
+        // Sum the contributions from each light source, currently only the primary one.
+        source += "vec3 color = vec3(0.0);\n";
+        for (unsigned i = 0; i < std::min(static_cast<unsigned int>(props.nLights), 1u); i++)
+        {
+            source += "    float cosTheta = dot(eyeDir, " + LightProperty(i, "direction") + ");\n";
+            source += ScatteringPhaseFunctions(props);
+            source += "    color += (phRayleigh * rayleighCoeff + phMie * mieCoeff) * " + ScatteredColor(i) + ";\n";
+        }
+        source += "    fragColor = vec4(color, 0.0);\n";
+    }
     source += "}\n";
 
     DumpFSSource(source);

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -99,6 +99,7 @@ enum class LightingEffects : std::uint16_t
     VolumetricAbsorption      = 0x0002,
     VolumetricEmission        = 0x0004,
     CloudLighting             = 0x0008,
+    AtmosphereTransmission    = 0x0010,
 };
 
 enum class FisheyeOverrideMode : int

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -100,6 +100,7 @@ enum class LightingEffects : std::uint16_t
     VolumetricEmission        = 0x0004,
     CloudLighting             = 0x0008,
     AtmosphereTransmission    = 0x0010,
+    AtmosphereDualSource      = 0x0020,
 };
 
 enum class FisheyeOverrideMode : int

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -353,16 +353,30 @@ AtmosphereRenderer::render(
     shadprop.texUsage |= TexUsage::Scattering;
     shadprop.lightModel = LightingModel::AtmosphereModel;
 
+    bool useDualSource = false;
+    GLenum scatteringBlendDestination = GL_ONE;
+    useDualSource = ls.nLights > 0 && gl::dualSourceBlending;
+    if (useDualSource)
+#ifdef GL_ES
+        scatteringBlendDestination = GL_SRC1_COLOR_EXT;
+#else
+        scatteringBlendDestination = GL_SRC1_COLOR;
+#endif
+
     ShaderProperties transmissionProps = shadprop;
     transmissionProps.nLights = 0;
     transmissionProps.effects = LightingEffects::AtmosphereTransmission;
 
-    CelestiaGLProgram* transmissionProg =
-        m_renderer.getShaderManager().getShader(transmissionProps);
+    if (useDualSource)
+        shadprop.effects = LightingEffects::AtmosphereDualSource;
+
+    CelestiaGLProgram* transmissionProg = useDualSource
+        ? nullptr
+        : m_renderer.getShaderManager().getShader(transmissionProps);
     CelestiaGLProgram* scatteringProg = ls.nLights == 0
         ? nullptr
         : m_renderer.getShaderManager().getShader(shadprop);
-    if (transmissionProg == nullptr ||
+    if ((!useDualSource && transmissionProg == nullptr) ||
         (ls.nLights > 0 && scatteringProg == nullptr))
         return;
 
@@ -381,8 +395,6 @@ AtmosphereRenderer::render(
         prog->setMVPMatrices(*m.projection, (*m.modelview) * math::scale(atmScale));
     };
 
-    setupAtmosphereProgram(transmissionProg);
-
 #if 0
     // Currently eclipse shadows are ignored when rendering atmospheres
     if (shadprop.shadowCounts != 0)
@@ -393,16 +405,21 @@ AtmosphereRenderer::render(
 
     Renderer::PipelineState ps;
     ps.blending = true;
-    ps.blendFunc = {GL_ZERO, GL_SRC_COLOR};
     ps.depthTest = true;
-    m_renderer.setPipelineState(ps);
 
     math::Frustum shellFrustum = frustum;
     shellFrustum.transform(math::scale(1.0f / atmScale));
-    m_renderer.m_lodSphere->render(LODSphereMesh::Normals,
-                                   shellFrustum,
-                                   ri.pixWidth,
-                                   nullptr);
+
+    if (transmissionProg != nullptr)
+    {
+        setupAtmosphereProgram(transmissionProg);
+        ps.blendFunc = {GL_ZERO, GL_SRC_COLOR};
+        m_renderer.setPipelineState(ps);
+        m_renderer.m_lodSphere->render(LODSphereMesh::Normals,
+                                       shellFrustum,
+                                       ri.pixWidth,
+                                       nullptr);
+    }
 
     if (scatteringProg != nullptr)
     {
@@ -411,7 +428,7 @@ AtmosphereRenderer::render(
         scatteringProg->ambientColor = Eigen::Vector3f::Zero();
         setupAtmosphereProgram(scatteringProg);
 
-        ps.blendFunc = {GL_ONE, GL_ONE};
+        ps.blendFunc = {GL_ONE, scatteringBlendDestination};
         m_renderer.setPipelineState(ps);
         m_renderer.m_lodSphere->render(LODSphereMesh::Normals,
                                        shellFrustum,

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -347,37 +347,41 @@ AtmosphereRenderer::render(
     const math::Frustum      &frustum,
     const Matrices           &m)
 {
-    // Currently, we just skip rendering an atmosphere when there are no
-    // light sources, even though the atmosphere would still the light
-    // of planets and stars behind it.
-    if (ls.nLights == 0)
-        return;
-
     ShaderProperties shadprop;
     shadprop.nLights = static_cast<ushort>(ls.nLights);
 
     shadprop.texUsage |= TexUsage::Scattering;
     shadprop.lightModel = LightingModel::AtmosphereModel;
 
-    // Get a shader for the current rendering configuration
-    CelestiaGLProgram* prog = m_renderer.getShaderManager().getShader(shadprop);
-    if (prog == nullptr)
+    ShaderProperties transmissionProps = shadprop;
+    transmissionProps.nLights = 0;
+    transmissionProps.effects = LightingEffects::AtmosphereTransmission;
+
+    CelestiaGLProgram* transmissionProg =
+        m_renderer.getShaderManager().getShader(transmissionProps);
+    CelestiaGLProgram* scatteringProg = ls.nLights == 0
+        ? nullptr
+        : m_renderer.getShaderManager().getShader(shadprop);
+    if (transmissionProg == nullptr ||
+        (ls.nLights > 0 && scatteringProg == nullptr))
         return;
-
-    prog->use();
-
-    prog->setLightParameters(ls, ri.color, ri.specularColor, Color::Black);
-    prog->ambientColor = Eigen::Vector3f::Zero();
 
     float extinctionThreshold = m_renderer.getAtmosphereExtinctionThreshold();
     float atmosphereRadius = radius +
                              m_renderer.getAtmosphereShellHeight(atmosphere.mieScaleHeight);
     float atmScale = atmosphereRadius / radius;
 
-    prog->eyePosition = ls.eyePos_obj / atmScale;
-    prog->setAtmosphereParameters(atmosphere, radius, atmosphereRadius, atmosphereRadius,
-                                  m_renderer.getAtmosphereSegmentCount(),
-                                  extinctionThreshold);
+    auto setupAtmosphereProgram = [&](CelestiaGLProgram* prog)
+    {
+        prog->use();
+        prog->eyePosition = ls.eyePos_obj / atmScale;
+        prog->setAtmosphereParameters(atmosphere, radius, atmosphereRadius, atmosphereRadius,
+                                      m_renderer.getAtmosphereSegmentCount(),
+                                      extinctionThreshold);
+        prog->setMVPMatrices(*m.projection, (*m.modelview) * math::scale(atmScale));
+    };
+
+    setupAtmosphereProgram(transmissionProg);
 
 #if 0
     // Currently eclipse shadows are ignored when rendering atmospheres
@@ -385,13 +389,11 @@ AtmosphereRenderer::render(
         prog->setEclipseShadowParameters(ls, radius, planetOrientation);
 #endif
 
-    prog->setMVPMatrices(*m.projection, (*m.modelview) * math::scale(atmScale));
-
     glFrontFace(GL_CW);
 
     Renderer::PipelineState ps;
     ps.blending = true;
-    ps.blendFunc = {GL_ONE, GL_SRC_ALPHA};
+    ps.blendFunc = {GL_ZERO, GL_SRC_COLOR};
     ps.depthTest = true;
     m_renderer.setPipelineState(ps);
 
@@ -401,6 +403,21 @@ AtmosphereRenderer::render(
                                    shellFrustum,
                                    ri.pixWidth,
                                    nullptr);
+
+    if (scatteringProg != nullptr)
+    {
+        scatteringProg->use();
+        scatteringProg->setLightParameters(ls, ri.color, ri.specularColor, Color::Black);
+        scatteringProg->ambientColor = Eigen::Vector3f::Zero();
+        setupAtmosphereProgram(scatteringProg);
+
+        ps.blendFunc = {GL_ONE, GL_ONE};
+        m_renderer.setPipelineState(ps);
+        m_renderer.m_lodSphere->render(LODSphereMesh::Normals,
+                                       shellFrustum,
+                                       ri.pixWidth,
+                                       nullptr);
+    }
 
     glFrontFace(GL_CCW);
 }


### PR DESCRIPTION
Correct atmosphere compositing to preserve RGB transmittance instead of collapsing extinction to scalar alpha.

Uses dual-source blending for single-draw compositing when supported, with a portable two-pass fallback for unsupported devices.