### PR TITLE
Fix MSAA atmosphere limb dashes with centroid-interpolated shell position

### DIFF
--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -2012,15 +2012,15 @@ buildAtmosphereVertexShader(const ShaderProperties& props, bool fisheyeEnabled)
 
     source += DeclareLights(props);
     source += DeclareUniform("eyePosition", Shader_Vector3);
-    source += DeclareOutput("position", Shader_Vector3);
-    source += DeclareOutput("normal", Shader_Vector3);
+    // centroid avoids MSAA extrapolating position past the triangle at the shell
+    // silhouette, which over-brightens edge samples into dashes along the limb.
+    source += "centroid " + DeclareOutput("position", Shader_Vector3);
 
     source += VPFunction(props.fishEyeOverride != FisheyeOverrideMode::Disabled && fisheyeEnabled);
 
     // Begin main() function
     source += "\nvoid main(void)\n{\n";
     source += "    position = in_Position.xyz;\n";
-    source += "    normal = in_Normal;\n";
     source += VertexPosition(props);
     source += "}\n";
 
@@ -2056,8 +2056,8 @@ buildAtmosphereFragmentShader(const ShaderProperties& props)
     source += DeclareUniform("eyePosition", Shader_Vector3);
     source += ScatteringConstantDeclarations(props);
 
-    source += DeclareInput("position", Shader_Vector3);
-    source += DeclareInput("normal", Shader_Vector3);
+    // Must match the centroid output in buildAtmosphereVertexShader.
+    source += "centroid " + DeclareInput("position", Shader_Vector3);
 
     if (!transmissionOnly)
     {
@@ -2068,9 +2068,7 @@ buildAtmosphereFragmentShader(const ShaderProperties& props)
     source += "\nvoid main(void)\n{\n";
 
     source += "vec3 nposition = normalize(position);\n";
-    source += "vec3 N = normalize(normal);\n";
     source += "vec3 eyeDir = normalize(eyePosition - nposition);\n";
-    source += "float NV = dot(N, eyeDir);\n";
 
     source += DeclareLocal("scatterEx", Shader_Vector3);
     if (transmissionOnly)
@@ -2080,7 +2078,6 @@ buildAtmosphereFragmentShader(const ShaderProperties& props)
     }
     else
     {
-        source += DeclareLocal("NL", Shader_Float);
         source += AtmosphericEffects(props);
 
         // Sum the contributions from each light source, currently only the primary one.

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -415,7 +415,7 @@ AtmosphereRenderer::render(
         setupAtmosphereProgram(transmissionProg);
         ps.blendFunc = {GL_ZERO, GL_SRC_COLOR};
         m_renderer.setPipelineState(ps);
-        m_renderer.m_lodSphere->render(LODSphereMesh::Normals,
+        m_renderer.m_lodSphere->render(0,
                                        shellFrustum,
                                        ri.pixWidth,
                                        nullptr);
@@ -430,7 +430,7 @@ AtmosphereRenderer::render(
 
         ps.blendFunc = {GL_ONE, scatteringBlendDestination};
         m_renderer.setPipelineState(ps);
-        m_renderer.m_lodSphere->render(LODSphereMesh::Normals,
+        m_renderer.m_lodSphere->render(0,
                                        shellFrustum,
                                        ri.pixWidth,
                                        nullptr);


### PR DESCRIPTION
Also drop the normal attribute since it is not used at all.