### PR TITLE
Use reference counting for GL buffers

### DIFF
--- a/src/celengine/glmarker.cpp
+++ b/src/celengine/glmarker.cpp
@@ -33,10 +33,9 @@ constexpr float pif = celestia::numbers::pi_v<float>;
 #include "markers.inc"
 
 void
-initialize(LineRenderer &lr, gl::VertexObject &vo, gl::Buffer &bo)
+initialize(LineRenderer &lr, gl::VertexObject &vo)
 {
-
-    bo.setData(FilledMarkersData, gl::Buffer::BufferUsage::StaticDraw);
+    auto bo = gl::Buffer::create(gl::Buffer::TargetHint::Array, FilledMarkersData);
 
     vo.addVertexBuffer(
         bo,
@@ -44,7 +43,7 @@ initialize(LineRenderer &lr, gl::VertexObject &vo, gl::Buffer &bo)
         2,
         gl::VertexObject::DataType::Float);
 
-    bo.unbind();
+    bo->unbind();
 
     lr.setHints(LineRenderer::DISABLE_FISHEYE_TRANFORMATION);
 
@@ -52,7 +51,7 @@ initialize(LineRenderer &lr, gl::VertexObject &vo, gl::Buffer &bo)
         lr.addVertex(HollowMarkersData[i], HollowMarkersData[i+1]);
 }
 
-}
+} // end unnamed namespace
 
 void
 Renderer::renderMarker(MarkerRepresentation::Symbol symbol,
@@ -64,7 +63,7 @@ Renderer::renderMarker(MarkerRepresentation::Symbol symbol,
 
     if (!m_markerDataInitialized)
     {
-        initialize(*m_hollowMarkerRenderer, *m_markerVO, *m_markerBO);
+        initialize(*m_hollowMarkerRenderer, *m_markerVO);
         m_markerDataInitialized = true;
     }
 
@@ -142,7 +141,7 @@ Renderer::renderSelectionPointer(const Observer& observer,
 
     if (!m_markerDataInitialized)
     {
-        initialize(*m_hollowMarkerRenderer, *m_markerVO, *m_markerBO);
+        initialize(*m_hollowMarkerRenderer, *m_markerVO);
         m_markerDataInitialized = true;
     }
 
@@ -179,7 +178,7 @@ Renderer::renderCrosshair(float selectionSizeInPixels,
 
     if (!m_markerDataInitialized)
     {
-        initialize(*m_hollowMarkerRenderer, *m_markerVO, *m_markerBO);
+        initialize(*m_hollowMarkerRenderer, *m_markerVO);
         m_markerDataInitialized = true;
     }
 

--- a/src/celengine/lodspheremesh.cpp
+++ b/src/celengine/lodspheremesh.cpp
@@ -612,7 +612,7 @@ LODSphereMesh::renderSection(int phi0, int theta0, int extent,
     // Get or create the cached index buffer
     CachedIndexBuffer* cachedIB = getOrCreateIndexBuffer(nSlices);
 
-    cachedIB->buffer.bind();
+    cachedIB->buffer->bind();
     auto stride = static_cast<GLsizei>(vertexSize * sizeof(float));
     int texCoordOffset = ((ri.attributes & Tangents) != 0) ? 6 : 3;
 
@@ -736,10 +736,9 @@ LODSphereMesh::CachedIndexBuffer*
 LODSphereMesh::getOrCreateIndexBuffer(int nSlices)
 {
     // Check if we already have this configuration cached
-    if (auto it = indexBufferCache.find(nSlices); it != indexBufferCache.end())
-    {
+    auto [it, inserted] = indexBufferCache.try_emplace(nSlices);
+    if (!inserted)
         return &it->second;
-    }
 
     // Create new index buffer
     // nRings is always nSlices / 2
@@ -769,11 +768,9 @@ LODSphereMesh::getOrCreateIndexBuffer(int nSlices)
         }
     }
 
-    celestia::gl::Buffer buffer(celestia::gl::Buffer::TargetHint::ElementArray,
-                                celestia::util::array_view<void>(indices.data(), indices.size() * sizeof(unsigned short)),
-                                celestia::gl::Buffer::BufferUsage::StaticDraw);
-    CachedIndexBuffer cached{ std::move(buffer), static_cast<int>(indices.size()) };
-    const auto& [it, inserted] = indexBufferCache.try_emplace(nSlices, std::move(cached));
-    assert(inserted);
+    it->second.buffer = celestia::gl::Buffer::create(celestia::gl::Buffer::TargetHint::ElementArray,
+                                                     celestia::util::array_view<void>(indices.data(),
+                                                                                      indices.size() * sizeof(unsigned short)));
+    it->second.indexCount = static_cast<int>(indices.size());
     return &it->second;
 }

--- a/src/celengine/lodspheremesh.h
+++ b/src/celengine/lodspheremesh.h
@@ -83,7 +83,7 @@ public:
 
     struct CachedIndexBuffer
     {
-        celestia::gl::Buffer buffer;
+        celestia::gl::Buffer::SharedPtr buffer;
         int indexCount{ 0 };
     };
 

--- a/src/celengine/modelgeometry.cpp
+++ b/src/celengine/modelgeometry.cpp
@@ -80,7 +80,7 @@ convert(cmod::VertexAttributeSemantic semantic)
 }
 
 void
-setVertexArrays(gl::VertexObject &vao, const gl::Buffer &vbo, const cmod::VertexDescription& desc)
+setVertexArrays(gl::VertexObject &vao, const gl::Buffer::SharedPtr &vbo, const cmod::VertexDescription& desc)
 {
     auto attributes = desc.attributes();
     for (const auto &attribute : attributes)
@@ -112,9 +112,9 @@ public:
 
 private:
     std::shared_ptr<const cmod::Model> m_model;
-    std::vector<gl::Buffer> m_vbos;
     std::vector<gl::VertexObject> m_vaos;
     std::size_t m_gpuBytes{ 0 };
+    unsigned int m_vboCount{ 0 };
 };
 
 ModelRenderGeometry::ModelRenderGeometry(std::shared_ptr<const cmod::Model> model) :
@@ -134,8 +134,8 @@ ModelRenderGeometry::ModelRenderGeometry(std::shared_ptr<const cmod::Model> mode
         const cmod::VertexDescription& vertexDesc = mesh->getVertexDescription();
 
         const std::size_t vertexBytes = mesh->getVertexCount() * vertexDesc.strideBytes();
-        m_vbos.emplace_back(gl::Buffer::TargetHint::Array,
-                            util::array_view<void>(mesh->getVertexData(), vertexBytes));
+        auto vbo = gl::Buffer::create(gl::Buffer::TargetHint::Array,
+                                      util::array_view<void>(mesh->getVertexData(), vertexBytes));
         m_gpuBytes += vertexBytes;
 
         indices.reserve(std::max(indices.capacity(), static_cast<std::size_t>(mesh->getIndexCount())));
@@ -146,12 +146,13 @@ ModelRenderGeometry::ModelRenderGeometry(std::shared_ptr<const cmod::Model> mode
         }
 
         m_gpuBytes += indices.size() * sizeof(cmod::Index32);
-        gl::Buffer indexBuffer(gl::Buffer::TargetHint::ElementArray, indices);
+        auto indexBuffer = gl::Buffer::create(gl::Buffer::TargetHint::ElementArray, indices);
         indices.clear();
 
         gl::VertexObject& vao = m_vaos.emplace_back(gl::VertexObject::Primitive::Triangles);
-        setVertexArrays(vao, m_vbos.back(), mesh->getVertexDescription());
-        vao.setIndexBuffer(std::move(indexBuffer), 0, gl::VertexObject::IndexType::UnsignedInt);
+        setVertexArrays(vao, vbo, mesh->getVertexDescription());
+        vao.setIndexBuffer(indexBuffer, 0, gl::VertexObject::IndexType::UnsignedInt);
+        ++m_vboCount;
     }
 }
 
@@ -169,9 +170,9 @@ ModelRenderGeometry::render(RenderContext& rc, double /* t */)
     {
         const cmod::Mesh* mesh = m_model->getMesh(meshIndex);
 
-        if (meshIndex >= m_vbos.size())
+        if (meshIndex >= m_vboCount)
         {
-            GetLogger()->error(_("Mesh index {} is higher than VBO count {}!"), meshIndex, m_vbos.size());
+            GetLogger()->error(_("Mesh index {} is higher than VBO count {}!"), meshIndex, m_vboCount);
             return;
         }
 

--- a/src/celengine/pointstarvertexbuffer.cpp
+++ b/src/celengine/pointstarvertexbuffer.cpp
@@ -8,7 +8,6 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
 #include <celutil/color.h>
 #include "glsupport.h"
@@ -95,12 +94,12 @@ void PointStarVertexBuffer::setupVertexArrayObject()
     {
         m_initialized = true;
 
-        m_bo = std::make_unique<gl::Buffer>(gl::Buffer::TargetHint::Array);
+        m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array);
         m_vo1 = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::Points);
         m_vo2 = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::Points);
 
         m_vo1->addVertexBuffer(
-            *m_bo,
+            m_bo,
             CelestiaGLProgram::VertexCoordAttributeIndex,
             3,
             gl::VertexObject::DataType::Float,
@@ -109,7 +108,7 @@ void PointStarVertexBuffer::setupVertexArrayObject()
             offsetof(StarVertex, position));
 
         m_vo1->addVertexBuffer(
-            *m_bo,
+            m_bo,
             CelestiaGLProgram::ColorAttributeIndex,
             4,
             gl::VertexObject::DataType::UnsignedByte,
@@ -118,7 +117,7 @@ void PointStarVertexBuffer::setupVertexArrayObject()
             offsetof(StarVertex, color));
 
         m_vo1->addVertexBuffer(
-            *m_bo,
+            m_bo,
             CelestiaGLProgram::PointSizeAttributeIndex,
             1,
             gl::VertexObject::DataType::Float,
@@ -127,7 +126,7 @@ void PointStarVertexBuffer::setupVertexArrayObject()
             offsetof(StarVertex, size));
 
         m_vo2->addVertexBuffer(
-            *m_bo,
+            m_bo,
             CelestiaGLProgram::VertexCoordAttributeIndex,
             3,
             gl::VertexObject::DataType::Float,
@@ -136,7 +135,7 @@ void PointStarVertexBuffer::setupVertexArrayObject()
             offsetof(StarVertex, position));
 
         m_vo2->addVertexBuffer(
-            *m_bo,
+            m_bo,
             CelestiaGLProgram::ColorAttributeIndex,
             4,
             gl::VertexObject::DataType::UnsignedByte,

--- a/src/celengine/pointstarvertexbuffer.h
+++ b/src/celengine/pointstarvertexbuffer.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <Eigen/Core>
 
+#include <celrender/gl/buffer.h>
 #include "starpipelineowner.h"
 
 class Color;
@@ -22,7 +23,6 @@ class CelestiaGLProgram;
 
 namespace celestia::gl
 {
-class Buffer;
 class VertexObject;
 }
 
@@ -68,9 +68,9 @@ private:
     float                           m_pointScale            { 1.0f };
     CelestiaGLProgram              *m_prog                  { nullptr };
 
-    std::unique_ptr<celestia::gl::Buffer>        m_bo;
-    std::unique_ptr<celestia::gl::VertexObject>  m_vo1;
-    std::unique_ptr<celestia::gl::VertexObject>  m_vo2;
+    celestia::gl::Buffer::SharedPtr             m_bo;
+    std::unique_ptr<celestia::gl::VertexObject> m_vo1;
+    std::unique_ptr<celestia::gl::VertexObject> m_vo2;
     bool m_initialized{ false };
 
     void makeCurrent();

--- a/src/celengine/psfstarvertexbuffer.cpp
+++ b/src/celengine/psfstarvertexbuffer.cpp
@@ -11,7 +11,6 @@
 
 #include <cmath>
 
-#include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
 #include <celastro/astro.h>
 #include <celcompat/numbers.h>
@@ -132,11 +131,11 @@ PsfStarVertexBuffer::setupVertexArrayObject()
 
     m_initialized = true;
 
-    m_bo = std::make_unique<gl::Buffer>(gl::Buffer::TargetHint::Array);
+    m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array);
     m_vo = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::Points);
 
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::VertexCoordAttributeIndex,
         3,
         gl::VertexObject::DataType::Float,
