### PR TITLE
Fix PSF rendering bounds, transitions, and batch state

### DIFF
--- a/shaders/largestar_vert.glsl
+++ b/shaders/largestar_vert.glsl
@@ -3,7 +3,7 @@
 // Six vertices per star; per-star fields are replicated.
 
 layout(location = 0) in vec2  in_Position;   // quad corner in [-1, 1]
-layout(location = 1) in vec3  in_Normal;     // star world position
+layout(location = 15) in vec3 in_Center;    // star world position
 layout(location = 2) in vec2  in_TexCoord0;  // quad UV in [0, 1]
 layout(location = 8) in vec4  in_Color;
 layout(location = 9) in float in_Intensity;  // size in physical pixels (full diameter)
@@ -18,7 +18,7 @@ void main(void)
     texCoord = in_TexCoord0;
     v_color  = in_Color;
 
-    set_vp(vec4(in_Normal, 1.0));
+    set_vp(vec4(in_Center, 1.0));
 
     vec2 extent = in_Intensity * viewportRcp;
     gl_Position.xy += in_Position * extent * gl_Position.w;

--- a/shaders/psfstarglowlarge_vert.glsl
+++ b/shaders/psfstarglowlarge_vert.glsl
@@ -14,7 +14,7 @@
 // per-star fields are replicated so the whole frame's glows draw at once.
 
 layout(location = 0) in vec2  in_Position;    // quad corner in [-1, 1]
-layout(location = 1) in vec3  in_Normal;      // star world position
+layout(location = 15) in vec3 in_Center;     // star world position
 layout(location = 2) in vec2  in_TexCoord0;   // quad UV in [0, 1]
 layout(location = 8) in vec3  in_Color;       // linear RGB
 layout(location = 9) in float in_Intensity;   // peak radiance
@@ -75,7 +75,7 @@ void main(void)
     v_valLimb   = valLimb;
     v_alphaFade = pow(v_alpha, fadeExp);
 
-    set_vp(vec4(in_Normal, 1.0));
+    set_vp(vec4(in_Center, 1.0));
 
     float sizePhys = 2.0 * rEff * psfPointScale;
     vec2  extent   = sizePhys * psfViewportRcp;

--- a/shaders/psfstarpoint_frag.glsl
+++ b/shaders/psfstarpoint_frag.glsl
@@ -19,10 +19,18 @@ in vec3  v_color;
 in float v_peakRadiance;
 in float v_pointSize;
 
+#ifdef BILLBOARD
+in vec2 v_uv;
+#endif
+
 void main(void)
 {
     // Pixel offset from the centre of the point sprite (in screen pixels).
+#ifdef BILLBOARD
+    vec2  d  = (v_uv - vec2(0.5)) * v_pointSize;
+#else
     vec2  d  = (gl_PointCoord.xy - vec2(0.5)) * v_pointSize;
+#endif
     float px = length(d) / pointScale;
 
     float falloff = clamp(1.0 - px / pointRadius, 0.0, 1.0);

--- a/shaders/psfstarpoint_vert.glsl
+++ b/shaders/psfstarpoint_vert.glsl
@@ -11,7 +11,15 @@
 
 // Point Spread Function (PSF) star renderer - point (cone) pass.
 
+#ifdef BILLBOARD
+layout(location = 0) in vec2 in_Position;
+layout(location = 15) in vec3 in_Center;
+layout(location = 2) in vec2 in_TexCoord0;
+uniform vec2 viewportRcp;
+out vec2 v_uv;
+#else
 layout(location = 0) in vec4 in_Position;
+#endif
 layout(location = 8) in vec3 in_Color;        // green-normalised, linear-space, 8-bit per channel
 layout(location = 9) in float in_Intensity;   // peakRadiance = exposure * 3 * irradiance / (pi * pointRadius^2)
 
@@ -29,6 +37,12 @@ void main(void)
 
     float size = 2.0 * pointRadius * pointScale;
     v_pointSize = size;
+#ifdef BILLBOARD
+    v_uv = in_TexCoord0;
+    set_vp(vec4(in_Center, 1.0));
+    gl_Position.xy += in_Position * size * viewportRcp * gl_Position.w;
+#else
     gl_PointSize = size;
     set_vp(in_Position);
+#endif
 }

--- a/src/celengine/pointstarrenderer.cpp
+++ b/src/celengine/pointstarrenderer.cpp
@@ -36,6 +36,17 @@ namespace render = celestia::render;
 using render::PsfStarVertexBuffer;
 using render::psfGreenNormalization;
 
+namespace
+{
+
+float smoothStep(float t)
+{
+    t = std::clamp(t, 0.0f, 1.0f);
+    return t * t * (3.0f - 2.0f * t);
+}
+
+} // namespace
+
 float
 celestia::engine::detail::psfAtmosphereBrightness(
     float faintestMagnitude,
@@ -44,6 +55,28 @@ celestia::engine::detail::psfAtmosphereBrightness(
     return std::min(1.0f,
                     astro::magToIrradiance(faintestMagnitudeWithoutAtmosphere
                                            - faintestMagnitude));
+}
+
+float
+celestia::engine::detail::psfGlowOnset(float peakRadiance)
+{
+    return smoothStep(peakRadiance - 1.0f);
+}
+
+float
+celestia::engine::detail::psfReflectiveGlowOnset(float glowPeak, float linkedGlowPeak)
+{
+    return linkedGlowPeak > 0.0f ? psfGlowOnset(glowPeak / linkedGlowPeak) : 1.0f;
+}
+
+float
+celestia::engine::detail::psfPointFade(float discRadiusPixels,
+                                     float pointRadius,
+                                     float pointScale)
+{
+    // Keep at least one pixel of transition even for the smallest cones.
+    float fadeEnd = std::max(2.0f, pointRadius * pointScale);
+    return smoothStep((fadeEnd - discRadiusPixels) / (fadeEnd - 1.0f));
 }
 
 // Convert a position in the universal coordinate system to astrocentric
@@ -159,6 +192,8 @@ void PointStarRenderer::process(const Star& star, float distance, float appMag)
                 // Glow (eye-PSF) contribution, additive on top of the point cone
                 if (peakRadCol > 1.0f && psf.optimization > 0.0f)
                 {
+                    float alpha = celestia::engine::detail::psfGlowOnset(peakRadCol);
+
                     // Soft-clip very bright stars so the eye-PSF radius
                     // stays bounded.  Without this, a single bright star
                     // (or a high faintest-magnitude setting) produces a
@@ -174,11 +209,11 @@ void PointStarRenderer::process(const Star& star, float distance, float appMag)
                     // everything smaller stays on the point-sprite path.
                     if (glowPeak > psf.glowPeakLargeThreshold)
                     {
-                        psf.glowLargeRenderer->addStar(relPos, linearStarColor, glowPeak);
+                        psf.glowLargeRenderer->addStar(relPos, linearStarColor, glowPeak, 0.0f, alpha);
                     }
                     else
                     {
-                        psf.glowBuffer->addStar(relPos, linearStarColor, glowPeak);
+                        psf.glowBuffer->addStar(relPos, linearStarColor, glowPeak, 0.0f, alpha);
                     }
                 }
             }

