### PR TITLE
Avoid undefined behavior when copying LightingState

### DIFF
--- a/src/celengine/lightenv.h
+++ b/src/celengine/lightenv.h
@@ -12,51 +12,50 @@
 
 #pragma once
 
+#include <array>
+#include <vector>
+
 #include <celutil/color.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <vector>
 
-constexpr unsigned int MaxLights = 8;
+constexpr inline unsigned int MaxLights = 8;
 
 class Body;
 struct RingSystem;
 
-class DirectionalLight
+struct DirectionalLight
 {
-public:
     Color color;
-    float irradiance;
-    Eigen::Vector3f direction_eye;
-    Eigen::Vector3f direction_obj;
+    float irradiance{ 0.0f };
+    Eigen::Vector3f direction_eye{ Eigen::Vector3f::UnitZ() };
+    Eigen::Vector3f direction_obj{ Eigen::Vector3f::UnitZ() };
 
     // Required for eclipse shadows only--may be able to use
     // distance instead of position.
-    Eigen::Vector3d position;  // position relative to the lit object
-    float apparentSize;
-    bool castsShadows;
+    Eigen::Vector3d position{ Eigen::Vector3d::Zero() };  // position relative to the lit object
+    float apparentSize{ 0.0f };
+    bool castsShadows{ false };
 };
 
-class EclipseShadow
+struct EclipseShadow
 {
-public:
-    const Body* caster;
-    Eigen::Quaternionf casterOrientation;
-    Eigen::Vector3f origin;
-    Eigen::Vector3f direction;
-    float penumbraRadius;
-    float umbraRadius;
-    float maxDepth;
+    const Body* caster{ nullptr };
+    Eigen::Quaternionf casterOrientation{ Eigen::Quaternionf::Identity() };
+    Eigen::Vector3f origin{ Eigen::Vector3f::Zero() };
+    Eigen::Vector3f direction{ Eigen::Vector3f::UnitZ() };
+    float penumbraRadius{ 0.0f };
+    float umbraRadius{ 0.0f };
+    float maxDepth{ 0.0f };
 };
 
-class RingShadow
+struct RingShadow
 {
-public:
-    RingSystem* ringSystem;
-    Eigen::Quaternionf casterOrientation;
-    Eigen::Vector3f origin;
-    Eigen::Vector3f direction;
-    float texLod;
+    const RingSystem* ringSystem{ nullptr };
+    Eigen::Quaternionf casterOrientation{ Eigen::Quaternionf::Identity() };
+    Eigen::Vector3f origin{ Eigen::Vector3f::Zero() };
+    Eigen::Vector3f direction{ Eigen::Vector3f::UnitZ() };
+    float texLod{ 0.0f };
 };
 
 class LightingState
@@ -64,29 +63,21 @@ class LightingState
 public:
     using EclipseShadowVector = std::vector<EclipseShadow>;
 
-    LightingState() :
-        nLights(0),
-        shadowingRingSystem(nullptr),
-        eyeDir_obj(-Eigen::Vector3f::UnitZ()),
-        eyePos_obj(-Eigen::Vector3f::UnitZ())
+    LightingState()
     {
-        shadows[0] = nullptr;
-        for (auto &ringShadow : ringShadows)
-        {
-            ringShadow.ringSystem = nullptr;
-        }
+        shadows.fill(nullptr);
     };
 
-    unsigned int nLights;
-    DirectionalLight lights[MaxLights];
-    EclipseShadowVector* shadows[MaxLights];
-    RingShadow ringShadows[MaxLights];
-    RingSystem* shadowingRingSystem; // nullptr when there are no ring shadows
-    Eigen::Vector3f ringPlaneNormal;
-    Eigen::Vector3f ringCenter;
+    unsigned int nLights{ 0 };
+    std::array<DirectionalLight, MaxLights> lights;
+    std::array<EclipseShadowVector*, MaxLights> shadows;
+    std::array<RingShadow, MaxLights> ringShadows;
+    const RingSystem* shadowingRingSystem{ nullptr }; // nullptr when there are no ring shadows
+    Eigen::Vector3f ringPlaneNormal{ Eigen::Vector3f::UnitZ() };
+    Eigen::Vector3f ringCenter{ Eigen::Vector3f::Zero() };
 