@@ -146,7 +145,7 @@ PsfStarVertexBuffer::setupVertexArrayObject()
 
     // peakRadiance bound to IntensityAttributeIndex (vec1 float)
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::IntensityAttributeIndex,
         1,
         gl::VertexObject::DataType::Float,
@@ -156,7 +155,7 @@ PsfStarVertexBuffer::setupVertexArrayObject()
 
     // continuous distance-derived glow fade; float for a smooth transition
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::AlphaAttributeIndex,
         1,
         gl::VertexObject::DataType::Float,
@@ -165,7 +164,7 @@ PsfStarVertexBuffer::setupVertexArrayObject()
         offsetof(StarVertex, alpha));
 
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::LimbRadiusAttributeIndex,
         1,
         gl::VertexObject::DataType::Float,
@@ -174,7 +173,7 @@ PsfStarVertexBuffer::setupVertexArrayObject()
         offsetof(StarVertex, limbRadius));
 
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::ColorAttributeIndex,
         3,
         gl::VertexObject::DataType::UnsignedByte,

--- a/src/celengine/psfstarvertexbuffer.h
+++ b/src/celengine/psfstarvertexbuffer.h
@@ -15,6 +15,7 @@
 
 #include <Eigen/Core>
 
+#include <celrender/gl/buffer.h>
 #include "starpipelineowner.h"
 
 class Color;
@@ -23,7 +24,6 @@ class CelestiaGLProgram;
 
 namespace celestia::gl
 {
-class Buffer;
 class VertexObject;
 }
 
@@ -87,8 +87,8 @@ private:
     float                           m_pointScale            { 1.0f };
     CelestiaGLProgram              *m_prog                  { nullptr };
 
-    std::unique_ptr<celestia::gl::Buffer>        m_bo;
-    std::unique_ptr<celestia::gl::VertexObject>  m_vo;
+    celestia::gl::Buffer::SharedPtr             m_bo;
+    std::unique_ptr<celestia::gl::VertexObject> m_vo;
     bool m_initialized{ false };
 
     void makeCurrent();

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -74,7 +74,6 @@
 #include <celrender/referencemarkrenderer.h>
 #include <celrender/ringrenderer.h>
 #include <celrender/skygridrenderer.h>
-#include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
 #include <celutil/logger.h>
 #include <celutil/utf8.h>
