### PR TITLE
Fix some minor issues

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -4721,8 +4721,13 @@ void Renderer::loadTextures(Body* body)
     if (util::is_set(renderFlags, RenderFlags::ShowCloudMaps))
     {
         const Atmosphere* atmosphere = bodyFeaturesManager->getAtmosphere(body);
-        if (atmosphere != nullptr && atmosphere->cloudTexture != util::TextureHandle::Invalid)
-            m_textureManager->find(atmosphere->cloudTexture);
+        if (atmosphere != nullptr)
+        {
+            if (atmosphere->cloudTexture != util::TextureHandle::Invalid)
+                m_textureManager->find(atmosphere->cloudTexture);
+            if (atmosphere->cloudNormalMap != util::TextureHandle::Invalid)
+                m_textureManager->find(atmosphere->cloudNormalMap);
+        }
     }
 
     if (auto rings = bodyFeaturesManager->getRings(body);

--- a/src/celengine/renderglsl.cpp
+++ b/src/celengine/renderglsl.cpp
@@ -579,7 +579,7 @@ void renderClouds_GLSL(const RenderInfo& ri,
 
     ShaderProperties shadprop;
     shadprop.texUsage = TexUsage::TextureCoordTransform;
-    shadprop.nLights = ls.nLights;
+    shadprop.nLights = std::min(ls.nLights, MaxShaderLights);
     shadprop.effects = LightingEffects::CloudLighting;
 
     // Set up the textures used by this object
@@ -606,7 +606,7 @@ void renderClouds_GLSL(const RenderInfo& ri,
     }
 
     // Set the shadow information.
-    for (unsigned int li = 0; li < ls.nLights; li++)
+    for (unsigned int li = 0; li < shadprop.nLights; li++)
     {
         if (ls.shadows[li] && !ls.shadows[li]->empty())
         {

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -11,8 +11,10 @@
 #include "virtualtex.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstdio>
 #include <fstream>
+#include <limits>
 #include <optional>
 #include <system_error>
 #include <utility>
@@ -34,6 +36,8 @@ namespace
 {
 
 constexpr int MaxResolutionLevels = 13;
+constexpr unsigned int MaxBaseSplit =
+    std::numeric_limits<int>::digits - MaxResolutionLevels - 1;
 
 constexpr bool
 isPow2(int x)
@@ -54,7 +58,10 @@ CreateVirtualTexture(const util::AssociativeArray* texParams,
     }
 
     std::optional<double> baseSplit = texParams->getNumber<double>("BaseSplit");
-    if (!baseSplit.has_value() || *baseSplit < 0.0 || *baseSplit != floor(*baseSplit))
+    if (!baseSplit.has_value() ||
+        *baseSplit < 0.0 ||
+        *baseSplit > MaxBaseSplit ||
+        *baseSplit != std::floor(*baseSplit))
     {
         GetLogger()->error("BaseSplit in virtual texture missing or has bad value\n");
         return nullptr;
@@ -67,9 +74,12 @@ CreateVirtualTexture(const util::AssociativeArray* texParams,
         return nullptr;
     }
 
-    if (*tileSize != floor(*tileSize) ||
+    auto baseSplitValue = static_cast<unsigned int>(*baseSplit);
+    auto maxTileSize = std::numeric_limits<int>::max() >> (baseSplitValue + 1);
+    if (*tileSize != std::floor(*tileSize) ||
         *tileSize < 64.0 ||
-        !isPow2((int) *tileSize))
+        *tileSize > maxTileSize ||
+        !isPow2(static_cast<int>(*tileSize)))
     {
         GetLogger()->error("Virtual texture tile size must be a power of two >= 64\n");
         return nullptr;
@@ -94,8 +104,8 @@ CreateVirtualTexture(const util::AssociativeArray* texParams,
     if (directory.is_relative())
         directory = path / directory;
     return std::make_unique<VirtualTexture>(directory,
-                                            (unsigned int) *baseSplit,
-                                            (unsigned int) *tileSize,
+                                            baseSplitValue,
+                                            static_cast<unsigned int>(*tileSize),
                                             tilePrefix,
                                             tileType,
                                             colorspace);

--- a/src/celengine/virtualtex.cpp
+++ b/src/celengine/virtualtex.cpp
@@ -75,8 +75,8 @@ CreateVirtualTexture(const util::AssociativeArray* texParams,
     }
 
     auto baseSplitValue = static_cast<unsigned int>(*baseSplit);
-    auto maxTileSize = std::numeric_limits<int>::max() >> (baseSplitValue + 1);
-    if (*tileSize != std::floor(*tileSize) ||
+    if (auto maxTileSize = std::numeric_limits<int>::max() >> (baseSplitValue + 1);
+        *tileSize != std::floor(*tileSize) ||
         *tileSize < 64.0 ||
         *tileSize > maxTileSize ||
         !isPow2(static_cast<int>(*tileSize)))
@@ -319,7 +319,7 @@ VirtualTexture::requestTile(Tile* tile, unsigned int lod, unsigned int u, unsign
 
     tile->state = TileState::Loading;
 
-    unsigned int diskLod = lod >> baseSplit;
+    unsigned int diskLod = lod - baseSplit;
     auto filename = std::filesystem::u8path(fmt::format("{}{}_{}", tilePrefix, u, v));
     filename += tileExt;
     auto path = tilePath / fmt::format("level{:d}", diskLod) / filename;
@@ -395,7 +395,7 @@ VirtualTexture::drainReady(std::size_t byteBudget)
             continue;
         }
 
-        unsigned int diskLod = ready.lod >> baseSplit;
+        unsigned int diskLod = ready.lod - baseSplit;
         MipMapMode mipMapMode = diskLod == 0 ? DefaultMipMaps : NoMipMaps;
         tile->tex = std::make_unique<ImageTexture>(*ready.image, EdgeClamp, mipMapMode);
         tile->state = TileState::Loaded;

--- a/src/celestia/qt/qtbookmark.cpp
+++ b/src/celestia/qt/qtbookmark.cpp
@@ -29,6 +29,7 @@
 #include <QStyle>
 #include <QTreeView>
 #include <QVariant>
+#include <QtAlgorithms>
 
 #include <celestia/url.h>
 #include <celutil/gettext.h>
@@ -70,6 +71,11 @@ BookmarkItem::BookmarkItem(Type type, BookmarkItem* parent) :
     m_parent(parent)
 {
 
+}
+
+BookmarkItem::~BookmarkItem()
+{
+    qDeleteAll(m_children);
 }
 
 BookmarkItem::Type
@@ -214,14 +220,10 @@ void
 BookmarkItem::removeChildren(int index, int count)
 {
     Q_ASSERT(index + count <= m_children.size());
-    for (int i = 1; i < count; i++)  // (if i = 0: critical error)
-    {
-        m_children[index + i]->setParent(nullptr);
-        //m_children[index + i]->setPosition(0);
-    }
-
-    // TODO: delete the child
-    m_children.erase(m_children.begin() + index, m_children.begin() + index + count);
+    auto first = m_children.begin() + index;
+    auto last = first + count;
+    qDeleteAll(first, last);
+    m_children.erase(first, last);
 }
 
 BookmarkItem*
@@ -451,11 +453,14 @@ BookmarkTreeModel::dropMimeData(const QMimeData* data, Qt::DropAction action, in
 
     QByteArray encodedData = data->data("application/celestia.text.list");
     QDataStream stream(&encodedData, QIODevice::ReadOnly);
-    BookmarkItem item;
+    const BookmarkItem* item = nullptr;
 
     // Read the pointer (ugh) from the encoded mime data. Bail out now
     // if the data was incomplete for some reason.
     if (stream.readRawData(reinterpret_cast<char*>(&item), sizeof(item)) != sizeof(item))
+        return false;
+
+    if (item == nullptr)
         return false;
 
     BookmarkItem* parentFolder = nullptr;
@@ -476,7 +481,7 @@ BookmarkTreeModel::dropMimeData(const QMimeData* data, Qt::DropAction action, in
     // is inserted in the new position, then the old item is removed. Bad things
     // happen when the item appears in two separate places, so we'll insert a copy
     // of the old data into the new position.
-    BookmarkItem* clone = item.clone(parentFolder);
+    BookmarkItem* clone = item->clone(parentFolder);
 
     beginInsertRows(parent, row, row);
     parentFolder->insert(clone, row);
@@ -520,7 +525,8 @@ BookmarkTreeModel::mimeData(const QModelIndexList& indexes) const
 
     const BookmarkItem* item = getItem(indexes.at(0));
     QDataStream stream(&encodedData, QIODevice::WriteOnly);
-    stream.writeRawData(reinterpret_cast<const char*>(&item), sizeof(*item));
+    // QDataStream::writeRawData requires a const char*; std::byte is not accepted.
+    stream.writeRawData(reinterpret_cast<const char*>(&item), sizeof(item)); //NOSONAR
     mimeData->setData("application/celestia.text.list", encodedData);
 
     return mimeData;

--- a/src/celestia/qt/qtbookmark.h
+++ b/src/celestia/qt/qtbookmark.h
@@ -56,6 +56,14 @@ public:
     BookmarkItem() = default;
 
     BookmarkItem(Type type, BookmarkItem* parent);
+    ~BookmarkItem();
+
+    // Owns its children via raw pointers, so it is not copyable or movable;
+    // use clone() for a deep copy.
+    BookmarkItem(const BookmarkItem&) = delete;
+    BookmarkItem& operator=(const BookmarkItem&) = delete;
+    BookmarkItem(BookmarkItem&&) = delete;
+    BookmarkItem& operator=(BookmarkItem&&) = delete;
 
     BookmarkItem::Type type() const;
     BookmarkItem* parent() const;

--- a/src/celestia/url.cpp
+++ b/src/celestia/url.cpp
@@ -394,7 +394,7 @@ Url::encodeString(std::string_view str)
 }
 
 bool
-Url::parse(std::string_view urlStr)
+Url::parse(std::string_view urlStr) //NOSONAR
 {
     constexpr auto npos = std::string_view::npos;
 
@@ -408,8 +408,13 @@ Url::parse(std::string_view urlStr)
     // extract @path and @params from the URL
     auto pos = urlStr.find('?');
     auto pathStr = urlStr.substr(PROTOCOL.length(), pos - PROTOCOL.length());
-    while (pathStr.back() == '/')
+    while (!pathStr.empty() && pathStr.back() == '/')
         pathStr.remove_suffix(1);
+    if (pathStr.empty())
+    {
+        GetLogger()->error(_("URL must have at least mode and time!\n"));
+        return false;
+    }
     std::string_view paramsStr;
     if (pos != npos)
         paramsStr = urlStr.substr(pos + 1);

--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -262,10 +262,8 @@ DecompressDXTc(std::uint32_t width, std::uint32_t height, PixelFormat format, bo
     {
         for (std::uint32_t x = 0; x < width; x += 4)
         {
-            if (!in.good())
+            if (!in.read(reinterpret_cast<char*>(block.data()), blocksize)) /* Flawfinder: ignore */
                 return nullptr;
-
-            in.read(reinterpret_cast<char*>(block.data()), blocksize); /* Flawfinder: ignore */
             switch (format)
             {
             case PixelFormat::DXT1:
@@ -438,8 +436,10 @@ Image* LoadDDSImage(const std::filesystem::path& filename)
                                        static_cast<std::int32_t>(ddsd.width),
                                        static_cast<std::int32_t>(ddsd.height),
                                        std::max(static_cast<std::int32_t>(ddsd.mipMapLevels), INT32_C(1)));
-    in.read(reinterpret_cast<char*>(img->getPixels()), img->getSize()); /* Flawfinder: ignore */
-    if (!in.eof() && !in.good())
+    std::int32_t dataSize = 0;
+    for (std::int32_t mip = 0; mip < img->getMipLevelCount(); ++mip)
+        dataSize += img->getMipLevelSize(mip);
+    if (!in.read(reinterpret_cast<char*>(img->getPixels()), dataSize)) /* Flawfinder: ignore */
     {
         util::GetLogger()->error("Failed reading data from DDS texture file {}.\n", filename);
         return nullptr;

--- a/src/celimage/dds.cpp
+++ b/src/celimage/dds.cpp
@@ -328,7 +328,7 @@ CreateDecompressedImage(const DDSurfaceDesc& ddsd, PixelFormat format, std::istr
         std::uint32_t numberOfPixels = ddsd.width * ddsd.height;
         for (std::uint32_t index = 0; index < numberOfPixels; ++index)
         {
-            std::memcpy(&ptr[3 * index], &ptr[4 * index], sizeof(char) * 3);
+            std::memmove(&ptr[3 * index], &ptr[4 * index], sizeof(char) * 3);
         }
     }
 
@@ -392,6 +392,16 @@ Image* LoadDDSImage(const std::filesystem::path& filename)
         return nullptr;
     }
 
+    std::uint32_t mipMapLevels = std::max(ddsd.mipMapLevels, UINT32_C(1));
+    std::uint32_t maxMipMapLevels = 1;
+    for (std::uint32_t size = std::max(ddsd.width, ddsd.height); size > 1; size >>= 1)
+        ++maxMipMapLevels;
+    if (mipMapLevels > maxMipMapLevels)
+    {
+        util::GetLogger()->error("DDS file {} has too many mip levels.\n", filename);
+        return nullptr;
+    }
+
     PixelFormat format;
     if (ddsd.format.fourCC == FourCC("DX10"))
     {
@@ -435,7 +445,7 @@ Image* LoadDDSImage(const std::filesystem::path& filename)
     auto img = std::make_unique<Image>(format,
                                        static_cast<std::int32_t>(ddsd.width),
                                        static_cast<std::int32_t>(ddsd.height),
-                                       std::max(static_cast<std::int32_t>(ddsd.mipMapLevels), INT32_C(1)));
+                                       static_cast<std::int32_t>(mipMapLevels));
     std::int32_t dataSize = 0;
     for (std::int32_t mip = 0; mip < img->getMipLevelCount(); ++mip)
         dataSize += img->getMipLevelSize(mip);

--- a/src/celrender/ringrenderer.cpp
+++ b/src/celrender/ringrenderer.cpp
@@ -54,7 +54,7 @@ createShaderProperties(const LightingState& ls,
     if (renderShadow)
     {
         // Set one shadow (the planet's) per light
-        for (unsigned int li = 0; li < ls.nLights; li++)
+        for (unsigned int li = 0; li < shadprop.nLights; li++)
             shadprop.setEclipseShadowCountForLight(li, 1);
     }
 
@@ -69,19 +69,18 @@ setUpShadowParameters(CelestiaGLProgram* prog,
                       const LightingState& ls,
                       float planetOblateness)
 {
-    for (unsigned int li = 0; li < ls.nLights; li++)
+    unsigned int lightCount = std::min(ls.nLights, MaxShaderLights);
+    for (unsigned int li = 0; li < lightCount; li++)
     {
         const DirectionalLight& light = ls.lights[li];
 
         // Compute the projection vectors based on the sun direction.
-        // I'm being a little careless here--if the sun direction lies
-        // along the y-axis, this will fail.  It's unlikely that a
-        // planet would ever orbit underneath its sun (an orbital
-        // inclination of 90 degrees), but this should be made
-        // more robust anyway.
         Eigen::Vector3f axis = Eigen::Vector3f::UnitY().cross(light.direction_obj);
         float cosAngle = Eigen::Vector3f::UnitY().dot(light.direction_obj);
-        axis.normalize();
+        if (axis.isZero())
+            axis = Eigen::Vector3f::UnitX();
+        else
+            axis.normalize();
 
         float tScale = 1.0f;
         if (planetOblateness != 0.0f)

--- a/src/celscript/legacy/cmdparser.cpp
+++ b/src/celscript/legacy/cmdparser.cpp
@@ -16,6 +16,7 @@
 #endif
 #include <array>
 #include <cctype>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -460,10 +461,15 @@ ParseResult parseTimeCommand(const AssociativeArray& paramList, const ScriptMaps
         if (utc == nullptr)
             return makeError("Missing either time or utc parameter to time");
 
-        astro::Date date(0.0);
-        std::sscanf(utc->c_str(), "%d-%d-%dT%d:%d:%lf",
-                    &date.year, &date.month, &date.day,
-                    &date.hour, &date.minute, &date.seconds);
+        astro::Date date;
+        int parsedLength = 0;
+        std::sscanf(utc->c_str(), "%*d-%*d-%*dT%*d:%*d:%*lf%n", &parsedLength);
+        if (parsedLength != static_cast<int>(utc->size()) ||
+            !astro::parseDate(*utc, date) ||
+            !std::isfinite(date.seconds))
+        {
+            return makeError("Invalid utc parameter to time");
+        }
         jd = static_cast<double>(date);
     }
 
@@ -541,9 +547,25 @@ ParseResult parseSetOrientationCommand(const AssociativeArray& paramList, const 
 {
     if (auto angle = paramList.getNumber<double>("angle"); angle.has_value())
     {
-        auto axis = paramList.getVector3<double>("axis").value_or(Eigen::Vector3d::Zero());
-        auto orientation = Eigen::Quaternionf(Eigen::AngleAxisf(static_cast<float>(math::degToRad(*angle)),
-                                                                axis.cast<float>().normalized()));
+        auto axis = paramList.getVector3<double>("axis");
+        if (!std::isfinite(*angle) ||
+            !axis.has_value() ||
+            !axis->allFinite() ||
+            axis->squaredNorm() == 0.0)
+        {
+            return makeError("Invalid angle or axis parameter to setorientation");
+        }
+
+        float angleRadians = static_cast<float>(math::degToRad(*angle));
+        Eigen::Vector3f axisValue = axis->cast<float>();
+        if (!std::isfinite(angleRadians) ||
+            !axisValue.allFinite() ||
+            axisValue.squaredNorm() == 0.0f)
+        {
+            return makeError("Invalid angle or axis parameter to setorientation");
+        }
+
+        auto orientation = Eigen::Quaternionf(Eigen::AngleAxisf(angleRadians, axisValue.normalized()));
         return std::make_unique<CommandSetOrientation>(orientation);
     }
 
@@ -552,6 +574,9 @@ ParseResult parseSetOrientationCommand(const AssociativeArray& paramList, const 
     auto oy = paramList.getNumber<double>("oy").value_or(0.0);
     auto oz = paramList.getNumber<double>("oz").value_or(0.0);
     Eigen::Quaternionf orientation(ow, ox, oy, oz);
+    if (!orientation.coeffs().allFinite() || orientation.squaredNorm() == 0.0f)
+        return makeError("Invalid quaternion parameters to setorientation");
+
     return std::make_unique<CommandSetOrientation>(orientation);
 }
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -5,6 +5,8 @@ set(UNIT_TEST_SOURCES
   constellation_test.cpp
   greek_test.cpp
   kepler_test.cpp
+  legacy_cmdparser_test.cpp
+  loader_validation_test.cpp
   logger_test.cpp
   ranges_test.cpp
   resourcesystem_test.cpp

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -12,7 +12,8 @@ set(UNIT_TEST_SOURCES
   resourcesystem_test.cpp
   stellarclass_test.cpp
   strnatcmp_test.cpp
-  tokenizer_test.cpp)
+  tokenizer_test.cpp
+  url_test.cpp)
 
 if(USE_ICU)
   list(APPEND UNIT_TEST_SOURCES unicode_test.cpp)

--- a/test/unit/legacy_cmdparser_test.cpp
+++ b/test/unit/legacy_cmdparser_test.cpp
@@ -1,0 +1,44 @@
+#include <sstream>
+#include <string_view>
+
+#include <doctest.h>
+
+#include <celscript/common/scriptmaps.h>
+#include <celscript/legacy/cmdparser.h>
+
+namespace
+{
+
+bool
+parsesSuccessfully(std::string_view source)
+{
+    std::istringstream input{ std::string(source) };
+    celestia::scripts::ScriptMaps scriptMaps;
+    celestia::scripts::CommandParser parser(input, scriptMaps);
+    auto sequence = parser.parse();
+    return sequence.size() == 1 && parser.getErrors().empty();
+}
+
+} // namespace
+
+TEST_SUITE_BEGIN("Legacy command parser");
+
+TEST_CASE("Time command validates UTC dates")
+{
+    CHECK(parsesSuccessfully(R"({ time { utc "2000-01-01T12:00:00" } })"));
+    CHECK_FALSE(parsesSuccessfully(R"({ time { utc "not-a-date" } })"));
+    CHECK_FALSE(parsesSuccessfully(R"({ time { utc "2000-13-01T12:00:00" } })"));
+    CHECK_FALSE(parsesSuccessfully(R"({ time { utc "2000-01-01T12:00:00junk" } })"));
+}
+
+TEST_CASE("Setorientation rejects invalid rotations")
+{
+    CHECK(parsesSuccessfully(R"({ setorientation { angle 10 axis [1 0 0] } })"));
+    CHECK(parsesSuccessfully(R"({ setorientation { ow 1 } })"));
+    CHECK_FALSE(parsesSuccessfully(R"({ setorientation { angle 10 } })"));
+    CHECK_FALSE(parsesSuccessfully(R"({ setorientation { angle 10 axis [0 0 0] } })"));
+    CHECK_FALSE(parsesSuccessfully(R"({ setorientation { angle 10 axis [1e-50 0 0] } })"));
+    CHECK_FALSE(parsesSuccessfully(R"({ setorientation { } })"));
+}
+
+TEST_SUITE_END();

--- a/test/unit/legacy_cmdparser_test.cpp
+++ b/test/unit/legacy_cmdparser_test.cpp
@@ -1,3 +1,12 @@
+// legacy_cmdparser_test.cpp
+//
+// Copyright (C) 2026-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
 #include <sstream>
 #include <string_view>
 

--- a/test/unit/loader_validation_test.cpp
+++ b/test/unit/loader_validation_test.cpp
@@ -1,0 +1,131 @@
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#include <doctest.h>
+
+#include <celengine/texture.h>
+#include <celengine/virtualtex.h>
+#include <celimage/image.h>
+#include <celimage/imageformats.h>
+
+namespace
+{
+
+class TemporaryDirectory
+{
+public:
+    TemporaryDirectory()
+    {
+        std::random_device random;
+        const auto base = std::filesystem::temp_directory_path();
+        for (int attempt = 0; attempt < 100; ++attempt)
+        {
+            path = base / ("celestia-loader-validation-" +
+                           std::to_string(random()) + "-" +
+                           std::to_string(random()));
+            std::error_code ec;
+            if (std::filesystem::create_directory(path, ec))
+                return;
+        }
+
+        throw std::runtime_error("Failed to create temporary test directory");
+    }
+
+    ~TemporaryDirectory()
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+
+    std::filesystem::path getPath(std::string_view name) const
+    {
+        return path / name;
+    }
+
+private:
+    std::filesystem::path path;
+};
+
+void
+writeLE32(std::ostream& out, std::uint32_t value)
+{
+    std::array<char, 4> bytes{
+        static_cast<char>(value),
+        static_cast<char>(value >> 8),
+        static_cast<char>(value >> 16),
+        static_cast<char>(value >> 24),
+    };
+    out.write(bytes.data(), bytes.size());
+}
+
+void
+writeRGBA8DDS(const std::filesystem::path& path, std::size_t payloadSize)
+{
+    std::ofstream out(path, std::ios::binary);
+    out.write("DDS ", 4);
+
+    std::array<std::uint32_t, 31> header{};
+    header[0] = 124;
+    header[2] = 1;
+    header[3] = 1;
+    header[4] = 4;
+    header[18] = 32;
+    header[21] = 32;
+    header[22] = 0x000000ff;
+    header[23] = 0x0000ff00;
+    header[24] = 0x00ff0000;
+    header[25] = 0xff000000;
+    for (std::uint32_t value : header)
+        writeLE32(out, value);
+
+    constexpr std::array<char, 4> payload{ '\x01', '\x02', '\x03', '\x04' };
+    out.write(payload.data(), static_cast<std::streamsize>(payloadSize));
+}
+
+} // namespace
+
+TEST_SUITE_BEGIN("Loader validation");
+
+TEST_CASE("DDS loader rejects truncated pixel data")
+{
+    TemporaryDirectory directory;
+    auto path = directory.getPath("truncated.dds");
+    writeRGBA8DDS(path, 3);
+    std::unique_ptr<celestia::engine::Image> image(
+        celestia::engine::LoadDDSImage(path));
+    CHECK(image == nullptr);
+}
+
+TEST_CASE("DDS loader accepts complete pixel data")
+{
+    TemporaryDirectory directory;
+    auto path = directory.getPath("complete.dds");
+    writeRGBA8DDS(path, 4);
+    std::unique_ptr<celestia::engine::Image> image(
+        celestia::engine::LoadDDSImage(path));
+    REQUIRE(image != nullptr);
+    CHECK(image->getWidth() == 1);
+    CHECK(image->getHeight() == 1);
+}
+
+TEST_CASE("Virtual texture loader rejects unsafe dimensions")
+{
+    TemporaryDirectory directory;
+    auto path = directory.getPath("invalid.ctx");
+    {
+        std::ofstream out(path);
+        out << "VirtualTexture { ImageDirectory \".\" BaseSplit 18 TileSize 64 }";
+    }
+
+    auto texture = LoadVirtualTexture(path, Texture::DefaultColorspace);
+    CHECK(texture == nullptr);
+}
+
+TEST_SUITE_END();

--- a/test/unit/loader_validation_test.cpp
+++ b/test/unit/loader_validation_test.cpp
@@ -1,3 +1,12 @@
+// loader_validation_test.cpp
+//
+// Copyright (C) 2026-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
 #include <array>
 #include <cstdint>
 #include <filesystem>
@@ -66,26 +75,37 @@ writeLE32(std::ostream& out, std::uint32_t value)
 }
 
 void
-writeRGBA8DDS(const std::filesystem::path& path, std::size_t payloadSize)
+writeDDS(const std::filesystem::path& path,
+         std::uint32_t width,
+         std::uint32_t height,
+         std::uint32_t mipLevels,
+         std::uint32_t fourCC,
+         std::size_t payloadSize)
 {
     std::ofstream out(path, std::ios::binary);
     out.write("DDS ", 4);
 
     std::array<std::uint32_t, 31> header{};
     header[0] = 124;
-    header[2] = 1;
-    header[3] = 1;
-    header[4] = 4;
+    header[2] = height;
+    header[3] = width;
+    header[6] = mipLevels;
     header[18] = 32;
-    header[21] = 32;
-    header[22] = 0x000000ff;
-    header[23] = 0x0000ff00;
-    header[24] = 0x00ff0000;
-    header[25] = 0xff000000;
+    header[20] = fourCC;
+    if (fourCC == 0)
+    {
+        header[4] = width * 4;
+        header[21] = 32;
+        header[22] = 0x000000ff;
+        header[23] = 0x0000ff00;
+        header[24] = 0x00ff0000;
+        header[25] = 0xff000000;
+    }
     for (std::uint32_t value : header)
         writeLE32(out, value);
 
-    constexpr std::array<char, 4> payload{ '\x01', '\x02', '\x03', '\x04' };
+    std::array<char, 32> payload{};
+    REQUIRE(payloadSize <= payload.size());
     out.write(payload.data(), static_cast<std::streamsize>(payloadSize));
 }
 
@@ -97,7 +117,7 @@ TEST_CASE("DDS loader rejects truncated pixel data")
 {
     TemporaryDirectory directory;
     auto path = directory.getPath("truncated.dds");
-    writeRGBA8DDS(path, 3);
+    writeDDS(path, 1, 1, 1, 0, 3);
     std::unique_ptr<celestia::engine::Image> image(
         celestia::engine::LoadDDSImage(path));
     CHECK(image == nullptr);
@@ -107,12 +127,22 @@ TEST_CASE("DDS loader accepts complete pixel data")
 {
     TemporaryDirectory directory;
     auto path = directory.getPath("complete.dds");
-    writeRGBA8DDS(path, 4);
+    writeDDS(path, 1, 1, 1, 0, 4);
     std::unique_ptr<celestia::engine::Image> image(
         celestia::engine::LoadDDSImage(path));
     REQUIRE(image != nullptr);
     CHECK(image->getWidth() == 1);
     CHECK(image->getHeight() == 1);
+}
+
+TEST_CASE("DDS loader rejects excessive mip levels")
+{
+    TemporaryDirectory directory;
+    auto path = directory.getPath("excessive-mips.dds");
+    writeDDS(path, 1, 1, 32, 0, 4);
+    std::unique_ptr<celestia::engine::Image> image(
+        celestia::engine::LoadDDSImage(path));
+    CHECK(image == nullptr);
 }
 
 TEST_CASE("Virtual texture loader rejects unsafe dimensions")

--- a/test/unit/url_test.cpp
+++ b/test/unit/url_test.cpp
@@ -1,0 +1,24 @@
+// url_test.cpp
+//
+// Copyright (C) 2026-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <doctest.h>
+
+#include <celestia/url.h>
+
+TEST_SUITE_BEGIN("URL");
+
+TEST_CASE("URL parser rejects an empty path")
+{
+    Url url(nullptr);
+    CHECK_FALSE(url.parse("cel://"));
+    CHECK_FALSE(url.parse("cel:///"));
+    CHECK_FALSE(url.parse("cel://?x=1"));
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
1. Clamp cloud rendering to the shader-supported light count.
2. Preload cloud normal maps with the other cloud textures.
3. Fall back to a valid axis for ring shadows when the light is parallel to the ring normal.
4. Validate legacy UTC and orientation command parameters.
5. Reject truncated DDS payloads without rejecting valid mipmapped textures.
6. Prevent unsafe VirtualTexture dimension shifts and fix the disk LOD mapping.
7. Reject empty  cel://  URLs safely.
8. Fix a bookmark drag-and-drop use-after-free and subtree leak.