### PR TITLE
Fix ring rendering clipping and shadow

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -5258,6 +5258,14 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
     // Remove objects from the render list that lie completely outside the
     // view frustum.
     auto notCulled = renderList.begin();
+
+    // Pull the near plane out if needed to keep the far/near ratio in range.
+    auto clampNearForRatio = [](float &nearZ, float farZ)
+    {
+        if (farZ / nearZ > MaxFarNearRatio * 0.5f)
+            nearZ = farZ / (MaxFarNearRatio * 0.5f);
+    };
+
     const BodyFeaturesManager* bodyFeaturesManager = GetBodyFeaturesManager();
     for (auto &ri : renderList)
     {
@@ -5265,6 +5273,8 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
         float radius = 1.0f;
         float cullRadius = 1.0f;
         float cloudHeight = 0.0f;
+        float ringOuterRadius = 0.0f;
+        float ringInnerRadius = 0.0f;
 
         switch (ri.renderableType)
         {
@@ -5288,13 +5298,14 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
                 rings != nullptr && util::is_set(renderFlags, RenderFlags::ShowPlanetRings) &&
                 ri.distance <= rings->innerRadius)
             {
-                // Inside the rings: they are drawn inline with the body (no
-                // separate ring entry), so the body entry must encompass the
-                // ring extent for culling and depth partitioning.
-                radius = rings->outerRadius;
-                convex = false;
+                // Inside the rings: cull and far-clip to the ring extent, but
+                // keep the near plane based on the planet so a nearby surface
+                // isn't clipped.
+                ringOuterRadius = rings->outerRadius;
+                ringInnerRadius = rings->innerRadius;
             }
-            else if (!ri.body->isEllipsoid())
+
+            if (!ri.body->isEllipsoid())
                 convex = false;
 
             cullRadius = radius;
@@ -5304,6 +5315,7 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
                 cloudHeight = max(atmosphere->cloudHeight,
                                   getAtmosphereShellHeight(atmosphere->mieScaleHeight));
             }
+            cullRadius = std::max(cullRadius, ringOuterRadius);
             break;
 
         default:
@@ -5346,11 +5358,19 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
                 }
                 ri.nearZ = std::min(nearZ, -bodyMinNearZ);
 
+                // Pull the near plane in to the nearest possible ring point so
+                // rings near the inner edge aren't clipped.
+                if (ringInnerRadius > 0.0f)
+                {
+                    float ringClearance = std::max(ringInnerRadius - d, MinNearPlaneDistance);
+                    float ringNearZ = std::max(MinNearPlaneDistance, ringClearance * nearZcoeff);
+                    ri.nearZ = std::max(ri.nearZ, -ringNearZ);
+                }
+
                 if (!convex)
                 {
-                    ri.farZ = center.z() - radius;
-                    if (ri.farZ / ri.nearZ > MaxFarNearRatio * 0.5f)
-                        ri.nearZ = ri.farZ / (MaxFarNearRatio * 0.5f);
+                    ri.farZ = center.z() - std::max(radius, ringOuterRadius);
+                    clampNearForRatio(ri.nearZ, ri.farZ);
                 }
                 else
                 {
@@ -5379,6 +5399,13 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
                                           ? std::sqrt(math::square(d) - math::square(eradius)) * 1.1f
                                           : MinNearPlaneDistance;
                         ri.farZ = -horizon;
+                    }
+
+                    // Extend the far plane to the back of the rings.
+                    if (ringOuterRadius > 0.0f)
+                    {
+                        ri.farZ = std::min(ri.farZ, center.z() - ringOuterRadius);
+                        clampNearForRatio(ri.nearZ, ri.farZ);
                     }
                 }
             }

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -3022,16 +3022,16 @@ CelestiaGLProgram::initSamplers()
         nSamplers++;
     }
 
-    if (util::is_set(props.texUsage, TexUsage::RingShadowTexture))
+    if (util::is_set(props.texUsage, TexUsage::CloudShadowTexture))
     {
-        if (GLint slot = glGetUniformLocation(program.getID(), "ringTex"); slot != -1)
+        if (GLint slot = glGetUniformLocation(program.getID(), "cloudShadowTex"); slot != -1)
             glUniform1i(slot, nSamplers);
         nSamplers++;
     }
 
-    if (util::is_set(props.texUsage, TexUsage::CloudShadowTexture))
+    if (util::is_set(props.texUsage, TexUsage::RingShadowTexture))
     {
-        if (GLint slot = glGetUniformLocation(program.getID(), "cloudShadowTex"); slot != -1)
+        if (GLint slot = glGetUniformLocation(program.getID(), "ringTex"); slot != -1)
             glUniform1i(slot, nSamplers);
         nSamplers++;
     }


### PR DESCRIPTION
- Surface/rings clipped when inside the rings:  `removeInvisibleItems`  inflated the body radius to the ring outer radius, pushing the near plane too far out and clipping the nearby surface. Now the near plane stays based on the planet radius; the ring extent is used only for culling and the far plane.
- Ring shadow sampled the wrong texture with cloud shadows on:  `initSamplers()`  assigned  ringTex  before  cloudShadowTex , mismatching the GPU bind order. Swapped so  `cloudShadowTex`  comes first.