@@ -470,10 +469,9 @@ bool Renderer::init(int winWidth, int winHeight,
         return false;
 
     m_markerVO = std::make_unique<celestia::gl::VertexObject>(celestia::gl::VertexObject::Primitive::Triangles);
-    m_markerBO = std::make_unique<celestia::gl::Buffer>(celestia::gl::Buffer::TargetHint::Array);
 
     m_rectVO = std::make_unique<celestia::gl::VertexObject>(celestia::gl::VertexObject::Primitive::TriangleFan);
-    m_rectBO = std::make_unique<celestia::gl::Buffer>(celestia::gl::Buffer::TargetHint::Array);
+    m_rectBO = celestia::gl::Buffer::create(celestia::gl::Buffer::TargetHint::Array);
 
     m_lodSphere = std::make_unique<LODSphereMesh>();
 
@@ -5346,7 +5344,7 @@ static void draw_rectangle_solid(const Renderer &renderer,
                                  const Eigen::Matrix4f& p,
                                  const Eigen::Matrix4f& m,
                                  celestia::gl::VertexObject &vo,
-                                 celestia::gl::Buffer &bo,
+                                 const celestia::gl::Buffer::SharedPtr &bo,
                                  bool &initialized)
 {
     namespace gl = celestia::gl;
@@ -5383,7 +5381,7 @@ static void draw_rectangle_solid(const Renderer &renderer,
             r.colors[i].get(vertices[i].color);
     }
 
-    bo.bind().setData(vertices, gl::Buffer::BufferUsage::StreamDraw);
+    bo->bind().setData(vertices, gl::Buffer::BufferUsage::StreamDraw);
 
     if (!initialized)
     {
@@ -5432,7 +5430,7 @@ void Renderer::drawRectangle(const celestia::Rect &r,
     if(r.type == celestia::Rect::Type::BorderOnly)
         draw_rectangle_border(*this, r, fishEyeOverrideMode, p, m);
     else
-        draw_rectangle_solid(*this, r, fishEyeOverrideMode, p, m, *m_rectVO, *m_rectBO, m_rectInitialized);
+        draw_rectangle_solid(*this, r, fishEyeOverrideMode, p, m, *m_rectVO, m_rectBO, m_rectInitialized);
 }
 
 void Renderer::setRenderRegion(int x, int y, int width, int height, bool withScissor)

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -33,6 +33,7 @@
 #include <celengine/texmanager.h>
 #include <celengine/textlayout.h>
 #include <celimage/pixelformat.h>
+#include <celrender/gl/buffer.h>
 #include <celrender/rendererfwd.h>
 #include "rendercolors.h"
 #include "renderflags.h"
@@ -834,11 +835,10 @@ class Renderer
     std::unique_ptr<FramebufferObject> m_shadowFBO;
 
     std::unique_ptr<celestia::gl::VertexObject> m_markerVO;
-    std::unique_ptr<celestia::gl::Buffer> m_markerBO;
     bool m_markerDataInitialized{ false };
 
     std::unique_ptr<celestia::gl::VertexObject> m_rectVO;
-    std::unique_ptr<celestia::gl::Buffer> m_rectBO;
+    celestia::gl::Buffer::SharedPtr m_rectBO;
     mutable bool m_rectInitialized{ false };
 
     // Saturation magnitude used to calculate a point star size

--- a/src/celengine/viewporteffect.cpp
+++ b/src/celengine/viewporteffect.cpp
@@ -101,7 +101,7 @@ void PassthroughViewportEffect::initialize()
     };
 
     vo = gl::VertexObject(gl::VertexObject::Primitive::Triangles);
-    bo = gl::Buffer(gl::Buffer::TargetHint::Array, quadVertices, gl::Buffer::BufferUsage::StaticDraw);
+    auto bo = gl::Buffer::create(gl::Buffer::TargetHint::Array, quadVertices, gl::Buffer::BufferUsage::StaticDraw);
 
     vo.setCount(6);
     vo.addVertexBuffer(
@@ -163,9 +163,7 @@ void WarpMeshViewportEffect::initialize()
     initialized = true;
 
     vo = gl::VertexObject(gl::VertexObject::Primitive::Triangles);
-    bo = gl::Buffer(gl::Buffer::TargetHint::Array);
-
-    mesh->setUpVertexObject(vo, bo);
+    mesh->setUpVertexObject(vo);
 }
 
 bool WarpMeshViewportEffect::distortXY(float &x, float &y)

--- a/src/celengine/viewporteffect.h
+++ b/src/celengine/viewporteffect.h
@@ -58,7 +58,6 @@ private:
     bool m_needsFloatSource;
 
     celestia::gl::VertexObject vo;
-    celestia::gl::Buffer bo;
 
     void initialize();
 
@@ -77,7 +76,6 @@ public:
 
 private:
     celestia::gl::VertexObject vo;
-    celestia::gl::Buffer bo;
 
     std::unique_ptr<WarpMesh> mesh;
 

--- a/src/celengine/warpmesh.cpp
+++ b/src/celengine/warpmesh.cpp
@@ -134,8 +134,7 @@ setIndices(gl::VertexObject& vo,
         ++idx;
     }
 
-    gl::Buffer indexBuffer(gl::Buffer::TargetHint::ElementArray, indices);
-    vo.setIndexBuffer(std::move(indexBuffer), 0, IndexType);
+    vo.setIndexBuffer(gl::Buffer::create(gl::Buffer::TargetHint::ElementArray, indices), 0, IndexType);
     vo.setCount(static_cast<GLsizei>(indices.size()));
 }
 
@@ -209,13 +208,13 @@ WarpMesh::WarpMesh(std::uint32_t nx, std::uint32_t ny,
 WarpMesh::~WarpMesh() = default;
 
 void
-WarpMesh::setUpVertexObject(gl::VertexObject& vo, gl::Buffer& buf) const
+WarpMesh::setUpVertexObject(gl::VertexObject& vo) const
 {
     static_assert(sizeof(WarpMesh::WarpVertex) == 5 * sizeof(float));
     static_assert(std::is_standard_layout_v<WarpMesh::WarpVertex>);
 
     const std::uint32_t vertexCount = m_nx * m_ny;
-    buf.setData(m_data, gl::Buffer::BufferUsage::StaticDraw);
+    auto buf = gl::Buffer::create(gl::Buffer::TargetHint::Array, m_data, gl::Buffer::BufferUsage::StaticDraw);
 
     vo.addVertexBuffer(
         buf,

--- a/src/celengine/warpmesh.h
+++ b/src/celengine/warpmesh.h
@@ -34,7 +34,7 @@ public:
     static std::unique_ptr<WarpMesh> load(const std::filesystem::path&);
 
     // Map data to triangle vertices used for drawing
-    void setUpVertexObject(celestia::gl::VertexObject& vo, celestia::gl::Buffer& buf) const;
+    void setUpVertexObject(celestia::gl::VertexObject& vo) const;
 
     // Convert a vertex coordinate to texture coordinate
     bool mapVertex(float x, float y, float& u, float& v) const;

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -64,7 +64,7 @@ void AtmosphereRenderer::initGL()
     m_skyContour.reserve(MaxSkySlices + 1);
 
     m_vo = gl::VertexObject(gl::VertexObject::Primitive::Triangles);
-    m_bo = gl::Buffer(gl::Buffer::TargetHint::Array);
+    m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array);
 
     m_vo.addVertexBuffer(
         m_bo,
@@ -82,7 +82,8 @@ void AtmosphereRenderer::initGL()
         true,
         sizeof(SkyVertex),
         offsetof(SkyVertex, color));
-    m_vo.setIndexBuffer(gl::Buffer(gl::Buffer::TargetHint::ElementArray), 0, gl::VertexObject::IndexType::UnsignedShort);
+    m_ibo = gl::Buffer::create(gl::Buffer::TargetHint::ElementArray);
+    m_vo.setIndexBuffer(m_ibo, 0, gl::VertexObject::IndexType::UnsignedShort);
 }
 
 void
@@ -327,8 +328,8 @@ AtmosphereRenderer::renderLegacy(
     ps.blendFunc = {GL_ONE, GL_ONE_MINUS_SRC_ALPHA};
     m_renderer.setPipelineState(ps);
 
-    m_bo.invalidateData().setData(m_skyVertices, gl::Buffer::BufferUsage::StreamDraw);
-    m_vo.getIndexBuffer().invalidateData().setData(m_skyIndices, gl::Buffer::BufferUsage::StreamDraw);
+    m_bo->invalidateData().setData(m_skyVertices, gl::Buffer::BufferUsage::StreamDraw);
+    m_ibo->invalidateData().setData(m_skyIndices, gl::Buffer::BufferUsage::StreamDraw);
 
     prog->use();
     prog->setMVPMatrices(*m.projection, *m.modelview);

--- a/src/celrender/atmosphererenderer.h
+++ b/src/celrender/atmosphererenderer.h
@@ -97,7 +97,8 @@ private:
     std::vector<SkyVertex>        m_skyVertices;
     std::vector<unsigned short>   m_skyIndices;
     std::vector<SkyContourPoint>  m_skyContour;
-    gl::Buffer                    m_bo;
+    gl::Buffer::SharedPtr         m_bo;
+    gl::Buffer::SharedPtr         m_ibo;
     gl::VertexObject              m_vo;
     bool                          m_initialized{ false };
 };

--- a/src/celrender/cometrenderer.cpp
+++ b/src/celrender/cometrenderer.cpp
@@ -66,7 +66,8 @@ CometRenderer::initGL()
     m_brightnessLoc = m_prog->attribIndex("in_Brightness");
 
     m_vo = gl::VertexObject(gl::VertexObject::Primitive::TriangleStrip);
-    m_bo = gl::Buffer(gl::Buffer::TargetHint::Array);
+    m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array);
+    m_ibo = gl::Buffer::create(gl::Buffer::TargetHint::ElementArray);
 
     m_vo
         .addVertexBuffer(
@@ -93,7 +94,7 @@ CometRenderer::initGL()
             false,
             sizeof(CometTailVertex),
             offsetof(CometTailVertex, brightness))
-        .setIndexBuffer(gl::Buffer(gl::Buffer::TargetHint::ElementArray), 0, gl::VertexObject::IndexType::UnsignedShort);
+        .setIndexBuffer(m_ibo, 0, gl::VertexObject::IndexType::UnsignedShort);
 
     m_initialized = true;
     return true;
@@ -245,11 +246,11 @@ CometRenderer::render(const Body &body,
     m_prog->vec3Param("viewDir") = pos.normalized();
     m_prog->floatParam("fadeFactor") = fadeFactor;
 
-    m_bo.invalidateData().setData(
+    m_bo->invalidateData().setData(
         util::array_view(m_vertices.get(), MaxVertices),
         gl::Buffer::BufferUsage::StreamDraw);
 
-    m_vo.getIndexBuffer().invalidateData().setData(
+    m_ibo->invalidateData().setData(
         util::array_view(m_indices.get(), MaxIndices),
         gl::Buffer::BufferUsage::StreamDraw);
 

--- a/src/celrender/cometrenderer.h
+++ b/src/celrender/cometrenderer.h
@@ -60,7 +60,8 @@ private:
     bool                               m_initialized{ false };
     std::unique_ptr<CometTailVertex[]> m_vertices;
     std::unique_ptr<unsigned short[]>  m_indices;
-    gl::Buffer                         m_bo;
+    gl::Buffer::SharedPtr              m_bo;
+    gl::Buffer::SharedPtr              m_ibo;
     gl::VertexObject                   m_vo;
 };
 

--- a/src/celrender/galaxyrenderer.cpp
+++ b/src/celrender/galaxyrenderer.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cmath>
+#include <memory>
 
 #include <celengine/galaxy.h>
 #include <celengine/galaxyform.h>
@@ -57,13 +58,11 @@ colorTextureEval(float u, float /*v*/, std::uint8_t *pixel)
 
 struct GalaxyRenderer::RenderData
 {
-    RenderData(gl::Buffer &&bo, gl::VertexObject &&vo) :
-        bo(std::move(bo)),
+    explicit RenderData(gl::VertexObject &&vo) :
         vo(std::move(vo))
     {
     }
 
-    gl::Buffer       bo;
     gl::VertexObject vo;
 };
 
@@ -317,7 +316,7 @@ GalaxyRenderer::initializeGL2(const CelestiaGLProgram *prog)
                 indices.push_back(baseIndex + 3);
             }
 
-            gl::Buffer bo(gl::Buffer::TargetHint::Array, glVertices);
+            auto bo = gl::Buffer::create(gl::Buffer::TargetHint::Array, glVertices);
 
             gl::VertexObject vo(gl::VertexObject::Primitive::Triangles);
 
@@ -337,13 +336,13 @@ GalaxyRenderer::initializeGL2(const CelestiaGLProgram *prog)
             vo.addVertexBuffer(
                 bo, CelestiaGLProgram::TextureCoord0AttributeIndex, 2, gl::VertexObject::DataType::UnsignedByte,
                 true, sizeof(GalaxyVtx), offsetof(GalaxyVtx, texCoord));
-            gl::Buffer io(gl::Buffer::TargetHint::ElementArray, indices);
-            vo.setIndexBuffer(std::move(io), 0, gl::VertexObject::IndexType::UnsignedInt);
-            m_renderData.emplace_back(std::move(bo), std::move(vo));
+            auto io = gl::Buffer::create(gl::Buffer::TargetHint::ElementArray, indices);
+            vo.setIndexBuffer(io, 0, gl::VertexObject::IndexType::UnsignedInt);
+            m_renderData.emplace_back(std::move(vo));
         }
         else
         {
-            m_renderData.emplace_back(gl::Buffer{}, gl::VertexObject{});
+            m_renderData.emplace_back(gl::VertexObject{});
         }
         glVertices.clear();
         indices.clear();
@@ -446,7 +445,7 @@ GalaxyRenderer::initializeGL3(const CelestiaGLProgram *prog)
                 glVertices.push_back(v);
             }
 
