### PR TITLE
Fix some unnecessary reallocations in orphan buffer pattern

### DIFF
--- a/src/celengine/pointstarvertexbuffer.cpp
+++ b/src/celengine/pointstarvertexbuffer.cpp
@@ -46,23 +46,21 @@ void PointStarVertexBuffer::startBasicPoints()
 
 void PointStarVertexBuffer::render()
 {
-    if (m_nStars != 0)
-    {
-        makeCurrent();
+    if (m_nStars == 0)
+        return;
 
-        if (m_texture != nullptr)
-            m_texture->bind();
+    makeCurrent();
 
-        m_bo->invalidateData().setData(
-            util::array_view(m_vertices.get(), m_nStars),
-            gl::Buffer::BufferUsage::StreamDraw);
+    if (m_texture != nullptr)
+        m_texture->bind();
 
-        if (m_pointSizeFromVertex)
-            m_vo1->draw(m_nStars);
-        else
-            m_vo2->draw(m_nStars);
-        m_nStars = 0;
-    }
+    m_bo->invalidateData().setSubData(0, util::array_view(m_vertices.get(), m_nStars));
+
+    if (m_pointSizeFromVertex)
+        m_vo1->draw(m_nStars);
+    else
+        m_vo2->draw(m_nStars);
+    m_nStars = 0;
 }
 
 void PointStarVertexBuffer::makeCurrent()
@@ -90,59 +88,61 @@ void PointStarVertexBuffer::makeCurrent()
 
 void PointStarVertexBuffer::setupVertexArrayObject()
 {
-    if (!m_initialized)
-    {
-        m_initialized = true;
+    if (m_initialized)
+        return;
 
-        m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array);
-        m_vo1 = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::Points);
-        m_vo2 = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::Points);
+    m_initialized = true;
 
-        m_vo1->addVertexBuffer(
-            m_bo,
-            CelestiaGLProgram::VertexCoordAttributeIndex,
-            3,
-            gl::VertexObject::DataType::Float,
-            false,
-            sizeof(StarVertex),
-            offsetof(StarVertex, position));
+    m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array,
+                              static_cast<GLsizeiptr>(sizeof(StarVertex) * m_capacity),
+                              gl::Buffer::BufferUsage::StreamDraw);
+    m_vo1 = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::Points);
+    m_vo2 = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::Points);
 
-        m_vo1->addVertexBuffer(
-            m_bo,
-            CelestiaGLProgram::ColorAttributeIndex,
-            4,
-            gl::VertexObject::DataType::UnsignedByte,
-            true,
-            sizeof(StarVertex),
-            offsetof(StarVertex, color));
+    m_vo1->addVertexBuffer(
+        m_bo,
+        CelestiaGLProgram::VertexCoordAttributeIndex,
+        3,
+        gl::VertexObject::DataType::Float,
+        false,
+        sizeof(StarVertex),
+        offsetof(StarVertex, position));
 
-        m_vo1->addVertexBuffer(
-            m_bo,
-            CelestiaGLProgram::PointSizeAttributeIndex,
-            1,
-            gl::VertexObject::DataType::Float,
-            false,
-            sizeof(StarVertex),
-            offsetof(StarVertex, size));
+    m_vo1->addVertexBuffer(
+        m_bo,
+        CelestiaGLProgram::ColorAttributeIndex,
+        4,
+        gl::VertexObject::DataType::UnsignedByte,
+        true,
+        sizeof(StarVertex),
+        offsetof(StarVertex, color));
 
-        m_vo2->addVertexBuffer(
-            m_bo,
-            CelestiaGLProgram::VertexCoordAttributeIndex,
-            3,
-            gl::VertexObject::DataType::Float,
-            false,
-            sizeof(StarVertex),
-            offsetof(StarVertex, position));
+    m_vo1->addVertexBuffer(
+        m_bo,
+        CelestiaGLProgram::PointSizeAttributeIndex,
+        1,
+        gl::VertexObject::DataType::Float,
+        false,
+        sizeof(StarVertex),
+        offsetof(StarVertex, size));
 
