### PR TITLE
Render rings and atmosphere separately from the object and split ring rendering when needed

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2586,6 +2586,11 @@ void Renderer::renderObject(const Vector3f& pos,
     {
         // calculate ring segment size in pixels, actual size is segmentSizeInPixels * tan(segmentAngle)
         float segmentSizeInPixels = 2.0f * obj.rings->outerRadius / (max(nearPlaneDistance, altitude) * pixelSize);
+        // Atmosphere shell radius in planet-radius units, used to split the ring
+        // fragments in front of / behind the atmosphere limb.
+        float atmosphereRadius = splitRingsAroundAtmosphere
+            ? (radius + obj.atmosphere->height) / radius
+            : 0.0f;
         m_ringRenderer->renderRings(*obj.rings, ri, ls,
                                     radius, 1.0f - obj.semiAxes.y(),
                                     util::is_set(renderFlags, RenderFlags::ShowRingShadows) && lit,
@@ -2593,7 +2598,8 @@ void Renderer::renderObject(const Vector3f& pos,
                                     ringsMVP, distance <= obj.rings->innerRadius,
                                     splitRingsAroundAtmosphere
                                         ? celestia::render::RingRenderHalf::Far
-                                        : celestia::render::RingRenderHalf::Both);
+                                        : celestia::render::RingRenderHalf::Both,
+                                    atmosphereRadius);
     }
 
     if (atmosphere != nullptr)
@@ -3182,13 +3188,21 @@ void Renderer::renderRingSystem(Body& body,
 
     float segmentSizeInPixels = 2.0f * rings->outerRadius / (max(nearPlaneDistance, altitude) * pixelSize);
 
+    // Atmosphere shell radius in planet-radius units, matching the far half
+    // drawn inline by renderObject so the split boundary is identical.
+    const Atmosphere* atmosphere = bodyFeaturesManager->getAtmosphere(&body);
+    float atmosphereRadius = (atmosphere != nullptr && atmosphere->height > 0.0f)
+        ? (radius + atmosphere->height) / radius
+        : 0.0f;
+
     m_ringRenderer->renderRings(*rings, ri, lights,
                                 radius, 1.0f - semiAxes.y(),
                                 renderShadow,
                                 segmentSizeInPixels,
                                 ringsMVP,
                                 false,
-                                renderHalf);
+                                renderHalf,
+                                atmosphereRadius);
 }
 
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -5739,9 +5739,12 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
     std::sort(renderList.begin(), renderList.end(),
               [](const RenderListEntry& a, const RenderListEntry& b)
               {
-                  // Reversed because -z points into the screen. renderOrder
-                  // breaks ties so a larger value sorts farther, drawn earlier.
-                  return a.centerZ - a.radius - a.renderOrder > b.centerZ - b.radius - b.renderOrder;
+                  // Operation is reversed because -z axis points into the screen
+                  float ka = a.centerZ - a.radius;
+                  float kb = b.centerZ - b.radius;
+                  if (ka != kb)
+                      return ka > kb;
+                  return a.renderOrder < b.renderOrder;
               });
 }
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2885,26 +2885,20 @@ bool Renderer::testEclipse(const Body& receiver,
 }
 
 