-            gl::Buffer bo(gl::Buffer::TargetHint::Array, glVertices);
+            auto bo = gl::Buffer::create(gl::Buffer::TargetHint::Array, glVertices);
 
             gl::VertexObject vo(gl::VertexObject::Primitive::Points);
 
@@ -464,11 +463,11 @@ GalaxyRenderer::initializeGL3(const CelestiaGLProgram *prog)
                 bo, brightnessLoc, 1, gl::VertexObject::DataType::UnsignedByte,
                 true, sizeof(GalaxyVtx), offsetof(GalaxyVtx, brightness));
 
-            m_renderData.emplace_back(std::move(bo), std::move(vo));
+            m_renderData.emplace_back(std::move(vo));
         }
         else
         {
-            m_renderData.emplace_back(gl::Buffer{}, gl::VertexObject{});
+            m_renderData.emplace_back(gl::VertexObject{});
         }
         glVertices.clear();
     }

--- a/src/celrender/gl/binder.cpp
+++ b/src/celrender/gl/binder.cpp
@@ -22,13 +22,13 @@ Binder::get()
 }
 
 Binder&
-Binder::bind(const BufferRef &bo)
+Binder::bind(const Buffer &bo)
 {
     return bindVBO(bo.targetHint(), bo.id());
 }
 
 Binder&
