### PR TITLE
Make texture anisotropy configurable

### DIFF
--- a/celestia.cfg.in
+++ b/celestia.cfg.in
@@ -390,6 +390,10 @@ StarTextures
 #     reduce the jagged edges of eclipse shadows and shadows on planet
 #     rings, but it will decrease the amount of memory available for
 #     planet textures.
+#
+#   TextureAnisotropy controls anisotropic texture filtering. The default
+#   is 8. A value of 1 disables it. The configured value is limited to
+#   what the graphics driver supports.
 #------------------------------------------------------------------------
   OrbitPathSamplePoints  100
   AtmosphereSegmentCount 6
@@ -398,6 +402,7 @@ StarTextures
 
   ShadowTextureSize      256
   EclipseTextureSize     128
+  TextureAnisotropy      8
 
 
 #------------------------------------------------------------------------

--- a/src/celengine/texture.cpp
+++ b/src/celengine/texture.cpp
@@ -34,6 +34,8 @@ using celestia::engine::expandLuminanceAlphaToRGBA;
 namespace
 {
 
+GLint PreferredTextureAnisotropy = 8; // NOSONAR
+
 // When sRGB rendering is disabled, strip sRGB pixel formats to their
 // non-sRGB equivalents so the GPU does not linearize on sample.
 PixelFormat
@@ -63,28 +65,13 @@ struct TextureCaps
     GLint preferredAnisotropy;
 };
 
-const TextureCaps&
+TextureCaps
 GetTextureCaps()
 {
-    static TextureCaps texCaps;
-    static bool texCapsInitialized = false;
+    if (!gl::EXT_texture_filter_anisotropic)
+        return { 1 };
 
-    if (!texCapsInitialized)
-    {
-        texCapsInitialized = true;
-
-        texCaps.preferredAnisotropy = 1;
-#ifndef GL_ES
-        if (gl::EXT_texture_filter_anisotropic)
-        {
-            // Cap the preferred level texture anisotropy to 8; eventually, we should allow
-            // the user to control this.
-            texCaps.preferredAnisotropy = std::min(8, gl::maxTextureAnisotropy);
-        }
-#endif
-    }
-
-    return texCaps;
+    return { std::min(PreferredTextureAnisotropy, gl::maxTextureAnisotropy) };
 }
 
 bool
@@ -609,6 +596,12 @@ ComputeTileMipMaps(const Image& img, Image& tile,
 }
 
 } // end unnamed namespace
+
+void
+celestia::engine::SetTextureAnisotropy(int anisotropy)
+{
+    PreferredTextureAnisotropy = std::max(anisotropy, 1);
+}
 
 Texture::Texture(int _width, int _height, bool _alpha) :
     width(_width),

--- a/src/celengine/texture.h
+++ b/src/celengine/texture.h
@@ -25,6 +25,11 @@
 
 typedef void (*ProceduralTexEval)(float, float, float, std::uint8_t*);
 
