### PR TITLE
Re-order parameters of lerp to be consistent with C++20

### DIFF
--- a/src/celengine/observer.cpp
+++ b/src/celengine/observer.cpp
@@ -58,7 +58,7 @@ slerp(double t, const Eigen::Vector3d& v0, const Eigen::Vector3d& v1)
     double cThetaT;
     math::sincos(theta * t, sThetaT, cThetaT);
 
-    return (cThetaT * u + sThetaT * v) * math::lerp(t, r0, r1);
+    return (cThetaT * u + sThetaT * v) * math::lerp(r0, r1, t);
 }
 
 std::optional<Eigen::Vector3d>

--- a/src/celengine/warpmesh.cpp
+++ b/src/celengine/warpmesh.cpp
@@ -149,8 +149,8 @@ normalizeUV(float& u, float& v)
 inline void
 interpolateUV(float f, const WarpMesh::WarpVertex* a, const WarpMesh::WarpVertex* b, float& u, float& v)
 {
-    u = math::lerp(f, a->u, b->u);
-    v = math::lerp(f, a->v, b->v);
+    u = math::lerp(a->u, b->u, f);
+    v = math::lerp(a->v, b->v, f);
     normalizeUV(u, v);
 }
 

--- a/src/celephem/samporbit.cpp
+++ b/src/celephem/samporbit.cpp
@@ -216,9 +216,9 @@ SampledOrbit<T>::computePositionLinear(double jd, std::uint32_t n) const
 
     const Eigen::Matrix<T, 3, 1>& s0 = positions[n - 1];
     const Eigen::Matrix<T, 3, 1>& s1 = positions[n];
-    return Eigen::Vector3d(math::lerp(t, static_cast<double>(s0.x()), static_cast<double>(s1.x())),
-                           math::lerp(t, static_cast<double>(s0.y()), static_cast<double>(s1.y())),
-                           math::lerp(t, static_cast<double>(s0.z()), static_cast<double>(s1.z())));
+    return Eigen::Vector3d(math::lerp(static_cast<double>(s0.x()), static_cast<double>(s1.x()), t),
+                           math::lerp(static_cast<double>(s0.y()), static_cast<double>(s1.y()), t),
+                           math::lerp(static_cast<double>(s0.z()), static_cast<double>(s1.z()), t));
 }
 
 template<typename T>

--- a/src/celmath/mathlib.h
+++ b/src/celmath/mathlib.h
@@ -55,7 +55,7 @@ template<> inline void sincos(double angle, double& s, double& c)
 #endif
 
 #if __cplusplus < 202002L
-template<typename T> constexpr T lerp(T t, T a, T b)
+template<typename T> constexpr T lerp(T a, T b, T t)
 {
     return a + t * (b - a);
 }

--- a/src/celmath/randutils.cpp
+++ b/src/celmath/randutils.cpp
@@ -98,7 +98,7 @@ float noise(float arg)
     float dx1 = dx0 - 1.0f;
     float g0 = perlinData.gradientAt(x0);
     float g1 = perlinData.gradientAt(x1);
-    return lerp(smooth(dx0), dx0 * g0, dx1 * g1);
+    return lerp(dx0 * g0, dx1 * g1, smooth(dx0));
 }
 
 float noise(const Eigen::Vector2f& arg)
@@ -120,9 +120,9 @@ float noise(const Eigen::Vector2f& arg)
     Eigen::Vector2f v01{dx0[0], dx1[1]};
     Eigen::Vector2f v11{dx1[0], dx1[1]};
     float t[2] {smooth(dx0[0]), smooth(dx0[1])};
-    float nx[2] {lerp(t[0], g00.dot(v00), g10.dot(v10)),
-                 lerp(t[0], g01.dot(v01), g11.dot(v11))};
-    return lerp(t[1], nx[0], nx[1]);
+    float nx[2] {lerp(g00.dot(v00), g10.dot(v10), t[0]),
+                 lerp(g01.dot(v01), g11.dot(v11), t[0])};
+    return lerp(nx[0], nx[1], t[1]);
 }
 
 float noise(const Eigen::Vector3f& arg)
@@ -155,13 +155,13 @@ float noise(const Eigen::Vector3f& arg)
     Eigen::Vector3f v011{dx0[0], dx1[1], dx1[2]};
     Eigen::Vector3f v111{dx1[0], dx1[1], dx1[2]};
     float t[3] {smooth(dx0[0]), smooth(dx0[1]), smooth(dx0[2])};
-    float nx[4] {lerp(t[0], g000.dot(v000), g100.dot(v100)),
-                 lerp(t[0], g010.dot(v010), g110.dot(v110)),
-                 lerp(t[0], g001.dot(v001), g101.dot(v101)),
-                 lerp(t[0], g011.dot(v011), g111.dot(v111))};
-    float ny[2] {lerp(t[1], nx[0], nx[1]),
-                 lerp(t[1], nx[2], nx[3])};
-    return lerp(t[2], ny[0], ny[1]);
+    float nx[4] {lerp(g000.dot(v000), g100.dot(v100), t[0]),
+                 lerp(g010.dot(v010), g110.dot(v110), t[0]),
+                 lerp(g001.dot(v001), g101.dot(v101), t[0]),
+                 lerp(g011.dot(v011), g111.dot(v111), t[0])};
+    float ny[2] {lerp(nx[0], nx[1], t[1]),
+                 lerp(nx[2], nx[3], t[1])};
+    return lerp(ny[0], ny[1], t[2]);
 }
 
 float turbulence(const Eigen::Vector2f& p, float freq)

--- a/src/celrender/atmosphererenderer.cpp
+++ b/src/celrender/atmosphererenderer.cpp
@@ -246,7 +246,7 @@ AtmosphereRenderer::computeLegacy(
         float hh = std::sqrt(h);
         float u = i <= nHorizonRings ? 0.0f :
             static_cast<float>(i - nHorizonRings) / static_cast<float>(nRings - nHorizonRings);
-        float r = math::lerp(h, 1.0f - (horizonHeight * 0.05f), 1.0f + horizonHeight);
+        float r = math::lerp(1.0f - (horizonHeight * 0.05f), 1.0f + horizonHeight, h);
 
         for (int j = 0; j < nSlices; j++)
         {


### PR DESCRIPTION
C++20 [`std::lerp`](https://en.cppreference.com/cpp/numeric/lerp) puts `t` as the last parameter instead of the first.

Issue detected during experimental C++20 testing in #2686