-Binder::unbind(const BufferRef &bo)
+Binder::unbind(const Buffer &bo)
 {
     switch (bo.targetHint())
     {

--- a/src/celrender/gl/binder.h
+++ b/src/celrender/gl/binder.h
@@ -37,7 +37,7 @@ public:
      * @param bo Buffer to bind.
      * @return self
      */
-    Binder &bind(const BufferRef &bo);
+    Binder &bind(const Buffer &bo);
 
     /**
      * @brief Unbind the currently bound Buffer.
@@ -47,7 +47,7 @@ public:
      * @param bo a Buffer to unbind.
      * @return self
      */
-    Binder &unbind(const BufferRef &bo);
+    Binder &unbind(const Buffer &bo);
 
     /**
      * @brief Bind a VertexObject.

--- a/src/celrender/gl/buffer.cpp
+++ b/src/celrender/gl/buffer.cpp
@@ -9,23 +9,17 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include "binder.h"
 #include "buffer.h"
+
+#include "binder.h"
 
 namespace celestia::gl
 {
 
-Buffer::Buffer(Buffer::TargetHint targetHint) :
+Buffer::Buffer(GLuint id, Buffer::TargetHint targetHint) :
+    m_id(id),
     m_targetHint(targetHint)
 {
-    glGenBuffers(1, &m_id);
-}
-
-Buffer::Buffer(Buffer::TargetHint targetHint, util::array_view<void> data, Buffer::BufferUsage usage) :
-    Buffer(targetHint)
-{
-    Binder::get().bind(*this);
-    setData(data, usage);
 }
 
 Buffer::Buffer(Buffer &&other) noexcept :
@@ -111,6 +105,7 @@ Buffer::setData(util::array_view<void> data, Buffer::BufferUsage usage)
 Buffer&
 Buffer::setSubData(GLintptr offset, util::array_view<void> data)
 {
+    Binder::get().bind(*this);
     glBufferSubData(GLenum(m_targetHint), offset, data.size(), data.data());
     return *this;
 }
@@ -119,6 +114,29 @@ Buffer&
 Buffer::invalidateData()
 {
     return setData(util::array_view<void>(nullptr, m_bufferSize), m_usage);
+}
+
+Buffer::SharedPtr
+Buffer::create(TargetHint targetHint)
+{
+    GLuint id;
+    glGenBuffers(1, &id);
+    return Buffer::SharedPtr(new Buffer(id, targetHint), false);
+}
+
+Buffer::SharedPtr
+Buffer::create(TargetHint targetHint,
+               util::array_view<void> data,
+               BufferUsage usage)
+{
+    auto buffer = create(targetHint);
+    if (buffer)
+    {
+        Binder::get().bind(*buffer);
+        buffer->setData(data, usage);
+    }
+
+    return buffer;
 }
 
 } // namespace celestia::gl

--- a/src/celrender/gl/buffer.cpp
+++ b/src/celrender/gl/buffer.cpp
@@ -22,32 +22,6 @@ Buffer::Buffer(GLuint id, Buffer::TargetHint targetHint) :
 {
 }
 
-Buffer::Buffer(Buffer &&other) noexcept :
-    m_bufferSize(other.m_bufferSize),
-    m_id(other.m_id),
-    m_targetHint(other.m_targetHint),
-    m_usage(other.m_usage)
-{
-    other.clear();
-}
-
-Buffer& Buffer::operator=(Buffer &&other) noexcept
-{
-    if (this != &other)
-    {
-        destroy();
-
-        m_bufferSize = other.m_bufferSize;
-        m_id         = other.m_id;
-        m_targetHint = other.m_targetHint;
-        m_usage      = other.m_usage;
-
-        other.clear();
-    }
-
-    return *this;
-}
-
 Buffer::~Buffer()
 {
     destroy();

--- a/src/celrender/gl/buffer.h
+++ b/src/celrender/gl/buffer.h
@@ -11,8 +11,14 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstdint>
+
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+
 #include <celengine/glsupport.h>
 #include <celutil/array_view.h>
+#include <celutil/classops.h>
 
 namespace celestia::gl
 {
@@ -22,9 +28,11 @@ namespace celestia::gl
  *
  * Wraps an OpenGL buffer object.
  */
-class Buffer
+class Buffer : private util::NoCopy
 {
 public:
+    using SharedPtr = boost::intrusive_ptr<Buffer>;
+
     /**
      * @brief Buffer usage.
      *
@@ -56,56 +64,17 @@ public:
         ElementArray = GL_ELEMENT_ARRAY_BUFFER,
     };
 
-    /**
-     * @brief Construct a new Buffer object.
-     *
-     * Create a C++ object but don't create OpenGL objects.
-     */
-    Buffer() = default;
-
-    /**
-     * @brief Construct a new Buffer object.
-     *
-     * Create C++ and OpenGL objects.
-     *
-     * @param targetHint Buffer target.
-     *
-     * @see @ref TargetHint
-     */
-    explicit Buffer(TargetHint targetHint);
-
-    /**
-     * @brief Construct a new Buffer object.
-     *
-     * Create C++ and OpenGL objects and upload data.
-     *
-     * @param targetHint Buffer target.
-     * @param data Data.
-     * @param usage Buffer usage.
-     *
-     * @see @ref TargetHint @ref BufferUsage
-     */
-    Buffer(TargetHint             targetHint,
-           util::array_view<void> data,
-           BufferUsage            usage = BufferUsage::StaticDraw);
-
-    //! Copying is prohibited.
-    Buffer(const Buffer &) = delete;
-
     //! Move constructor.
     Buffer(Buffer &&) noexcept;
 
     //! Destructor.
     ~Buffer();
 
-    //! Copying is prohibited.
-    Buffer& operator=(const Buffer&) = delete;
-
     //! Move operator.
     Buffer& operator=(Buffer&&) noexcept;
 
     //! Return an OpenGL identificator of an underlying buffer.
-    GLuint id() const;
+    GLuint id() const noexcept;
 
     //! Bind the buffer to use.
     Buffer& bind();
@@ -135,16 +104,58 @@ public:
     Buffer& invalidateData();
 
     //! Return target, @see @ref TargetHint.
-    TargetHint targetHint() const;
+    TargetHint targetHint() const noexcept;
 
     //! Bind the default buffer (0) to target. @see @ref TargetHint @ref bind()
     static void unbind(TargetHint target);
 
+    /**
+     * @brief Construct a new Buffer object.
+     *
+     * Create C++ and OpenGL objects.
+     *
+     * @param targetHint Buffer target.
+     *
+     * @see @ref TargetHint
+     */
+    static SharedPtr create(TargetHint targetHint);
+
+    /**
+     * @brief Construct a new Buffer object.
+     *
+     * Create C++ and OpenGL objects and upload data.
+     *
+     * @param targetHint Buffer target.
+     * @param data Data.
+     * @param usage Buffer usage.
+     *
+     * @see @ref TargetHint @ref BufferUsage
+     */
+    static SharedPtr create(TargetHint             targetHint,
+                            util::array_view<void> data,
+                            BufferUsage            usage = BufferUsage::StaticDraw);
+
 private:
+    Buffer(GLuint, TargetHint);
+
     //! Reset object to initial state
     void clear();
     //! Destroy underlying OpenGL resources
     void destroy() noexcept;
+
+    inline friend void
+    intrusive_ptr_add_ref(Buffer* p)
+    {
+        p->m_refCount.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    inline friend void
+    intrusive_ptr_release(Buffer* p)
+    {
+        if (p->m_refCount.fetch_sub(1, std::memory_order_acq_rel) == 1)
+            delete p; //NOSONAR
+    }
+
 
     //! Buffer size
     GLsizeiptr m_bufferSize{ 0 };
@@ -158,40 +169,19 @@ private:
 
     BufferUsage m_usage{ BufferUsage::StaticDraw };
 
-    friend class VertexObject;
+    std::atomic<std::uint32_t> m_refCount{ 1 };
 };
 
 inline GLuint
-Buffer::id() const
+Buffer::id() const noexcept
 {
     return m_id;
 }
 
 inline Buffer::TargetHint
-Buffer::targetHint() const
+Buffer::targetHint() const noexcept
 {
     return m_targetHint;
 }
-
-class BufferRef
-{
-public:
-    BufferRef(const Buffer& buffer) : //NOSONAR
-        m_id(buffer.id()), m_targetHint(buffer.targetHint())
-    {
-    }
-
-    BufferRef(GLuint id, Buffer::TargetHint targetHint) :
-        m_id(id), m_targetHint(targetHint)
-    {
-    }
-
-    GLuint id() const noexcept { return m_id; }
-    Buffer::TargetHint targetHint() const noexcept { return m_targetHint; }
-
-private:
-    GLuint m_id;
-    Buffer::TargetHint m_targetHint;
-};
 
 } // namespace celestia::gl

--- a/src/celrender/gl/buffer.h
+++ b/src/celrender/gl/buffer.h
@@ -28,7 +28,7 @@ namespace celestia::gl
  *
  * Wraps an OpenGL buffer object.
  */
-class Buffer : private util::NoCopy
+class Buffer : private util::NoMove
 {
 public:
     using SharedPtr = boost::intrusive_ptr<Buffer>;
@@ -64,14 +64,8 @@ public:
         ElementArray = GL_ELEMENT_ARRAY_BUFFER,
     };
 
-    //! Move constructor.
-    Buffer(Buffer &&) noexcept;
-
     //! Destructor.
     ~Buffer();
-
-    //! Move operator.
-    Buffer& operator=(Buffer&&) noexcept;
 
     //! Return an OpenGL identificator of an underlying buffer.
     GLuint id() const noexcept;

--- a/src/celrender/gl/vertexobject.cpp
+++ b/src/celrender/gl/vertexobject.cpp
@@ -20,15 +20,15 @@ namespace celestia::gl
 
 struct VertexObject::BufferDesc
 {
-    BufferDesc(GLsizeiptr    offset,
-               GLuint        bufferId,
-               std::uint16_t type,
-               std::int16_t  location,
-               std::uint8_t  elemSize,
-               std::uint8_t  stride,
-               bool          normalized) :
+    BufferDesc(GLsizeiptr               offset,
+               const Buffer::SharedPtr &buffer,
+               std::uint16_t            type,
+               std::int16_t             location,
+               std::uint8_t             elemSize,
+               std::uint8_t             stride,
+               bool                     normalized) :
+        buffer(buffer),
         offset(offset),
-        bufferId(bufferId),
         type(type),
         location(location),
         elemSize(elemSize),
@@ -37,13 +37,13 @@ struct VertexObject::BufferDesc
     {
     }
 
-    GLsizeiptr    offset;
-    GLuint        bufferId;
-    std::uint16_t type;       // all constants < 0xFFFF
-    std::int16_t  location;
-    std::uint8_t  elemSize;   // 1, 2, 3, 4
-    std::uint8_t  stride;     // WebGL allows only 255 bytes max
-    bool          normalized;
+    Buffer::SharedPtr buffer;
+    GLsizeiptr        offset;
+    std::uint16_t     type;       // all constants < 0xFFFF
+    std::int16_t      location;
+    std::uint8_t      elemSize;   // 1, 2, 3, 4
+    std::uint8_t      stride;     // WebGL allows only 255 bytes max
+    bool              normalized;
 };
 
 VertexObject::VertexObject() = default;
@@ -122,13 +122,19 @@ VertexObject::clear()
 }
 
 VertexObject&
-VertexObject::addVertexBuffer(const Buffer &buffer, int location, int elemSize, VertexObject::DataType type, bool normalized, int stride, std::ptrdiff_t offset)
+VertexObject::addVertexBuffer(const Buffer::SharedPtr &buffer,
+                              int location,
+                              int elemSize,
+                              VertexObject::DataType type,
+                              bool normalized,
+                              int stride,
+                              std::ptrdiff_t offset)
 {
-    if (buffer.targetHint() != Buffer::TargetHint::Array)
+    if (buffer->targetHint() != Buffer::TargetHint::Array)
         return *this;
 
     m_bufferDesc.emplace_back(offset,
-                              buffer.id(),
+                              buffer,
                               static_cast<std::uint16_t>(type),
                               static_cast<std::uint16_t>(location),
                               static_cast<std::uint8_t>(elemSize),
@@ -173,19 +179,13 @@ VertexObject::draw(VertexObject::Primitive primitive, GLsizei count, GLint first
     return *this;
 }
 
-Buffer&
-VertexObject::getIndexBuffer() noexcept
-{
-    return m_indexBuffer;
-}
-
 VertexObject&
-VertexObject::setIndexBuffer(Buffer &&buffer, std::ptrdiff_t /*offset*/, VertexObject::IndexType type)
+VertexObject::setIndexBuffer(const Buffer::SharedPtr &buffer, std::ptrdiff_t /*offset*/, VertexObject::IndexType type)
 {
-    if (buffer.targetHint() != Buffer::TargetHint::ElementArray)
+    if (buffer->targetHint() != Buffer::TargetHint::ElementArray)
         return *this;
 
-    m_indexBuffer = std::move(buffer);
+    m_indexBuffer = buffer;
     m_indexType = type;
 
     return *this;
@@ -198,14 +198,14 @@ VertexObject::enableAttribArrays() const
 
     for (const auto &p : m_bufferDesc)
     {
-        binder.bind(BufferRef(p.bufferId, Buffer::TargetHint::Array));
+        binder.bind(*p.buffer);
 
         glEnableVertexAttribArray(p.location);
         glVertexAttribPointer(p.location, p.elemSize, p.type, p.normalized ? GL_TRUE : GL_FALSE, p.stride, PTR(p.offset));
     }
 
     if (isIndexed())
-        binder.bind(m_indexBuffer);
+        binder.bind(*m_indexBuffer);
 }
 
 void
@@ -217,7 +217,6 @@ VertexObject::bind()
     {
         m_initialized = true;
         enableAttribArrays();
-        m_bufferDesc.clear();
     }
 }
 

--- a/src/celrender/gl/vertexobject.h
+++ b/src/celrender/gl/vertexobject.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 #include <celengine/glsupport.h>
 
@@ -215,12 +216,7 @@ public:
      *
      * @see @ref DataType
      */
-    VertexObject& addVertexBuffer(const Buffer &buffer, int location, int elemSize, DataType type, bool normalized = false, int stride = 0, std::ptrdiff_t offset = 0);
-
-    /**
-     * @brief Gets the index buffer
-     */
-    Buffer& getIndexBuffer() noexcept;
+    VertexObject& addVertexBuffer(const Buffer::SharedPtr&, int location, int elemSize, DataType type, bool normalized = false, int stride = 0, std::ptrdiff_t offset = 0);
 
     /**
      * @brief Add index buffer and become its owner.
@@ -231,7 +227,7 @@ public:
      *
      * @see @ref IndexType
      */
-    VertexObject& setIndexBuffer(Buffer &&buffer, std::ptrdiff_t offset, IndexType type);
+    VertexObject& setIndexBuffer(const Buffer::SharedPtr&, std::ptrdiff_t offset, IndexType type);
 
 private:
     //! Reset object to initial state
@@ -251,7 +247,7 @@ private:
     std::vector<BufferDesc> m_bufferDesc;
 
     //! Index buffer
-    Buffer m_indexBuffer;
+    Buffer::SharedPtr m_indexBuffer;
 
     //! Index type
     IndexType m_indexType{ IndexType::UnsignedShort };
@@ -284,7 +280,7 @@ VertexObject::count() const
 inline bool
 VertexObject::isIndexed() const
 {
-    return m_indexBuffer.id() != 0;
+    return static_cast<bool>(m_indexBuffer);
 }
 
 inline GLuint

--- a/src/celrender/globularrenderer.cpp
+++ b/src/celrender/globularrenderer.cpp
@@ -68,7 +68,6 @@ struct Blob
 struct GlobularForm
 {
     std::vector<Blob> gblobs;
-    mutable gl::Buffer bo;
     mutable gl::VertexObject vo;
     mutable bool GLDataInitialized{ false };
 };
@@ -175,7 +174,7 @@ colorTextureEval(float u, float /*v*/, std::uint8_t *pixel)
 }
 
 void
-initGlobularData(gl::Buffer &bo, gl::VertexObject &vo, util::array_view<Blob> points)
+initGlobularData(gl::VertexObject &vo, util::array_view<Blob> points)
 {
     struct GlobularVtx
     {
@@ -232,7 +231,7 @@ initGlobularData(gl::Buffer &bo, gl::VertexObject &vo, util::array_view<Blob> po
         globularVtx.push_back(vtx);
     }
 
-    bo = gl::Buffer(gl::Buffer::TargetHint::Array, globularVtx);
+    auto bo = gl::Buffer::create(gl::Buffer::TargetHint::Array, globularVtx);
     vo = gl::VertexObject(gl::VertexObject::Primitive::Points);
     vo.addVertexBuffer(
         bo,
@@ -618,7 +617,7 @@ GlobularRenderer::renderForm(CelestiaGLProgram *tidalProg, CelestiaGLProgram *gl
 
     if (!form->GLDataInitialized)
     {
-        initGlobularData(form->bo, vo, form->gblobs);
+        initGlobularData(vo, form->gblobs);
         form->GLDataInitialized = true;
     }
 

--- a/src/celrender/largestarrenderer.cpp
+++ b/src/celrender/largestarrenderer.cpp
@@ -15,7 +15,6 @@
 #include <celengine/glsupport.h>
 #include <celengine/render.h>
 #include <celengine/shadermanager.h>
-#include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
 #include <celutil/array_view.h>
 #include <celutil/color.h>
@@ -120,7 +119,7 @@ LargeStarRenderer::setupVertexArrayObject()
 
     m_initialized = true;
 
-    m_bo = std::make_unique<gl::Buffer>(gl::Buffer::TargetHint::Array);
+    m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array);
     m_vo = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::Triangles);
 
     // Two triangles per quad: (0,1,2) and (0,2,3).
@@ -136,11 +135,11 @@ LargeStarRenderer::setupVertexArrayObject()
         out[4] = static_cast<GLushort>(base + 2);
         out[5] = static_cast<GLushort>(base + 3);
     }
-    gl::Buffer indexBuffer(gl::Buffer::TargetHint::ElementArray, indices);
-    m_vo->setIndexBuffer(std::move(indexBuffer), 0, gl::VertexObject::IndexType::UnsignedShort);
+    auto indexBuffer = gl::Buffer::create(gl::Buffer::TargetHint::ElementArray, indices);
+    m_vo->setIndexBuffer(indexBuffer, 0, gl::VertexObject::IndexType::UnsignedShort);
 
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::VertexCoordAttributeIndex,
         2,
         gl::VertexObject::DataType::Byte,
@@ -149,7 +148,7 @@ LargeStarRenderer::setupVertexArrayObject()
         offsetof(StarVertex, corner));
 
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::NormalAttributeIndex,
         3,
         gl::VertexObject::DataType::Float,
@@ -158,7 +157,7 @@ LargeStarRenderer::setupVertexArrayObject()
         offsetof(StarVertex, center));
 
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::TextureCoord0AttributeIndex,
         2,
         gl::VertexObject::DataType::UnsignedByte,