-        m_vo2->addVertexBuffer(
-            m_bo,
-            CelestiaGLProgram::ColorAttributeIndex,
-            4,
-            gl::VertexObject::DataType::UnsignedByte,
-            true,
-            sizeof(StarVertex),
-            offsetof(StarVertex, color));
-    }
+    m_vo2->addVertexBuffer(
+        m_bo,
+        CelestiaGLProgram::VertexCoordAttributeIndex,
+        3,
+        gl::VertexObject::DataType::Float,
+        false,
+        sizeof(StarVertex),
+        offsetof(StarVertex, position));
+
+    m_vo2->addVertexBuffer(
+        m_bo,
+        CelestiaGLProgram::ColorAttributeIndex,
+        4,
+        gl::VertexObject::DataType::UnsignedByte,
+        true,
+        sizeof(StarVertex),
+        offsetof(StarVertex, color));
 }
 
 void PointStarVertexBuffer::finish()

--- a/src/celengine/pointstarvertexbuffer.h
+++ b/src/celengine/pointstarvertexbuffer.h
@@ -10,10 +10,12 @@
 
 #pragma once
 
+#include <cassert>
 #include <memory>
 #include <Eigen/Core>
 
 #include <celrender/gl/buffer.h>
+#include <celutil/classops.h>
 #include "starpipelineowner.h"
 
 class Color;
@@ -27,7 +29,8 @@ class VertexObject;
 }
 
 // PointStarVertexBuffer is used when hardware supports point sprites.
