### PR TITLE
Expose cloudSegmentCount to config file

### DIFF
--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -371,8 +371,9 @@ StarTextures
 #   rendering orbit paths. The default value is 100.
 #
 #   AtmosphereSegmentCount defines how many segments to use when
-#   integrating atmospheric scattering. The valid range is 1 to 16,
-#   and the default value is 6.
+#   integrating atmospheric scattering. CloudSegmentCount defines
+#   segments to use for clouds. The valid range is 1 to 16, and
+#   the default values are 6 and 2, respectively.
 #
 #   AtmosphereExtinctionThreshold defines the relative density at the
 #   outer edge of an atmosphere. It must be between 0 and 1. The default
@@ -392,6 +393,7 @@ StarTextures
 #------------------------------------------------------------------------
   OrbitPathSamplePoints  100
   AtmosphereSegmentCount 6
+  CloudSegmentCount  2
   AtmosphereExtinctionThreshold 0.000125
 
   ShadowTextureSize      256

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -415,6 +415,7 @@ bool Renderer::init(int winWidth, int winHeight,
     m_textureManager = std::make_unique<TextureManager>(texturePaths, resolution, *m_resourceSystem);
     detailOptions = _detailOptions;
     atmosphereSegmentCount = detailOptions.atmosphereSegmentCount;
+    cloudSegmentCount = detailOptions.cloudSegmentCount;
     atmosphereExtinctionThreshold = detailOptions.atmosphereExtinctionThreshold;
     atmosphereExtinctionFactor = -std::log(atmosphereExtinctionThreshold);
 
@@ -4808,6 +4809,12 @@ unsigned int
 Renderer::getAtmosphereSegmentCount() const noexcept
 {
     return atmosphereSegmentCount;
+}
+
+unsigned int
+Renderer::getCloudSegmentCount() const noexcept
+{
+    return cloudSegmentCount;
 }
 
 float

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -125,6 +125,7 @@ class Renderer
     {
         unsigned int orbitPathSamplePoints{ 100 };
         unsigned int atmosphereSegmentCount{ 6 };
+        unsigned int cloudSegmentCount{ 2 };
         float atmosphereExtinctionThreshold{ 0.000125f };
         unsigned int shadowTextureSize{ 256 };
         unsigned int eclipseTextureSize{ 128 };
@@ -219,6 +220,7 @@ class Renderer
     void setSolarSystemMaxDistance(float);
     void setShadowMapSize(unsigned);
     unsigned int getAtmosphereSegmentCount() const noexcept;
+    unsigned int getCloudSegmentCount() const noexcept;
     float getAtmosphereExtinctionThreshold() const noexcept;
     float getAtmosphereShellHeight(float scaleHeight) const noexcept;
 
@@ -730,8 +732,9 @@ class Renderer
     const Eigen::Matrix4f *m_projectionPtr { &m_projMatrix };
 
     DetailOptions detailOptions;
-    unsigned int atmosphereSegmentCount{ 3 };
-    float atmosphereExtinctionThreshold{ 0.05f };
+    unsigned int atmosphereSegmentCount{ 6 };
+    unsigned int cloudSegmentCount{ 2 };
+    float atmosphereExtinctionThreshold{ 0.000125f };
     float atmosphereExtinctionFactor{ 0.0f };
 
     std::uint32_t frameCount{ 0 };

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -643,7 +643,7 @@ void renderClouds_GLSL(const RenderInfo& ri,
             float atmosphereRadius = radius +
                                      renderer->getAtmosphereShellHeight(atmosphere->mieScaleHeight);
             prog->setAtmosphereParameters(*atmosphere, radius, cloudRadius, atmosphereRadius,
-                                          1,
+                                          renderer->getCloudSegmentCount(),
                                           extinctionThreshold);
         }
     }

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -199,6 +199,8 @@ applyRenderDetails(CelestiaConfig::RenderDetails& renderDetails, const Associati
     applyNumber(renderDetails.orbitPathSamplePoints, hash, "OrbitPathSamplePoints"sv);
     applyNumber(renderDetails.atmosphere.segmentCount, hash, "AtmosphereSegmentCount"sv);
     renderDetails.atmosphere.segmentCount = std::clamp(renderDetails.atmosphere.segmentCount, 1u, 16u);
+    applyNumber(renderDetails.atmosphere.cloudSegmentCount, hash, "CloudSegmentCount"sv);
+    renderDetails.atmosphere.cloudSegmentCount = std::clamp(renderDetails.atmosphere.cloudSegmentCount, 1u, 16u);
     applyNumber(renderDetails.atmosphere.extinctionThreshold, hash, "AtmosphereExtinctionThreshold"sv);
     if (renderDetails.atmosphere.extinctionThreshold <= 0.0f ||
         renderDetails.atmosphere.extinctionThreshold >= 1.0f)

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -102,8 +102,9 @@ struct CelestiaConfig
         OutputRendering output{ };
         struct AtmosphereRendering
         {
-            unsigned int segmentCount{ 3 };
-            float extinctionThreshold{ 0.05f };
+            unsigned int segmentCount{ 6 };
+            unsigned int cloudSegmentCount{ 2 };
+            float extinctionThreshold{ 0.000125f };
         };
         AtmosphereRendering atmosphere{ };
         struct StarRendering


### PR DESCRIPTION
The config file now has option to change cloudSegmentCount, which is used to determine how many segments the atmosphere in cloud pixels should be rendered with, in addition to atmosphereSegmentCount which was added to config file in #2635.

Clouds originally used the same segmentCount as the atmosphere, but it can be especially laggy to render, hence in #2639, its segment count was changed to a hard-coded 1. However, this resulted in unrealistic cloud appearance, and hence I decided this parameter needs to be exposed in order to allow testing of its appropriate value. Currently it is set to 2.