+namespace celestia::engine
+{
+void SetTextureAnisotropy(int);
+}
+
 struct TextureTile
 {
     TextureTile(unsigned int _texID) :

--- a/src/celestia/celestiacore.cpp
+++ b/src/celestia/celestiacore.cpp
@@ -58,6 +58,7 @@
 #include <celengine/textlayout.h>
 #include <celengine/timeline.h>
 #include <celengine/timelinephase.h>
+#include <celengine/texture.h>
 #include <celengine/rectangle.h>
 #include <celengine/urlmanager.h>
 #include <celengine/visibleregion.h>
@@ -2770,6 +2771,7 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
                                 [[maybe_unused]] bool useMesaPackInvert)
 {
     gl::sRGBRendering = sRGBRendering.value_or(config->renderDetails.output.sRGB);
+    celestia::engine::SetTextureAnisotropy(config->renderDetails.textures.anisotropy);
 
     if (gl::sRGBRendering)
     {
@@ -2791,8 +2793,8 @@ bool CelestiaCore::initRenderer(engine::TextureResolution resolution,
     detailOptions.atmosphereSegmentCount = config->renderDetails.atmosphere.segmentCount;
     detailOptions.cloudSegmentCount = config->renderDetails.atmosphere.cloudSegmentCount;
     detailOptions.atmosphereExtinctionThreshold = config->renderDetails.atmosphere.extinctionThreshold;
-    detailOptions.shadowTextureSize = config->renderDetails.shadowTextureSize;
-    detailOptions.eclipseTextureSize = config->renderDetails.eclipseTextureSize;
+    detailOptions.shadowTextureSize = config->renderDetails.textures.shadowSize;
+    detailOptions.eclipseTextureSize = config->renderDetails.textures.eclipseSize;
     detailOptions.orbitWindowEnd = config->renderDetails.orbitWindowEnd;
     detailOptions.orbitPeriodsShown = config->renderDetails.orbitPeriodsShown;
     detailOptions.linearFadeFraction = config->renderDetails.linearFadeFraction;

--- a/src/celestia/configfile.cpp
+++ b/src/celestia/configfile.cpp
@@ -209,8 +209,8 @@ applyRenderDetails(CelestiaConfig::RenderDetails& renderDetails, const Associati
     applyNumber(renderDetails.labelConstellationsFadeStartDist, hash, "LabelConstellationsFadeStartDist"sv);
     applyNumber(renderDetails.labelConstellationsFadeEndDist, hash, "LabelConstellationsFadeEndDist"sv);
 
-    applyNumber(renderDetails.shadowTextureSize, hash, "ShadowTextureSize"sv);
-    applyNumber(renderDetails.eclipseTextureSize, hash, "EclipseTextureSize"sv);
+    applyNumber(renderDetails.textures.shadowSize, hash, "ShadowTextureSize"sv);
+    applyNumber(renderDetails.textures.eclipseSize, hash, "EclipseTextureSize"sv);
     applyNumber(renderDetails.orbitPathSamplePoints, hash, "OrbitPathSamplePoints"sv);
     applyNumber(renderDetails.atmosphere.segmentCount, hash, "AtmosphereSegmentCount"sv);
     renderDetails.atmosphere.segmentCount = std::clamp(renderDetails.atmosphere.segmentCount, 1u, 16u);
@@ -224,6 +224,8 @@ applyRenderDetails(CelestiaConfig::RenderDetails& renderDetails, const Associati
         renderDetails.atmosphere.extinctionThreshold = 0.000125f;
     }
     applyNumber(renderDetails.aaSamples, hash, "AntialiasingSamples"sv);
+    applyNumber(renderDetails.textures.anisotropy, hash, "TextureAnisotropy"sv);
+    renderDetails.textures.anisotropy = std::max(renderDetails.textures.anisotropy, 1);
     applyNumber(renderDetails.SolarSystemMaxDistance, hash, "SolarSystemMaxDistance"sv);
     renderDetails.SolarSystemMaxDistance = std::clamp(renderDetails.SolarSystemMaxDistance, 1.0f, 10.0f);
     applyNumber(renderDetails.ShadowMapSize, hash, "ShadowMapSize"sv);

--- a/src/celestia/configfile.h
+++ b/src/celestia/configfile.h
@@ -87,13 +87,18 @@ struct CelestiaConfig
         float labelConstellationsFadeStartDist{ 6.0f };
         float labelConstellationsFadeEndDist{ 20.0f };
 
-        unsigned int shadowTextureSize{ 256 };
-        unsigned int eclipseTextureSize{ 128 };
         unsigned int orbitPathSamplePoints{ 100 };
         unsigned int aaSamples{ 1 };
         float SolarSystemMaxDistance{ 1.0f };
         unsigned int ShadowMapSize{ 0 };
         std::vector<std::string> ignoreGLExtensions{ };
+        struct TextureRendering
+        {
+            unsigned int shadowSize{ 256 };
+            unsigned int eclipseSize{ 128 };
+            int anisotropy{ 8 };
+        };
+        TextureRendering textures{ };
         struct OutputRendering
         {
             bool sRGB{ false };


### PR DESCRIPTION
remove the `GL_ES` guard as well