@@ -169,7 +168,7 @@ LargeStarRenderer::setupVertexArrayObject()
     // Color stays 4-component: this layout is shared with
     // LegacyLargeStarRenderer, whose shader reads in_Color.a.
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::ColorAttributeIndex,
         4,
         gl::VertexObject::DataType::UnsignedByte,
@@ -178,7 +177,7 @@ LargeStarRenderer::setupVertexArrayObject()
         offsetof(StarVertex, color));
 
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::IntensityAttributeIndex,
         1,
         gl::VertexObject::DataType::Float,
@@ -189,7 +188,7 @@ LargeStarRenderer::setupVertexArrayObject()
     // continuous distance-derived glow fade; float for a smooth transition
     // (unused by the legacy shader)
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::AlphaAttributeIndex,
         1,
         gl::VertexObject::DataType::Float,
@@ -198,7 +197,7 @@ LargeStarRenderer::setupVertexArrayObject()
         offsetof(StarVertex, alpha));
 
     m_vo->addVertexBuffer(
-        *m_bo,
+        m_bo,
         CelestiaGLProgram::LimbRadiusAttributeIndex,
         1,
         gl::VertexObject::DataType::Float,

--- a/src/celrender/largestarrenderer.h
+++ b/src/celrender/largestarrenderer.h
@@ -16,6 +16,7 @@
 #include <Eigen/Core>
 
 #include <celengine/starpipelineowner.h>
+#include "gl/buffer.h"
 
 class Color;
 class Renderer;
@@ -24,7 +25,6 @@ enum class StaticShader;
 
 namespace celestia::gl
 {
-class Buffer;
 class VertexObject;
 } // namespace celestia::gl
 
@@ -89,7 +89,7 @@ private:
     std::vector<StarVertex>           m_vertices;
 
     CelestiaGLProgram                *m_prog        { nullptr };
-    std::unique_ptr<gl::Buffer>       m_bo;
+    gl::Buffer::SharedPtr             m_bo;
     std::unique_ptr<gl::VertexObject> m_vo;
     bool                              m_initialized { false };
 };