-void Renderer::renderPlanet(Body& body,
-                            const Vector3f& pos,
-                            double distance,
-                            float appMag,
-                            const Observer& observer,
-                            float nearPlaneDistance,
-                            float farPlaneDistance,
-                            const Matrices &m)
+// Computes the render properties, orientation and lighting state (including
+// eclipse and ring shadows) for a planet. Shared by the surface and the
+// separately sorted atmosphere render passes so their lighting matches.
+void Renderer::setupPlanetLighting(Body& body,
+                                   const Vector3f& pos,
+                                   double now,
+                                   float nearPlaneDistance,
+                                   float altitude,
+                                   RenderProperties& rp,
+                                   LightingState& lights,
+                                   Quaterniond& q)
 {
-    double now = observer.getTime();
-    float altitude = static_cast<float>(distance - body.getRadius());
-    float discSizeInPixels = body.getRadius() /
-        (max(nearPlaneDistance, altitude) * pixelSize);
+    auto bodyFeaturesManager = GetBodyFeaturesManager();
 
-    float maxDiscSize = (starStyle == StarStyle::ScaledDiscStars) ? MaxScaledDiscStarSize : 1.0f;
-    if (discSizeInPixels >= maxDiscSize && body.hasVisibleGeometry())
-    {
-        auto bodyFeaturesManager = GetBodyFeaturesManager();
-
-        RenderProperties rp;
         if (displayedSurface.empty())
         {
             rp.surface = &body.getSurface();
@@ -2922,7 +2916,7 @@ void Renderer::renderPlanet(Body& body,
         rp.semiAxes = body.getSemiAxes() * (1.0f / rp.radius);
         rp.geometryScale = body.getGeometryScale();
 
-        Quaterniond q = body.getRotationModel(now)->spin(now) *
+        q = body.getRotationModel(now)->spin(now) *
                         body.getEclipticToEquatorial(now);
 
         rp.orientation = body.getGeometryOrientation() * q.cast<float>();
@@ -2945,7 +2939,6 @@ void Renderer::renderPlanet(Body& body,
             scaleFactors = Vector3f::Constant(rp.geometryScale);
         }
 
-        LightingState lights;
         setupObjectLighting(lightSourceList,
                             secondaryIlluminators,
                             rp.orientation,
@@ -3084,6 +3077,33 @@ void Renderer::renderPlanet(Body& body,
             // adjustment is needed here.
             lights.ringShadows[li].texLod = lod;
         }
+
+}
+
+
+void Renderer::renderPlanet(Body& body,
+                            const Vector3f& pos,
+                            double distance,
+                            float appMag,
+                            const Observer& observer,
+                            float nearPlaneDistance,
+                            float farPlaneDistance,
+                            const Matrices &m)
+{
+    double now = observer.getTime();
+    float altitude = static_cast<float>(distance - body.getRadius());
+    float discSizeInPixels = body.getRadius() /
+        (max(nearPlaneDistance, altitude) * pixelSize);
+
+    float maxDiscSize = (starStyle == StarStyle::ScaledDiscStars) ? MaxScaledDiscStarSize : 1.0f;
+    if (discSizeInPixels >= maxDiscSize && body.hasVisibleGeometry())
+    {
+        auto bodyFeaturesManager = GetBodyFeaturesManager();
+
+        RenderProperties rp;
+        LightingState lights;
+        Quaterniond q;
+        setupPlanetLighting(body, pos, now, nearPlaneDistance, altitude, rp, lights, q);
 
         renderObject(pos, distance, observer,
                      nearPlaneDistance, farPlaneDistance,

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2728,16 +2728,19 @@ void Renderer::renderPlanetAtmosphere(Body& body,
     RenderProperties rp;
     LightingState ls;
     Quaterniond q;
-    // The surface pass runs first and caches this planet's lighting; reuse it.
-    auto it = planetLightingCache.find(&body);
-    if (it == planetLightingCache.end())
+    // Reuse the surface pass's lighting if it ran this frame; otherwise compute
+    // it (the body disc may have been too small for renderPlanet to draw, e.g.
+    // under the ScaledDiscStars star style).
+    if (auto it = planetLightingCache.find(&body); it != planetLightingCache.end())
     {
-        assert(false);
-        return;
+        rp = it->second.rp;
+        ls = it->second.lights;
+        q = it->second.q;
     }
-    rp = it->second.rp;
-    ls = it->second.lights;
-    q = it->second.q;
+    else
+    {
+        setupPlanetLighting(body, pos, now, nearPlaneDistance, altitude, rp, ls, q);
+    }
 
     RenderInfo ri;
     ri.sunDir_eye = Vector3f::UnitY();
@@ -3219,17 +3222,22 @@ void Renderer::renderPlanet(Body& body,
         Quaterniond q;
         setupPlanetLighting(body, pos, now, nearPlaneDistance, altitude, rp, lights, q);
 
-        // Cache this lighting so the atmosphere entry can reuse it this frame.
-        // Copy the eclipse shadows and re-point at the copies, since
-        // lights.shadows aliases the shared eclipseShadows scratch.
-        PlanetLightingCacheEntry& cache = planetLightingCache[&body];
-        cache.rp = rp;
-        cache.q = q;
-        cache.lights = lights;
-        for (unsigned int li = 0; li < lights.nLights; ++li)
+        // Cache this lighting so the atmosphere entry can reuse it this frame;
+        // only atmospheric bodies have such an entry. Copy the eclipse shadows
+        // and re-point at the copies, since lights.shadows aliases the shared
+        // eclipseShadows scratch.
+        if (rp.atmosphere != nullptr &&
+            (rp.atmosphere->height > 0.0f || rp.atmosphere->cloudTexture != util::TextureHandle::Invalid))
         {
-            cache.eclipseShadows[li] = eclipseShadows[li];
-            cache.lights.shadows[li] = &cache.eclipseShadows[li];
+            PlanetLightingCacheEntry& cache = planetLightingCache[&body];
+            cache.rp = rp;
+            cache.q = q;
+            cache.lights = lights;
+            for (unsigned int li = 0; li < lights.nLights; ++li)
+            {
+                cache.eclipseShadows[li] = eclipseShadows[li];
+                cache.lights.shadows[li] = &cache.eclipseShadows[li];
+            }
         }
 
         renderObject(pos, distance, observer,
@@ -3327,9 +3335,11 @@ void Renderer::renderRingSystem(Body& body,
         ringsScaleFactor = geometryScale;
     }
 
-    // Reuse the ring lighting across the near and far half draws this frame.
+    // Reuse the ring lighting across the near and far half draws. Only the split
+    // draws in two halves, so the whole-ring (Both) case skips the cache.
     LightingState lights;
-    if (auto it = ringLightingCache.find(&body); it != ringLightingCache.end())
+    bool split = renderHalf != celestia::render::RingRenderHalf::Both;
+    if (auto it = ringLightingCache.find(&body); split && it != ringLightingCache.end())
     {
         lights = it->second;
     }
@@ -3344,7 +3354,8 @@ void Renderer::renderRingSystem(Body& body,
                             lights);
         assert(lights.nLights <= MaxLights);
         lights.ambientColor = ambientColor.toVector3();
-        ringLightingCache[&body] = lights;
+        if (split)
+            ringLightingCache[&body] = lights;
     }
 
     // Build the rings model-view matrix.
@@ -3689,7 +3700,10 @@ void Renderer::addRenderListEntries(RenderListEntry& rle,
                                 static_cast<float>(rle.distance - body.getRadius()),
                                 pixelSize);
 
-    if (atmosphere != nullptr && atmosphere->height > 0.0f && rle.discSizeInPixels > 1)
+    bool hasAtmosphereOrClouds = atmosphere != nullptr &&
+        (atmosphere->height > 0.0f || atmosphere->cloudTexture != util::TextureHandle::Invalid);
+
+    if (hasAtmosphereOrClouds && rle.discSizeInPixels > 1)
     {
         float atmosphereRadius = body.getRadius() + atmosphere->height;
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2604,103 +2604,130 @@ void Renderer::renderObject(const Vector3f& pos,
 
     if (atmosphere != nullptr)
     {
-        // Compute the apparent thickness in pixels of the atmosphere.
-        // If it's only one pixel thick, it can look quite unsightly
-        // due to aliasing.  To avoid popping, we gradually fade in the
-        // atmosphere as it grows from two to three pixels thick.
-        float fade;
-        float thicknessInPixels = 0.0f;
-        if (distance - radius > 0.0f)
+        renderAtmosphere(atmosphere, ri, ls, obj, pos, distance, radius,
+                         scaleFactors, insidePlanet, lit,
+                         cloudTex, cloudNormalMap, cloudTexOffset,
+                         viewFrustum, planetMV, m);
+    }
+}
+
+
+// Renders an atmosphere and its cloud layer (if any) for a planet.
+void Renderer::renderAtmosphere(const Atmosphere* atmosphere,
+                                const RenderInfo& ri,
+                                const LightingState& ls,
+                                const RenderProperties& obj,
+                                const Vector3f& pos,
+                                double distance,
+                                float radius,
+                                const Vector3f& scaleFactors,
+                                bool insidePlanet,
+                                bool lit,
+                                Texture* cloudTex,
+                                Texture* cloudNormalMap,
+                                float cloudTexOffset,
+                                const math::Frustum& viewFrustum,
+                                const Matrix4f& planetMV,
+                                const Matrices& m)
+{
+    Matrices planetMVP = { m.projection, &planetMV };
+
+    // Compute the apparent thickness in pixels of the atmosphere.
+    // If it's only one pixel thick, it can look quite unsightly
+    // due to aliasing.  To avoid popping, we gradually fade in the
+    // atmosphere as it grows from two to three pixels thick.
+    float fade;
+    float thicknessInPixels = 0.0f;
+    if (distance - radius > 0.0f)
+    {
+        thicknessInPixels = static_cast<float>(atmosphere->height /
+            ((distance - radius) * pixelSize));
+        fade = std::clamp(thicknessInPixels - MinAtmosphereThicknessInPixels, 0.0f, 1.0f);
+    }
+    else
+    {
+        fade = 1.0f;
+    }
+
+    if (fade > 0 && util::is_set(renderFlags, RenderFlags::ShowAtmospheres) && atmosphere->height > 0.0f &&
+        !insidePlanet)
+    {
+        // Only use new atmosphere code in OpenGL 2.0 path when new style parameters are defined.
+        // TODO: convert old style atmopshere parameters
+        if (atmosphere->mieScaleHeight > 0.0f)
         {
-            thicknessInPixels = static_cast<float>(atmosphere->height /
-                ((distance - radius) * pixelSize));
-            fade = std::clamp(thicknessInPixels - MinAtmosphereThicknessInPixels, 0.0f, 1.0f);
+            m_atmosphereRenderer->render(
+                ri,
+                *atmosphere,
+                ls,
+                obj.orientation,
+                radius,
+                viewFrustum,
+                planetMVP);
         }
         else
         {
-            fade = 1.0f;
+            Eigen::Matrix4f modelView = math::rotate(getCameraOrientationf());
+            Matrices mvp = { m.projection, &modelView };
+            m_atmosphereRenderer->renderLegacy(
+                *atmosphere,
+                ls,
+                pos,
+                obj.orientation,
+                scaleFactors,
+                ri.sunDir_eye,
+                thicknessInPixels,
+                lit,
+                mvp);
         }
+    }
 
-        if (fade > 0 && util::is_set(renderFlags, RenderFlags::ShowAtmospheres) && atmosphere->height > 0.0f &&
-            !insidePlanet)
+    // If there's a cloud layer, we'll render it now.
+    if (cloudTex != nullptr && !insidePlanet)
+    {
+        float cloudScale = 1.0f + atmosphere->cloudHeight / radius;
+        Matrix4f cmv = math::scale(planetMV, cloudScale);
+        Matrices mvp = { m.projection, &cmv };
+
+        // If we're beneath the cloud level, render the interior of
+        // the cloud sphere.
+        if (distance - radius < atmosphere->cloudHeight)
+            glFrontFace(GL_CW);
+
+        cloudTex->bind();
+
+        // Cloud layers can be trouble for the depth buffer, since they tend
+        // to be very close to the surface of a planet relative to the radius
+        // of the planet. We'll help out by offsetting the cloud layer toward
+        // the viewer.
+        if (distance > radius * 1.1f)
         {
-            // Only use new atmosphere code in OpenGL 2.0 path when new style parameters are defined.
-            // TODO: convert old style atmopshere parameters
-            if (atmosphere->mieScaleHeight > 0.0f)
-            {
-                m_atmosphereRenderer->render(
-                    ri,
-                    *atmosphere,
-                    ls,
-                    obj.orientation,
-                    radius,
-                    viewFrustum,
-                    planetMVP);
-            }
-            else
-            {
-                Eigen::Matrix4f modelView = math::rotate(getCameraOrientationf());
-                Matrices mvp = { m.projection, &modelView };
-                m_atmosphereRenderer->renderLegacy(
-                    *atmosphere,
-                    ls,
-                    pos,
-                    obj.orientation,
-                    scaleFactors,
-                    ri.sunDir_eye,
-                    thicknessInPixels,
-                    lit,
-                    mvp);
-            }
+            glEnable(GL_POLYGON_OFFSET_FILL);
+            glPolygonOffset(-1.0f, -1.0f);
         }
 
-        // If there's a cloud layer, we'll render it now.
-        if (cloudTex != nullptr && !insidePlanet)
+        if (lit)
         {
-            float cloudScale = 1.0f + atmosphere->cloudHeight / radius;
-            Matrix4f cmv = math::scale(planetMV, cloudScale);
-            Matrices mvp = { m.projection, &cmv };
-
-            // If we're beneath the cloud level, render the interior of
-            // the cloud sphere.
-            if (distance - radius < atmosphere->cloudHeight)
-                glFrontFace(GL_CW);
-
-            cloudTex->bind();
-
-            // Cloud layers can be trouble for the depth buffer, since they tend
-            // to be very close to the surface of a planet relative to the radius
-            // of the planet. We'll help out by offsetting the cloud layer toward
-            // the viewer.
-            if (distance > radius * 1.1f)
-            {
-                glEnable(GL_POLYGON_OFFSET_FILL);
-                glPolygonOffset(-1.0f, -1.0f);
-            }
-
-            if (lit)
-            {
-                renderClouds_GLSL(ri, ls,
-                                  atmosphere,
-                                  cloudTex,
-                                  cloudNormalMap,
-                                  cloudTexOffset,
-                                  scaleFactors,
-                                  renderFlags,
-                                  obj.orientation,
-                                  viewFrustum,
-                                  mvp,
-                                  this,
-                                  m_lodSphere.get());
-            }
-            else
-            {
-                renderCloudsUnlit(ri,viewFrustum, cloudTex, cloudTexOffset, mvp, this, m_lodSphere.get());
-            }
-
-            glDisable(GL_POLYGON_OFFSET_FILL);
-            glFrontFace(GL_CCW);
+            renderClouds_GLSL(ri, ls,
+                              atmosphere,
+                              cloudTex,
+                              cloudNormalMap,
+                              cloudTexOffset,
+                              scaleFactors,
+                              renderFlags,
+                              obj.orientation,
+                              viewFrustum,
+                              mvp,
+                              this,
+                              m_lodSphere.get());
         }
+        else
+        {
+            renderCloudsUnlit(ri, viewFrustum, cloudTex, cloudTexOffset, mvp, this, m_lodSphere.get());
+        }
+
+        glDisable(GL_POLYGON_OFFSET_FILL);
+        glFrontFace(GL_CCW);
     }
 }
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -2585,7 +2585,7 @@ void Renderer::renderObject(const Vector3f& pos,
 
 
 // Draws a planet's atmosphere and cloud layer.
-void Renderer::renderAtmosphere(const Atmosphere* atmosphere,
+void Renderer::renderAtmosphere(const Atmosphere* atmosphere, // NOSONAR(cpp:S107)
                                 const RenderInfo& ri,
                                 const LightingState& ls,
                                 const RenderProperties& obj,
@@ -3005,7 +3005,7 @@ bool Renderer::testEclipse(const Body& receiver,
 // Builds the render properties, orientation and lighting (eclipse and ring
 // shadows) for a planet. Shared by the surface and atmosphere passes so their
 // lighting matches.
-void Renderer::setupPlanetLighting(Body& body,
+void Renderer::setupPlanetLighting(Body& body, // NOSONAR(cpp:S107,cpp:S3776)
                                    const Vector3f& pos,
                                    double now,
                                    float nearPlaneDistance,
@@ -3652,7 +3652,7 @@ static bool isBodyVisible(const Body* body, BodyClassification bodyVisibilityMas
     }
 }
 
-void Renderer::addRenderListEntries(RenderListEntry& rle,
+void Renderer::addRenderListEntries(RenderListEntry& rle, // NOSONAR(cpp:S3776)
                                     Body& body,
                                     bool isLabeled)
 {
@@ -3700,10 +3700,9 @@ void Renderer::addRenderListEntries(RenderListEntry& rle,
                                 static_cast<float>(rle.distance - body.getRadius()),
                                 pixelSize);
 
-    bool hasAtmosphereOrClouds = atmosphere != nullptr &&
-        (atmosphere->height > 0.0f || atmosphere->cloudTexture != util::TextureHandle::Invalid);
-
-    if (hasAtmosphereOrClouds && rle.discSizeInPixels > 1)
+    if (atmosphere != nullptr &&
+        (atmosphere->height > 0.0f || atmosphere->cloudTexture != util::TextureHandle::Invalid) &&
+        rle.discSizeInPixels > 1)
     {
         float atmosphereRadius = body.getRadius() + atmosphere->height;
 
@@ -5740,9 +5739,7 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
               [](const RenderListEntry& a, const RenderListEntry& b)
               {
                   // Operation is reversed because -z axis points into the screen
-                  float ka = a.centerZ - a.radius;
-                  float kb = b.centerZ - b.radius;
-                  if (ka != kb)
+                  if (float ka = a.centerZ - a.radius, kb = b.centerZ - b.radius; ka != kb)
                       return ka > kb;
                   return a.renderOrder < b.renderOrder;
               });

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1474,6 +1474,8 @@ void Renderer::render(const Observer& observer,
     // renderList.
     renderList.clear();
     orbitPathList.clear();
+    planetLightingCache.clear();
+    ringLightingCache.clear();
     lightSourceList.clear();
     secondaryIlluminators.clear();
     nearStars.clear();
@@ -2726,7 +2728,16 @@ void Renderer::renderPlanetAtmosphere(Body& body,
     RenderProperties rp;
     LightingState ls;
     Quaterniond q;
-    setupPlanetLighting(body, pos, now, nearPlaneDistance, altitude, rp, ls, q);
+    // The surface pass runs first and caches this planet's lighting; reuse it.
+    auto it = planetLightingCache.find(&body);
+    if (it == planetLightingCache.end())
+    {
+        assert(false);
+        return;
+    }
+    rp = it->second.rp;
+    ls = it->second.lights;
+    q = it->second.q;
 
     RenderInfo ri;
     ri.sunDir_eye = Vector3f::UnitY();
@@ -3208,6 +3219,19 @@ void Renderer::renderPlanet(Body& body,
         Quaterniond q;
         setupPlanetLighting(body, pos, now, nearPlaneDistance, altitude, rp, lights, q);
 
+        // Cache this lighting so the atmosphere entry can reuse it this frame.
+        // Copy the eclipse shadows and re-point at the copies, since
+        // lights.shadows aliases the shared eclipseShadows scratch.
+        PlanetLightingCacheEntry& cache = planetLightingCache[&body];
+        cache.rp = rp;
+        cache.q = q;
+        cache.lights = lights;
+        for (unsigned int li = 0; li < lights.nLights; ++li)
+        {
+            cache.eclipseShadows[li] = eclipseShadows[li];
+            cache.lights.shadows[li] = &cache.eclipseShadows[li];
+        }
+
         renderObject(pos, distance, observer,
                      nearPlaneDistance, farPlaneDistance,
                      rp, lights, m);
@@ -3303,16 +3327,25 @@ void Renderer::renderRingSystem(Body& body,
         ringsScaleFactor = geometryScale;
     }
 
+    // Reuse the ring lighting across the near and far half draws this frame.
     LightingState lights;
-    setupObjectLighting(lightSourceList,
-                        secondaryIlluminators,
-                        bodyOrientation,
-                        scaleFactors,
-                        pos,
-                        isNormalized,
-                        lights);
-    assert(lights.nLights <= MaxLights);
-    lights.ambientColor = ambientColor.toVector3();
+    if (auto it = ringLightingCache.find(&body); it != ringLightingCache.end())
+    {
+        lights = it->second;
+    }
+    else
+    {
+        setupObjectLighting(lightSourceList,
+                            secondaryIlluminators,
+                            bodyOrientation,
+                            scaleFactors,
+                            pos,
+                            isNormalized,
+                            lights);
+        assert(lights.nLights <= MaxLights);
+        lights.ambientColor = ambientColor.toVector3();
+        ringLightingCache[&body] = lights;
+    }
 
     // Build the rings model-view matrix.
     Affine3f transform = Translation3f(pos) * bodyOrientation.conjugate();

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -127,6 +127,11 @@ static constexpr float MaxFarNearRatio      = 2000000.0f;
 
 static constexpr float MinRelativeOccluderRadius = 0.005f;
 
+// Apparent thickness in pixels below which a planet's atmosphere is treated as
+// invisible. The atmosphere fades in over the following pixel, and the ring
+// system is only split around the atmosphere once it reaches this thickness.
+static constexpr float MinAtmosphereThicknessInPixels = 2.0f;
+
 // Size at which the orbit cache will be flushed of old orbit paths
 static constexpr unsigned int OrbitCacheCullThreshold = 200;
 // Age in frames at which unused orbit paths may be eliminated from the cache
@@ -151,6 +156,19 @@ inline float inchesToMm(float in)
 inline float sizeFade(float screenSize, float minScreenSize, float opaqueScale)
 {
     return min(1.0f, (screenSize - minScreenSize) / (minScreenSize * (opaqueScale - 1)));
+}
+
+// A planet's atmosphere obscures its ring system when the atmosphere is
+// visible and large enough on screen relative to the observer's altitude.
+// In that case the rings must be split around the atmosphere render pass so
+// the near half is drawn behind it.
+inline bool
+atmosphereObscuresRings(const Atmosphere* atmosphere, float altitude, float pixelSize)
+{
+    return atmosphere != nullptr &&
+           atmosphere->height > 0.0f &&
+           altitude > 0.0f &&
+           atmosphere->height / (altitude * pixelSize) > MinAtmosphereThicknessInPixels;
 }
 
 inline void glVertexAttrib(GLuint index, const Color &color)
@@ -1347,13 +1365,25 @@ void Renderer::renderItem(const RenderListEntry& rle,
         break;
 
     case RenderListEntry::RenderableRingSystem:
+    {
+        const Atmosphere* atmosphere =
+            GetBodyFeaturesManager()->getAtmosphere(rle.body);
+        float altitude =
+            static_cast<float>(rle.distance - rle.body->getRadius());
+        bool splitAroundAtmosphere =
+            util::is_set(renderFlags, RenderFlags::ShowAtmospheres) &&
+            atmosphereObscuresRings(atmosphere, altitude, pixelSize);
         renderRingSystem(*rle.body,
                          rle.position,
                          static_cast<float>(rle.distance),
                          observer,
                          nearPlaneDistance,
-                         m);
+                         m,
+                         splitAroundAtmosphere
+                             ? celestia::render::RingRenderHalf::Near
+                             : celestia::render::RingRenderHalf::Both);
         break;
+    }
 
     case RenderListEntry::RenderableCometTail:
         renderCometTail(*rle.body,
@@ -2386,8 +2416,22 @@ void Renderer::renderObject(const Vector3f& pos,
 
     Matrices ringsMVP;
     Matrix4f ringsMV;
-    // Outside rings are rendered separately at the end of a depth partition
-    bool showRings = obj.rings != nullptr && util::is_set(renderFlags, RenderFlags::ShowPlanetRings) && distance <= obj.rings->innerRadius;
+    // When an atmosphere is visible, split the rings around its render pass:
+    // the far half is drawn inline before the atmosphere and the near half is
+    // drawn later by the transparent ring-system entry.
+    bool splitRingsAroundAtmosphere =
+        obj.rings != nullptr &&
+        util::is_set(renderFlags, RenderFlags::ShowPlanetRings) &&
+        util::is_set(renderFlags, RenderFlags::ShowAtmospheres) &&
+        distance > obj.rings->innerRadius &&
+        atmosphereObscuresRings(obj.atmosphere,
+                                static_cast<float>(distance - obj.radius),
+                                pixelSize);
+    bool showRings =
+        obj.rings != nullptr &&
+        util::is_set(renderFlags, RenderFlags::ShowPlanetRings) &&
+        (distance <= obj.rings->innerRadius ||
+         splitRingsAroundAtmosphere);
     if (showRings)
     {
         ringsMV  = (*m.modelview) * (transform * Scaling(ringsScaleFactor)).matrix();
@@ -2546,7 +2590,10 @@ void Renderer::renderObject(const Vector3f& pos,
                                     radius, 1.0f - obj.semiAxes.y(),
                                     util::is_set(renderFlags, RenderFlags::ShowRingShadows) && lit,
                                     segmentSizeInPixels,
-                                    ringsMVP, true);
+                                    ringsMVP, distance <= obj.rings->innerRadius,
+                                    splitRingsAroundAtmosphere
+                                        ? celestia::render::RingRenderHalf::Far
+                                        : celestia::render::RingRenderHalf::Both);
     }
 
     if (atmosphere != nullptr)
@@ -2561,7 +2608,7 @@ void Renderer::renderObject(const Vector3f& pos,
         {
             thicknessInPixels = static_cast<float>(atmosphere->height /
                 ((distance - radius) * pixelSize));
-            fade = std::clamp(thicknessInPixels - 2.0f, 0.0f, 1.0f);
+            fade = std::clamp(thicknessInPixels - MinAtmosphereThicknessInPixels, 0.0f, 1.0f);
         }
         else
         {
@@ -3046,7 +3093,8 @@ void Renderer::renderRingSystem(Body& body,
                                 float distance,
                                 const Observer& observer,
                                 float nearPlaneDistance,
-                                const Matrices &m)
+                                const Matrices &m,
+                                celestia::render::RingRenderHalf renderHalf)
 {
     const BodyFeaturesManager* bodyFeaturesManager = GetBodyFeaturesManager();
 
@@ -3139,7 +3187,8 @@ void Renderer::renderRingSystem(Body& body,
                                 renderShadow,
                                 segmentSizeInPixels,
                                 ringsMVP,
-                                false);
+                                false,
+                                renderHalf);
 }
 
 

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1365,25 +1365,32 @@ void Renderer::renderItem(const RenderListEntry& rle,
         break;
 
     case RenderListEntry::RenderableRingSystem:
+    case RenderListEntry::RenderableRingSystemNear:
+    case RenderListEntry::RenderableRingSystemFar:
     {
-        const Atmosphere* atmosphere =
-            GetBodyFeaturesManager()->getAtmosphere(rle.body);
-        float altitude =
-            static_cast<float>(rle.distance - rle.body->getRadius());
-        bool splitAroundAtmosphere =
-            util::is_set(renderFlags, RenderFlags::ShowAtmospheres) &&
-            atmosphereObscuresRings(atmosphere, altitude, pixelSize);
+        celestia::render::RingRenderHalf half = celestia::render::RingRenderHalf::Both;
+        if (rle.renderableType == RenderListEntry::RenderableRingSystemNear)
+            half = celestia::render::RingRenderHalf::Near;
+        else if (rle.renderableType == RenderListEntry::RenderableRingSystemFar)
+            half = celestia::render::RingRenderHalf::Far;
         renderRingSystem(*rle.body,
                          rle.position,
                          static_cast<float>(rle.distance),
                          observer,
                          nearPlaneDistance,
                          m,
-                         splitAroundAtmosphere
-                             ? celestia::render::RingRenderHalf::Near
-                             : celestia::render::RingRenderHalf::Both);
+                         half);
         break;
     }
+
+    case RenderListEntry::RenderableAtmosphere:
+        renderPlanetAtmosphere(*rle.body,
+                               rle.position,
+                               rle.distance,
+                               observer,
+                               nearPlaneDistance, farPlaneDistance,
+                               m);
+        break;
 
     case RenderListEntry::RenderableCometTail:
         renderCometTail(*rle.body,
@@ -2416,22 +2423,12 @@ void Renderer::renderObject(const Vector3f& pos,
 
     Matrices ringsMVP;
     Matrix4f ringsMV;
-    // When an atmosphere is visible, split the rings around its render pass:
-    // the far half is drawn inline before the atmosphere and the near half is
-    // drawn later by the transparent ring-system entry.
-    bool splitRingsAroundAtmosphere =
-        obj.rings != nullptr &&
-        util::is_set(renderFlags, RenderFlags::ShowPlanetRings) &&
-        util::is_set(renderFlags, RenderFlags::ShowAtmospheres) &&
-        distance > obj.rings->innerRadius &&
-        atmosphereObscuresRings(obj.atmosphere,
-                                static_cast<float>(distance - obj.radius),
-                                pixelSize);
+    // Draw rings inline only from inside; otherwise they are transparent
+    // entries (split around the atmosphere when it hides them).
     bool showRings =
         obj.rings != nullptr &&
         util::is_set(renderFlags, RenderFlags::ShowPlanetRings) &&
-        (distance <= obj.rings->innerRadius ||
-         splitRingsAroundAtmosphere);
+        distance <= obj.rings->innerRadius;
     if (showRings)
     {
         ringsMV  = (*m.modelview) * (transform * Scaling(ringsScaleFactor)).matrix();
@@ -2515,23 +2512,11 @@ void Renderer::renderObject(const Vector3f& pos,
     viewFrustum.transform(invMV);
 
     // Get cloud layer parameters
-    Texture* cloudTex       = nullptr;
-    Texture* cloudNormalMap = nullptr;
     float cloudTexOffset    = 0.0f;
     const Atmosphere* atmosphere = obj.atmosphere;
 
-    if (atmosphere != nullptr)
-    {
-        if (util::is_set(renderFlags, RenderFlags::ShowCloudMaps))
-        {
-            if (atmosphere->cloudTexture != util::TextureHandle::Invalid)
-                cloudTex = m_textureManager->find(atmosphere->cloudTexture);
-            if (atmosphere->cloudNormalMap != util::TextureHandle::Invalid)
-                cloudNormalMap = m_textureManager->find(atmosphere->cloudNormalMap);
-        }
-        if (atmosphere->cloudSpeed != 0.0f)
-            cloudTexOffset = (float) (-math::pfmod(now * atmosphere->cloudSpeed * 0.5 * celestia::numbers::inv_pi, 1.0));
-    }
+    if (atmosphere != nullptr && atmosphere->cloudSpeed != 0.0f)
+        cloudTexOffset = static_cast<float>(-math::pfmod(now * atmosphere->cloudSpeed * 0.5 * celestia::numbers::inv_pi, 1.0));
 
     if (obj.geometry == engine::GeometryHandle::Invalid)
     {
@@ -2586,33 +2571,18 @@ void Renderer::renderObject(const Vector3f& pos,
     {
         // calculate ring segment size in pixels, actual size is segmentSizeInPixels * tan(segmentAngle)
         float segmentSizeInPixels = 2.0f * obj.rings->outerRadius / (max(nearPlaneDistance, altitude) * pixelSize);
-        // Atmosphere shell radius in planet-radius units, used to split the ring
-        // fragments in front of / behind the atmosphere limb.
-        float atmosphereRadius = splitRingsAroundAtmosphere
-            ? (radius + obj.atmosphere->height) / radius
-            : 0.0f;
         m_ringRenderer->renderRings(*obj.rings, ri, ls,
                                     radius, 1.0f - obj.semiAxes.y(),
                                     util::is_set(renderFlags, RenderFlags::ShowRingShadows) && lit,
                                     segmentSizeInPixels,
                                     ringsMVP, distance <= obj.rings->innerRadius,
-                                    splitRingsAroundAtmosphere
-                                        ? celestia::render::RingRenderHalf::Far
-                                        : celestia::render::RingRenderHalf::Both,
-                                    atmosphereRadius);
-    }
-
-    if (atmosphere != nullptr)
-    {
-        renderAtmosphere(atmosphere, ri, ls, obj, pos, distance, radius,
-                         scaleFactors, insidePlanet, lit,
-                         cloudTex, cloudNormalMap, cloudTexOffset,
-                         viewFrustum, planetMV, m);
+                                    celestia::render::RingRenderHalf::Both,
+                                    0.0f);
     }
 }
 
 
-// Renders an atmosphere and its cloud layer (if any) for a planet.
+// Draws a planet's atmosphere and cloud layer.
 void Renderer::renderAtmosphere(const Atmosphere* atmosphere,
                                 const RenderInfo& ri,
                                 const LightingState& ls,
@@ -2729,6 +2699,139 @@ void Renderer::renderAtmosphere(const Atmosphere* atmosphere,
         glDisable(GL_POLYGON_OFFSET_FILL);
         glFrontFace(GL_CCW);
     }
+}
+
+
+// Renders a planet's atmosphere and clouds as a sortable transparent pass.
+// Rebuilds the per-object state from renderObject and takes lighting from
+// setupPlanetLighting, so cloud eclipse and ring shadows match the surface.
+void Renderer::renderPlanetAtmosphere(Body& body,
+                                      const Vector3f& pos,
+                                      double distance,
+                                      const Observer& observer,
+                                      float nearPlaneDistance,
+                                      float farPlaneDistance,
+                                      const Matrices& m)
+{
+    const BodyFeaturesManager* bodyFeaturesManager = GetBodyFeaturesManager();
+    const Atmosphere* atmosphere = bodyFeaturesManager->getAtmosphere(&body);
+    if (atmosphere == nullptr)
+        return;
+
+    double now = observer.getTime();
+    float radius = body.getRadius();
+    float altitude = static_cast<float>(distance - radius);
+    float discSizeInPixels = radius / (max(nearPlaneDistance, altitude) * pixelSize);
+
+    RenderProperties rp;
+    LightingState ls;
+    Quaterniond q;
+    setupPlanetLighting(body, pos, now, nearPlaneDistance, altitude, rp, ls, q);
+
+    RenderInfo ri;
+    ri.sunDir_eye = Vector3f::UnitY();
+    ri.sunDir_obj = Vector3f::UnitY();
+    ri.sunColor = Color::Black;
+    if (ls.nLights > 0)
+    {
+        ri.sunDir_eye = ls.lights[0].direction_eye;
+        ri.sunDir_obj = ls.lights[0].direction_obj;
+        ri.sunColor   = ls.lights[0].color;
+    }
+
+    const RenderGeometry* geometry = nullptr;
+    if (rp.geometry != engine::GeometryHandle::Invalid)
+        geometry = m_geometryManager->find(rp.geometry);
+
+    if (rp.surface->baseTexture != util::TextureHandle::Invalid)
+        ri.baseTex = m_textureManager->find(rp.surface->baseTexture);
+
+    Vector3f scaleFactors;
+    Matrix4f invMV;
+    if (geometry == nullptr || geometry->isNormalized())
+    {
+        scaleFactors = radius * rp.semiAxes;
+        Affine3f invModelView = Scaling(rp.semiAxes).inverse() *
+                                rp.orientation *
+                                Translation3f(-pos / radius) *
+                                getCameraOrientationf().conjugate();
+        invMV = invModelView.matrix();
+    }
+    else
+    {
+        scaleFactors = Vector3f::Constant(rp.geometryScale);
+        Affine3f invModelView = rp.orientation *
+                                Translation3f(-pos / radius) *
+                                getCameraOrientationf().conjugate();
+        invMV = invModelView.matrix();
+    }
+
+    Affine3f transform = Translation3f(pos) * rp.orientation.conjugate();
+    Matrix4f planetMV  = (*m.modelview) * (transform * Scaling(scaleFactors)).matrix();
+
+    Matrix3f planetRotation = rp.orientation.toRotationMatrix();
+    ri.eyeDir_obj = -(planetRotation * pos).normalized();
+    ri.eyePos_obj = -(planetRotation * (pos.cwiseQuotient(scaleFactors)));
+
+    bool insidePlanet =
+        rp.geometry == engine::GeometryHandle::Invalid &&
+        (scaleFactors.x() == scaleFactors.y() && scaleFactors.x() == scaleFactors.z()
+             ? distance < static_cast<double>(scaleFactors.x())
+             : (planetRotation * pos).cwiseQuotient(scaleFactors).squaredNorm() < 1.0f);
+
+    ri.orientation = getCameraOrientationf() * rp.orientation.conjugate();
+    ri.pixWidth = discSizeInPixels;
+
+    if (ri.baseTex == nullptr ||
+        util::is_set(rp.surface->appearanceFlags, Surface::Flags::BlendTexture))
+    {
+        ri.color = rp.surface->color.linearize(gl::sRGBRendering);
+    }
+    ri.ambientColor = ambientColor;
+    ri.specularColor = rp.surface->specularColor.linearize(gl::sRGBRendering);
+    ri.specularPower = rp.surface->specularPower;
+    ri.lunarLambert = rp.surface->lunarLambert;
+
+    bool lit = !util::is_set(rp.surface->appearanceFlags, Surface::Flags::Emissive);
+
+    // Match renderObject's far plane so the atmosphere and clouds aren't clipped.
+    float frustumFarPlane = farPlaneDistance;
+    if (rp.geometry == engine::GeometryHandle::Invalid)
+    {
+        float d = pos.norm();
+        float eradius = scaleFactors.minCoeff();
+        if (d > eradius)
+            frustumFarPlane = std::sqrt(math::square(d) - math::square(eradius)) * 1.1f;
+
+        float atmosphereHeight = max(atmosphere->cloudHeight,
+                                     getAtmosphereShellHeight(atmosphere->mieScaleHeight));
+        if (atmosphereHeight > 0.0f)
+        {
+            float atmosphereRadius = eradius + atmosphereHeight;
+            frustumFarPlane += std::sqrt(math::square(atmosphereRadius) - math::square(eradius));
+        }
+    }
+
+    auto viewFrustum = projectionMode->getFrustum(nearPlaneDistance / radius, frustumFarPlane / radius, observer.getZoom());
+    viewFrustum.transform(invMV);
+
+    Texture* cloudTex       = nullptr;
+    Texture* cloudNormalMap = nullptr;
+    float cloudTexOffset    = 0.0f;
+    if (util::is_set(renderFlags, RenderFlags::ShowCloudMaps))
+    {
+        if (atmosphere->cloudTexture != util::TextureHandle::Invalid)
+            cloudTex = m_textureManager->find(atmosphere->cloudTexture);
+        if (atmosphere->cloudNormalMap != util::TextureHandle::Invalid)
+            cloudNormalMap = m_textureManager->find(atmosphere->cloudNormalMap);
+    }
+    if (atmosphere->cloudSpeed != 0.0f)
+        cloudTexOffset = static_cast<float>(-math::pfmod(now * atmosphere->cloudSpeed * 0.5 * celestia::numbers::inv_pi, 1.0));
+
+    renderAtmosphere(atmosphere, ri, ls, rp, pos, distance, radius,
+                     scaleFactors, insidePlanet, lit,
+                     cloudTex, cloudNormalMap, cloudTexOffset,
+                     viewFrustum, planetMV, m);
 }
 
 
@@ -2885,9 +2988,9 @@ bool Renderer::testEclipse(const Body& receiver,
 }
 
 
-// Computes the render properties, orientation and lighting state (including
-// eclipse and ring shadows) for a planet. Shared by the surface and the
-// separately sorted atmosphere render passes so their lighting matches.
+// Builds the render properties, orientation and lighting (eclipse and ring
+// shadows) for a planet. Shared by the surface and atmosphere passes so their
+// lighting matches.
 void Renderer::setupPlanetLighting(Body& body,
                                    const Vector3f& pos,
                                    double now,
@@ -3533,20 +3636,70 @@ void Renderer::addRenderListEntries(RenderListEntry& rle,
         renderList.push_back(rle);
     }
 
-    if (const RingSystem* rings = bodyFeaturesManager->getRings(&body);
-        rings != nullptr && util::is_set(renderFlags, RenderFlags::ShowPlanetRings))
+    // Rings, atmosphere and clouds are transparent entries sorted with other
+    // geometry. When the atmosphere hides the rings, the disc splits into far
+    // and near halves so the order is far ring, atmosphere, near ring.
+    const Atmosphere* atmosphere = bodyFeaturesManager->getAtmosphere(&body);
+    const RingSystem* rings = bodyFeaturesManager->getRings(&body);
+    bool showRings = rings != nullptr && util::is_set(renderFlags, RenderFlags::ShowPlanetRings);
+    float ringDiscSize = showRings
+        ? static_cast<float>((rings->outerRadius / rle.distance) / pixelSize)
+        : 0.0f;
+
+    // Inside the rings they are drawn inline, so only add entries from outside.
+    bool outsideRings = showRings && ringDiscSize > 1 && rle.distance > rings->innerRadius;
+
+    bool splitAroundAtmosphere =
+        outsideRings &&
+        util::is_set(renderFlags, RenderFlags::ShowAtmospheres) &&
+        atmosphereObscuresRings(atmosphere,
+                                static_cast<float>(rle.distance - body.getRadius()),
+                                pixelSize);
+
+    if (atmosphere != nullptr && atmosphere->height > 0.0f && rle.discSizeInPixels > 1)
     {
-        // When the observer is inside the rings (distance <= innerRadius) the
-        // rings are drawn inline by renderObject. Only add a separate
-        // transparent render-list entry for the outside case.
-        float ringDiscSize = static_cast<float>((rings->outerRadius / rle.distance) / pixelSize);
-        if (ringDiscSize > 1 && rle.distance > rings->innerRadius)
+        float atmosphereRadius = body.getRadius() + atmosphere->height;
+
+        rle.renderableType = RenderListEntry::RenderableAtmosphere;
+        rle.body = &body;
+        rle.isOpaque = false;
+        rle.radius = atmosphereRadius;
+        rle.renderOrder = 0;
+        rle.discSizeInPixels = static_cast<float>((atmosphereRadius / rle.distance) / pixelSize);
+
+        // Rank behind the near half, sharing the ring radius as the sort key.
+        if (splitAroundAtmosphere)
+        {
+            rle.radius = rings->outerRadius;
+            rle.renderOrder = 1;
+        }
+
+        renderList.push_back(rle);
+        rle.renderOrder = 0;
+    }
+
+    if (outsideRings)
+    {
+        rle.body = &body;
+        rle.isOpaque = false;
+        rle.radius = rings->outerRadius;
+        rle.discSizeInPixels = ringDiscSize;
+
+        if (splitAroundAtmosphere)
+        {
+            // Far half behind the atmosphere, near half in front.
+            rle.renderableType = RenderListEntry::RenderableRingSystemFar;
+            rle.renderOrder = 2;
+            renderList.push_back(rle);
+
+            rle.renderableType = RenderListEntry::RenderableRingSystemNear;
+            rle.renderOrder = 0;
+            renderList.push_back(rle);
+        }
+        else
         {
             rle.renderableType = RenderListEntry::RenderableRingSystem;
-            rle.body = &body;
-            rle.isOpaque = false;
-            rle.radius = rings->outerRadius;
-            rle.discSizeInPixels = ringDiscSize;
+            rle.renderOrder = 0;
             renderList.push_back(rle);
         }
     }
@@ -5396,6 +5549,9 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
         case RenderListEntry::RenderableCometTail:
         case RenderListEntry::RenderableReferenceMark:
         case RenderListEntry::RenderableRingSystem:
+        case RenderListEntry::RenderableRingSystemNear:
+        case RenderListEntry::RenderableRingSystemFar:
+        case RenderListEntry::RenderableAtmosphere:
             radius = ri.radius;
             cullRadius = radius;
             convex = false;
@@ -5536,8 +5692,9 @@ Renderer::removeInvisibleItems(const math::InfiniteFrustum &frustum)
     std::sort(renderList.begin(), renderList.end(),
               [](const RenderListEntry& a, const RenderListEntry& b)
               {
-                  // Operation is reversed because -z axis points into the screen
-                  return a.centerZ - a.radius > b.centerZ - b.radius;
+                  // Reversed because -z points into the screen. renderOrder
+                  // breaks ties so a larger value sorts farther, drawn earlier.
+                  return a.centerZ - a.radius - a.renderOrder > b.centerZ - b.radius - b.renderOrder;
               });
 }
 

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -47,6 +47,7 @@ namespace celestia::render { class PsfStarVertexBuffer; class StarPipelineOwner;
 namespace celestia::engine { class ResourceSystem; }
 class Observer;
 struct Surface;
+struct RenderInfo;
 class Texture;
 class TextureFont;
 class FramebufferObject;
@@ -504,6 +505,23 @@ class Renderer
                       const RenderProperties& obj,
                       const LightingState&,
                       const Matrices&);
+
+    void renderAtmosphere(const Atmosphere* atmosphere,
+                          const RenderInfo& ri,
+                          const LightingState& ls,
+                          const RenderProperties& obj,
+                          const Eigen::Vector3f& pos,
+                          double distance,
+                          float radius,
+                          const Eigen::Vector3f& scaleFactors,
+                          bool insidePlanet,
+                          bool lit,
+                          Texture* cloudTex,
+                          Texture* cloudNormalMap,
+                          float cloudTexOffset,
+                          const celestia::math::Frustum& viewFrustum,
+                          const Eigen::Matrix4f& planetMV,
+                          const Matrices& m);
 
     void renderPlanet(Body& body,
                       const Eigen::Vector3f& pos,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -518,7 +518,8 @@ class Renderer
                           float distance,
                           const Observer& observer,
                           float nearPlaneDistance,
-                          const Matrices&);
+                          const Matrices&,
+                          celestia::render::RingRenderHalf);
 
     void renderStar(const Star& star,
                     const Eigen::Vector3f& pos,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -540,6 +540,14 @@ class Renderer
                              LightingState& lights,
                              Eigen::Quaterniond& q);
 
+    void renderPlanetAtmosphere(Body& body,
+                                const Eigen::Vector3f& pos,
+                                double distance,
+                                const Observer& observer,
+                                float nearPlaneDistance,
+                                float farPlaneDistance,
+                                const Matrices& m);
+
     void renderRingSystem(Body& body,
                           const Eigen::Vector3f& pos,
                           float distance,

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <Eigen/Core>
@@ -756,6 +757,21 @@ class Renderer
     std::vector<Annotation> objectAnnotations;
     std::vector<OrbitPathListEntry> orbitPathList;
     LightingState::EclipseShadowVector eclipseShadows[MaxLights];
+
+    // Per-frame cache of each planet's computed lighting so the atmosphere and
+    // ring entries reuse it instead of redoing the eclipse/ring-shadow setup.
+    // The entry owns its eclipse-shadow vectors because LightingState::shadows
+    // otherwise points into the shared eclipseShadows scratch above.
+    struct PlanetLightingCacheEntry
+    {
+        RenderProperties rp;
+        LightingState lights;
+        Eigen::Quaterniond q;
+        std::array<LightingState::EclipseShadowVector, MaxLights> eclipseShadows;
+    };
+    std::unordered_map<const Body*, PlanetLightingCacheEntry> planetLightingCache;
+    std::unordered_map<const Body*, LightingState> ringLightingCache;
+
     std::vector<const Star*> nearStars;
 
     std::vector<LightSource> lightSourceList;

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -531,6 +531,15 @@ class Renderer
                       float, float,
                       const Matrices&);
 
+    void setupPlanetLighting(Body& body,
+                             const Eigen::Vector3f& pos,
+                             double now,
+                             float nearPlaneDistance,
+                             float altitude,
+                             RenderProperties& rp,
+                             LightingState& lights,
+                             Eigen::Quaterniond& q);
+
     void renderRingSystem(Body& body,
                           const Eigen::Vector3f& pos,
                           float distance,

--- a/src/celengine/renderlistentry.h
+++ b/src/celengine/renderlistentry.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <Eigen/Core>
 
 class Star;
@@ -23,6 +25,9 @@ struct RenderListEntry
         RenderableStar,
         RenderableBody,
         RenderableRingSystem,
+        RenderableRingSystemNear,
+        RenderableRingSystemFar,
+        RenderableAtmosphere,
         RenderableCometTail,
         RenderableReferenceMark,
     };
@@ -45,4 +50,8 @@ struct RenderListEntry
     float appMag;
     RenderableType renderableType;
     bool isOpaque;
+
+    // Tie-break rank for co-centered transparent entries. A larger value sorts
+    // farther and is drawn earlier: far ring, atmosphere, near ring.
+    std::uint8_t renderOrder{ 0 };
 };

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -1911,39 +1911,21 @@ buildRingsFragmentShader(const ShaderProperties& props)
 
     source += "\nvoid main(void)\n{\n";
 
-    // Capture the texture gradients up front, before the ring split branch
-    // below can diverge control flow. Sampling with these gradients keeps the
-    // mip selection identical on both sides of the split so the near and far
-    // halves meet without a seam.
-    if (util::is_set(props.texUsage, TexUsage::DiffuseTexture))
-    {
-        source += "vec2 ringTexDx = dFdx(diffTexCoord.st);\n";
-        source += "vec2 ringTexDy = dFdy(diffTexCoord.st);\n";
-    }
-
-    // When splitting the ring around the atmosphere, classify each fragment by
-    // whether the view ray reaches the atmosphere shell before the fragment:
-    // if so the fragment is behind the atmosphere and belongs to the far half,
-    // otherwise the near half. This follows the curved atmosphere limb exactly,
-    // unlike a flat split through the planet center. ringHalf > 0 keeps the near
-    // half, < 0 the far half, 0 the whole ring. The dropped half is made
-    // transparent (alpha 0) rather than discarded: an explicit discard makes the
-    // driver mask the dropped lane, corrupting the screen-space texture
-    // derivatives of the kept neighbour and leaving a faint mip seam along the
-    // split. Keeping every lane alive matches the derivatives of an unsplit draw.
+    // When splitting the ring around the atmosphere, drop the half that belongs
+    // to the other side. A fragment is behind the atmosphere when the eye->
+    // fragment ray crosses the shell, i.e. a ray-sphere root lies in (0, 1).
+    // The eye and ring are always outside the shell here (the split only runs
+    // outside the rings, which dwarf the atmosphere), so the test needs no sqrt
+    // or divide: b < 0 and a + b > 0 place the near root in (0, 1), b*b >= a*c
+    // makes the roots real. The drop uses alpha 0, not discard, so every lane
+    // stays alive and texture derivatives match an unsplit draw (no mip seam).
     source += "bool dropFragment = false;\n";
     source += "if (ringHalf != 0.0)\n{\n";
     source += "    vec3 ringDir = position - eyePosition;\n";
     source += "    float a = dot(ringDir, ringDir);\n";
     source += "    float b = dot(eyePosition, ringDir);\n";
     source += "    float c = dot(eyePosition, eyePosition) - ringAtmosphereRadius * ringAtmosphereRadius;\n";
-    source += "    float disc = b * b - a * c;\n";
-    source += "    bool behind = false;\n";
-    source += "    if (disc >= 0.0)\n";
-    source += "    {\n";
-    source += "        float t = (-b - sqrt(disc)) / a;\n";
-    source += "        behind = t > 0.0 && t < 1.0;\n";
-    source += "    }\n";
+    source += "    bool behind = b < 0.0 && a + b > 0.0 && b * b >= a * c;\n";
     source += "    dropFragment = (ringHalf > 0.0 && behind) || (ringHalf < 0.0 && !behind);\n";
     source += "}\n";
     source += "vec4 diff = vec4(ambientColor, 1.0);\n";
@@ -1953,7 +1935,7 @@ buildRingsFragmentShader(const ShaderProperties& props)
 
     source += DeclareLocal("color", Shader_Vector4);
     if (util::is_set(props.texUsage, TexUsage::DiffuseTexture))
-        source += "color = textureGrad(diffTex, diffTexCoord.st, ringTexDx, ringTexDy);\n";
+        source += "color = texture(diffTex, diffTexCoord.st);\n";
     else
         source += "color = vec4(1.0);\n";
     source += DeclareLocal("opticalDepth", Shader_Float, "color.a");

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -1880,6 +1880,7 @@ buildRingsFragmentShader(const ShaderProperties& props)
 
     source += DeclareUniform("ambientColor", Shader_Vector3);
     source += DeclareUniform("ringHalf", Shader_Float);
+    source += DeclareUniform("ringAtmosphereRadius", Shader_Float);
 
     source += DeclareLights(props);
 
@@ -1910,11 +1911,37 @@ buildRingsFragmentShader(const ShaderProperties& props)
 
     source += "\nvoid main(void)\n{\n";
 
-    // ringHalf selects the near (+1), far (-1) or whole (0) ring. Keep only
-    // the requested half; the boundary fragment goes to the far half.
-    source += "float ringSide = dot(position, eyePosition);\n";
-    source += "if ((ringHalf > 0.0 && ringSide <= 0.0) || "
-              "(ringHalf < 0.0 && ringSide > 0.0)) discard;\n";
+    // Capture the texture gradients up front, before the ring split branch
+    // below can diverge control flow. Sampling with these gradients keeps the
+    // mip selection identical on both sides of the split so the near and far
+    // halves meet without a seam.
+    if (util::is_set(props.texUsage, TexUsage::DiffuseTexture))
+    {
+        source += "vec2 ringTexDx = dFdx(diffTexCoord.st);\n";
+        source += "vec2 ringTexDy = dFdy(diffTexCoord.st);\n";
+    }
+
+    // When splitting the ring around the atmosphere, classify each fragment by
+    // whether the view ray reaches the atmosphere shell before the fragment:
+    // if so the fragment is behind the atmosphere and belongs to the far half,
+    // otherwise the near half. This follows the curved atmosphere limb exactly,
+    // unlike a flat split through the planet center. ringHalf > 0 keeps the near
+    // half, < 0 the far half, 0 the whole ring.
+    source += "bool dropFragment = false;\n";
+    source += "if (ringHalf != 0.0)\n{\n";
+    source += "    vec3 ringDir = position - eyePosition;\n";
+    source += "    float a = dot(ringDir, ringDir);\n";
+    source += "    float b = dot(eyePosition, ringDir);\n";
+    source += "    float c = dot(eyePosition, eyePosition) - ringAtmosphereRadius * ringAtmosphereRadius;\n";
+    source += "    float disc = b * b - a * c;\n";
+    source += "    bool behind = false;\n";
+    source += "    if (disc >= 0.0)\n";
+    source += "    {\n";
+    source += "        float t = (-b - sqrt(disc)) / a;\n";
+    source += "        behind = t > 0.0 && t < 1.0;\n";
+    source += "    }\n";
+    source += "    dropFragment = (ringHalf > 0.0 && behind) || (ringHalf < 0.0 && !behind);\n";
+    source += "}\n";
     source += "vec4 diff = vec4(ambientColor, 1.0);\n";
 
     // Get the normalized direction from the eye to the vertex
@@ -1922,7 +1949,7 @@ buildRingsFragmentShader(const ShaderProperties& props)
 
     source += DeclareLocal("color", Shader_Vector4);
     if (util::is_set(props.texUsage, TexUsage::DiffuseTexture))
-        source += "color = texture(diffTex, diffTexCoord.st);\n";
+        source += "color = textureGrad(diffTex, diffTexCoord.st, ringTexDx, ringTexDy);\n";
     else
         source += "color = vec4(1.0);\n";
     source += DeclareLocal("opticalDepth", Shader_Float, "color.a");
@@ -1971,6 +1998,7 @@ buildRingsFragmentShader(const ShaderProperties& props)
         }
     }
 
+    source += "if (dropFragment) discard;\n";
     source += "fragColor = vec4(color.rgb * diff.rgb, opticalDepth);\n";
 
     source += "}\n";
@@ -2931,6 +2959,7 @@ CelestiaGLProgram::initParameters()
         ringWidth            = floatParam("ringWidth");
         ringRadius           = floatParam("ringRadius");
         ringHalf             = floatParam("ringHalf");
+        ringAtmosphereRadius = floatParam("ringAtmosphereRadius");
     }
 
     textureOffset = floatParam("texCoordOffset");

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -1919,16 +1919,16 @@ buildRingsFragmentShader(const ShaderProperties& props)
     // or divide: b < 0 and a + b > 0 place the near root in (0, 1), b*b >= a*c
     // makes the roots real. The drop uses alpha 0, not discard, so every lane
     // stays alive and texture derivatives match an unsplit draw (no mip seam).
-    source += "bool dropFragment = false;\n";
-    source += "if (ringHalf != 0.0)\n{\n";
-    source += "    vec3 ringDir = position - eyePosition;\n";
-    source += "    float a = dot(ringDir, ringDir);\n";
-    source += "    float b = dot(eyePosition, ringDir);\n";
-    source += "    float c = dot(eyePosition, eyePosition) - ringAtmosphereRadius * ringAtmosphereRadius;\n";
-    source += "    bool behind = b < 0.0 && a + b > 0.0 && b * b >= a * c;\n";
-    source += "    dropFragment = (ringHalf > 0.0 && behind) || (ringHalf < 0.0 && !behind);\n";
-    source += "}\n";
-    source += "vec4 diff = vec4(ambientColor, 1.0);\n";
+    source += "bool dropFragment = false;\n"
+              "if (ringHalf != 0.0)\n{\n"
+              "    vec3 ringDir = position - eyePosition;\n"
+              "    float a = dot(ringDir, ringDir);\n"
+              "    float b = dot(eyePosition, ringDir);\n"
+              "    float c = dot(eyePosition, eyePosition) - ringAtmosphereRadius * ringAtmosphereRadius;\n"
+              "    bool behind = b < 0.0 && a + b > 0.0 && b * b >= a * c;\n"
+              "    dropFragment = (ringHalf > 0.0 && behind) || (ringHalf < 0.0 && !behind);\n"
+              "}\n"
+              "vec4 diff = vec4(ambientColor, 1.0);\n";
 
     // Get the normalized direction from the eye to the vertex
     source += "vec3 eyeDir = normalize(eyePosition - position);\n";

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -1879,6 +1879,7 @@ buildRingsFragmentShader(const ShaderProperties& props)
     source += FragmentHeader;
 
     source += DeclareUniform("ambientColor", Shader_Vector3);
+    source += DeclareUniform("ringHalf", Shader_Float);
 
     source += DeclareLights(props);
 
@@ -1909,6 +1910,11 @@ buildRingsFragmentShader(const ShaderProperties& props)
 
     source += "\nvoid main(void)\n{\n";
 
+    // ringHalf selects the near (+1), far (-1) or whole (0) ring. Keep only
+    // the requested half; the boundary fragment goes to the far half.
+    source += "float ringSide = dot(position, eyePosition);\n";
+    source += "if ((ringHalf > 0.0 && ringSide <= 0.0) || "
+              "(ringHalf < 0.0 && ringSide > 0.0)) discard;\n";
     source += "vec4 diff = vec4(ambientColor, 1.0);\n";
 
     // Get the normalized direction from the eye to the vertex
@@ -2924,6 +2930,7 @@ CelestiaGLProgram::initParameters()
     {
         ringWidth            = floatParam("ringWidth");
         ringRadius           = floatParam("ringRadius");
+        ringHalf             = floatParam("ringHalf");
     }
 
     textureOffset = floatParam("texCoordOffset");

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -1926,7 +1926,11 @@ buildRingsFragmentShader(const ShaderProperties& props)
     // if so the fragment is behind the atmosphere and belongs to the far half,
     // otherwise the near half. This follows the curved atmosphere limb exactly,
     // unlike a flat split through the planet center. ringHalf > 0 keeps the near
-    // half, < 0 the far half, 0 the whole ring.
+    // half, < 0 the far half, 0 the whole ring. The dropped half is made
+    // transparent (alpha 0) rather than discarded: an explicit discard makes the
+    // driver mask the dropped lane, corrupting the screen-space texture
+    // derivatives of the kept neighbour and leaving a faint mip seam along the
+    // split. Keeping every lane alive matches the derivatives of an unsplit draw.
     source += "bool dropFragment = false;\n";
     source += "if (ringHalf != 0.0)\n{\n";
     source += "    vec3 ringDir = position - eyePosition;\n";
@@ -1998,7 +2002,7 @@ buildRingsFragmentShader(const ShaderProperties& props)
         }
     }
 
-    source += "if (dropFragment) discard;\n";
+    source += "if (dropFragment) opticalDepth = 0.0;\n";
     source += "fragColor = vec4(color.rgb * diff.rgb, opticalDepth);\n";
 
     source += "}\n";

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -286,6 +286,7 @@ public:
 
     FloatShaderParameter ringWidth;
     FloatShaderParameter ringRadius;
+    FloatShaderParameter ringHalf;
     Vec4ShaderParameter ringPlane;
     Vec3ShaderParameter ringCenter;
 

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -287,6 +287,7 @@ public:
     FloatShaderParameter ringWidth;
     FloatShaderParameter ringRadius;
     FloatShaderParameter ringHalf;
+    FloatShaderParameter ringAtmosphereRadius;
     Vec4ShaderParameter ringPlane;
     Vec3ShaderParameter ringCenter;
 

--- a/src/celrender/rendererfwd.h
+++ b/src/celrender/rendererfwd.h
@@ -15,7 +15,7 @@ class NebulaRenderer;
 class OpenClusterRenderer;
 class PsfGlowLargeRenderer;
 class ReferenceMarkRenderer;
-enum class RingRenderHalf;
+enum class RingRenderHalf : int;
 class RingRenderer;
 class SkyGridRenderer;
 }

--- a/src/celrender/rendererfwd.h
+++ b/src/celrender/rendererfwd.h
@@ -15,6 +15,7 @@ class NebulaRenderer;
 class OpenClusterRenderer;
 class PsfGlowLargeRenderer;
 class ReferenceMarkRenderer;
+enum class RingRenderHalf;
 class RingRenderer;
 class SkyGridRenderer;
 }

--- a/src/celrender/ringrenderer.cpp
+++ b/src/celrender/ringrenderer.cpp
@@ -153,7 +153,8 @@ RingRenderer::renderRings(const RingSystem& rings,
                           bool renderShadow,
                           float segmentSizeInPixels,
                           const Matrices &m,
-                          bool inside)
+                          bool inside,
+                          RingRenderHalf renderHalf)
 {
     float inner = rings.innerRadius / planetRadius;
     float outer = rings.outerRadius / planetRadius;
@@ -175,6 +176,20 @@ RingRenderer::renderRings(const RingSystem& rings,
 
     prog->ringRadius = inner;
     prog->ringWidth = outer - inner;
+
+    float ringHalf = 0.0f;
+    switch (renderHalf)
+    {
+    case RingRenderHalf::Near:
+        ringHalf = 1.0f;
+        break;
+    case RingRenderHalf::Far:
+        ringHalf = -1.0f;
+        break;
+    case RingRenderHalf::Both:
+        break;
+    }
+    prog->ringHalf = ringHalf;
 
     setUpShadowParameters(prog, ls, planetOblateness);
 

--- a/src/celrender/ringrenderer.cpp
+++ b/src/celrender/ringrenderer.cpp
@@ -154,7 +154,8 @@ RingRenderer::renderRings(const RingSystem& rings,
                           float segmentSizeInPixels,
                           const Matrices &m,
                           bool inside,
-                          RingRenderHalf renderHalf)
+                          RingRenderHalf renderHalf,
+                          float atmosphereRadius)
 {
     float inner = rings.innerRadius / planetRadius;
     float outer = rings.outerRadius / planetRadius;
@@ -190,6 +191,7 @@ RingRenderer::renderRings(const RingSystem& rings,
         break;
     }
     prog->ringHalf = ringHalf;
+    prog->ringAtmosphereRadius = atmosphereRadius;
 
     setUpShadowParameters(prog, ls, planetOblateness);
 

--- a/src/celrender/ringrenderer.h
+++ b/src/celrender/ringrenderer.h
@@ -47,7 +47,8 @@ public:
                      float segmentSizeInPixels,
                      const Matrices &m,
                      bool inside,
-                     RingRenderHalf renderHalf);
+                     RingRenderHalf renderHalf,
+                     float atmosphereRadius);
 
 private:
     void initializeLOD(unsigned int, std::uint32_t);

--- a/src/celrender/ringrenderer.h
+++ b/src/celrender/ringrenderer.h
@@ -25,6 +25,13 @@ struct RingSystem;
 namespace celestia::render
 {
 
+enum class RingRenderHalf
+{
+    Both,
+    Near,
+    Far,
+};
+
 class RingRenderer
 {
 public:
@@ -39,7 +46,8 @@ public:
                      bool renderShadow,
                      float segmentSizeInPixels,
                      const Matrices &m,
-                     bool inside);
+                     bool inside,
+                     RingRenderHalf renderHalf);
 
 private:
     void initializeLOD(unsigned int, std::uint32_t);

--- a/src/celrender/ringrenderer.h
+++ b/src/celrender/ringrenderer.h
@@ -25,7 +25,7 @@ struct RingSystem;
 namespace celestia::render
 {
 
-enum class RingRenderHalf
+enum class RingRenderHalf : int
 {
     Both,
     Near,


### PR DESCRIPTION
1. Move non-opaque items (like atmosphere and rings) to be rendered at the end of the depth partition
2. Split ring rendering into far and near rings when the atmosphere is visible (far ring -> atmosphere -> near ring) 