### PR TITLE
Fix PSF star visibility in daylight

### DIFF
--- a/src/celengine/pointstarrenderer.cpp
+++ b/src/celengine/pointstarrenderer.cpp
@@ -36,6 +36,16 @@ namespace render = celestia::render;
 using render::PsfStarVertexBuffer;
 using render::psfGreenNormalization;
 
+float
+celestia::engine::detail::psfAtmosphereBrightness(
+    float faintestMagnitude,
+    float faintestMagnitudeWithoutAtmosphere)
+{
+    return std::min(1.0f,
+                    astro::magToIrradiance(faintestMagnitudeWithoutAtmosphere
+                                           - faintestMagnitude));
+}
+
 // Convert a position in the universal coordinate system to astrocentric
 // coordinates, taking into account possible orbital motion of the star.
 static Vector3d astrocentricPosition(const UniversalCoord& pos,

--- a/src/celengine/pointstarrenderer.h
+++ b/src/celengine/pointstarrenderer.h
@@ -35,6 +35,14 @@ constexpr inline float BaseStarDiscSize      = 5.0f;
 constexpr inline float MaxScaledDiscStarSize = 8.0f;
 constexpr inline float GlareOpacity          = 0.65f;
 
+namespace celestia::engine::detail
+{
+
+float psfAtmosphereBrightness(float faintestMagnitude,
+                              float faintestMagnitudeWithoutAtmosphere);
+
+} // namespace celestia::engine::detail
+
 class PointStarRenderer : public ObjectRenderer<Star, float>
 {
 public:

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1531,10 +1531,17 @@ void Renderer::render(const Observer& observer,
     // atmosphere.  If so, we need to adjust the sky color as well as the
     // limiting magnitude of stars (so stars aren't visible in the daytime
     // on planets with thick atmospheres.)
+    float faintestMagWithoutAtmosphere = faintestMag;
     if (util::is_set(renderFlags, RenderFlags::ShowAtmospheres))
     {
         adjustMagnitudeInsideAtmosphere(faintestMag, saturationMag, now);
     }
+    starAtmosphereBrightness =
+        starStyle == StarStyle::PointSpreadFunction
+            ? celestia::engine::detail::psfAtmosphereBrightness(
+                  faintestMag,
+                  faintestMagWithoutAtmosphere)
+            : 1.0f;
 
     // Now we need to determine how to scale the brightness of stars.  The
     // brightness will be proportional to the apparent magnitude, i.e.
@@ -1845,7 +1852,7 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
 
     float exposureFactor = std::max(starExposure, 1.0e-6f);
     float r              = std::max(starPointRadius, 1.0e-3f);
-    float peakRadScale   = exposureFactor * 3.0f
+    float peakRadScale   = exposureFactor * starAtmosphereBrightness * 3.0f
                            / (celestia::numbers::pi_v<float> * r * r);
     float irradiance     = astro::magToIrradiance(appMag);
     float peakRad        = peakRadScale * irradiance;
@@ -4442,17 +4449,18 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
                                                 * glowA / (2.0f * scale),
                                                 2.5f);
 
-        starRenderer.psf.peakRadScale          = exposureFactor * 3.0f
+        starRenderer.psf.peakRadScale          = exposureFactor * starAtmosphereBrightness * 3.0f
                                                  / (celestia::numbers::pi_v<float> * rLog * rLog);
         starRenderer.psf.dimGate               = dimGate;
         starRenderer.psf.glowA                 = glowA;
         starRenderer.psf.glowPeakLargeThreshold = glowPeakLargeThreshold;
 
         // Extend the iteration cutoff to the soft-clip's natural fade-in
-        // threshold so stars actually grow through dimGate instead of
-        // popping in at whatever peakRad they happen to have just past
-        // Celestia's perceptual faintestMag cutoff.
-        //   peakRad = dimGate  =>  m = (1/0.4) * log10(exposure * 3 / (pi * r^2 * dimGate))
+        // threshold. peakRadScale includes atmospheric eye adaptation, so
+        // daylight shifts this threshold brighter instead of restoring the
+        // night-sky cutoff.
+        //   peakRad = dimGate  =>  m = (1/0.4) *
+        //       log10(atmosphereBrightness * exposure * 3 / (pi * r^2 * dimGate))
         float psfFaintMag = std::log10(starRenderer.psf.peakRadScale / dimGate) / 0.4f;
         iterFaintestMag = std::max(faintestMagNight, psfFaintMag);
     }

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -728,6 +728,7 @@ class Renderer
     float brightnessScale{ 1.0f };
     float faintestMag{ 0.0f };
     float faintestPlanetMag{ 0.0f };
+    float starAtmosphereBrightness{ 1.0f };
     float saturationMagNight{ 1.0f };
     float saturationMag{ 1.0f };
     StarStyle starStyle{ StarStyle::FuzzyPointStars };


### PR DESCRIPTION
Temporary fix so that stars in PSF mode are not visible inside atmosphere on Earth during the day.

Note that it doesn't handle occlusion from eclipse/rings yet.