--- a/src/celengine/pointstarrenderer.h
+++ b/src/celengine/pointstarrenderer.h
@@ -41,6 +41,15 @@ namespace celestia::engine::detail
 float psfAtmosphereBrightness(float faintestMagnitude,
                               float faintestMagnitudeWithoutAtmosphere);
 
+// Fade glow in over peak radiance [1, 2], before the glow's soft-clip.
+float psfGlowOnset(float peakRadiance);
+
+// Fade reflective glow over [1, 2] times the peak needed to reach the limb.
+float psfReflectiveGlowOnset(float glowPeak, float linkedGlowPeak);
+
+// Fade the cone after the mesh resolves, using physical pixels for the disc radius.
+float psfPointFade(float discRadiusPixels, float pointRadius, float pointScale);
+
 } // namespace celestia::engine::detail
 
 class PointStarRenderer : public ObjectRenderer<Star, float>

--- a/src/celengine/pointstarvertexbuffer.cpp
+++ b/src/celengine/pointstarvertexbuffer.cpp
@@ -46,7 +46,7 @@ void PointStarVertexBuffer::startBasicPoints()
 
 void PointStarVertexBuffer::render()
 {
-    if (m_nStars == 0)
+    if (m_nStars == 0 || m_prog == nullptr)
         return;
 
     makeCurrent();
@@ -56,17 +56,23 @@ void PointStarVertexBuffer::render()
 
     m_bo->invalidateData().setSubData(0, util::array_view(m_vertices.get(), m_nStars));
 
+#ifndef GL_ES
+    glEnable(GL_PROGRAM_POINT_SIZE);
+#endif
     if (m_pointSizeFromVertex)
         m_vo1->draw(m_nStars);
     else
         m_vo2->draw(m_nStars);
+#ifndef GL_ES
+    glDisable(GL_PROGRAM_POINT_SIZE);
+#endif
     m_nStars = 0;
 }
 
 void PointStarVertexBuffer::makeCurrent()
 {
     auto &owner = m_renderer.starPipelineOwner();
-    if (owner.isActive(this) || m_prog == nullptr)
+    if (m_prog == nullptr)
         return;
 
     owner.setActive(this);  // flushes whoever held the pipeline before
@@ -149,20 +155,6 @@ void PointStarVertexBuffer::finish()
 {
     render();
     m_renderer.starPipelineOwner().clearIfActive(this);
-}
-
-void PointStarVertexBuffer::enable()
-{
-#ifndef GL_ES
-    glEnable(GL_PROGRAM_POINT_SIZE);
-#endif
-}
-
-void PointStarVertexBuffer::disable()
-{
-#ifndef GL_ES
-    glDisable(GL_PROGRAM_POINT_SIZE);
-#endif
 }
 
 void PointStarVertexBuffer::setTexture(Texture *texture)

--- a/src/celengine/pointstarvertexbuffer.h
+++ b/src/celengine/pointstarvertexbuffer.h
@@ -47,9 +47,6 @@ public:
     void setTexture(Texture* texture);
     void setPointScale(float);
 
-    static void enable();
-    static void disable();
-
 private:
     struct StarVertex
     {

--- a/src/celengine/psfstarvertexbuffer.cpp
+++ b/src/celengine/psfstarvertexbuffer.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 
 #include <celrender/gl/vertexobject.h>
+#include <celrender/psfpointlargerenderer.h>
 #include <celastro/astro.h>
 #include <celcompat/numbers.h>
 #include <celutil/color.h>
@@ -70,10 +71,24 @@ PsfStarVertexBuffer::PsfStarVertexBuffer(const Renderer &renderer,
 {
 }
 
+PsfStarVertexBuffer::~PsfStarVertexBuffer() = default;
+
 void
 PsfStarVertexBuffer::start(Mode mode)
 {
     m_mode = mode;
+    m_useLargePoints = mode == Mode::Point
+                      && 2.0f * m_pointRadius * m_pointScale > static_cast<float>(gl::maxPointSize);
+    if (m_useLargePoints)
+    {
+        if (m_largePointRenderer == nullptr)
+            m_largePointRenderer = std::make_unique<PsfPointLargeRenderer>(m_renderer, m_capacity);
+        m_largePointRenderer->setPointRadius(m_pointRadius);
+        m_largePointRenderer->setPointScale(m_pointScale);
+        m_largePointRenderer->start();
+        return;
+    }
+
     StaticShader id = (mode == Mode::Point) ? StaticShader::PsfStarPoint
                                             : StaticShader::PsfStarGlow;
     m_prog = m_renderer.getShaderManager().getShader(id);
@@ -82,6 +97,12 @@ PsfStarVertexBuffer::start(Mode mode)
 void
 PsfStarVertexBuffer::render()
 {
+    if (m_useLargePoints)
+    {
+        m_largePointRenderer->render();
+        return;
+    }
+
     if (m_nStars == 0 || m_prog == nullptr)
         return;
 
@@ -89,7 +110,14 @@ PsfStarVertexBuffer::render()
 
     m_bo->invalidateData().setSubData(0, util::array_view(m_vertices.get(), m_nStars));
 
+#ifndef GL_ES
+    // makeCurrent() may flush another buffer, so enable only after it returns.
+    glEnable(GL_PROGRAM_POINT_SIZE);
+#endif
     m_vo->draw(m_nStars);
+#ifndef GL_ES
+    glDisable(GL_PROGRAM_POINT_SIZE);
+#endif
     m_nStars = 0;
 }
 
@@ -97,7 +125,7 @@ void
 PsfStarVertexBuffer::makeCurrent()
 {
     auto &owner = m_renderer.starPipelineOwner();
-    if (owner.isActive(this) || m_prog == nullptr)
+    if (m_prog == nullptr)
         return;
 
     owner.setActive(this);  // flushes whoever held the pipeline before
@@ -186,24 +214,14 @@ PsfStarVertexBuffer::setupVertexArrayObject()
 void
 PsfStarVertexBuffer::finish()
 {
+    if (m_useLargePoints)
+    {
+        m_largePointRenderer->finish();
+        return;
+    }
+
     render();
     m_renderer.starPipelineOwner().clearIfActive(this);
-}
-
-void
-PsfStarVertexBuffer::enable()
-{
-#ifndef GL_ES
-    glEnable(GL_PROGRAM_POINT_SIZE);
-#endif
-}
-
-void
-PsfStarVertexBuffer::disable()
-{
-#ifndef GL_ES
-    glDisable(GL_PROGRAM_POINT_SIZE);
-#endif
 }
 
 void
@@ -213,6 +231,12 @@ PsfStarVertexBuffer::addStar(const Eigen::Vector3f &pos,
                              float limbRadius,
                              float alpha)
 {
+    if (m_useLargePoints)
+    {
+        m_largePointRenderer->addStar(pos, color, peakRadiance);
+        return;
+    }
+
     assert(m_nStars < m_capacity);
     m_vertices[m_nStars].position = pos;
     m_vertices[m_nStars].peakRadiance = peakRadiance;

--- a/src/celengine/psfstarvertexbuffer.h
+++ b/src/celengine/psfstarvertexbuffer.h
@@ -30,10 +30,12 @@ class VertexObject;
 namespace celestia::render
 {
 
+class PsfPointLargeRenderer;
+
 // Vertex buffer used by StarStyle::PointSpreadFunction.
 // Vertices carry per-star peak radiance (HDR float) and a linear, green-
-// normalised colour.  The shader is the same in both modes; a uniform
-// selects "point" (fixed pixel disc) or "glow" (PSF approximation).
+// normalised colour.  Oversized center cones use an instanced billboard
+// fallback selected by start() from the configured radius and DPI scale.
 class PsfStarVertexBuffer : public StarPipelineFlushable, private util::NoMove
 {
 public:
@@ -46,7 +48,7 @@ public:
     };
 
     PsfStarVertexBuffer(const Renderer &renderer, capacity_t capacity);
-    ~PsfStarVertexBuffer() override = default;
+    ~PsfStarVertexBuffer() override;
     PsfStarVertexBuffer() = delete;
 
     void start(Mode mode);
@@ -59,9 +61,6 @@ public:
     void setPointRadius(float r)      { m_pointRadius = r; }
     void setOptimization(float opt)   { m_optimization = opt; }
     void setPointScale(float scale)   { m_pointScale = scale; }
-
-    static void enable();
-    static void disable();
 
 private:
     struct StarVertex
@@ -82,6 +81,8 @@ private:
     float                           m_optimization          { 0.1f };
     float                           m_pointScale            { 1.0f };
     CelestiaGLProgram              *m_prog                  { nullptr };
+    std::unique_ptr<PsfPointLargeRenderer> m_largePointRenderer;
+    bool m_useLargePoints{ false };
 
     celestia::gl::Buffer::SharedPtr             m_bo;
     std::unique_ptr<celestia::gl::VertexObject> m_vo;

--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -137,6 +137,9 @@ static constexpr unsigned int OrbitCacheCullThreshold = 200;
 // Age in frames at which unused orbit paths may be eliminated from the cache
 static constexpr std::uint32_t OrbitCacheRetireAge = 16;
 
+static constexpr unsigned int StarBufferCapacity = 2048;
+static constexpr unsigned int LegacyLargeStarCapacity = 512;
+
 
 // Some useful unit conversions
 inline float mmToInches(float mm)
@@ -212,10 +215,10 @@ Renderer::Renderer() :
 #ifndef GL_ES
     renderMode(GL_FILL),
 #endif
-    pointStarVertexBuffer(std::make_unique<PointStarVertexBuffer>(*this, 2048)),
-    glareVertexBuffer(std::make_unique<PointStarVertexBuffer>(*this, 2048)),
-    psfPointBuffer(std::make_unique<PsfStarVertexBuffer>(*this, 2048)),
-    psfGlowBuffer(std::make_unique<PsfStarVertexBuffer>(*this, 2048)),
+    pointStarVertexBuffer(std::make_unique<PointStarVertexBuffer>(*this, StarBufferCapacity)),
+    glareVertexBuffer(std::make_unique<PointStarVertexBuffer>(*this, StarBufferCapacity)),
+    psfPointBuffer(std::make_unique<PsfStarVertexBuffer>(*this, StarBufferCapacity)),
+    psfGlowBuffer(std::make_unique<PsfStarVertexBuffer>(*this, StarBufferCapacity)),
     m_starPipelineOwner(std::make_unique<celestia::render::StarPipelineOwner>()),
     curvePlotVertexBuffer(std::make_unique<CurvePlotVertexBuffer>(*this)),
     m_atmosphereRenderer(std::make_unique<AtmosphereRenderer>(*this)),
@@ -223,9 +226,9 @@ Renderer::Renderer() :
     m_eclipticLineRenderer(std::make_unique<EclipticLineRenderer>(*this)),
     m_galaxyRenderer(std::make_unique<GalaxyRenderer>(*this)),
     m_globularRenderer(std::make_unique<GlobularRenderer>(*this)),
-    m_legacyLargeStarRenderer(std::make_unique<LegacyLargeStarRenderer>(*this)),
-    m_legacyLargeGlareRenderer(std::make_unique<LegacyLargeStarRenderer>(*this)),
-    m_psfGlowLargeRenderer(std::make_unique<PsfGlowLargeRenderer>(*this)),
+    m_legacyLargeStarRenderer(std::make_unique<LegacyLargeStarRenderer>(*this, LegacyLargeStarCapacity)),
+    m_legacyLargeGlareRenderer(std::make_unique<LegacyLargeStarRenderer>(*this, LegacyLargeStarCapacity)),
+    m_psfGlowLargeRenderer(std::make_unique<PsfGlowLargeRenderer>(*this, StarBufferCapacity)),
     m_hollowMarkerRenderer(std::make_unique<LineRenderer>(*this, 1.0f, LineRenderer::PrimType::Lines, LineRenderer::StorageType::Static)),
     m_nebulaRenderer(std::make_unique<NebulaRenderer>(*this)),
     m_openClusterRenderer(std::make_unique<OpenClusterRenderer>(*this)),
@@ -1583,6 +1586,10 @@ void Renderer::render(const Observer& observer,
         renderDeepSkyObjects(universe, observer, faintestMag);
     }
 
+    // Planets also use PSF buffers, even when stars are hidden.
+    if (starStyle == StarStyle::PointSpreadFunction)
+        preparePsfStarBuffers();
+
     // Render stars
     if (util::is_set(renderFlags, RenderFlags::ShowStars) && universe.getStarCatalog() != nullptr)
     {
@@ -1730,14 +1737,8 @@ void Renderer::renderObjectAsPoint(const PointObjectInfo& info,
 {
     const Vector3f& position = info.position;
     float radius = info.radius;
-    // In PSF mode, route through the PSF path when the body is a
-    // genuine light source (stars), or when it's still unresolved
-    // (any body — the point representation works regardless of
-    // whether it emits).  A resolved reflective body is excluded
-    // because the PSF's radial falloff inevitably paints a bright
-    // saturated core inside the mesh and a dim tail extending many
-    // disc radii past the limb, both of which are visible artifacts
-    // on a planet whose true visual is just the sharp-edged disc.
+    // Stars and reflective bodies share the PSF point-to-disc transition.
+    // The PSF path separately controls whether a resolved body gets a glow.
     if (starStyle == StarStyle::PointSpreadFunction)
     {
         float pointScale = static_cast<float>(screenDpi) / 96.0f;
@@ -1875,10 +1876,10 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
 
     Eigen::Vector3f frontPos = calculateQuadCenter(getCameraOrientationf(), position, radius);
 
-    // Suppress the cone-cap sprite once the body is resolved as a
-    // mesh; the linked glow below handles the bloom around the disc.
-    if (discSizeInPixels <= 1.0f)
-        psfPointBuffer->addStar(frontPos, linearStarColor, peakRadCol);
+    // Fade the cone as the mesh takes over, without changing the glow's peak.
+    if (float pointFade = celestia::engine::detail::psfPointFade(discSizeInPixels, r, pointScale);
+        pointFade > 0.0f)
+        psfPointBuffer->addStar(frontPos, linearStarColor, peakRadCol * pointFade);
 
     // Gate on the irradiance-based peak so the linked term only
     // enhances an already-firing glow, never starts one (keeps
@@ -1913,12 +1914,6 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
             glowPeak = (1.0f - 1.0f / (peakRadCol / starMaxIrradiance + 1.0f))
                        * starMaxIrradiance;
         }
-        // Always render the glow in front of the body (calculateQuadCenter
-        // puts it on the near-side tangent plane).  Skip entirely for
-        // resolved reflective bodies that aren't bright enough to overflow.
-        if (glowPeak <= linkedGlowPeak && !emissive)
-            return;
-
         Vector3f glowPos = frontPos;
         // Size tracks whichever peak is larger: glowPeak in the far/overflow
         // regime, linkedGlowPeak once the disc resolves so the sprite keeps
@@ -1930,6 +1925,9 @@ void Renderer::addStarAsPsfPoint(const PointObjectInfo &info,
         // continuous distance-derived value, so pass it as a float to keep
         // the transition smooth.
         float alpha = computePsfGlowAlpha(distance, radius, fadeLinkedGlowPeak, glowPeak);
+        alpha *= celestia::engine::detail::psfGlowOnset(peakRadCol);
+        if (!emissive)
+            alpha *= celestia::engine::detail::psfReflectiveGlowOnset(glowPeak, linkedGlowPeak);
         if (alpha <= 0.0f)
             return;
 
@@ -4356,6 +4354,26 @@ static float calcMaxFOV(float fovY_degrees, float aspectRatio)
 }
 
 
+void Renderer::preparePsfStarBuffers()
+{
+    float scale = static_cast<float>(screenDpi) / 96.0f;
+
+    psfPointBuffer->setPointScale(scale);
+    psfPointBuffer->setPointRadius(starPointRadius);
+    psfPointBuffer->setOptimization(starOptimization);
+    psfGlowBuffer->setPointScale(scale);
+    psfGlowBuffer->setPointRadius(starPointRadius);
+    psfGlowBuffer->setOptimization(starOptimization);
+    m_psfGlowLargeRenderer->setPointScale(scale);
+    m_psfGlowLargeRenderer->setPointRadius(starPointRadius);
+    m_psfGlowLargeRenderer->setOptimization(starOptimization);
+
+    psfPointBuffer->start(PsfStarVertexBuffer::Mode::Point);
+    psfGlowBuffer->start(PsfStarVertexBuffer::Mode::Glow);
+    m_psfGlowLargeRenderer->start();
+}
+
+
 void Renderer::renderPointStars(const StarDatabase& starDB,
                                 float faintestMagNight,
                                 const Observer& observer)
@@ -4423,21 +4441,6 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
 
     if (starStyle == StarStyle::PointSpreadFunction)
     {
-        starRenderer.psf.pointBuffer->setPointScale(scale);
-        starRenderer.psf.pointBuffer->setPointRadius(starPointRadius);
-        starRenderer.psf.pointBuffer->setOptimization(starOptimization);
-        starRenderer.psf.glowBuffer->setPointScale(scale);
-        starRenderer.psf.glowBuffer->setPointRadius(starPointRadius);
-        starRenderer.psf.glowBuffer->setOptimization(starOptimization);
-        m_psfGlowLargeRenderer->setPointScale(scale);
-        m_psfGlowLargeRenderer->setPointRadius(starPointRadius);
-        m_psfGlowLargeRenderer->setOptimization(starOptimization);
-
-        PsfStarVertexBuffer::enable();
-        starRenderer.psf.pointBuffer->start(PsfStarVertexBuffer::Mode::Point);
-        starRenderer.psf.glowBuffer->start(PsfStarVertexBuffer::Mode::Glow);
-        m_psfGlowLargeRenderer->start();
-
         ps.blendFunc = {GL_ONE, GL_ONE};
 
         // Precompute per-frame PSF constants once instead of recomputing
@@ -4475,7 +4478,6 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
     }
     else
     {
-        PointStarVertexBuffer::enable();
         starRenderer.glareVertexBuffer->startSprites();
         if (starStyle == StarStyle::PointStars)
             starRenderer.starVertexBuffer->startBasicPoints();
@@ -4499,13 +4501,11 @@ void Renderer::renderPointStars(const StarDatabase& starDB,
         starRenderer.psf.pointBuffer->finish();
         starRenderer.psf.glowBuffer->finish();
         m_psfGlowLargeRenderer->finish();
-        PsfStarVertexBuffer::disable();
     }
     else
     {
         starRenderer.starVertexBuffer->finish();
         starRenderer.glareVertexBuffer->finish();
-        PointStarVertexBuffer::disable();
     }
 
 #ifndef GL_ES
@@ -4989,7 +4989,13 @@ float Renderer::getStarPointRadius() const
 
 void Renderer::setStarOptimization(float opt)
 {
-    starOptimization = std::clamp(opt, 0.0f, 10.0f);
+    if (std::isnan(opt))
+    {
+        GetLogger()->warn("Ignoring NaN star optimization.\n");
+        return;
+    }
+
+    starOptimization = opt <= 0.0f ? 0.0f : std::clamp(opt, 0.05f, 1.0f);
     markSettingsChanged();
 }
 
@@ -6241,7 +6247,6 @@ Renderer::renderSolarSystemObjects(const Observer &observer,
         ps.depthTest = true;
         setPipelineState(ps);
 
-        PointStarVertexBuffer::enable();
         glareVertexBuffer->startSprites();
         glareVertexBuffer->render();
         glareVertexBuffer->finish();
@@ -6251,17 +6256,15 @@ Renderer::renderSolarSystemObjects(const Observer &observer,
             pointStarVertexBuffer->startSprites();
         pointStarVertexBuffer->render();
         pointStarVertexBuffer->finish();
-        PointStarVertexBuffer::disable();
 
         m_legacyLargeStarRenderer->render();
         m_legacyLargeGlareRenderer->render();
 
-        // Drain any close-star PSF point-sprites added by
-        // Drain any close-star PSF point-sprites added by
+        // Drain PSF points and glows added by
         // renderObjectAsPoint during renderItem above.  Uses the current
         // per-interval (km-scale) projection so Sol-at-1AU stays inside
-        // the depth range.  The buffers were started+finished once in
-        // renderPointStars (m_prog persists), so render() can pick up the
+        // the depth range.  The buffers were prepared before either the
+        // star or solar-system pass, so render() can pick up the
         // current MVP via makeCurrent() without re-calling start().
         if (starStyle == StarStyle::PointSpreadFunction)
         {
@@ -6271,14 +6274,12 @@ Renderer::renderSolarSystemObjects(const Observer &observer,
             psPsf.depthTest = true;
             setPipelineState(psPsf);
 
-            PsfStarVertexBuffer::enable();
             psfPointBuffer->render();
             psfGlowBuffer->render();
             m_psfGlowLargeRenderer->render();
             psfPointBuffer->finish();
             psfGlowBuffer->finish();
             m_psfGlowLargeRenderer->finish();
-            PsfStarVertexBuffer::disable();
         }
 
         // Render annotations in this interval

--- a/src/celengine/render.h
+++ b/src/celengine/render.h
@@ -308,6 +308,7 @@ class Renderer
     // Point Spread Function star renderer settings (StarStyle::PointSpreadFunction).
     void  setStarPointRadius(float r);
     float getStarPointRadius() const;
+    // Positive values are clamped to [0.05, 1.0]; nonpositive values disable glow.
     void  setStarOptimization(float opt);
     float getStarOptimization() const;
     void  setStarMaxIrradiance(float v);
@@ -458,6 +459,7 @@ class Renderer
 
  private:
     void setFieldOfView(float);
+    void preparePsfStarBuffers();
     void renderPointStars(const StarDatabase& starDB,
                           float faintestVisible,
                           const Observer& observer);

--- a/src/celengine/shadermanager.cpp
+++ b/src/celengine/shadermanager.cpp
@@ -2598,8 +2598,10 @@ buildProgram(std::string_view vs, std::string_view fs, bool fisheyeEnabled,
 {
     std::string_view toneMapDefine =
         util::is_set(options, StaticShaderOptions::ToneMap) ? "#define TONE_MAP\n"sv : ""sv;
-    std::string vsSrc = fmt::format("{}{}{}{}{}\n", VersionHeader, CommonHeader, VertexHeader, VPFunction(fisheyeEnabled), vs);
-    std::string fsSrc = fmt::format("{}{}{}{}{}\n", VersionHeader, CommonHeader, FragmentHeader, toneMapDefine, fs);
+    std::string_view billboardDefine =
+        util::is_set(options, StaticShaderOptions::Billboard) ? "#define BILLBOARD\n"sv : ""sv;
+    std::string vsSrc = fmt::format("{}{}{}{}{}{}\n", VersionHeader, CommonHeader, VertexHeader, billboardDefine, VPFunction(fisheyeEnabled), vs);
+    std::string fsSrc = fmt::format("{}{}{}{}{}{}\n", VersionHeader, CommonHeader, FragmentHeader, toneMapDefine, billboardDefine, fs);
 
     DumpVSSource(vsSrc);
     DumpFSSource(fsSrc);

--- a/src/celengine/shadermanager.h
+++ b/src/celengine/shadermanager.h
@@ -50,8 +50,9 @@ enum class StaticShader
 // Compile-time options that select variants of a static shader via #define injection.
 enum class StaticShaderOptions : std::uint8_t
 {
-    None    = 0,
-    ToneMap = 0x01,
+    None      = 0,
+    ToneMap   = 0x01,
+    Billboard = 0x02,
 };
 
 ENUM_CLASS_BITWISE_OPS(StaticShaderOptions);
@@ -277,6 +278,7 @@ public:
         LineSideAttributeIndex      = 12,
         AlphaAttributeIndex         = 13,
         LimbRadiusAttributeIndex    = 14,
+        CenterAttributeIndex        = 15,
     };
 
     CelestiaGLProgramLight lights[MaxShaderLights];

--- a/src/celengine/starpipelineowner.h
+++ b/src/celengine/starpipelineowner.h
@@ -12,26 +12,24 @@
 namespace celestia::render
 {
 
-// Anything that owns transient GL pipeline state (a bound program,
-// VAO, uniforms) for star rendering and can be drained on demand.
+// A star buffer that can drain its pending vertices on demand.
 class StarPipelineFlushable
 {
 public:
     virtual ~StarPipelineFlushable() = default;
 
     // Drain any pending vertices and release the "active" claim with
-    // the owner.  Implementations should not call setActive() from
-    // here; the owner clears the active pointer itself before
-    // delegating to finish() to keep reentry simple.
+    // the owner.  The owner clears the active pointer before calling
+    // finish(), so rendering can reacquire it without recursively
+    // flushing the same buffer.
     virtual void finish() = 0;
 };
 
-// Tracks which star-pipeline buffer last bound its GL program/VAO,
-// so the next buffer that wants to bind can first flush whoever was
-// holding the pipeline.  Replaces the per-class `static current`
-// pointers in PointStarVertexBuffer / PsfStarVertexBuffer, which only
-// interlocked within their own class and could be left stale when
-// the other class bound a different program behind their back.
+// Tracks the last star buffer to submit a batch, so switching buffers
+// first drains its pending vertices.  This is not a GL binding cache:
+// other renderers can change programs and uniforms between submissions.
+// Every batch must rebind its program and refresh its uniforms, even
+// when its buffer is still active here.
 class StarPipelineOwner
 {
 public:
@@ -44,12 +42,7 @@ public:
         return m_active == p;
     }
 
-    // Drain whoever is currently active.  Use before binding a
-    // foreign GL program (e.g. a one-shot draw outside the star
-    // pipeline) so that buffer's pending vertices are submitted under
-    // its own program and its "active" claim is released — otherwise
-    // it would later early-return from makeCurrent() while the
-    // foreign program is still bound and draw garbage.
+    // Drain whoever is currently active and release its claim.
     void flush()
     {
         if (m_active != nullptr)

--- a/src/celrender/CMakeLists.txt
+++ b/src/celrender/CMakeLists.txt
@@ -19,6 +19,8 @@ set(CELRENDER_SOURCES
   legacylargestarrenderer.h
   psfglowlargerenderer.cpp
   psfglowlargerenderer.h
+  psfpointlargerenderer.cpp
+  psfpointlargerenderer.h
   linerenderer.cpp
   linerenderer.h
   nebularenderer.cpp

--- a/src/celrender/largestarrenderer.cpp
+++ b/src/celrender/largestarrenderer.cpp
@@ -44,11 +44,13 @@ constexpr std::array<Corner, 4> kQuadCorners = {{
 
 } // namespace
 
-LargeStarRenderer::LargeStarRenderer(Renderer    &renderer,
+LargeStarRenderer::LargeStarRenderer(const Renderer &renderer,
                                      StaticShader shaderId,
-                                     capacity_t   capacity) :
+                                     capacity_t   capacity,
+                                     StaticShaderOptions shaderOptions) :
     m_renderer(renderer),
     m_shaderId(shaderId),
+    m_shaderOptions(shaderOptions),
     m_capacity(capacity),
     m_instances(std::make_unique<StarInstance[]>(capacity))
 {
@@ -59,7 +61,7 @@ LargeStarRenderer::~LargeStarRenderer() = default;
 void
 LargeStarRenderer::start()
 {
-    m_prog   = m_renderer.getShaderManager().getShader(m_shaderId);
+    m_prog   = m_renderer.getShaderManager().getShader(m_shaderId, m_shaderOptions);
     m_nStars = 0;
 }
 
@@ -89,7 +91,7 @@ void
 LargeStarRenderer::makeCurrent()
 {
     auto &owner = m_renderer.starPipelineOwner();
-    if (owner.isActive(this) || m_prog == nullptr)
+    if (m_prog == nullptr)
         return;
 
     owner.setActive(this);
@@ -145,7 +147,7 @@ LargeStarRenderer::setupVertexArrayObject()
 
     m_vo->addInstanceBuffer(
         m_bo,
-        CelestiaGLProgram::NormalAttributeIndex,
+        CelestiaGLProgram::CenterAttributeIndex,
         3,
         gl::VertexObject::DataType::Float,
         false,

--- a/src/celrender/largestarrenderer.h
+++ b/src/celrender/largestarrenderer.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <memory>
 
 #include <Eigen/Core>
@@ -22,6 +23,7 @@ class Color;
 class Renderer;
 class CelestiaGLProgram;
 enum class StaticShader;
+enum class StaticShaderOptions : std::uint8_t;
 
 namespace celestia::gl
 {
@@ -53,9 +55,10 @@ public:
                  float limbRadius = 0.0f, float alpha = 1.0f);
 
 protected:
-    explicit LargeStarRenderer(Renderer &renderer, StaticShader shaderId, capacity_t capacity);
+    LargeStarRenderer(const Renderer &renderer, StaticShader shaderId, capacity_t capacity,
+                      StaticShaderOptions shaderOptions);
 
-    Renderer&          renderer() noexcept       { return m_renderer; }
+    const Renderer&    renderer() const noexcept { return m_renderer; }
     CelestiaGLProgram* program()  const noexcept { return m_prog; }
 
     // Called from makeCurrent() after the program is bound and MVP set.
@@ -76,8 +79,9 @@ private:
     void makeCurrent();
     void setupVertexArrayObject();
 
-    Renderer                         &m_renderer;
+    const Renderer                   &m_renderer;
     StaticShader                      m_shaderId;
+    StaticShaderOptions               m_shaderOptions;
     capacity_t                        m_capacity;
     capacity_t                        m_nStars      { 0 };
     std::unique_ptr<StarInstance[]>   m_instances; //NOSONAR

--- a/src/celrender/legacylargestarrenderer.cpp
+++ b/src/celrender/legacylargestarrenderer.cpp
@@ -17,8 +17,8 @@
 namespace celestia::render
 {
 
-LegacyLargeStarRenderer::LegacyLargeStarRenderer(Renderer &renderer, capacity_t capacity) :
-    LargeStarRenderer(renderer, StaticShader::LargeStar, capacity)
+LegacyLargeStarRenderer::LegacyLargeStarRenderer(const Renderer &renderer, capacity_t capacity) :
+    LargeStarRenderer(renderer, StaticShader::LargeStar, capacity, StaticShaderOptions::None)
 {
 }
 

--- a/src/celrender/psfglowlargerenderer.cpp
+++ b/src/celrender/psfglowlargerenderer.cpp
@@ -19,8 +19,8 @@
 namespace celestia::render
 {
 
-PsfGlowLargeRenderer::PsfGlowLargeRenderer(Renderer &renderer, capacity_t capacity) :
-    LargeStarRenderer(renderer, StaticShader::PsfStarGlowLarge, capacity)
+PsfGlowLargeRenderer::PsfGlowLargeRenderer(const Renderer &renderer, capacity_t capacity) :
+    LargeStarRenderer(renderer, StaticShader::PsfStarGlowLarge, capacity, StaticShaderOptions::None)
 {
 }
 

--- a/src/celrender/psfglowlargerenderer.h
+++ b/src/celrender/psfglowlargerenderer.h
@@ -19,7 +19,7 @@ namespace celestia::render
 class PsfGlowLargeRenderer : public LargeStarRenderer
 {
 public:
-    explicit PsfGlowLargeRenderer(Renderer &renderer, capacity_t capacity = 2048);
+    PsfGlowLargeRenderer(const Renderer &renderer, capacity_t capacity);
     ~PsfGlowLargeRenderer() override;
 
     void setPointRadius(float r)    { m_pointRadius  = r; }

--- a/src/celrender/psfpointlargerenderer.cpp
+++ b/src/celrender/psfpointlargerenderer.cpp
@@ -1,0 +1,30 @@
+// psfpointlargerenderer.cpp
+//
+// Copyright (C) 2026-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include "psfpointlargerenderer.h"
+
+#include <celengine/shadermanager.h>
+
+namespace celestia::render
+{
+
+PsfPointLargeRenderer::PsfPointLargeRenderer(const Renderer &renderer, capacity_t capacity) :
+    LargeStarRenderer(renderer, StaticShader::PsfStarPoint, capacity, StaticShaderOptions::Billboard)
+{
+}
+
+void
+PsfPointLargeRenderer::onMakeCurrent(const Eigen::Vector2f &viewportRcp)
+{
+    program()->floatParam("pointRadius") = m_pointRadius;
+    program()->floatParam("pointScale") = m_pointScale;
+    program()->vec2Param("viewportRcp") = viewportRcp;
+}
+
+} // namespace celestia::render

--- a/src/celrender/psfpointlargerenderer.h
+++ b/src/celrender/psfpointlargerenderer.h
@@ -1,4 +1,4 @@
-// legacylargestarrenderer.h
+// psfpointlargerenderer.h
 //
 // Copyright (C) 2026-present, the Celestia Development Team
 //
@@ -11,26 +11,23 @@
 
 #include <celrender/largestarrenderer.h>
 
-class Texture;
-
 namespace celestia::render
 {
 
-// Batched textured-billboard renderer for point-sprite stars whose
-// gl_PointSize would exceed the driver's GL_ALIASED_POINT_SIZE_RANGE.
-class LegacyLargeStarRenderer : public LargeStarRenderer
+class PsfPointLargeRenderer : public LargeStarRenderer
 {
 public:
-    LegacyLargeStarRenderer(const Renderer &renderer, capacity_t capacity);
-    ~LegacyLargeStarRenderer() override;
+    PsfPointLargeRenderer(const Renderer &renderer, capacity_t capacity);
 
-    void setTexture(Texture *texture) { m_texture = texture; }
+    void setPointRadius(float radius) { m_pointRadius = radius; }
+    void setPointScale(float scale) { m_pointScale = scale; }
 
 protected:
     void onMakeCurrent(const Eigen::Vector2f &viewportRcp) override;
 
 private:
-    Texture *m_texture { nullptr };
+    float m_pointRadius{ 1.5f };
+    float m_pointScale{ 1.0f };
 };
 
 } // namespace celestia::render

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -8,6 +8,7 @@ set(UNIT_TEST_SOURCES
   legacy_cmdparser_test.cpp
   loader_validation_test.cpp
   logger_test.cpp
+  psf_test.cpp
   ranges_test.cpp
   resourcesystem_test.cpp
   stellarclass_test.cpp

--- a/test/unit/psf_test.cpp
+++ b/test/unit/psf_test.cpp
@@ -1,0 +1,139 @@
+// psf_test.cpp
+//
+// Copyright (C) 2026-present, the Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include <doctest.h>
+
+#include <celengine/pointstarrenderer.h>
+
+using celestia::engine::detail::psfGlowOnset;
+using celestia::engine::detail::psfPointFade;
+using celestia::engine::detail::psfReflectiveGlowOnset;
+
+TEST_SUITE_BEGIN("PSF");
+
+TEST_CASE("PSF glow fades in between peak radiance one and two")
+{
+    CHECK(psfGlowOnset(0.0f) == 0.0f);
+    CHECK(psfGlowOnset(0.5f) == 0.0f);
+    CHECK(psfGlowOnset(1.0f) == 0.0f);
+    CHECK(psfGlowOnset(1.25f) == doctest::Approx(0.15625f));
+    CHECK(psfGlowOnset(1.5f) == doctest::Approx(0.5f));
+    CHECK(psfGlowOnset(1.75f) == doctest::Approx(0.84375f));
+    CHECK(psfGlowOnset(2.0f) == 1.0f);
+    CHECK(psfGlowOnset(100.0f) == 1.0f);
+    CHECK(psfGlowOnset(std::numeric_limits<float>::max()) == 1.0f);
+}
+
+TEST_CASE("PSF glow onset is continuous at both thresholds")
+{
+    float aboveOne = psfGlowOnset(std::nextafter(1.0f, 2.0f));
+    CHECK(aboveOne > 0.0f);
+    CHECK(aboveOne < 1.0e-6f);
+    CHECK(psfGlowOnset(std::nextafter(1.0f, 0.0f)) == 0.0f);
+
+    CHECK(psfGlowOnset(std::nextafter(2.0f, 1.0f)) > 1.0f - 1.0e-6f);
+    CHECK(psfGlowOnset(std::nextafter(2.0f, 3.0f)) == 1.0f);
+}
+
+TEST_CASE("PSF glow onset is bounded and monotonic")
+{
+    float previous = 0.0f;
+    for (int i = 0; i <= 300; ++i)
+    {
+        float alpha = psfGlowOnset(static_cast<float>(i) / 100.0f);
+        CHECK(alpha >= previous);
+        CHECK(alpha >= 0.0f);
+        CHECK(alpha <= 1.0f);
+        previous = alpha;
+    }
+}
+
+TEST_CASE("PSF point fades out as the disc resolves")
+{
+    CHECK(psfPointFade(0.0f, 1.5f, 1.0f) == 1.0f);
+    CHECK(psfPointFade(0.5f, 1.5f, 1.0f) == 1.0f);
+    CHECK(psfPointFade(1.0f, 1.5f, 1.0f) == 1.0f);
+    CHECK(psfPointFade(1.25f, 1.5f, 1.0f) == doctest::Approx(0.84375f));
+    CHECK(psfPointFade(1.5f, 1.5f, 1.0f) == doctest::Approx(0.5f));
+    CHECK(psfPointFade(1.75f, 1.5f, 1.0f) == doctest::Approx(0.15625f));
+    CHECK(psfPointFade(2.0f, 1.5f, 1.0f) == 0.0f);
+    CHECK(psfPointFade(100.0f, 1.5f, 1.0f) == 0.0f);
+}
+
+TEST_CASE("PSF reflective glow fades smoothly at the limb overflow threshold")
+{
+    CHECK(psfReflectiveGlowOnset(10.0f, 0.0f) == 1.0f);
+    for (float linkedPeak : { 0.1f, 1.0f, 10.0f, 1000.0f })
+    {
+        CAPTURE(linkedPeak);
+        CHECK(psfReflectiveGlowOnset(0.0f, linkedPeak) == 0.0f);
+        CHECK(psfReflectiveGlowOnset(linkedPeak, linkedPeak) == 0.0f);
+        CHECK(psfReflectiveGlowOnset(1.5f * linkedPeak, linkedPeak) == doctest::Approx(0.5f));
+        CHECK(psfReflectiveGlowOnset(2.0f * linkedPeak, linkedPeak) == 1.0f);
+        CHECK(psfReflectiveGlowOnset(10.0f * linkedPeak, linkedPeak) == 1.0f);
+        CHECK(psfReflectiveGlowOnset(std::nextafter(linkedPeak, 0.0f), linkedPeak) == 0.0f);
+        CHECK(psfReflectiveGlowOnset(std::nextafter(linkedPeak, 2.0f * linkedPeak), linkedPeak) < 1.0e-6f);
+        CHECK(psfReflectiveGlowOnset(std::nextafter(2.0f * linkedPeak, linkedPeak), linkedPeak) > 1.0f - 1.0e-6f);
+
+        float previous = 0.0f;
+        for (int i = 0; i <= 300; ++i)
+        {
+            float alpha = psfReflectiveGlowOnset(linkedPeak * (static_cast<float>(i) / 100.0f), linkedPeak);
+            CHECK(alpha >= previous);
+            CHECK(alpha >= 0.0f);
+            CHECK(alpha <= 1.0f);
+            previous = alpha;
+        }
+    }
+}
+
+TEST_CASE("PSF point transition follows the DPI-scaled cone radius")
+{
+    CHECK(psfPointFade(1.5f, 1.0f, 1.0f) == doctest::Approx(0.5f));
+    CHECK(psfPointFade(1.5f, 1.0f, 0.5f) == doctest::Approx(0.5f));
+    CHECK(psfPointFade(2.0f, 1.5f, 2.0f) == doctest::Approx(0.5f));
+    CHECK(psfPointFade(2.0f, 3.0f, 1.0f) == doctest::Approx(0.5f));
+    CHECK(psfPointFade(3.0f, 1.5f, 2.0f) == 0.0f);
+    CHECK(psfPointFade(10.5f, 10.0f, 2.0f) == doctest::Approx(0.5f));
+    CHECK(psfPointFade(20.0f, 10.0f, 2.0f) == 0.0f);
+}
+
+TEST_CASE("PSF point fade is continuous and monotonic across radii and DPI scales")
+{
+    for (float radius : { 1.0f, 1.5f, 10.0f })
+    {
+        for (float scale : { 0.5f, 1.0f, 2.0f, 4.0f })
+        {
+            CAPTURE(radius);
+            CAPTURE(scale);
+            float fadeEnd = std::max(2.0f, radius * scale);
+            CHECK(psfPointFade(1.0f, radius, scale) == 1.0f);
+            CHECK(psfPointFade(std::nextafter(1.0f, 2.0f), radius, scale) > 1.0f - 1.0e-6f);
+            CHECK(psfPointFade(std::nextafter(fadeEnd, 1.0f), radius, scale) < 1.0e-6f);
+            CHECK(psfPointFade(fadeEnd, radius, scale) == 0.0f);
+
+            float previous = 1.0f;
+            for (int i = 0; i <= 200; ++i)
+            {
+                float discRadius = static_cast<float>(i) * fadeEnd / 100.0f;
+                float fade = psfPointFade(discRadius, radius, scale);
+                CHECK(fade <= previous);
+                CHECK(fade >= 0.0f);
+                CHECK(fade <= 1.0f);
+                previous = fade;
+            }
+        }
+    }
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
Constrain optimization parameters and initialize PSF buffers independently of star visibility. Smooth glow onset, reflective-body glow cutoff, and center-cone fading.

Restore shader state for every star batch and scope programmable point sizes to individual draws. Handle oversized center cones with an instanced billboard fallback and a dedicated center attribute.

before vs after:

<img width="1680" height="927" alt="psf-before-after" src="https://github.com/user-attachments/assets/6db823d0-977e-47c1-88c5-689d3865699c" />