--- a/src/celrender/linerenderer.cpp
+++ b/src/celrender/linerenderer.cpp
@@ -70,7 +70,7 @@ LineRenderer::draw_triangle_strip(int count, int offset)
     m_trVO.draw(gl::VertexObject::Primitive::TriangleStrip, count, offset);
 }
 
-//! Draw lines defained with segments.
+//! Draw lines defined with segments.
 void
 LineRenderer::draw_lines(int count, int offset)
 {
@@ -124,9 +124,9 @@ void
 LineRenderer::create_vbo_lines()
 {
     m_lnVO = gl::VertexObject(gl::VertexObject::Primitive::Triangles);
-    m_lnBO = gl::Buffer(gl::Buffer::TargetHint::Array);
+    m_lnBO = gl::Buffer::create(gl::Buffer::TargetHint::Array);
 
-    m_lnBO.setData(m_vertices, static_cast<gl::Buffer::BufferUsage>(m_storageType));
+    m_lnBO->setData(m_vertices, static_cast<gl::Buffer::BufferUsage>(m_storageType));
 
     m_lnVO.addVertexBuffer(
         m_lnBO,
@@ -158,7 +158,7 @@ LineRenderer::setup_vbo_lines()
     {
         if (m_storageType != StorageType::Static)
         {
-            m_lnBO.invalidateData().setData(m_vertices);
+            m_lnBO->invalidateData().setData(m_vertices);
         }
     }
     else
@@ -172,7 +172,7 @@ void
 LineRenderer::create_vbo_triangles()
 {
     m_trVO = gl::VertexObject(gl::VertexObject::Primitive::Triangles);
-    m_trBO = gl::Buffer(gl::Buffer::TargetHint::Array);
+    m_trBO = gl::Buffer::create(gl::Buffer::TargetHint::Array);
 
     GLsizei                    stride;
     std::array<std::size_t, 5> offset;
@@ -188,7 +188,7 @@ LineRenderer::create_vbo_triangles()
             offsetof(LineSegment, point1) + offsetof(Vertex, color)
         };
 
-        m_trBO.setData(m_segments, static_cast<gl::Buffer::BufferUsage>(m_storageType));
+        m_trBO->setData(m_segments, static_cast<gl::Buffer::BufferUsage>(m_storageType));
         m_segments.clear();
     }
     else
@@ -203,7 +203,7 @@ LineRenderer::create_vbo_triangles()
             offsetof(LineVertex, point) + offsetof(Vertex, color)
         };
 
-        m_trBO.setData(m_verticesTr, static_cast<gl::Buffer::BufferUsage>(m_storageType));
+        m_trBO->setData(m_verticesTr, static_cast<gl::Buffer::BufferUsage>(m_storageType));
         m_verticesTr.clear();
     }
     m_trVO.addVertexBuffer(
@@ -259,15 +259,15 @@ LineRenderer::setup_vbo_triangles()
     {
         if (m_storageType != StorageType::Static)
         {
-            m_trBO.invalidateData();
+            m_trBO->invalidateData();
 
             if (m_primType == PrimType::Lines || (m_hints & PREFER_SIMPLE_TRIANGLES) != 0)
             {
-                m_trBO.setData(m_segments);
+                m_trBO->setData(m_segments);
             }
             else
             {
-                m_trBO.setData(m_verticesTr);
+                m_trBO->setData(m_verticesTr);
             }
         }
     }
@@ -461,19 +461,19 @@ LineRenderer::clear()
 void
 LineRenderer::orphan()
 {
-    if (m_lnBO.id() != 0)
-        m_lnBO.invalidateData();
-    if (m_trBO.id() != 0)
-        m_trBO.invalidateData();
+    if (m_lnBO)
+        m_lnBO->invalidateData();
+    if (m_trBO)
+        m_trBO->invalidateData();
 }
 
 void
 LineRenderer::finish()
 {
-    if (m_lnBO.id() != 0)
-        m_lnBO.unbind();
-    if (m_trBO.id() != 0)
-        m_trBO.unbind();
+    if (m_lnBO)
+        m_lnBO->unbind();
+    if (m_trBO)
+        m_trBO->unbind();
     m_inUse = false;
     m_prog = nullptr;
 }

--- a/src/celrender/linerenderer.h
+++ b/src/celrender/linerenderer.h
@@ -283,8 +283,8 @@ private:
     std::vector<Color>        m_colors;
     gl::VertexObject          m_lnVO;
     gl::VertexObject          m_trVO;
-    gl::Buffer                m_lnBO;
-    gl::Buffer                m_trBO;
+    gl::Buffer::SharedPtr     m_lnBO;
+    gl::Buffer::SharedPtr     m_trBO;
     const Renderer           &m_renderer;
     float                     m_width;
     PrimType                  m_primType;

--- a/src/celrender/referencemarkrenderer.cpp
+++ b/src/celrender/referencemarkrenderer.cpp
@@ -143,15 +143,15 @@ ArrowRenderer::ArrowRenderer(const Renderer& renderer) :
     auto vertices = getArrowVertices();
     auto indices = getArrowIndices();
 
-    m_buffer.setData(vertices, gl::Buffer::BufferUsage::StaticDraw);
+    auto m_buffer = gl::Buffer::create(gl::Buffer::TargetHint::Array, vertices);
 
     m_vo.addVertexBuffer(m_buffer,
                          CelestiaGLProgram::VertexCoordAttributeIndex,
                          3,
                          gl::VertexObject::DataType::Float);
-    gl::Buffer indexBuffer(gl::Buffer::TargetHint::ElementArray, indices);
+    auto indexBuffer = gl::Buffer::create(gl::Buffer::TargetHint::ElementArray, indices);
     m_vo.setCount(static_cast<int>(indices.size()));
-    m_vo.setIndexBuffer(std::move(indexBuffer), 0, gl::VertexObject::IndexType::UnsignedShort);
+    m_vo.setIndexBuffer(indexBuffer, 0, gl::VertexObject::IndexType::UnsignedShort);
 
     ShaderProperties shaderProperties;
     shaderProperties.texUsage = TexUsage::VertexColors;

--- a/src/celrender/referencemarkrenderer.h
+++ b/src/celrender/referencemarkrenderer.h
@@ -33,7 +33,6 @@ public:
 
 private:
     CelestiaGLProgram* m_prog;
-    gl::Buffer m_buffer{ gl::Buffer::TargetHint::Array };
     gl::VertexObject m_vo{ gl::VertexObject::Primitive::Triangles };
     LineRenderer m_lineRenderer;
 };

