### PR TITLE
Fix distance filtering in star browser

### DIFF
--- a/src/celengine/starbrowser.cpp
+++ b/src/celengine/starbrowser.cpp
@@ -216,7 +216,7 @@ DistanceProcessor::process(const Star& star)
     }
 
     if (m_records->front().star != oldWorst)
-        m_maxDistance = std::sqrt(distance2);
+        m_maxDistance = std::sqrt(m_records->front().distance);
 }
 
 void


### PR DESCRIPTION
From Discord: why does GJ 1151 not appear in the star browser when the "with planets" option is checked?

Answer: incorrect worst distance value update