### PR TITLE
Use instanced rendering for text

### DIFF
--- a/shaders/text_vert.glsl
+++ b/shaders/text_vert.glsl
@@ -1,5 +1,8 @@
-layout(location = 0) in vec2 in_Position;
-layout(location = 2) in vec2 in_TexCoord0;
+layout(location = 0) in vec2 in_VertexPos;
+layout(location = 1) in vec2 in_InstancePos;
+layout(location = 2) in vec2 in_Size;
+layout(location = 3) in vec2 in_TexCoord;
+layout(location = 4) in vec2 in_TexSize;
 layout(location = 8) in vec4 in_Color;
 
 out vec2 texCoord;
@@ -7,7 +10,7 @@ out vec4 color;
 
 void main(void)
 {
-    gl_Position = MVPMatrix * vec4(in_Position.xy, 0, 1);
-    texCoord = in_TexCoord0.st;
+    gl_Position = MVPMatrix * vec4(in_InstancePos + in_Size * in_VertexPos, 0.0, 1.0);
+    texCoord = in_TexCoord + in_TexSize * vec2(in_VertexPos.x, 1.0 - in_VertexPos.y);
     color = in_Color;
 }

--- a/src/celrender/gl/vertexobject.cpp
+++ b/src/celrender/gl/vertexobject.cpp
@@ -9,14 +9,25 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-#include "binder.h"
-#include "buffer.h"
 #include "vertexobject.h"
 
-#define PTR(p) (reinterpret_cast<void*>(p))
+#include <celutil/flag.h>
+#include "binder.h"
+#include "buffer.h"
+
+#define PTR(p) (reinterpret_cast<const void*>(static_cast<std::intptr_t>(p)))
 
 namespace celestia::gl
 {
+
+enum class BufferFlags : std::uint8_t
+{
+    None = 0,
+    Normalized = 1,
+    Instance = 2,
+};
+
+ENUM_CLASS_BITWISE_OPS(BufferFlags)
 
 struct VertexObject::BufferDesc
 {
@@ -26,14 +37,14 @@ struct VertexObject::BufferDesc
                std::int16_t             location,
                std::uint8_t             elemSize,
                std::uint8_t             stride,
-               bool                     normalized) :
+               BufferFlags              flags) :
         buffer(buffer),
         offset(offset),
         type(type),
         location(location),
         elemSize(elemSize),
         stride(stride),
-        normalized(normalized)
+        flags(flags)
     {
     }
 
@@ -43,7 +54,7 @@ struct VertexObject::BufferDesc
     std::int16_t      location;
     std::uint8_t      elemSize;   // 1, 2, 3, 4
     std::uint8_t      stride;     // WebGL allows only 255 bytes max
-    bool              normalized;
+    BufferFlags       flags;
 };
 
 VertexObject::VertexObject() = default;
@@ -139,7 +150,34 @@ VertexObject::addVertexBuffer(const Buffer::SharedPtr &buffer,
                               static_cast<std::uint16_t>(location),
                               static_cast<std::uint8_t>(elemSize),
                               static_cast<std::uint8_t>(stride),
-                              normalized);
+                              normalized ? BufferFlags::Normalized : BufferFlags::None);
+
+    return *this;
+}
+
+VertexObject&
+VertexObject::addInstanceBuffer(const Buffer::SharedPtr &buffer,
+                                int location,
+                                int elemSize,
+                                VertexObject::DataType type,
+                                bool normalized,
+                                int stride,
+                                std::ptrdiff_t offset)
+{
+    if (buffer->targetHint() != Buffer::TargetHint::Array)
+        return *this;
+
+    auto flags = BufferFlags::Instance;
+    if (normalized)
+        flags |= BufferFlags::Normalized;
+
+    m_bufferDesc.emplace_back(offset,
+                              buffer,
+                              static_cast<std::uint16_t>(type),
+                              static_cast<std::uint16_t>(location),
+                              static_cast<std::uint8_t>(elemSize),
+                              static_cast<std::uint8_t>(stride),
+                              flags);
 
     return *this;
 }
@@ -151,7 +189,7 @@ VertexObject::draw()
 }
 
 VertexObject&