-    Eigen::Vector3f eyeDir_obj;
-    Eigen::Vector3f eyePos_obj;
+    Eigen::Vector3f eyeDir_obj{ -Eigen::Vector3f::UnitZ() };
+    Eigen::Vector3f eyePos_obj{ -Eigen::Vector3f::UnitZ() };
 
-    Eigen::Vector3f ambientColor;
+    Eigen::Vector3f ambientColor{ Eigen::Vector3f::Zero() };
 };

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -84,6 +84,7 @@
 #include <cstring>
 #include <cassert>
 #include <cmath>
+#include <optional>
 #include <sstream>
 #include <iomanip>
 #include <numeric>
@@ -2292,8 +2293,8 @@ setupObjectLighting(const vector<LightSource>& suns,
     }
     else if (nLights > 2)
     {
-        sort(ls.lights, ls.lights + nLights,
-             [](const auto &l0, const auto &l1) { return l0.irradiance > l1.irradiance; });
+        std::sort(ls.lights.begin(), ls.lights.begin() + nLights,
+                  [](const auto &l0, const auto &l1) { return l0.irradiance > l1.irradiance; });
     }
 
     // Compute the total irradiance
@@ -2760,7 +2761,8 @@ void Renderer::renderPlanetAtmosphere(Body& body,
     float discSizeInPixels = radius / (max(nearPlaneDistance, altitude) * pixelSize);
 
     RenderProperties rp;
-    LightingState ls;
+    // Use optional to avoid unnecessary initialization if we load from the cache
+    std::optional<LightingState> lsOpt;
     Quaterniond q;
     // Reuse the surface pass's lighting if it ran this frame; otherwise compute
     // it (the body disc may have been too small for renderPlanet to draw, e.g.
@@ -2768,13 +2770,16 @@ void Renderer::renderPlanetAtmosphere(Body& body,
     if (auto it = planetLightingCache.find(&body); it != planetLightingCache.end())
     {
         rp = it->second.rp;
-        ls = it->second.lights;
+        lsOpt = it->second.lights;
         q = it->second.q;
     }
     else
     {
-        setupPlanetLighting(body, pos, now, nearPlaneDistance, altitude, rp, ls, q);
+        setupPlanetLighting(body, pos, now, nearPlaneDistance, altitude, rp, lsOpt.emplace(), q);
     }
+
+    // At this point we know the optional is initialized, so the following is safe
+    LightingState& ls = *lsOpt;
 
     RenderInfo ri;
     ri.sunDir_eye = Vector3f::UnitY();
@@ -3181,7 +3186,7 @@ void Renderer::setupPlanetLighting(Body& body, // NOSONAR(cpp:S107,cpp:S3776)
         // that exotic cases with shadows from two ring different ring systems aren't handled.
         for (unsigned int li = 0; li < lights.nLights; li++)
         {
-            RingSystem* rings = lights.ringShadows[li].ringSystem;
+            const RingSystem* rings = lights.ringShadows[li].ringSystem;
             if (!rings)
                 continue;
 

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -3239,7 +3239,7 @@ CelestiaGLProgram::setEclipseShadowParameters(const LightingState& ls,
 
             for (unsigned int i = 0; i < nShadows; i++)
             {
-                EclipseShadow& shadow = ls.shadows[li]->at(i);
+                const EclipseShadow& shadow = (*ls.shadows[li])[i];
                 CelestiaGLProgramShadow& shadowParams = shadows[li][i];
 
                 // Compute shadow parameters: max depth of at the center of the shadow


### PR DESCRIPTION
Noticed when trying to debug the code and running into UB sanitization failure when the `LightingState` gets copied to the cache results in the `bool` getting assigned an out-of-range value.

Copying uninitialized values when transferring `LightingState` to/from the cache triggers undefined behavior. As a workaround, ensure that all fields are initialized when the `LightingState` is constructed. Use `std::optional` to avoid unnecessary initialization when loading from the cache.