### PR TITLE
Expose cloudSegmentCount to config file part 2

### DIFF
--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -2789,6 +2789,7 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
     Renderer::DetailOptions detailOptions;
     detailOptions.orbitPathSamplePoints = config->renderDetails.orbitPathSamplePoints;
     detailOptions.atmosphereSegmentCount = config->renderDetails.atmosphere.segmentCount;
+    detailOptions.cloudSegmentCount = config->renderDetails.atmosphere.cloudSegmentCount;
     detailOptions.atmosphereExtinctionThreshold = config->renderDetails.atmosphere.extinctionThreshold;
     detailOptions.shadowTextureSize = config->renderDetails.shadowTextureSize;
     detailOptions.eclipseTextureSize = config->renderDetails.eclipseTextureSize;


### PR DESCRIPTION
A fix for #2644. This completes the path:

1. **celestia.cfg**: Value is defined with the "CloudSegmentCount" keyword.
2. **src/celestia/configfile.cpp**‎: Value is assigned to renderDetails.atmosphere.cloudSegmentCount.
3. ‎**src/celestia/celestiacore.cpp**‎: detailOptions.cloudSegmentCount = config->renderDetails.atmosphere.cloudSegmentCount
4. **src/celengine/render.cpp**: cloudSegmentCount = detailOptions.cloudSegmentCount
    (also defines function "getCloudSegmentCount" for renderer)

(Default values are assigned in configfile.h and render.h files.)

Now this value can be used by calling it with renderer->getCloudSegmentCount().