### PR TITLE
Add Qt information preferences

### DIFF
--- a/src/celestia/qt/preferences.ui
+++ b/src/celestia/qt/preferences.ui
@@ -1378,21 +1378,41 @@ Valid range: 1.0 to 100.0.</string>
      </widget>
      <widget class="QWidget" name="timeTab">
       <attribute name="title">
-       <string>Time</string>
+       <string>Information</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout">
        <property name="fieldGrowthPolicy">
         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
        </property>
        <item row="0" column="0">
+        <widget class="QLabel" name="timeZoneLabel">
+         <property name="text">
+          <string>Time zone:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="timeZoneBox"/>
+       </item>
+       <item row="1" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Date display format:</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
+       <item row="1" column="1">
         <widget class="QComboBox" name="dateFormatBox"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="hudDetailLabel">
+         <property name="text">
+          <string>Information text:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="hudDetailBox"/>
        </item>
       </layout>
      </widget>

--- a/src/celestia/qt/qtappwin.cpp
+++ b/src/celestia/qt/qtappwin.cpp
@@ -630,6 +630,8 @@ CelestiaAppWindow::writeSettings()
     bool useLocalTime = m_appCore->getTimeZoneBias() != 0;
     settings.setValue("LocalTime", useLocalTime);
     settings.setValue("TimeZoneName", QString::fromStdString(m_appCore->getTimeZoneName()));
+    settings.setValue("DateFormat", static_cast<int>(m_appCore->getDateFormat()));
+    settings.setValue("HudDetail", m_appCore->getHudDetail());
     settings.endGroup();
 
     settings.setValue("fps", ms_to_fps(timer->interval()));
@@ -1636,6 +1638,20 @@ CelestiaAppWindow::createMenus()
     if (settings.contains("TimeZoneName"))
     {
         m_appCore->setTimeZoneName(settings.value("TimeZoneName").toString().toStdString());
+    }
+
+    if (settings.contains("DateFormat"))
+    {
+        int dateFormat = settings.value("DateFormat").toInt();
+        if (dateFormat >= astro::Date::Locale && dateFormat < astro::Date::FormatCount)
+            m_appCore->setDateFormat(static_cast<astro::Date::Format>(dateFormat));
+    }
+
+    if (settings.contains("HudDetail"))
+    {
+        int hudDetail = settings.value("HudDetail").toInt();
+        if (hudDetail >= 0 && hudDetail <= 2)
+            m_appCore->setHudDetail(hudDetail);
     }
 
     /****** Help Menu ******/

--- a/src/celestia/qt/qtpreferencesdialog.cpp
+++ b/src/celestia/qt/qtpreferencesdialog.cpp
@@ -36,6 +36,7 @@
 #include <celengine/texmanager.h>
 #include <celestia/celestiacore.h>
 #include <celutil/gettext.h>
+#include <celutil/tzutil.h>
 
 namespace celestia::qt
 {
@@ -314,15 +315,35 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, CelestiaCore* core) :
     ui.autoMagnitudeCheck->setChecked(util::is_set(renderFlags, ::RenderFlags::ShowAutoMag));
 
     {
+        QSignalBlocker blocker(ui.timeZoneBox);
+        ui.timeZoneBox->addItem(_("Universal Time"), 0);
+
+        std::string tzName;
+        if (int localTimeZoneBias = 0; GetTZInfo(tzName, localTimeZoneBias))
+            ui.timeZoneBox->addItem(_("Local Time"), localTimeZoneBias);
+
+        ui.timeZoneBox->setCurrentIndex(appCore->getTimeZoneBias() == 0 ? 0 : 1);
+    }
+
+    {
         QSignalBlocker blocker(ui.dateFormatBox);
 #ifndef _WIN32
         ui.dateFormatBox->addItem(_("Local format"), astro::Date::Locale);
 #endif
         ui.dateFormatBox->addItem(_("Time zone name"), astro::Date::TZName);
         ui.dateFormatBox->addItem(_("UTC offset"), astro::Date::UTCOffset);
+        ui.dateFormatBox->addItem(_("ISO 8601"), astro::Date::ISO8601);
 
         astro::Date::Format dateFormat = appCore->getDateFormat();
         SetComboBoxValue(ui.dateFormatBox, dateFormat);
+    }
+
+    {
+        QSignalBlocker blocker(ui.hudDetailBox);
+        ui.hudDetailBox->addItem(_("None"), 0);
+        ui.hudDetailBox->addItem(_("Terse"), 1);
+        ui.hudDetailBox->addItem(_("Verbose"), 2);
+        SetComboBoxValue(ui.hudDetailBox, appCore->getHudDetail());
     }
 }
 
@@ -975,11 +996,23 @@ PreferencesDialog::on_starColorBox_currentIndexChanged(int index)
 // Time
 
 void
+PreferencesDialog::on_timeZoneBox_currentIndexChanged(int index)
+{
+    appCore->setTimeZoneBias(ui.timeZoneBox->itemData(index, Qt::UserRole).toInt());
+}
+
+void
 PreferencesDialog::on_dateFormatBox_currentIndexChanged(int index)
 {
     QVariant itemData = ui.dateFormatBox->itemData(index, Qt::UserRole);
-    astro::Date::Format dateFormat = (astro::Date::Format) itemData.toInt();
+    astro::Date::Format dateFormat = static_cast<astro::Date::Format>(itemData.toInt());
     appCore->setDateFormat(dateFormat);
+}
+
+void
+PreferencesDialog::on_hudDetailBox_currentIndexChanged(int index)
+{
+    appCore->setHudDetail(ui.hudDetailBox->itemData(index, Qt::UserRole).toInt());
 }
 
 } // end namespace celestia::qt

--- a/src/celestia/qt/qtpreferencesdialog.h
+++ b/src/celestia/qt/qtpreferencesdialog.h
@@ -137,7 +137,9 @@ private slots:
 
     void on_starColorBox_currentIndexChanged(int index);
 
+    void on_timeZoneBox_currentIndexChanged(int index);
     void on_dateFormatBox_currentIndexChanged(int index);
+    void on_hudDetailBox_currentIndexChanged(int index);
 
 protected:
     CelestiaCore* appCore;


### PR DESCRIPTION
Expose ISO 8601 formatting, time zone selection, and HUD detail controls in the Qt preferences dialog, and persist the display settings.