-VertexObject::draw(int count, int first)
+VertexObject::draw(GLsizei count, GLint first)
 {
     return draw(m_primitive, count, first);
 }
@@ -166,12 +204,47 @@ VertexObject::draw(VertexObject::Primitive primitive, GLsizei count, GLint first
 
     if (isIndexed())
     {
-        auto offset = static_cast<std::ptrdiff_t>(first * (m_indexType == IndexType::UnsignedShort ? sizeof(GLushort) : sizeof(GLuint)));
-        glDrawElements(GLenum(primitive), count, GLenum(m_indexType), PTR(offset));
+        auto offset = PTR(first * (m_indexType == IndexType::UnsignedShort ? sizeof(GLushort) : sizeof(GLuint)));
+        glDrawElements(GLenum(primitive), count, GLenum(m_indexType), offset);
     }
     else
     {
         glDrawArrays(GLenum(primitive), first, count);
+    }
+
+    unbind();
+
+    return *this;
+}
+
+VertexObject&
+VertexObject::drawInstances(GLsizei instanceCount)
+{
+    return drawInstances(instanceCount, m_primitive, m_count, 0);
+}
+
+VertexObject&
+VertexObject::drawInstances(GLsizei instanceCount, GLsizei count, GLint first)
+{
+    return drawInstances(instanceCount, m_primitive, count, first);
+}
+
+VertexObject&
+VertexObject::drawInstances(GLsizei instanceCount, VertexObject::Primitive primitive, GLsizei count, GLint first)
+{
+    if (count == 0)
+        return *this;
+
+    bind();
+
+    if (isIndexed())
+    {
+        auto offset = PTR(first * (m_indexType == IndexType::UnsignedShort ? sizeof(GLushort) : sizeof(GLuint)));
+        glDrawElementsInstanced(GLenum(primitive), count, GLenum(m_indexType), offset, instanceCount);
+    }
+    else
+    {
+        glDrawArraysInstanced(GLenum(primitive), first, count, instanceCount);
     }
 
     unbind();
@@ -201,7 +274,11 @@ VertexObject::enableAttribArrays() const
         binder.bind(*p.buffer);
 
         glEnableVertexAttribArray(p.location);
-        glVertexAttribPointer(p.location, p.elemSize, p.type, p.normalized ? GL_TRUE : GL_FALSE, p.stride, PTR(p.offset));
+
+        GLboolean normalized = util::is_set(p.flags, BufferFlags::Normalized) ? GL_TRUE : GL_FALSE;
+        glVertexAttribPointer(p.location, p.elemSize, p.type, normalized, p.stride, PTR(p.offset));
+        if (util::is_set(p.flags, BufferFlags::Instance))
+            glVertexAttribDivisor(p.location, 1);
     }
 
     if (isIndexed())

--- a/src/celrender/gl/vertexobject.h
+++ b/src/celrender/gl/vertexobject.h
@@ -153,6 +153,47 @@ public:
     VertexObject& draw(Primitive primitive, GLsizei count, GLint first = 0);
 
     /**
+     * @brief Render VertexObject with the given instance count
+     *
+     * Render VertexObject using a primitive set by constructor or setPrimitive.
+     *
+     * @param instanceCount Number of instances to draw.
+     * @return Reference to self.
+     *
+     * @see @ref Primitive @ref VertexObject(Primitive)
+     */
+    VertexObject& drawInstances(GLsizei instanceCount);
+
+    /**
+     * @brief Render VertexObject with the given instance count.
+     *
+     * Render VertexObject using a default primitive.
+     *
+     * @param instanceCount Number of instances to draw.
+     * @param count Number of vertices to draw.
+     * @param first First vertex to draw.
+     * @return Reference to self.
+     *
+     * @see @ref Primitive @ref VertexObject(Primitive)
+     */
+    VertexObject& drawInstances(GLsizei instanceCount, GLsizei count, GLint first = 0);
+
+    /**
+     * @brief Render VertexObject with the given instance count.
+     *
+     * Render VertexObject using a primitive provided.
+     *
+     * @param instanceCount Number of instances to draw.
+     * @param primitive Primitive.
+     * @param count Number of vertices to draw.
+     * @param first First vertex to draw.
+     * @return Reference to self.
+     *
+     * @see @ref Primitive @ref VertexObject(Primitive)
+     */
+    VertexObject& drawInstances(GLsizei instanceCount, Primitive primitive, GLsizei count, GLint first = 0);
+
+    /**
      * @brief Set the primitive.
      *
      * Set the default primitive type to be used by draw().
@@ -216,7 +257,40 @@ public:
      *
      * @see @ref DataType
      */