-class PointStarVertexBuffer : public celestia::render::StarPipelineFlushable
+class PointStarVertexBuffer : public celestia::render::StarPipelineFlushable,
+                              private celestia::util::NoMove
 {
 public:
     using capacity_t = unsigned int;
@@ -35,10 +38,6 @@ public:
     PointStarVertexBuffer(const Renderer &renderer, capacity_t capacity);
     ~PointStarVertexBuffer() override = default;
     PointStarVertexBuffer() = delete;
-    PointStarVertexBuffer(const PointStarVertexBuffer&) = delete;
-    PointStarVertexBuffer(PointStarVertexBuffer&&) = delete;
-    PointStarVertexBuffer& operator=(const PointStarVertexBuffer&) = delete;
-    PointStarVertexBuffer& operator=(PointStarVertexBuffer&&) = delete;
 
     void startBasicPoints();
     void startSprites();
@@ -82,17 +81,13 @@ PointStarVertexBuffer::addStar(const Eigen::Vector3f &pos,
                                const Color &color,
                                float size)
 {
-    if (m_nStars < m_capacity)
-    {
-        m_vertices[m_nStars].position = pos;
-        m_vertices[m_nStars].size = size;
-        color.get(m_vertices[m_nStars].color);
-        m_nStars++;
-    }
+    assert(m_nStars < m_capacity);
+
+    m_vertices[m_nStars].position = pos;
+    m_vertices[m_nStars].size = size;
+    color.get(m_vertices[m_nStars].color);
+    ++m_nStars;
 
     if (m_nStars == m_capacity)
-    {
         render();
-        m_nStars = 0;
-    }
 }

--- a/src/celengine/psfstarvertexbuffer.cpp
+++ b/src/celengine/psfstarvertexbuffer.cpp
@@ -9,6 +9,7 @@
 
 #include "psfstarvertexbuffer.h"
 
+#include <cassert>
 #include <cmath>
 
 #include <celrender/gl/vertexobject.h>
@@ -65,7 +66,7 @@ PsfStarVertexBuffer::PsfStarVertexBuffer(const Renderer &renderer,
                                          capacity_t capacity) :
     m_renderer(renderer),
     m_capacity(capacity),
-    m_vertices(capacity)
+    m_vertices(std::make_unique<StarVertex[]>(capacity))
 {
 }
 
@@ -86,9 +87,7 @@ PsfStarVertexBuffer::render()
 
     makeCurrent();
 
-    m_bo->invalidateData().setData(
-        util::array_view(m_vertices.data(), m_nStars),
-        gl::Buffer::BufferUsage::StreamDraw);
+    m_bo->invalidateData().setSubData(0, util::array_view(m_vertices.get(), m_nStars));
 
     m_vo->draw(m_nStars);
     m_nStars = 0;
@@ -131,7 +130,9 @@ PsfStarVertexBuffer::setupVertexArrayObject()
 
     m_initialized = true;
 
-    m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array);
+    m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array,
+                              static_cast<GLsizeiptr>(sizeof(StarVertex) * m_capacity),
+                              gl::Buffer::BufferUsage::StreamDraw);
     m_vo = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::Points);
 
     m_vo->addVertexBuffer(
@@ -212,15 +213,13 @@ PsfStarVertexBuffer::addStar(const Eigen::Vector3f &pos,
                              float limbRadius,
                              float alpha)
 {
-    if (m_nStars < m_capacity)
-    {
-        m_vertices[m_nStars].position = pos;
-        m_vertices[m_nStars].peakRadiance = peakRadiance;
-        m_vertices[m_nStars].limbRadius = limbRadius;
-        m_vertices[m_nStars].alpha = alpha;
-        color.get(m_vertices[m_nStars].color.data());
-        m_nStars++;
-    }
+    assert(m_nStars < m_capacity);
+    m_vertices[m_nStars].position = pos;
+    m_vertices[m_nStars].peakRadiance = peakRadiance;
+    m_vertices[m_nStars].limbRadius = limbRadius;
+    m_vertices[m_nStars].alpha = alpha;
+    color.get(m_vertices[m_nStars].color.data());
+    ++m_nStars;
 
     if (m_nStars == m_capacity)
     {

--- a/src/celengine/psfstarvertexbuffer.h
+++ b/src/celengine/psfstarvertexbuffer.h
@@ -11,11 +11,11 @@
 
 #include <array>
 #include <memory>
-#include <vector>
 
 #include <Eigen/Core>
 
 #include <celrender/gl/buffer.h>
+#include <celutil/classops.h>
 #include "starpipelineowner.h"
 
 class Color;
@@ -34,7 +34,7 @@ namespace celestia::render
 // Vertices carry per-star peak radiance (HDR float) and a linear, green-
 // normalised colour.  The shader is the same in both modes; a uniform
 // selects "point" (fixed pixel disc) or "glow" (PSF approximation).
-class PsfStarVertexBuffer : public StarPipelineFlushable
+class PsfStarVertexBuffer : public StarPipelineFlushable, private util::NoMove
 {
 public:
     using capacity_t = unsigned int;
@@ -48,10 +48,6 @@ public:
     PsfStarVertexBuffer(const Renderer &renderer, capacity_t capacity);
     ~PsfStarVertexBuffer() override = default;
     PsfStarVertexBuffer() = delete;
-    PsfStarVertexBuffer(const PsfStarVertexBuffer&) = delete;
-    PsfStarVertexBuffer(PsfStarVertexBuffer&&) = delete;
-    PsfStarVertexBuffer& operator=(const PsfStarVertexBuffer&) = delete;
-    PsfStarVertexBuffer& operator=(PsfStarVertexBuffer&&) = delete;
 
     void start(Mode mode);
     void render();
@@ -70,17 +66,17 @@ public:
 private:
     struct StarVertex
     {
-        Eigen::Vector3f            position;
-        float                      peakRadiance;
-        float                      limbRadius;   // resolved-body limb (px), 0 if none
-        float                      alpha;        // glow fade, full float precision
-        std::array<unsigned char, 4> color;      // rgb only; alpha byte unused
+        Eigen::Vector3f        position;
+        float                  peakRadiance;
+        float                  limbRadius;   // resolved-body limb (px), 0 if none
+        float                  alpha;        // glow fade, full float precision
+        std::array<GLubyte, 4> color;      // rgb only; alpha byte unused
     };
 
     const Renderer                 &m_renderer;
     capacity_t                      m_capacity;
     capacity_t                      m_nStars                { 0 };
-    std::vector<StarVertex>         m_vertices;
+    std::unique_ptr<StarVertex[]>   m_vertices; //NOSONAR
     Mode                            m_mode                  { Mode::Point };
     float                           m_pointRadius           { 1.5f };
     float                           m_optimization          { 0.1f };

--- a/src/celrender/gl/buffer.cpp
+++ b/src/celrender/gl/buffer.cpp
@@ -69,25 +69,35 @@ Buffer::unbind(Buffer::TargetHint target)
 Buffer&
 Buffer::setData(util::array_view<void> data, Buffer::BufferUsage usage)
 {
-    m_bufferSize = data.size();
+    setData(data.data(), static_cast<GLsizeiptr>(data.size()), usage);
+    return *this;
+}
+
+void
+Buffer::setData(const void* data, GLsizeiptr size, Buffer::BufferUsage usage) //NOSONAR
+{
+    m_bufferSize = size;
     m_usage = usage;
     Binder::get().bind(*this);
-    glBufferData(GLenum(m_targetHint), m_bufferSize, data.data(), GLenum(m_usage));
-    return *this;
+    glBufferData(static_cast<GLenum>(m_targetHint),
+                 size,
+                 data,
+                 static_cast<GLenum>(m_usage));
 }
 
 Buffer&
 Buffer::setSubData(GLintptr offset, util::array_view<void> data)
 {
     Binder::get().bind(*this);
-    glBufferSubData(GLenum(m_targetHint), offset, data.size(), data.data());
+    glBufferSubData(static_cast<GLenum>(m_targetHint), offset, data.size(), data.data());
     return *this;
 }
 
 Buffer&
 Buffer::invalidateData()
 {
-    return setData(util::array_view<void>(nullptr, m_bufferSize), m_usage);
+    setData(nullptr, m_bufferSize, m_usage);
+    return *this;
 }
 
 Buffer::SharedPtr
@@ -100,15 +110,24 @@ Buffer::create(TargetHint targetHint)
 
 Buffer::SharedPtr
 Buffer::create(TargetHint targetHint,
+               GLsizeiptr size,
+               BufferUsage usage)
+{
+    auto buffer = create(targetHint);
+    if (buffer)
+        buffer->setData(nullptr, size, usage);
+
+    return buffer;
+}
+
+Buffer::SharedPtr
+Buffer::create(TargetHint targetHint,
                util::array_view<void> data,
                BufferUsage usage)
 {
     auto buffer = create(targetHint);
     if (buffer)
-    {
-        Binder::get().bind(*buffer);
         buffer->setData(data, usage);
-    }
 
     return buffer;
 }

--- a/src/celrender/gl/buffer.h
+++ b/src/celrender/gl/buffer.h
@@ -114,6 +114,10 @@ public:
      */
     static SharedPtr create(TargetHint targetHint);
 
+    static SharedPtr create(TargetHint  targetHint,
+                            GLsizeiptr  size,
+                            BufferUsage usage);
+
     /**
      * @brief Construct a new Buffer object.
      *
@@ -136,6 +140,8 @@ private:
     void clear();
     //! Destroy underlying OpenGL resources
     void destroy() noexcept;
+
+    void setData(const void*, GLsizeiptr, BufferUsage);
 
     inline friend void
     intrusive_ptr_add_ref(Buffer* p)

--- a/src/celrender/largestarrenderer.cpp
+++ b/src/celrender/largestarrenderer.cpp
@@ -10,6 +10,7 @@
 #include "largestarrenderer.h"
 
 #include <array>
+#include <cassert>
 #include <cstddef>
 
 #include <celengine/glsupport.h>
@@ -49,7 +50,7 @@ LargeStarRenderer::LargeStarRenderer(Renderer    &renderer,
     m_renderer(renderer),
     m_shaderId(shaderId),
     m_capacity(capacity),
-    m_vertices(static_cast<std::size_t>(capacity))
+    m_instances(std::make_unique<StarInstance[]>(capacity))
 {
 }
 
@@ -70,9 +71,8 @@ LargeStarRenderer::render()
 
     makeCurrent();
 
-    m_bo->invalidateData().setData(
-        util::array_view(m_vertices.data(), static_cast<std::size_t>(m_nStars)),
-        gl::Buffer::BufferUsage::StreamDraw);
+    m_bo->invalidateData().setSubData(0, util::array_view(m_instances.get(),
+                                                          static_cast<std::size_t>(m_nStars)));
 
     m_vo->drawInstances(static_cast<GLsizei>(m_nStars));
     m_nStars = 0;
@@ -118,7 +118,9 @@ LargeStarRenderer::setupVertexArrayObject()
 
     auto vertexBuffer = gl::Buffer::create(gl::Buffer::TargetHint::Array, kQuadCorners);
 
-    m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array);
+    m_bo = gl::Buffer::create(gl::Buffer::TargetHint::Array,
+                              static_cast<GLsizeiptr>(sizeof(StarInstance) * m_capacity),
+                              gl::Buffer::BufferUsage::StreamDraw);
     m_vo = std::make_unique<gl::VertexObject>(gl::VertexObject::Primitive::TriangleStrip);
 
     m_vo->addVertexBuffer(
@@ -147,8 +149,8 @@ LargeStarRenderer::setupVertexArrayObject()
         3,
         gl::VertexObject::DataType::Float,
         false,
-        sizeof(StarVertex),
-        offsetof(StarVertex, center));
+        sizeof(StarInstance),
+        offsetof(StarInstance, center));
 
     // Color stays 4-component: this layout is shared with
     // LegacyLargeStarRenderer, whose shader reads in_Color.a.
@@ -158,8 +160,8 @@ LargeStarRenderer::setupVertexArrayObject()
         4,
         gl::VertexObject::DataType::UnsignedByte,
         true,
-        sizeof(StarVertex),
-        offsetof(StarVertex, color));
+        sizeof(StarInstance),
+        offsetof(StarInstance, color));
 
     m_vo->addInstanceBuffer(
         m_bo,
@@ -167,8 +169,8 @@ LargeStarRenderer::setupVertexArrayObject()
         1,
         gl::VertexObject::DataType::Float,
         false,
-        sizeof(StarVertex),
-        offsetof(StarVertex, scalar));
+        sizeof(StarInstance),
+        offsetof(StarInstance, scalar));
 
     // continuous distance-derived glow fade; float for a smooth transition
     // (unused by the legacy shader)
@@ -178,8 +180,8 @@ LargeStarRenderer::setupVertexArrayObject()
         1,
         gl::VertexObject::DataType::Float,
         false,
-        sizeof(StarVertex),
-        offsetof(StarVertex, alpha));
+        sizeof(StarInstance),
+        offsetof(StarInstance, alpha));
 
     m_vo->addInstanceBuffer(
         m_bo,
@@ -187,8 +189,8 @@ LargeStarRenderer::setupVertexArrayObject()
         1,
         gl::VertexObject::DataType::Float,
         false,
-        sizeof(StarVertex),
-        offsetof(StarVertex, limbRadius));
+        sizeof(StarInstance),
+        offsetof(StarInstance, limbRadius));
 }
 
 void
@@ -198,19 +200,17 @@ LargeStarRenderer::addStar(const Eigen::Vector3f &center,
                            float                  limbRadius,
                            float                  alpha)
 {
-    if (m_nStars < m_capacity)
-    {
-        std::array<unsigned char, 4> packedColor{};
-        color.get(packedColor.data());
+    assert(m_nStars < m_capacity);
+    std::array<unsigned char, 4> packedColor{};
+    color.get(packedColor.data());
 
-        StarVertex &out = m_vertices[static_cast<std::size_t>(m_nStars)];
-        out.center     = center;
-        out.scalar     = scalar;
-        out.limbRadius = limbRadius;
-        out.alpha      = alpha;
-        out.color      = packedColor;
-        ++m_nStars;
-    }
+    StarInstance &out = m_instances[static_cast<std::size_t>(m_nStars)];
+    out.center     = center;
+    out.scalar     = scalar;
+    out.limbRadius = limbRadius;
+    out.alpha      = alpha;
+    out.color      = packedColor;
+    ++m_nStars;
 
     if (m_nStars == m_capacity)
         render();

--- a/src/celrender/largestarrenderer.h
+++ b/src/celrender/largestarrenderer.h
@@ -11,11 +11,11 @@
 
 #include <array>
 #include <memory>
-#include <vector>
 
 #include <Eigen/Core>
 
 #include <celengine/starpipelineowner.h>
+#include <celutil/classops.h>
 #include "gl/buffer.h"
 
 class Color;
@@ -36,7 +36,7 @@ namespace celestia::render
 // Each star expands to a 4-vertex indexed quad, drawing the whole
 // frame's oversized stars in a single call.  Subclasses supply the
 // shader id and per-frame GL/shader configuration via onMakeCurrent().
-class LargeStarRenderer : public StarPipelineFlushable
+class LargeStarRenderer : public StarPipelineFlushable, private util::NoMove
 {
 public:
     using capacity_t = unsigned int;
@@ -44,10 +44,6 @@ public:
     ~LargeStarRenderer() override;
 
     LargeStarRenderer() = delete;
-    LargeStarRenderer(const LargeStarRenderer&) = delete;
-    LargeStarRenderer(LargeStarRenderer&&) = delete;
-    LargeStarRenderer& operator=(const LargeStarRenderer&) = delete;
-    LargeStarRenderer& operator=(LargeStarRenderer&&) = delete;
 
     void start();
     void render();
@@ -68,7 +64,7 @@ protected:
     virtual void onMakeCurrent(const Eigen::Vector2f &viewportRcp) = 0;
 
 private:
-    struct StarVertex
+    struct StarInstance
     {
         Eigen::Vector3f              center;
         float                        scalar;  // peak radiance or pixel size
@@ -84,7 +80,7 @@ private:
     StaticShader                      m_shaderId;
     capacity_t                        m_capacity;
     capacity_t                        m_nStars      { 0 };
-    std::vector<StarVertex>           m_vertices;
+    std::unique_ptr<StarInstance[]>   m_instances; //NOSONAR
 
     CelestiaGLProgram                *m_prog        { nullptr };
     gl::Buffer::SharedPtr             m_bo;

--- a/src/celttf/truetypefont.cpp
+++ b/src/celttf/truetypefont.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <system_error>
@@ -515,6 +516,7 @@ TextureFontPrivate::render(std::u16string_view line, float x, float y)
         if (g.bw > 0 && g.bh > 0)
         {
             // Only render characters if they have bitmaps
+            assert(m_instanceCount < MaxInstances);
             auto& instance = m_instances[m_instanceCount];
 
             // Make Sonar stop complaining about precision issues
@@ -550,7 +552,7 @@ TextureFontPrivate::flush()
     if (m_instanceCount == 0)
         return;
 
-    m_vbo->setSubData(0, util::array_view(m_instances.data(), m_instanceCount));
+    m_vbo->invalidateData().setSubData(0, util::array_view(m_instances.data(), m_instanceCount));
     m_vao.drawInstances(m_instanceCount);
     m_vbo->unbind();
 


### PR DESCRIPTION
For now, leaving the instances in atmosphererenderer, cometrenderer, linerenderer as the counts in those cases are less clear.