--- a/src/celrender/ringrenderer.cpp
+++ b/src/celrender/ringrenderer.cpp
@@ -247,8 +247,7 @@ RingRenderer::initializeLOD(unsigned int level, std::uint32_t nSections)
         ringCoord.push_back(vertex);
     }
 
-    auto& bo = buffers[level];
-    bo = gl::Buffer(gl::Buffer::TargetHint::Array, ringCoord);
+    auto bo = gl::Buffer::create(gl::Buffer::TargetHint::Array, ringCoord);
     auto& vo = vertexObjects[level];
     vo = gl::VertexObject(gl::VertexObject::Primitive::TriangleStrip);
     vo.setCount(static_cast<int>((nSections + 1) * 2))
@@ -266,7 +265,7 @@ RingRenderer::initializeLOD(unsigned int level, std::uint32_t nSections)
                        false,
                        sizeof(RingVertex),
                        offsetof(RingVertex, pos));
-    bo.unbind();
+    bo->unbind();
 }
 
 void

--- a/src/celrender/ringrenderer.h
+++ b/src/celrender/ringrenderer.h
@@ -57,7 +57,6 @@ private:
     static constexpr unsigned int nLODs = 4;
 
     std::array<float, nLODs - 1> sectionScales;
-    std::array<gl::Buffer, nLODs> buffers;
     std::array<gl::VertexObject, nLODs> vertexObjects;
     Renderer& renderer;
 };

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -155,8 +155,8 @@ struct TextureFontPrivate
 
     std::vector<FontVertex> m_fontVertices;
 
-    gl::VertexObject m_vao{ gl::VertexObject::Primitive::Triangles };
-    gl::Buffer       m_vbo{ gl::Buffer::TargetHint::Array };
+    gl::VertexObject      m_vao{ gl::VertexObject::Primitive::Triangles };
+    gl::Buffer::SharedPtr m_vbo{ gl::Buffer::create(gl::Buffer::TargetHint::Array) };
 
     bool m_shaderInUse{ false };
 
@@ -199,7 +199,7 @@ TextureFontPrivate::TextureFontPrivate(const Renderer *renderer) : m_renderer(re
         indexes.push_back(index + 2);
     }
 
-    m_vao.setIndexBuffer(gl::Buffer(gl::Buffer::TargetHint::ElementArray, indexes), 0, gl::VertexObject::IndexType::UnsignedShort);
+    m_vao.setIndexBuffer(gl::Buffer::create(gl::Buffer::TargetHint::ElementArray, indexes), 0, gl::VertexObject::IndexType::UnsignedShort);
 }
 
 TextureFontPrivate::~TextureFontPrivate()
@@ -532,11 +532,9 @@ TextureFontPrivate::flush()
     if (m_fontVertices.size() < 4)
         return;
 
-    m_vbo.invalidateData().setData(m_fontVertices, gl::Buffer::BufferUsage::StreamDraw);
-    m_vao.getIndexBuffer().bind();
+    m_vbo->invalidateData().setData(m_fontVertices, gl::Buffer::BufferUsage::StreamDraw);
     m_vao.draw(static_cast<GLsizei>(m_fontVertices.size() / 4 * 6));
-    m_vbo.unbind();
-    m_vao.getIndexBuffer().unbind();
+    m_vbo->unbind();
 
     m_fontVertices.clear();
 }

--- a/src/celutil/classops.h
+++ b/src/celutil/classops.h
@@ -18,4 +18,19 @@ protected:
     NoCopy& operator=(NoCopy&&) noexcept = default;
 };
 
+// Base class for non-movables (no move, no copy)
+// Use as a private base class
+class NoMove
+{
+protected:
+    NoMove() = default;
+    ~NoMove() = default;
+
+    NoMove(const NoMove&) = delete;
+    NoMove& operator=(const NoMove&) = delete;
+
+    NoMove(NoMove&&) = delete;
+    NoMove& operator=(NoMove&&) = delete;
+};
+
 }


### PR DESCRIPTION
- Vertex object owns its member buffers
- Use intrusive_ptr as weak references not necessary
