### PR TITLE
Fix SFINAE warning with gcc from moc compilation

### DIFF
--- a/src/tools/cmod/cmodview/mainwindow.h
+++ b/src/tools/cmod/cmodview/mainwindow.h
@@ -20,9 +20,10 @@
 #include <QObject>
 #include <QString>
 
+#include <celmodel/material.h>
+
 namespace cmod
 {
-struct Material;
 class Model;
 }
 


### PR DESCRIPTION
automoc does not like forward-declared types in signals/slots