-    VertexObject& addVertexBuffer(const Buffer::SharedPtr&, int location, int elemSize, DataType type, bool normalized = false, int stride = 0, std::ptrdiff_t offset = 0);
+    VertexObject& addVertexBuffer(const Buffer::SharedPtr&,
+                                  int location,
+                                  int elemSize,
+                                  DataType type,
+                                  bool normalized = false,
+                                  int stride = 0,
+                                  std::ptrdiff_t offset = 0);
+
+    /**
+     * @brief Define an array of generic instance attribute data.
+     *
+     * Define an array of generic vertex attribute data. See documentation for the glVertexAttribPointer
+     * and glVertexAttribDivisor OpenGL methods for more information.
+     *
+     * @param buffer Buffer with vertex data.
+     * @param location Index of the generic vertex attribute.
+     * @param elemSize Number of components per generic vertex attribute. Must be 1, 2, 3, or 4.
+     * @param type Data type of each component.
+     * @param normalized Whether fixed-point data values should be normalized (true) or
+     * converted directly as fixed-point values (false).
+     * @param stride Offset in bytes between consecutive generic vertex attributes. If stride is 0,
+     * the generic vertex attributes are understood to be tightly packed in the array.
+     * @param offset Offset of the first component of the first generic vertex attribute in the array.
+     * @return Reference to self.
+     *
+     * @see @ref DataType
+     */
+    VertexObject& addInstanceBuffer(const Buffer::SharedPtr&,
+                                    int location,
+                                    int elemSize,
+                                    DataType type,
+                                    bool normalized = false,
+                                    int stride = 0,
+                                    std::ptrdiff_t offset = 0);
 
     /**
      * @brief Add index buffer and become its owner.

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -27,6 +27,7 @@
 #include <celimage/image.h>
 #include <celrender/gl/buffer.h>
 #include <celrender/gl/vertexobject.h>
+#include <celutil/array_view.h>
 #include <celutil/fsutils.h>
 #include <celutil/logger.h>
 #include <celutil/utf8.h>
@@ -44,6 +45,7 @@ using celestia::engine::Image;
 using celestia::engine::PixelFormat;
 using celestia::util::GetLogger;
 namespace gl = celestia::gl;
+namespace util = celestia::util;
 
 namespace
 {
@@ -96,16 +98,23 @@ LoadFontFace(FT_Library ft, const std::filesystem::path &path, int index, int si
 
 struct TextureFontPrivate
 {
-    struct FontVertex
+    static constexpr std::size_t MaxInstances = 128; // This gives BO size 4kB
+
+    static constexpr GLuint VertexLocation = 0;
+    static constexpr GLuint PositionLocation = 1;
+    static constexpr GLuint SizeLocation = 2;
+    static constexpr GLuint TexCoordLocation = 3;
+    static constexpr GLuint TexSizeLocation = 4;
+
+    struct FontInstance
     {
-        FontVertex(float _x, float _y, float _u, float _v) : x(_x), y(_y), u(_u), v(_v)
-        {
-        }
-        float x, y;
-        float u, v;
+        Eigen::Vector2f position;
+        Eigen::Vector2f size;
+        Eigen::Vector2f texCoord;
+        Eigen::Vector2f texSize;
     };
 
-    static_assert(std::is_standard_layout_v<FontVertex>);
+    static_assert(std::is_standard_layout_v<FontInstance>);
 
     TextureFontPrivate(const Renderer *renderer);
     ~TextureFontPrivate();
@@ -145,7 +154,11 @@ struct TextureFontPrivate
 
     std::vector<Glyph> m_glyphs; // character information
 
-    std::array<UnicodeBlock, 2> m_unicodeBlocks;
+    static constexpr std::array<UnicodeBlock, 2> s_unicodeBlocks
+    {
+        UnicodeBlock{ 0x0020, 0x007e }, // Basic Latin
+        UnicodeBlock{ 0x03b1, 0x03cf }, // Lowercase Greek
+    };
 
     int m_commonGlyphsCount{ 0 };
     int m_inserted{ 0 };
@@ -153,53 +166,66 @@ struct TextureFontPrivate
     Eigen::Matrix4f m_projection;
     Eigen::Matrix4f m_modelView;
 
-    std::vector<FontVertex> m_fontVertices;
+    // We only ever create TextureFontPrivate on the heap, so using an array here should be fine
+    std::array<FontInstance, MaxInstances> m_instances;
+    unsigned int m_instanceCount{ 0 };
 
-    gl::VertexObject      m_vao{ gl::VertexObject::Primitive::Triangles };
+    gl::VertexObject      m_vao{ gl::VertexObject::Primitive::TriangleStrip };
     gl::Buffer::SharedPtr m_vbo{ gl::Buffer::create(gl::Buffer::TargetHint::Array) };
 
     bool m_shaderInUse{ false };
-
-    static constexpr std::size_t MaxVertices = 256; // This gives BO size 4kB, MUST be multiply of 4
-    static constexpr std::size_t MaxIndices = MaxVertices / 4 * 6;
 };
 
 
 TextureFontPrivate::TextureFontPrivate(const Renderer *renderer) : m_renderer(renderer)
 {
-    m_unicodeBlocks[0] = { 0x0020, 0x007E }; // Basic Latin
-    m_unicodeBlocks[1] = { 0x03B1, 0x03CF }; // Lower case Greek
-
+    constexpr std::array<std::uint8_t, 8> vertexData{ 0, 0, 255, 0, 0, 255, 255, 255 };
+    auto vertexBuffer = gl::Buffer::create(gl::Buffer::TargetHint::Array, vertexData);
     m_vao.addVertexBuffer(
+        vertexBuffer,
+        VertexLocation,
+        2,
+        gl::VertexObject::DataType::UnsignedByte,
+        true);
+    m_vao.setCount(4);
+
+    m_vbo->setData(util::array_view<void>(nullptr, sizeof(FontInstance) * MaxInstances), gl::Buffer::BufferUsage::StreamDraw);
+
+    m_vao.addInstanceBuffer(
         m_vbo,
-        CelestiaGLProgram::VertexCoordAttributeIndex,
+        PositionLocation,
         2,
         gl::VertexObject::DataType::Float,
         false,
-        sizeof(FontVertex),
-        offsetof(FontVertex, x));
-    m_vao.addVertexBuffer(
+        sizeof(FontInstance),
+        offsetof(FontInstance, position));
+
+    m_vao.addInstanceBuffer(
         m_vbo,
-        CelestiaGLProgram::TextureCoord0AttributeIndex,
+        SizeLocation,
         2,
         gl::VertexObject::DataType::Float,
         false,
-        sizeof(FontVertex),
-        offsetof(FontVertex, u));
+        sizeof(FontInstance),
+        offsetof(FontInstance, size));
 
-    std::vector<std::uint16_t> indexes;
-    indexes.reserve(MaxIndices);
-    for (std::uint16_t index = 0; index < static_cast<std::uint16_t>(MaxIndices); index += 4)
-    {
-        indexes.push_back(index + 0);
-        indexes.push_back(index + 1);
-        indexes.push_back(index + 2);
-        indexes.push_back(index + 1);
-        indexes.push_back(index + 3);
-        indexes.push_back(index + 2);
-    }
+    m_vao.addInstanceBuffer(
+        m_vbo,
+        TexCoordLocation,
+        2,
+        gl::VertexObject::DataType::Float,
+        false,
+        sizeof(FontInstance),
+        offsetof(FontInstance, texCoord));
 
-    m_vao.setIndexBuffer(gl::Buffer::create(gl::Buffer::TargetHint::ElementArray, indexes), 0, gl::VertexObject::IndexType::UnsignedShort);
+    m_vao.addInstanceBuffer(
+        m_vbo,
+        TexSizeLocation,
+        2,
+        gl::VertexObject::DataType::Float,
+        false,
+        sizeof(FontInstance),
+        offsetof(FontInstance, texSize));
 }
 
 TextureFontPrivate::~TextureFontPrivate()
@@ -236,7 +262,7 @@ TextureFontPrivate::initCommonGlyphs()
 
     m_glyphs.reserve(256);
 
-    for (auto const &block : m_unicodeBlocks)
+    for (auto const &block : s_unicodeBlocks)
     {
         for (FT_ULong ch = block.first, e = block.last; ch <= e; ch++)
         {
@@ -374,7 +400,7 @@ TextureFontPrivate::getCommonGlyphsCount()
 {
     if (m_commonGlyphsCount == 0)
     {
-        for (auto const &block : m_unicodeBlocks)
+        for (auto const &block : s_unicodeBlocks)
             m_commonGlyphsCount += (block.last - block.first + 1);
     }
     return m_commonGlyphsCount;
@@ -385,10 +411,10 @@ TextureFontPrivate::toPos(FT_ULong ch) const
 {
     std::size_t pos = 0;
 
-    if (ch > m_unicodeBlocks.back().last)
+    if (ch > s_unicodeBlocks.back().last)
         return INVALID_POS;
 
-    for (const auto &r : m_unicodeBlocks)
+    for (const auto &r : s_unicodeBlocks)
     {
         if (ch < r.first)
             return INVALID_POS;
@@ -486,33 +512,25 @@ TextureFontPrivate::render(std::u16string_view line, float x, float y)
             continue;
         }
         auto &g = getGlyph(ch, u'?');
+        if (g.bw > 0 && g.bh > 0)
+        {
+            // Only render characters if they have bitmaps
+            auto& instance = m_instances[m_instanceCount];
 
-        // Calculate the vertex and texture coordinates
-        const float x1 = x + g.bl;
-        const float y1 = y + g.bt - g.bh;
-        const float w  = g.bw;
-        const float h  = g.bh;
-        const float x2 = x1 + w;
-        const float y2 = y1 + h;
+            // Make Sonar stop complaining about precision issues
+            instance.position = Eigen::Vector2f(x + g.bl, y + g.bt - g.bh); //NOSONAR
+            instance.size = Eigen::Vector2f(g.bw, g.bh);
+            instance.texCoord = Eigen::Vector2f(g.tx, g.ty);
+            instance.texSize = Eigen::Vector2f(instance.size.x() / m_texWidth, instance.size.y() / m_texHeight); //NOSONAR
+
+            ++m_instanceCount;
+            if (m_instanceCount == MaxInstances)
+                flush();
+        }
 
         // Advance the cursor to the start of the next character
         x += g.ax;
         y += g.ay;
-
-        // Skip glyphs that have no pixels
-        if (g.bw == 0 || g.bh == 0) continue;
-
-        const float tx1 = g.tx;
-        const float ty1 = g.ty;
-        const float tx2 = tx1 + w / m_texWidth;
-        const float ty2 = ty1 + h / m_texHeight;
-
-        m_fontVertices.emplace_back(x1, y1, tx1, ty2);
-        m_fontVertices.emplace_back(x2, y1, tx2, ty2);
-        m_fontVertices.emplace_back(x1, y2, tx1, ty1);
-        m_fontVertices.emplace_back(x2, y2, tx2, ty1);
-
-        if (m_fontVertices.size() == MaxVertices) flush();
     }
 
     return {x, y};
@@ -529,14 +547,14 @@ TextureFontPrivate::getProgram()
 void
 TextureFontPrivate::flush()
 {
-    if (m_fontVertices.size() < 4)
+    if (m_instanceCount == 0)
         return;
 
-    m_vbo->invalidateData().setData(m_fontVertices, gl::Buffer::BufferUsage::StreamDraw);
-    m_vao.draw(static_cast<GLsizei>(m_fontVertices.size() / 4 * 6));
+    m_vbo->setSubData(0, util::array_view(m_instances.data(), m_instanceCount));
+    m_vao.drawInstances(m_instanceCount);
     m_vbo->unbind();
 
-    m_fontVertices.clear();
+    m_instanceCount = 0;
 }
 
 TextureFont::TextureFont(const Renderer *renderer) :


### PR DESCRIPTION
Reduces the amount of data per glyph from 16 to 8 floats, and eliminates the need for the index buffer.